### PR TITLE
Return ygot strcut from app module processGet() functions

### DIFF
--- a/translib/acl_app.go
+++ b/translib/acl_app.go
@@ -276,7 +276,7 @@ func (app *AclApp) processDelete(d *db.DB) (SetResponse, error) {
 	return resp, err
 }
 
-func (app *AclApp) processGet(dbs [db.MaxDB]*db.DB) (GetResponse, error) {
+func (app *AclApp) processGet(dbs [db.MaxDB]*db.DB, fmtType TranslibFmtType) (GetResponse, error) {
 	var err error
 	var payload []byte
 
@@ -286,12 +286,7 @@ func (app *AclApp) processGet(dbs [db.MaxDB]*db.DB) (GetResponse, error) {
 		return GetResponse{Payload: payload, ErrSrc: AppErr}, err
 	}
 
-	payload, err = generateGetResponsePayload(app.pathInfo.Path, (*app.ygotRoot).(*ocbinds.Device), app.ygotTarget)
-	if err != nil {
-		return GetResponse{Payload: payload, ErrSrc: AppErr}, err
-	}
-
-	return GetResponse{Payload: payload}, err
+	return generateGetResponse(app.pathInfo.Path, app.ygotRoot, fmtType)
 }
 
 func (app *AclApp) processAction(dbs [db.MaxDB]*db.DB) (ActionResponse, error) {

--- a/translib/api_tests_app.go
+++ b/translib/api_tests_app.go
@@ -121,7 +121,7 @@ func (app *apiTests) processDelete(d *db.DB) (SetResponse, error) {
 	return app.processSet()
 }
 
-func (app *apiTests) processGet(dbs [db.MaxDB]*db.DB) (GetResponse, error) {
+func (app *apiTests) processGet(dbs [db.MaxDB]*db.DB, fmtType TranslibFmtType) (GetResponse, error) {
 	var gr GetResponse
 	err := app.getError()
 	if err != nil {

--- a/translib/app_interface.go
+++ b/translib/app_interface.go
@@ -89,7 +89,7 @@ type appInterface interface {
 	processUpdate(d *db.DB) (SetResponse, error)
 	processReplace(d *db.DB) (SetResponse, error)
 	processDelete(d *db.DB) (SetResponse, error)
-	processGet(dbs [db.MaxDB]*db.DB) (GetResponse, error)
+	processGet(dbs [db.MaxDB]*db.DB, fmtType TranslibFmtType) (GetResponse, error)
 	processAction(dbs [db.MaxDB]*db.DB) (ActionResponse, error)
 }
 

--- a/translib/common_app.go
+++ b/translib/common_app.go
@@ -242,7 +242,7 @@ func (app *CommonApp) processDelete(d *db.DB) (SetResponse, error) {
 	return resp, err
 }
 
-func (app *CommonApp) processGet(dbs [db.MaxDB]*db.DB) (GetResponse, error) {
+func (app *CommonApp) processGet(dbs [db.MaxDB]*db.DB, fmtType TranslibFmtType) (GetResponse, error) {
     var err error
     var payload []byte
     var resPayload []byte
@@ -324,11 +324,7 @@ func (app *CommonApp) processGet(dbs [db.MaxDB]*db.DB) (GetResponse, error) {
 			    }
 		    }
 		    if resYgot != nil {
-			    resPayload, err = generateGetResponsePayload(app.pathInfo.Path, resYgot.(*ocbinds.Device), app.ygotTarget)
-			    if err != nil {
-				    log.Warning("generateGetResponsePayload() couldn't generate payload.")
-				    resPayload = payload
-			    }
+			    return generateGetResponse(app.pathInfo.Path, &resYgot, fmtType)
 		    } else {
 			resPayload = payload
 		    }

--- a/translib/lldp_app.go
+++ b/translib/lldp_app.go
@@ -198,7 +198,7 @@ func (app *lldpApp) processDelete(d *db.DB) (SetResponse, error)  {
     return resp, err
 }
 
-func (app *lldpApp) processGet(dbs [db.MaxDB]*db.DB) (GetResponse, error)  {
+func (app *lldpApp) processGet(dbs [db.MaxDB]*db.DB, fmtType TranslibFmtType) (GetResponse, error)  {
     var err error
     var payload []byte
 
@@ -206,6 +206,10 @@ func (app *lldpApp) processGet(dbs [db.MaxDB]*db.DB) (GetResponse, error)  {
     lldpIntfObj := app.getAppRootObject()
 
     targetUriPath, err := getYangPathFromUri(app.path.Path)
+    if err != nil {
+        return GetResponse{}, err
+    }
+
     log.Info("lldp processGet")
     log.Info("targetUriPath: ", targetUriPath)
 
@@ -223,12 +227,6 @@ func (app *lldpApp) processGet(dbs [db.MaxDB]*db.DB) (GetResponse, error)  {
             }
             ygot.BuildEmptyTree(oneIfInfo)
             app.getLldpNeighInfoFromInternalMap(&ifname, oneIfInfo)
-            if *app.ygotTarget == lldpIntfObj.Interfaces {
-                payload, err = dumpIetfJson(lldpIntfObj, true)
-            } else {
-                log.Info("Wrong request!")
-            }
-
         }
     } else if targetUriPath == "/openconfig-lldp:lldp/interfaces/interface" {
         intfObj := lldpIntfObj.Interfaces
@@ -240,23 +238,13 @@ func (app *lldpApp) processGet(dbs [db.MaxDB]*db.DB) (GetResponse, error)  {
                 ifInfo := intfObj.Interface[ifname]
                 ygot.BuildEmptyTree(ifInfo)
                 app.getLldpNeighInfoFromInternalMap(&ifname, ifInfo)
-
-                if *app.ygotTarget == intfObj.Interface[ifname] {
-                    payload, err = dumpIetfJson(intfObj, true)
-                    if err != nil {
-                        log.Info("Creation of subinterface subtree failed!")
-                        return GetResponse{Payload: payload, ErrSrc: AppErr}, err
-                    }
-                } else {
-                    log.Info("Wrong request!")
-                }
             }
         } else {
             log.Info("No data")
         }
    }
 
-   return GetResponse{Payload:payload}, err
+   return generateGetResponse(app.path.Path, app.ygotRoot, fmtType)
 }
 
 func (app *lldpApp) processAction(dbs [db.MaxDB]*db.DB) (ActionResponse, error) {

--- a/translib/pfm_app.go
+++ b/translib/pfm_app.go
@@ -152,7 +152,7 @@ func (app *PlatformApp) processDelete(d *db.DB) (SetResponse, error)  {
     return resp, err
 }
 
-func (app *PlatformApp) processGet(dbs [db.MaxDB]*db.DB) (GetResponse, error)  {
+func (app *PlatformApp) processGet(dbs [db.MaxDB]*db.DB, fmtType TranslibFmtType) (GetResponse, error)  {
     pathInfo := app.path
     log.Infof("Received GET for PlatformApp Template: %s ,path: %s, vars: %v",
     pathInfo.Template, pathInfo.Path, pathInfo.Vars)
@@ -187,10 +187,17 @@ func (app *PlatformApp) processGet(dbs [db.MaxDB]*db.DB) (GetResponse, error)  {
         return GetResponse{Payload: payload}, perr
     }
 
+    var err error
+
     if isSubtreeRequest(targetUriPath, "/openconfig-platform:components") {
-        return app.doGetSysEeprom()
+        err = app.doGetSysEeprom()
+    } else {
+        err = errors.New("Not supported component")
     }
-    err := errors.New("Not supported component")
+
+    if err == nil {
+        return generateGetResponse(pathInfo.Path, app.ygotRoot, fmtType)
+    }
     return GetResponse{Payload: payload}, err
 }
 
@@ -423,11 +430,10 @@ func (app *PlatformApp) getSysEepromFromDb (eeprom *ocbinds.OpenconfigPlatform_C
     return nil 
 }
 
-func (app *PlatformApp) doGetSysEeprom () (GetResponse, error) {
+func (app *PlatformApp) doGetSysEeprom () error {
 
     log.Infof("Preparing collection for system eeprom");
 
-    var payload []byte
     var err error
     pf_cpts := app.getAppRootObject()
 
@@ -437,32 +443,22 @@ func (app *PlatformApp) doGetSysEeprom () (GetResponse, error) {
         pf_comp,_ := pf_cpts.NewComponent("System Eeprom")
         ygot.BuildEmptyTree(pf_comp)
         err = app.getSysEepromFromDb(pf_comp.State, true)
-        if err != nil {
-            return GetResponse{Payload: payload}, err
-        }
-        payload, err = dumpIetfJson((*app.ygotRoot).(*ocbinds.Device), true)
+
     case "/openconfig-platform:components/component":
         compName := app.path.Var("name")
         if compName == "" {
             pf_comp,_ := pf_cpts.NewComponent("System Eeprom")
             ygot.BuildEmptyTree(pf_comp)
             err = app.getSysEepromFromDb(pf_comp.State, true)
-            if err != nil {
-                return GetResponse{Payload: payload}, err
-            }
-            payload, err = dumpIetfJson(pf_cpts, false)
         } else {
             if compName != "System Eeprom" {
                 err = errors.New("Invalid component name")
+                break
             }
             pf_comp := pf_cpts.Component[compName]
             if pf_comp != nil {
                 ygot.BuildEmptyTree(pf_comp)
                 err = app.getSysEepromFromDb(pf_comp.State, true)
-                if err != nil {
-                    return GetResponse{Payload: payload}, err
-                }
-                payload, err = dumpIetfJson(pf_cpts.Component[compName], false)
             } else {
                 err = errors.New("Invalid input component name")
             }
@@ -474,10 +470,6 @@ func (app *PlatformApp) doGetSysEeprom () (GetResponse, error) {
             if pf_comp != nil {
                 ygot.BuildEmptyTree(pf_comp)
                 err = app.getSysEepromFromDb(pf_comp.State, true)
-                if err != nil {
-                    return GetResponse{Payload: payload}, err
-                }
-                payload, err = dumpIetfJson(pf_cpts.Component[compName], false)
             } else {
                 err = errors.New("Invalid input component name")
             }
@@ -495,10 +487,6 @@ func (app *PlatformApp) doGetSysEeprom () (GetResponse, error) {
                 if pf_comp != nil {
                     ygot.BuildEmptyTree(pf_comp)
                     err = app.getSysEepromFromDb(pf_comp.State, false)
-                    if err != nil {
-                        return GetResponse{Payload: payload}, err
-                    }
-                    payload, err = dumpIetfJson(pf_cpts.Component[compName].State, false)
                 } else {
                     err = errors.New("Invalid input component name")
                 }
@@ -507,6 +495,6 @@ func (app *PlatformApp) doGetSysEeprom () (GetResponse, error) {
             err = errors.New("Invalid Path")
         }
     }
-    return  GetResponse{Payload: payload}, err
+    return  err
 }
 

--- a/translib/subscribe.go
+++ b/translib/subscribe.go
@@ -253,7 +253,7 @@ func getJson (nInfo *notificationInfo) ([]byte, error) {
         return payload, err
     }
 
-    resp, err := (*app).processGet(dbs)
+    resp, err := (*app).processGet(dbs, TRANSLIB_FMT_IETF_JSON)
 
     if err == nil {
         payload = resp.Payload

--- a/translib/sys_app.go
+++ b/translib/sys_app.go
@@ -252,7 +252,7 @@ func (app *SysApp) getSystemProcesses(sysprocs *ocbinds.OpenconfigSystem_System_
 	return
 }
 
-func (app *SysApp) processGet(dbs [db.MaxDB]*db.DB) (GetResponse, error) {
+func (app *SysApp) processGet(dbs [db.MaxDB]*db.DB, fmtType TranslibFmtType) (GetResponse, error) {
 	log.Info("SysApp: processGet Path: ", app.path.Path)
 
 	stateDb := dbs[db.StateDB]
@@ -317,32 +317,26 @@ func (app *SysApp) processGet(dbs [db.MaxDB]*db.DB) (GetResponse, error) {
 		if targetUriPath == "/openconfig-system:system/processes" {
 			ygot.BuildEmptyTree(sysObj)
 			app.getSystemProcesses(sysObj.Processes, false)
-			payload, err = dumpIetfJson(sysObj, false)
 		} else if targetUriPath == "/openconfig-system:system/processes/process" {
 			pid, perr := app.path.IntVar("pid")
 			if perr == nil {
 				if pid == 0 {
 					ygot.BuildEmptyTree(sysObj)
 					app.getSystemProcesses(sysObj.Processes, false)
-					payload, err = dumpIetfJson(sysObj.Processes, false)
 				} else {
 					app.getSystemProcesses(sysObj.Processes, true)
-					payload, err = dumpIetfJson(sysObj.Processes, false)
 				}
 			}
 		} else if targetUriPath == "/openconfig-system:system/processes/process/state" {
-			pid, _ := app.path.IntVar("pid")
 			app.getSystemProcesses(sysObj.Processes, true)
-			payload, err = dumpIetfJson(sysObj.Processes.Process[uint64(pid)], true)
 		} else if isSubtreeRequest(targetUriPath, "/openconfig-system:system/processes/process/state") {
-			pid, _ := app.path.IntVar("pid")
 			app.getSystemProcesses(sysObj.Processes, true)
-			payload, err = dumpIetfJson(sysObj.Processes.Process[uint64(pid)].State, true)
 		}
 	} else {
 		return GetResponse{Payload: payload}, errors.New("Not implemented processGet, path: ")
 	}
-	return GetResponse{Payload: payload}, err
+
+	return generateGetResponse(app.path.Path, app.ygotRoot, fmtType)
 }
 
 func (app *SysApp) processAction(dbs [db.MaxDB]*db.DB) (ActionResponse, error) {

--- a/translib/translib.go
+++ b/translib/translib.go
@@ -35,10 +35,12 @@ package translib
 
 import (
 	"sync"
+
 	"github.com/Azure/sonic-mgmt-common/translib/db"
 	"github.com/Azure/sonic-mgmt-common/translib/tlerr"
 	"github.com/Workiva/go-datastructures/queue"
 	log "github.com/golang/glog"
+	"github.com/openconfig/ygot/ygot"
 )
 
 //Write lock for all write operations to be synchronized
@@ -55,6 +57,13 @@ type ErrSource int
 const (
 	ProtoErr ErrSource = iota
 	AppErr
+)
+
+type TranslibFmtType int
+
+const (
+	TRANSLIB_FMT_IETF_JSON TranslibFmtType = iota
+	TRANSLIB_FMT_YGOT
 )
 
 type UserRoles struct {
@@ -78,6 +87,7 @@ type SetResponse struct {
 
 type GetRequest struct {
 	Path    string
+	FmtType TranslibFmtType
 	User    UserRoles
 	AuthEnabled bool
 	ClientVersion Version
@@ -88,8 +98,9 @@ type GetRequest struct {
 }
 
 type GetResponse struct {
-	Payload []byte
-	ErrSrc  ErrSource
+	Payload   []byte
+	ValueTree ygot.ValidatedGoStruct
+	ErrSrc    ErrSource
 }
 
 type ActionRequest struct {
@@ -522,7 +533,7 @@ func Get(req GetRequest) (GetResponse, error) {
 		return resp, err
 	}
 
-	resp, err = (*app).processGet(dbs)
+	resp, err = (*app).processGet(dbs, req.FmtType)
 
 	return resp, err
 }

--- a/translib/yanglib_app.go
+++ b/translib/yanglib_app.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/openconfig/goyang/pkg/yang"
+	"github.com/openconfig/ygot/ygot"
 )
 
 // yanglibApp implements app interface for the
@@ -134,7 +135,7 @@ func (app *yanglibApp) processAction(dbs [db.MaxDB]*db.DB) (ActionResponse, erro
 	return ActionResponse{}, errors.NotSupported("Unsupported")
 }
 
-func (app *yanglibApp) processGet(dbs [db.MaxDB]*db.DB) (GetResponse, error) {
+func (app *yanglibApp) processGet(dbs [db.MaxDB]*db.DB, fmtType TranslibFmtType) (GetResponse, error) {
 	glog.Infof("path = %s", app.pathInfo.Template)
 	glog.Infof("vars = %s", app.pathInfo.Vars)
 
@@ -156,8 +157,8 @@ func (app *yanglibApp) processGet(dbs [db.MaxDB]*db.DB) (GetResponse, error) {
 	}
 
 	if err == nil {
-		resp.Payload, err = generateGetResponsePayload(
-			app.pathInfo.Path, app.ygotRoot, app.ygotTarget)
+		var root ygot.GoStruct = app.ygotRoot
+		resp, err = generateGetResponse(app.pathInfo.Path, &root, fmtType)
 	}
 
 	return resp, err


### PR DESCRIPTION
* Updated the appInterface method processGet() to accept a TranslibFmtType argument indicating whether the response data should be returned as IETF json bytes or a ygot.GoStruct object. Translib subscription infra will use TranslibFmtType=ygot. The translib.Get() API will continue to use TranslibFmtType=ietf_json.

* Modified processGet() method signature in all existing app modules. All of them will call the common generateGetResponse() utility func which builds the response data as per TranslibFmtType input. Removed all direct dumpIetfJson() calls from app modules.

* GetResponse struct contains both []byte and ygot.GoStruct fields. One of them will be populated based on the TranslibFmtType input.

* Added TranslibFmtType field to GetRequest also. This can be used in future to support protocol specific response encodings like protobuf encoding.

Required for the subscription enhancements as described in HLD https://github.com/sonic-net/SONiC/pull/1287