### PR TITLE
Avoid duplicate ocbinds schema loading

### DIFF
--- a/translib/ocbinds/schema.go
+++ b/translib/ocbinds/schema.go
@@ -1,0 +1,34 @@
+////////////////////////////////////////////////////////////////////////////////
+//                                                                            //
+//  Copyright 2021 Broadcom. The term Broadcom refers to Broadcom Inc. and/or //
+//  its subsidiaries.                                                         //
+//                                                                            //
+//  Licensed under the Apache License, Version 2.0 (the "License");           //
+//  you may not use this file except in compliance with the License.          //
+//  You may obtain a copy of the License at                                   //
+//                                                                            //
+//     http://www.apache.org/licenses/LICENSE-2.0                             //
+//                                                                            //
+//  Unless required by applicable law or agreed to in writing, software       //
+//  distributed under the License is distributed on an "AS IS" BASIS,         //
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  //
+//  See the License for the specific language governing permissions and       //
+//  limitations under the License.                                            //
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+
+package ocbinds
+
+import (
+	"github.com/openconfig/ygot/ytypes"
+)
+
+// GetSchema is equivalent of the Schema function, but avoids
+// UnzipSchema call. Reuses the SchemaTree loaded during init.
+func GetSchema() (*ytypes.Schema, error) {
+	return &ytypes.Schema{
+		Root:       &Device{},
+		SchemaTree: SchemaTree,
+		Unmarshal:  Unmarshal,
+	}, nil
+}

--- a/translib/request_binder.go
+++ b/translib/request_binder.go
@@ -51,7 +51,7 @@ func init() {
 func initSchema() {
 	log.Flush()
 	var err error
-	if ygSchema, err = ocbinds.Schema(); err != nil {
+	if ygSchema, err = ocbinds.GetSchema(); err != nil {
 		panic("Error in getting the schema: " + err.Error())
 	}
 }

--- a/translib/transformer/xlate_to_db.go
+++ b/translib/transformer/xlate_to_db.go
@@ -32,7 +32,7 @@ import (
     log "github.com/golang/glog"
 )
 
-var ocbSch, _ = ocbinds.Schema()
+var ocbSch, _ = ocbinds.GetSchema()
 
 /* Fill redis-db map with field & value info */
 func dataToDBMapAdd(tableName string, dbKey string, result map[string]map[string]db.Value, field string, value string) {


### PR DESCRIPTION
Introduced a new function `ocbinds.GetSchema()`, which is equivalent of the generated function `ocbinds.Schema()`, but loads the schema only once. Translib request_binder and transformer components will use the new function. Avoids duplicate schema loads during init.