### PR TITLE
Support a new ACL table type called L3V4V6.

### DIFF
--- a/models/yang/sonic/sonic-acl.yang
+++ b/models/yang/sonic/sonic-acl.yang
@@ -61,6 +61,7 @@ module sonic-acl {
 						enum MIRRORV6;
 						enum L3;
 						enum L3V6;
+						enum L3V4V6;
 					}
 				}
 


### PR DESCRIPTION
Support a new ACL table type called L3V4V6.

This table supports both v4 and v6 Match types.

HLD: sonic-net/SONiC#1267

Signed-off-by: Ravi(Marvell) rck@innovium.com