### PR TITLE
DB Access:  DB scan cursor support for keys and fields to iterate it

### DIFF
--- a/translib/db/db_cursor.go
+++ b/translib/db/db_cursor.go
@@ -286,7 +286,7 @@ func (sc *ScanCursor) getNext(scOpts *ScanCursorOpts, returnRedisKeys bool) ([]K
 	}
 
 	if e != nil {
-		glog.Error("ScanCursor.getNext: ", sc.db.Name(), "pattern: ", sc.pattern, ": error: ", e)
+		glog.Error("ScanCursor.getNext: pattern: ", sc.pattern, ": error: ", e)
 	}
 
 	var keys []Key

--- a/translib/db/db_cursor.go
+++ b/translib/db/db_cursor.go
@@ -104,7 +104,7 @@ func (scnr *fieldScanner) scan(sc *ScanCursor, countHint int64) ([]string, uint6
 //  Exported Functions                                                        //
 ////////////////////////////////////////////////////////////////////////////////
 
-// NewScanCursor Factory method to create ScanCursor; Scan cursor will not be supported only for write enabled DB
+// NewScanCursor Factory method to create ScanCursor; Scan cursor will not be supported for write enabled DB.
 func (d *DB) NewScanCursor(ts *TableSpec, pattern Key, scOpts *ScanCursorOpts) (*ScanCursor, error) {
 	if glog.V(3) {
 		glog.Info("NewScanCursor: Begin: ts: ", ts, " pattern: ", pattern,
@@ -123,7 +123,6 @@ func (d *DB) NewScanCursor(ts *TableSpec, pattern Key, scOpts *ScanCursorOpts) (
 
 	// If pseudoDB then return not supported. Return NotSupport above too. TBD.
 
-	var e error
 	var countHint int64 = 10
 	scnType := KeyScanType // default is key scanner
 
@@ -162,7 +161,7 @@ func (d *DB) NewScanCursor(ts *TableSpec, pattern Key, scOpts *ScanCursorOpts) (
 	if glog.V(3) {
 		glog.Info("NewScanCursor: End: scanCursor: ", scanCursor, e)
 	}
-	return &scanCursor, e
+	return &scanCursor, nil
 }
 
 // DeleteScanCursor Gently release state/cache of ScanCursor

--- a/translib/db/db_cursor.go
+++ b/translib/db/db_cursor.go
@@ -159,7 +159,7 @@ func (d *DB) NewScanCursor(ts *TableSpec, pattern Key, scOpts *ScanCursorOpts) (
 	}
 
 	if glog.V(3) {
-		glog.Info("NewScanCursor: End: scanCursor: ", scanCursor, e)
+		glog.Info("NewScanCursor: End: scanCursor: ", scanCursor)
 	}
 	return &scanCursor, nil
 }

--- a/translib/db/db_cursor.go
+++ b/translib/db/db_cursor.go
@@ -1,0 +1,187 @@
+////////////////////////////////////////////////////////////////////////////////
+//                                                                            //
+//  Copyright 2020 Broadcom. The term Broadcom refers to Broadcom Inc. and/or //
+//  its subsidiaries.                                                         //
+//                                                                            //
+//  Licensed under the Apache License, Version 2.0 (the "License");           //
+//  you may not use this file except in compliance with the License.          //
+//  You may obtain a copy of the License at                                   //
+//                                                                            //
+//     http://www.apache.org/licenses/LICENSE-2.0                             //
+//                                                                            //
+//  Unless required by applicable law or agreed to in writing, software       //
+//  distributed under the License is distributed on an "AS IS" BASIS,         //
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  //
+//  See the License for the specific language governing permissions and       //
+//  limitations under the License.                                            //
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+
+package db
+
+import (
+	"github.com/golang/glog"
+)
+
+// Work Done vs Entries Returned (Need to return a fixed number of
+//  entries for every call? Is variable # of entries returned ok ?
+//  If fixed, it will partially negate the Time complexity advantage of
+//  pagination. [ Variable number of keys returned for every call to
+//  the ScanCursor API is ok. If fixed is needed, it may be implemented later.]
+
+// Duplicate Suppression? Redis can return duplicates. To supress them
+//  we need a cache. This will negate the Space complexity advantage of
+//  pagination. [ Duplicates to be suppressed. Currently the OnChange is
+//  getting all the keys first, so there is effectively a store of all the
+//  keys at some point. This will now be moved to a map/dictionary inside the
+//  ScanCursor to avoid duplicates.]
+
+////////////////////////////////////////////////////////////////////////////////
+//  Exported Types                                                            //
+////////////////////////////////////////////////////////////////////////////////
+
+// ScanCursor iterates over a set of keys
+
+type ScanCursor struct {
+	ts           *TableSpec
+	cursor       uint64
+	pattern      Key
+	count        int64
+	scanComplete bool
+	seenKeys     map[string]bool
+	lookAhead    []string // (TBD) For exactly CountHint # of keys
+	db           *DB
+}
+
+type ScanCursorOpts struct {
+	CountHint       int64 // Hint of redis work required
+	ReturnFixed     bool  // (TBD) Return exactly CountHint # of keys
+	AllowDuplicates bool  // Do not suppress redis duplicate keys
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//  Exported Functions                                                        //
+////////////////////////////////////////////////////////////////////////////////
+
+// NewScanCursor Factory method to create ScanCursor
+func (d *DB) NewScanCursor(ts *TableSpec, pattern Key, scOpts *ScanCursorOpts) (*ScanCursor, error) {
+	if glog.V(3) {
+		glog.Info("NewScanCursor: Begin: ts: ", ts, " pattern: ", pattern,
+			" scOpts: ", scOpts)
+	}
+
+	var e error
+	var countHint int64 = 10
+
+	if scOpts != nil && scOpts.CountHint != 0 {
+		countHint = scOpts.CountHint
+	}
+
+	// Create ScanCursor
+	scanCursor := ScanCursor{
+		ts:      ts,
+		pattern: pattern,
+		count:   countHint,
+		db:      d,
+	}
+
+	if !scOpts.AllowDuplicates {
+		scanCursor.seenKeys = make(map[string]bool, initialSCSeenKeysCacheSize)
+	}
+
+	if scOpts.ReturnFixed {
+		glog.Info("NewScanCursor: ReturnFixed is not implemented")
+		scanCursor.lookAhead = make([]string, 0, initialSCLookAheadBufferSize)
+	}
+
+	if glog.V(3) {
+		glog.Info("NewScanCursor: End: scanCursor: ", scanCursor, e)
+	}
+	return &scanCursor, e
+}
+
+// DeleteScanCursor Gently release state/cache of ScanCursor
+func (sc *ScanCursor) DeleteScanCursor() error {
+	if glog.V(6) {
+		glog.Info("DeleteScanCursor: Begin: sc: ", sc)
+	} else if glog.V(3) {
+		glog.Info("DeleteScanCursor: Begin: sc.pattern: ", sc.pattern,
+			" #keys: ", len(sc.seenKeys))
+	}
+
+	// Release any state/cache
+	sc.scanComplete = true
+	sc.seenKeys = nil
+	sc.lookAhead = nil
+
+	return nil
+}
+
+// GetNextKeys retrieves a few keys. bool returns true if the scan is complete.
+func (sc *ScanCursor) GetNextKeys(scOpts *ScanCursorOpts) ([]Key, bool, error) {
+	if glog.V(6) {
+		glog.Info("ScanCursor.GetNextKeys: Begin: sc: ", sc, "scOpts: ", scOpts)
+	} else if glog.V(3) {
+		glog.Info("ScanCursor.GetNextKeys: Begin: sc.pattern: ", sc.pattern)
+	}
+
+	var e error
+	var redisKeys []string
+	var cursor uint64
+
+	countHint := sc.count
+
+	if scOpts != nil && scOpts.CountHint != 0 {
+		countHint = scOpts.CountHint
+	}
+
+	for (!sc.scanComplete) && (len(redisKeys) == 0) && (e == nil) {
+		redisKeys, cursor, e = sc.db.client.Scan(sc.cursor,
+			sc.db.key2redis(sc.ts, sc.pattern), countHint).Result()
+		if glog.V(4) {
+			glog.Info("ScanCursor.GetNextKeys: redisKeys: ", redisKeys,
+				" cursor: ", cursor, " e: ", e)
+		}
+		sc.cursor = cursor
+		if sc.cursor == 0 {
+			sc.scanComplete = true
+		}
+	}
+
+	if e != nil {
+		glog.Error("ScanCursor.GetNextKeys: error: ", e)
+	}
+
+	keys := make([]Key, 0, len(redisKeys))
+	for i := 0; i < len(redisKeys); i++ {
+		if sc.seenKeys != nil {
+			if _, present := sc.seenKeys[redisKeys[i]]; present {
+				continue
+			}
+			sc.seenKeys[redisKeys[i]] = true
+		}
+		keys = append(keys, sc.db.redis2key(sc.ts, redisKeys[i]))
+	}
+
+	if glog.V(6) {
+		glog.Info("ScanCursor.GetNextKeys: End: keys: ", keys,
+			" scanComplete: ", sc.scanComplete, " e: ", e)
+	} else if glog.V(3) {
+		glog.Info("ScanCursor.GetNextKeys: End: #keys: ", len(keys),
+			" scanComplete: ", sc.scanComplete, " e: ", e)
+	}
+	return keys, sc.scanComplete, e
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//  Internal Constants                                                        //
+////////////////////////////////////////////////////////////////////////////////
+
+const (
+	initialSCSeenKeysCacheSize   = 100
+	initialSCLookAheadBufferSize = 100
+)
+
+////////////////////////////////////////////////////////////////////////////////
+//  Internal Functions                                                        //
+////////////////////////////////////////////////////////////////////////////////

--- a/translib/db/db_cursor_test.go
+++ b/translib/db/db_cursor_test.go
@@ -20,9 +20,17 @@
 package db
 
 import (
+	// "fmt"
+	// "errors"
+	// "flag"
+	// "github.com/golang/glog"
+	// "time"
+	// "github.com/Azure/sonic-mgmt-common/translib/tlerr"
+	// "os/exec"
 	"os"
 	"strconv"
 	"testing"
+	// "reflect"
 )
 
 func testSCAddDelKeys(t *testing.T, d *DB, ts *TableSpec, prefix string, count int, delete bool) {
@@ -102,9 +110,10 @@ func TestNewScanCursor(t *testing.T) {
 	prefix := "SCKEY_"
 	testSCAddDelKeys(t, d, &ts, prefix, 100, false)
 	defer testSCAddDelKeys(t, d, &ts, prefix, 100, true)
-
+	d.Opts.IsWriteDisabled = true //disabling the write for the scan cursor to work
 	t.Run("pattern=*", testSCGetNextKeys(d, &ts, "*", 100))
 	t.Run("pattern=SCKEY_0", testSCGetNextKeys(d, &ts, "SCKEY_0", 1))
 	t.Run("pattern=SCKEY_1*", testSCGetNextKeys(d, &ts, "SCKEY_1*", 11))
 	t.Run("pattern=NOTALIKELYKEY", testSCGetNextKeys(d, &ts, "NOTALIKELYKEY", 0))
+	d.Opts.IsWriteDisabled = false
 }

--- a/translib/db/db_cursor_test.go
+++ b/translib/db/db_cursor_test.go
@@ -1,0 +1,110 @@
+////////////////////////////////////////////////////////////////////////////////
+//                                                                            //
+//  Copyright 2021 Broadcom. The term Broadcom refers to Broadcom Inc. and/or //
+//  its subsidiaries.                                                         //
+//                                                                            //
+//  Licensed under the Apache License, Version 2.0 (the "License");           //
+//  you may not use this file except in compliance with the License.          //
+//  You may obtain a copy of the License at                                   //
+//                                                                            //
+//     http://www.apache.org/licenses/LICENSE-2.0                             //
+//                                                                            //
+//  Unless required by applicable law or agreed to in writing, software       //
+//  distributed under the License is distributed on an "AS IS" BASIS,         //
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  //
+//  See the License for the specific language governing permissions and       //
+//  limitations under the License.                                            //
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+
+package db
+
+import (
+	"os"
+	"strconv"
+	"testing"
+)
+
+func testSCAddDelKeys(t *testing.T, d *DB, ts *TableSpec, prefix string, count int, delete bool) {
+	var e error
+	var op string
+	for i := 0; i < count; i++ {
+		akey := Key{Comp: []string{prefix + strconv.Itoa(i)}}
+		avalue := Value{map[string]string{"k1": "v1", "k2": "v2"}}
+		if delete {
+			op = "delete"
+			e = d.DeleteEntry(ts, akey)
+		} else {
+			op = "create"
+			e = d.SetEntry(ts, akey, avalue)
+		}
+		if e != nil {
+			t.Fatalf("%v fails e = %v", op, e)
+		}
+	}
+}
+
+func testSCGetNextKeys(d *DB, ts *TableSpec, pattern string, expected int) func(*testing.T) {
+	return func(t *testing.T) {
+
+		patKey := Key{Comp: []string{pattern}}
+		scOpts := ScanCursorOpts{CountHint: 10}
+
+		sc, e := d.NewScanCursor(ts, patKey, &scOpts)
+
+		if (sc == nil) || (e != nil) {
+			t.Fatalf("testSCGetNextKeys() fails e = %v", e)
+			return
+		}
+
+		var keys []Key
+		var count int
+		for scanComplete := false; !scanComplete; {
+			keys, scanComplete, e = sc.GetNextKeys(&scOpts)
+			if e != nil {
+				t.Fatalf("sc.GetNextKeys() fails e = %v", e)
+				return
+			}
+			count += len(keys)
+		}
+
+		if count != expected {
+			t.Fatalf("testSCGetNextKeys() count: %v != expected: %v", count, expected)
+		}
+
+		if e = sc.DeleteScanCursor(); e != nil {
+			t.Fatalf("DeleteScanCursor() fails e = %v", e)
+		}
+	}
+
+}
+
+func TestNewScanCursor(t *testing.T) {
+
+	var pid int = os.Getpid()
+
+	d, e := NewDB(Options{
+		DBNo:               ConfigDB,
+		InitIndicator:      "",
+		TableNameSeparator: "|",
+		KeySeparator:       "|",
+		DisableCVLCheck:    false,
+	})
+
+	if (d == nil) || (e != nil) {
+		t.Fatalf("NewDB() fails e = %v", e)
+		return
+	}
+	defer d.DeleteDB()
+
+	ts := TableSpec{Name: "TESTSC_" + strconv.FormatInt(int64(pid), 10)}
+
+	prefix := "SCKEY_"
+	testSCAddDelKeys(t, d, &ts, prefix, 100, false)
+	defer testSCAddDelKeys(t, d, &ts, prefix, 100, true)
+
+	t.Run("pattern=*", testSCGetNextKeys(d, &ts, "*", 100))
+	t.Run("pattern=SCKEY_0", testSCGetNextKeys(d, &ts, "SCKEY_0", 1))
+	t.Run("pattern=SCKEY_1*", testSCGetNextKeys(d, &ts, "SCKEY_1*", 11))
+	t.Run("pattern=NOTALIKELYKEY", testSCGetNextKeys(d, &ts, "NOTALIKELYKEY", 0))
+}

--- a/translib/tlerr/tlerr.go
+++ b/translib/tlerr/tlerr.go
@@ -119,3 +119,10 @@ type TranslibXfmrRetError struct {
 func (e TranslibXfmrRetError) Error() string {
      return p.Sprintf("Translib transformer return %s", e.XlateFailDelReq)
 }
+
+type TranslibDBConnectionReset struct {
+}
+
+func (e TranslibDBConnectionReset) Error() string {
+	return p.Sprintf("Translib Redis Error: DB Connection Reset")
+}


### PR DESCRIPTION
Added following methods to scan and iterate the db entries using redis DB scan cursor.

 - NewScanCursor() :  to create ScanCursor type to perform the GetNext.. operation
 - GetNextKeys() : retrieves a few keys and returns true if the scan is complete.
 - GetNextFields() : retrieves a few matching fields and returns true if the scan is complete.
 - GetNextRedisKeys() : retrieves a few redisKeys and returns true if the scan is complete

Required for the subscription enhancements as described in HLD https://github.com/sonic-net/SONiC/pull/1287