### PR TITLE
SONIC-MGMT-COMMON : Support for L2 match fields for ACL

### DIFF
--- a/models/yang/sonic/sonic-acl.yang
+++ b/models/yang/sonic/sonic-acl.yang
@@ -168,6 +168,21 @@ module sonic-acl {
 							type inet:ipv6-prefix;    
 						}
 					}
+					case l2_src_dst {
+						when "(/sonic-acl/ACL_TABLE/ACL_TABLE_LIST[aclname=current()/aclname]/type = 'L2')";
+						leaf SRC_MAC {
+							mandatory true;
+							type string {
+								pattern "[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}|[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}/[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}";
+							}
+						}
+						leaf DST_MAC {
+							mandatory true;
+							type string {
+								pattern "[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}|[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}/[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}";
+							}
+						}
+					}
 				}
 
 				choice src_port {
@@ -214,6 +229,30 @@ module sonic-acl {
 
 				leaf DSCP { 
 					type inet:dscp;
+				}
+
+				leaf VLAN_ID {
+					type uint16 {
+						range "1..4094" {
+							error-app-tag vlan-id-invalid;
+						}
+					}
+				}
+
+				leaf VLAN_PCP {
+					type string {
+						pattern "[0-7]|[0-7]/[0-7]" {
+							error-app-tag vlan-pcp-invalid;
+						}
+					}
+				}
+
+				leaf VLAN_DEI {
+					type uint8 {
+						range "0..1" {
+							error-app-tag vlan-dei-invalid;
+						}
+					}
 				}
 			}
 		}


### PR DESCRIPTION
* Added SONIC yang for src mac, dst mac, vlan id, vlan pcp, vlan dei

Signed-off-by: arthig <arthig@celestica.com>

Added support for L2_TABLE related match fields for configuring rules to ACL L2 TABLE

Related pull requests
https://github.com/sonic-net/sonic-swss/pull/2540
https://github.com/sonic-net/sonic-mgmt-common/pull/65
https://github.com/sonic-net/sonic-utilities/pull/2514


Why I did it

ACL supports only L3 and L3V6 table type. There is no support for matching L2 fields.
When user wants to match fields like SRC_MAC, DST_MAC, VLAN_ID, VLAN_PCP, VLAN_DEI we do not have support for these fields in sonic-DB.
Added support for these fields in sonic-acl.yang.


How I verified it

Create L2 Table from CLICK
"config acl add table -s ingress -p <table_name> L2"
Add rules using CONFIG_DB format
add rules src mac, dst mac, ether type, pcp, dei & vlan id
"L2_TABLE|RULE_2": {
"SRC_MAC": "00:00:00:11:11:11/00:00:00:ff:ff:ff",
"DST_MAC": "00:00:00:22:22:22/00:00:00:ff:ff:ff",
"ETHER_TYPE": "0x0800",
"VLAN_ID": "100",
"VLAN_PCP": "5/7",
"VLAN_DEI": "1",
"PRIORITY": "5",
"PACKET_ACTION": "DROP"
}
Validate commands "show acl table"
Validate commands and fields in "show acl rule"
Validate commands "aclshow -a" /* Ensured that the counters are hitting the relevant rule */
Add rules using openconfig json format for supported fields "config acl update full/incremental <file.json>"
"source-mac": "00:00:00:11:11:12",
"source-mac-mask": "00:00:00:ff:ff:ff",
"destination-mac": "00:00:00:11:11:13",
"destination-mac-mask": "00:00:00:ff:ff:ff",
"ethertype": "ETHERTYPE_ARP"
All the rules are added for each field and combinations as well. and each field tested with traffic in Broadcom based platform.

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205