### PR TITLE
Path validator

### DIFF
--- a/translib/db/db_cursor.go
+++ b/translib/db/db_cursor.go
@@ -286,7 +286,7 @@ func (sc *ScanCursor) getNext(scOpts *ScanCursorOpts, returnRedisKeys bool) ([]K
 	}
 
 	if e != nil {
-		glog.Error("ScanCursor.getNext: ", sc.db.Name(), "pattern: ", sc.pattern, ": error: ", e)
+		glog.Error("ScanCursor.getNext: pattern: ", sc.pattern, ": error: ", e)
 	}
 
 	var keys []Key

--- a/translib/db/db_cursor.go
+++ b/translib/db/db_cursor.go
@@ -1,0 +1,187 @@
+////////////////////////////////////////////////////////////////////////////////
+//                                                                            //
+//  Copyright 2020 Broadcom. The term Broadcom refers to Broadcom Inc. and/or //
+//  its subsidiaries.                                                         //
+//                                                                            //
+//  Licensed under the Apache License, Version 2.0 (the "License");           //
+//  you may not use this file except in compliance with the License.          //
+//  You may obtain a copy of the License at                                   //
+//                                                                            //
+//     http://www.apache.org/licenses/LICENSE-2.0                             //
+//                                                                            //
+//  Unless required by applicable law or agreed to in writing, software       //
+//  distributed under the License is distributed on an "AS IS" BASIS,         //
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  //
+//  See the License for the specific language governing permissions and       //
+//  limitations under the License.                                            //
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+
+package db
+
+import (
+	"github.com/golang/glog"
+)
+
+// Work Done vs Entries Returned (Need to return a fixed number of
+//  entries for every call? Is variable # of entries returned ok ?
+//  If fixed, it will partially negate the Time complexity advantage of
+//  pagination. [ Variable number of keys returned for every call to
+//  the ScanCursor API is ok. If fixed is needed, it may be implemented later.]
+
+// Duplicate Suppression? Redis can return duplicates. To supress them
+//  we need a cache. This will negate the Space complexity advantage of
+//  pagination. [ Duplicates to be suppressed. Currently the OnChange is
+//  getting all the keys first, so there is effectively a store of all the
+//  keys at some point. This will now be moved to a map/dictionary inside the
+//  ScanCursor to avoid duplicates.]
+
+////////////////////////////////////////////////////////////////////////////////
+//  Exported Types                                                            //
+////////////////////////////////////////////////////////////////////////////////
+
+// ScanCursor iterates over a set of keys
+
+type ScanCursor struct {
+	ts           *TableSpec
+	cursor       uint64
+	pattern      Key
+	count        int64
+	scanComplete bool
+	seenKeys     map[string]bool
+	lookAhead    []string // (TBD) For exactly CountHint # of keys
+	db           *DB
+}
+
+type ScanCursorOpts struct {
+	CountHint       int64 // Hint of redis work required
+	ReturnFixed     bool  // (TBD) Return exactly CountHint # of keys
+	AllowDuplicates bool  // Do not suppress redis duplicate keys
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//  Exported Functions                                                        //
+////////////////////////////////////////////////////////////////////////////////
+
+// NewScanCursor Factory method to create ScanCursor
+func (d *DB) NewScanCursor(ts *TableSpec, pattern Key, scOpts *ScanCursorOpts) (*ScanCursor, error) {
+	if glog.V(3) {
+		glog.Info("NewScanCursor: Begin: ts: ", ts, " pattern: ", pattern,
+			" scOpts: ", scOpts)
+	}
+
+	var e error
+	var countHint int64 = 10
+
+	if scOpts != nil && scOpts.CountHint != 0 {
+		countHint = scOpts.CountHint
+	}
+
+	// Create ScanCursor
+	scanCursor := ScanCursor{
+		ts:      ts,
+		pattern: pattern,
+		count:   countHint,
+		db:      d,
+	}
+
+	if !scOpts.AllowDuplicates {
+		scanCursor.seenKeys = make(map[string]bool, initialSCSeenKeysCacheSize)
+	}
+
+	if scOpts.ReturnFixed {
+		glog.Info("NewScanCursor: ReturnFixed is not implemented")
+		scanCursor.lookAhead = make([]string, 0, initialSCLookAheadBufferSize)
+	}
+
+	if glog.V(3) {
+		glog.Info("NewScanCursor: End: scanCursor: ", scanCursor, e)
+	}
+	return &scanCursor, e
+}
+
+// DeleteScanCursor Gently release state/cache of ScanCursor
+func (sc *ScanCursor) DeleteScanCursor() error {
+	if glog.V(6) {
+		glog.Info("DeleteScanCursor: Begin: sc: ", sc)
+	} else if glog.V(3) {
+		glog.Info("DeleteScanCursor: Begin: sc.pattern: ", sc.pattern,
+			" #keys: ", len(sc.seenKeys))
+	}
+
+	// Release any state/cache
+	sc.scanComplete = true
+	sc.seenKeys = nil
+	sc.lookAhead = nil
+
+	return nil
+}
+
+// GetNextKeys retrieves a few keys. bool returns true if the scan is complete.
+func (sc *ScanCursor) GetNextKeys(scOpts *ScanCursorOpts) ([]Key, bool, error) {
+	if glog.V(6) {
+		glog.Info("ScanCursor.GetNextKeys: Begin: sc: ", sc, "scOpts: ", scOpts)
+	} else if glog.V(3) {
+		glog.Info("ScanCursor.GetNextKeys: Begin: sc.pattern: ", sc.pattern)
+	}
+
+	var e error
+	var redisKeys []string
+	var cursor uint64
+
+	countHint := sc.count
+
+	if scOpts != nil && scOpts.CountHint != 0 {
+		countHint = scOpts.CountHint
+	}
+
+	for (!sc.scanComplete) && (len(redisKeys) == 0) && (e == nil) {
+		redisKeys, cursor, e = sc.db.client.Scan(sc.cursor,
+			sc.db.key2redis(sc.ts, sc.pattern), countHint).Result()
+		if glog.V(4) {
+			glog.Info("ScanCursor.GetNextKeys: redisKeys: ", redisKeys,
+				" cursor: ", cursor, " e: ", e)
+		}
+		sc.cursor = cursor
+		if sc.cursor == 0 {
+			sc.scanComplete = true
+		}
+	}
+
+	if e != nil {
+		glog.Error("ScanCursor.GetNextKeys: error: ", e)
+	}
+
+	keys := make([]Key, 0, len(redisKeys))
+	for i := 0; i < len(redisKeys); i++ {
+		if sc.seenKeys != nil {
+			if _, present := sc.seenKeys[redisKeys[i]]; present {
+				continue
+			}
+			sc.seenKeys[redisKeys[i]] = true
+		}
+		keys = append(keys, sc.db.redis2key(sc.ts, redisKeys[i]))
+	}
+
+	if glog.V(6) {
+		glog.Info("ScanCursor.GetNextKeys: End: keys: ", keys,
+			" scanComplete: ", sc.scanComplete, " e: ", e)
+	} else if glog.V(3) {
+		glog.Info("ScanCursor.GetNextKeys: End: #keys: ", len(keys),
+			" scanComplete: ", sc.scanComplete, " e: ", e)
+	}
+	return keys, sc.scanComplete, e
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//  Internal Constants                                                        //
+////////////////////////////////////////////////////////////////////////////////
+
+const (
+	initialSCSeenKeysCacheSize   = 100
+	initialSCLookAheadBufferSize = 100
+)
+
+////////////////////////////////////////////////////////////////////////////////
+//  Internal Functions                                                        //
+////////////////////////////////////////////////////////////////////////////////

--- a/translib/db/db_cursor_test.go
+++ b/translib/db/db_cursor_test.go
@@ -20,9 +20,17 @@
 package db
 
 import (
+	// "fmt"
+	// "errors"
+	// "flag"
+	// "github.com/golang/glog"
+	// "time"
+	// "github.com/Azure/sonic-mgmt-common/translib/tlerr"
+	// "os/exec"
 	"os"
 	"strconv"
 	"testing"
+	// "reflect"
 )
 
 func testSCAddDelKeys(t *testing.T, d *DB, ts *TableSpec, prefix string, count int, delete bool) {
@@ -102,9 +110,10 @@ func TestNewScanCursor(t *testing.T) {
 	prefix := "SCKEY_"
 	testSCAddDelKeys(t, d, &ts, prefix, 100, false)
 	defer testSCAddDelKeys(t, d, &ts, prefix, 100, true)
-
+	d.Opts.IsWriteDisabled = true //disabling the write for the scan cursor to work
 	t.Run("pattern=*", testSCGetNextKeys(d, &ts, "*", 100))
 	t.Run("pattern=SCKEY_0", testSCGetNextKeys(d, &ts, "SCKEY_0", 1))
 	t.Run("pattern=SCKEY_1*", testSCGetNextKeys(d, &ts, "SCKEY_1*", 11))
 	t.Run("pattern=NOTALIKELYKEY", testSCGetNextKeys(d, &ts, "NOTALIKELYKEY", 0))
+	d.Opts.IsWriteDisabled = false
 }

--- a/translib/db/db_cursor_test.go
+++ b/translib/db/db_cursor_test.go
@@ -1,0 +1,110 @@
+////////////////////////////////////////////////////////////////////////////////
+//                                                                            //
+//  Copyright 2021 Broadcom. The term Broadcom refers to Broadcom Inc. and/or //
+//  its subsidiaries.                                                         //
+//                                                                            //
+//  Licensed under the Apache License, Version 2.0 (the "License");           //
+//  you may not use this file except in compliance with the License.          //
+//  You may obtain a copy of the License at                                   //
+//                                                                            //
+//     http://www.apache.org/licenses/LICENSE-2.0                             //
+//                                                                            //
+//  Unless required by applicable law or agreed to in writing, software       //
+//  distributed under the License is distributed on an "AS IS" BASIS,         //
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  //
+//  See the License for the specific language governing permissions and       //
+//  limitations under the License.                                            //
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+
+package db
+
+import (
+	"os"
+	"strconv"
+	"testing"
+)
+
+func testSCAddDelKeys(t *testing.T, d *DB, ts *TableSpec, prefix string, count int, delete bool) {
+	var e error
+	var op string
+	for i := 0; i < count; i++ {
+		akey := Key{Comp: []string{prefix + strconv.Itoa(i)}}
+		avalue := Value{map[string]string{"k1": "v1", "k2": "v2"}}
+		if delete {
+			op = "delete"
+			e = d.DeleteEntry(ts, akey)
+		} else {
+			op = "create"
+			e = d.SetEntry(ts, akey, avalue)
+		}
+		if e != nil {
+			t.Fatalf("%v fails e = %v", op, e)
+		}
+	}
+}
+
+func testSCGetNextKeys(d *DB, ts *TableSpec, pattern string, expected int) func(*testing.T) {
+	return func(t *testing.T) {
+
+		patKey := Key{Comp: []string{pattern}}
+		scOpts := ScanCursorOpts{CountHint: 10}
+
+		sc, e := d.NewScanCursor(ts, patKey, &scOpts)
+
+		if (sc == nil) || (e != nil) {
+			t.Fatalf("testSCGetNextKeys() fails e = %v", e)
+			return
+		}
+
+		var keys []Key
+		var count int
+		for scanComplete := false; !scanComplete; {
+			keys, scanComplete, e = sc.GetNextKeys(&scOpts)
+			if e != nil {
+				t.Fatalf("sc.GetNextKeys() fails e = %v", e)
+				return
+			}
+			count += len(keys)
+		}
+
+		if count != expected {
+			t.Fatalf("testSCGetNextKeys() count: %v != expected: %v", count, expected)
+		}
+
+		if e = sc.DeleteScanCursor(); e != nil {
+			t.Fatalf("DeleteScanCursor() fails e = %v", e)
+		}
+	}
+
+}
+
+func TestNewScanCursor(t *testing.T) {
+
+	var pid int = os.Getpid()
+
+	d, e := NewDB(Options{
+		DBNo:               ConfigDB,
+		InitIndicator:      "",
+		TableNameSeparator: "|",
+		KeySeparator:       "|",
+		DisableCVLCheck:    false,
+	})
+
+	if (d == nil) || (e != nil) {
+		t.Fatalf("NewDB() fails e = %v", e)
+		return
+	}
+	defer d.DeleteDB()
+
+	ts := TableSpec{Name: "TESTSC_" + strconv.FormatInt(int64(pid), 10)}
+
+	prefix := "SCKEY_"
+	testSCAddDelKeys(t, d, &ts, prefix, 100, false)
+	defer testSCAddDelKeys(t, d, &ts, prefix, 100, true)
+
+	t.Run("pattern=*", testSCGetNextKeys(d, &ts, "*", 100))
+	t.Run("pattern=SCKEY_0", testSCGetNextKeys(d, &ts, "SCKEY_0", 1))
+	t.Run("pattern=SCKEY_1*", testSCGetNextKeys(d, &ts, "SCKEY_1*", 11))
+	t.Run("pattern=NOTALIKELYKEY", testSCGetNextKeys(d, &ts, "NOTALIKELYKEY", 0))
+}

--- a/translib/path/path_validator.go
+++ b/translib/path/path_validator.go
@@ -1,0 +1,367 @@
+////////////////////////////////////////////////////////////////////////////////
+//                                                                            //
+//  Copyright 2021 Broadcom. The term Broadcom refers to Broadcom Inc. and/or //
+//  its subsidiaries.                                                         //
+//                                                                            //
+//  Licensed under the Apache License, Version 2.0 (the "License");           //
+//  you may not use this file except in compliance with the License.          //
+//  You may obtain a copy of the License at                                   //
+//                                                                            //
+//     http://www.apache.org/licenses/LICENSE-2.0                             //
+//                                                                            //
+//  Unless required by applicable law or agreed to in writing, software       //
+//  distributed under the License is distributed on an "AS IS" BASIS,         //
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  //
+//  See the License for the specific language governing permissions and       //
+//  limitations under the License.                                            //
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+
+package path
+
+import (
+	"reflect"
+	"strings"
+
+	"fmt"
+
+	"github.com/Azure/sonic-mgmt-common/translib/ocbinds"
+	log "github.com/golang/glog"
+	"github.com/kylelemons/godebug/pretty"
+	"github.com/openconfig/gnmi/proto/gnmi"
+	"github.com/openconfig/goyang/pkg/yang"
+	"github.com/openconfig/ygot/util"
+	"github.com/openconfig/ygot/ygot"
+	"github.com/openconfig/ygot/ytypes"
+)
+
+type pathValidator struct {
+	gPath        *gnmi.Path
+	rootObj      *ocbinds.Device
+	sField       *reflect.StructField
+	sValIntf     interface{}
+	parentIntf   interface{}
+	opts         []PathValidatorOpt
+	parentSchema *yang.Entry
+	err          error
+}
+
+// NewPathValidator returns the PathValidator struct to validate the gnmi path and also add the missing module
+// prefix and key names and wild card values in the gnmi path based on the given PathValidatorOpt
+func NewPathValidator(opts ...PathValidatorOpt) *pathValidator {
+	return &pathValidator{rootObj: &(ocbinds.Device{}), opts: opts}
+}
+
+func (pv *pathValidator) init(gPath *gnmi.Path) {
+	gPath.Element = nil
+	pv.gPath = gPath
+	pv.sField = nil
+	pv.sValIntf = pv.rootObj
+	pv.parentIntf = pv.rootObj
+	pv.parentSchema = nil
+	pv.err = nil
+}
+
+// Validate the path and also add the module prefix / wild card keys in the gnmi path
+// based on the given PathValidatorOpt while creating the path validator.
+func (pv *pathValidator) Validate(gPath *gnmi.Path) error {
+	if pv == nil {
+		log.Warningf("error: pathValidator is nil")
+		return fmt.Errorf("pathValidator is nil")
+	}
+	if gPath == nil {
+		log.Warningf("error: gnmi path nil")
+		pv.err = fmt.Errorf("gnmi path nil")
+		return pv.err
+	}
+	if log.V(4) {
+		log.Info("Validate: path: ", gPath.Elem)
+	}
+	pv.init(gPath)
+	if pv.err = pv.validatePath(); pv.err != nil {
+		log.Warningf("error in validating the path: ", pv.err)
+		return pv.err
+	}
+	return pv.err
+}
+
+func (pv *pathValidator) getYangSchema() (*yang.Entry, error) {
+	sVal := reflect.ValueOf(pv.sValIntf)
+	if sVal.Elem().Type().Kind() == reflect.Struct {
+		objName := sVal.Elem().Type().Name()
+		if log.V(4) {
+			log.Info("getYangSchema: ygot object name: ", objName)
+		}
+		if ygSchema := ocbinds.SchemaTree[objName]; ygSchema == nil {
+			log.Warningf("error: ygot object name %v not found in the schema for the given path: %v", objName, pv.gPath)
+			return ygSchema, fmt.Errorf("invalid path %v", pv.gPath)
+		} else {
+			if log.V(4) {
+				log.Infof("getYangSchema: found schema: %v for the field: %v", ygSchema.Name, *pv.sField)
+			}
+			return ygSchema, nil
+		}
+	} else {
+		ygSchema, err := util.ChildSchema(pv.parentSchema, *pv.sField)
+		if err != nil {
+			return nil, err
+		}
+		if ygSchema == nil {
+			return nil, fmt.Errorf("could not find schema for the field name %s", pv.sField.Name)
+		}
+		if log.V(4) {
+			log.Infof("getYangSchema:ChildSchema - found schema: %v for the field: %v", ygSchema.Name, *pv.sField)
+		}
+		return ygSchema, nil
+	}
+}
+
+func (pv *pathValidator) getStructField(nodeName string) *reflect.StructField {
+	var sField *reflect.StructField
+	sval := reflect.ValueOf(pv.sValIntf).Elem()
+	if sval.Kind() != reflect.Struct {
+		return nil
+	}
+	stype := sval.Type()
+	for i := 0; i < sval.NumField(); i++ {
+		fType := stype.Field(i)
+		if pathName, ok := fType.Tag.Lookup("path"); ok && pathName == nodeName {
+			if log.V(4) {
+				log.Infof("getStructField: found struct field: %v for the node name: %v ", fType, nodeName)
+			}
+			sField = &fType
+			break
+		}
+	}
+	return sField
+}
+
+func (pv *pathValidator) getModuleName() string {
+	modName, _ := pv.sField.Tag.Lookup("module")
+	return modName
+}
+
+func (pv *pathValidator) validatePath() error {
+	if log.V(4) {
+		log.Info("validatePath: path: ", pv.gPath.Elem)
+	}
+	isApnndModPrefix := pv.hasAppendModulePrefixOption()
+	isAddWcKey := pv.hasAddWildcardKeyOption()
+	isIgnoreKey := pv.hasIgnoreKeyValidationOption()
+	prevModName := ""
+	for idx, pathElem := range pv.gPath.Elem {
+		nodeName := pathElem.Name
+		modName := ""
+		names := strings.Split(pathElem.Name, ":")
+		if len(names) > 1 {
+			modName = names[0]
+			nodeName = names[1]
+			if log.V(4) {
+				log.Infof("validatePath: modName %v, and node name %v in the given path", modName, nodeName)
+			}
+		}
+
+		if sField := pv.getStructField(nodeName); sField == nil {
+			return fmt.Errorf("Node %v not found in the given gnmi path %v: ", pathElem.Name, pv.gPath)
+		} else {
+			pv.sField = sField
+		}
+
+		ygModName := pv.getModuleName()
+		if len(ygModName) == 0 {
+			return fmt.Errorf("Module name not found for the node %v in the given gnmi path %v: ", pathElem.Name, pv.gPath)
+		} else {
+			if log.V(4) {
+				log.Infof("validatePath: module name: %v found for the node %v: ", ygModName, pathElem.Name)
+			}
+		}
+
+		if len(modName) > 0 {
+			if ygModName != modName {
+				return fmt.Errorf("Invalid yang module prefix in the path node %v", pathElem.Name)
+			}
+		} else if isApnndModPrefix && (prevModName != ygModName || idx == 0) {
+			pv.gPath.Elem[idx].Name = ygModName + ":" + pathElem.Name
+			if log.V(4) {
+				log.Info("validatePath: appeneded the module prefix name for the path node: ", pv.gPath.Elem[idx])
+			}
+		}
+
+		pv.updateStructFieldVal()
+
+		ygSchema, err := pv.getYangSchema()
+		if err != nil {
+			return fmt.Errorf("yang schema not found for the node %v in the given path; %v", pathElem.Name, pv.gPath)
+		}
+
+		if !isIgnoreKey {
+			if ygSchema.IsList() {
+				if len(pathElem.Key) > 0 {
+					// validate the key names
+					keysMap := make(map[string]bool)
+					isWc := false
+					for kn, kv := range pathElem.Key {
+						keysMap[kn] = true
+						if kv == "*" && !isWc {
+							isWc = true
+						}
+					}
+					if log.V(4) {
+						log.Info("validatePath: validating the list key names for the node path: ", pathElem.Key)
+					}
+					if err := pv.validateListKeyNames(ygSchema, keysMap, idx); err != nil {
+						return err
+					}
+
+					if !isWc {
+						// validate the key values
+						gpath := &gnmi.Path{}
+						pElem := *pathElem
+						paths := strings.Split(pElem.Name, ":")
+						pElem.Name = paths[len(paths)-1]
+						gpath.Elem = append(gpath.Elem, &pElem)
+						if log.V(4) {
+							log.Info("validatePath: validating the list key values for the path: ", gpath)
+						}
+						if err := pv.validateListKeyValues(pv.parentSchema, gpath); err != nil {
+							return err
+						}
+					}
+				} else if isAddWcKey {
+					pv.gPath.Elem[idx].Key = make(map[string]string)
+					for _, kn := range strings.Fields(ygSchema.Key) {
+						pv.gPath.Elem[idx].Key[kn] = "*"
+					}
+					if log.V(4) {
+						log.Info("validatePath: added the key names and wild cards for the list node path: ", pv.gPath.Elem[idx])
+					}
+				}
+			}
+		}
+		prevModName = ygModName
+		pv.parentSchema = ygSchema
+	}
+	return nil
+}
+
+func (pv *pathValidator) validateListKeyNames(ygSchema *yang.Entry, keysMap map[string]bool, pathIdx int) error {
+	keyNames := strings.Fields(ygSchema.Key)
+	if len(keyNames) != len(keysMap) {
+		return fmt.Errorf("Invalid key names since number of keys present in the node: %v does not match with the given keys", ygSchema.Name)
+	}
+	for _, kn := range keyNames {
+		if !keysMap[kn] {
+			return fmt.Errorf("Invalid key name: %v in the list node path: %v", pv.gPath.Elem[pathIdx].Key, pv.gPath.Elem[pathIdx].Name)
+		}
+	}
+	return nil
+}
+
+func (pv *pathValidator) validateListKeyValues(schema *yang.Entry, gPath *gnmi.Path) error {
+	sVal := reflect.ValueOf(pv.parentIntf)
+	if log.V(4) {
+		log.Infof("validateListKeyValues: schema name: %v, and parent ygot type name: %v: ", schema.Name, sVal.Elem().Type().Name())
+	}
+	if objIntf, _, err := ytypes.GetOrCreateNode(schema, pv.parentIntf, gPath); err != nil {
+		log.Warningf("error in GetOrCreateNode: %v", err)
+		return fmt.Errorf("Invalid key present in the node path: %v", gPath)
+	} else {
+		if log.V(4) {
+			log.Infof("validateListKeyValues: objIntf: %v", reflect.ValueOf(objIntf).Elem())
+		}
+		if ygotStruct, ok := objIntf.(ygot.ValidatedGoStruct); ok {
+			if log.V(4) {
+				pretty.Print(ygotStruct)
+			}
+			if err := ygotStruct.Validate(&ytypes.LeafrefOptions{IgnoreMissingData: true}); err != nil {
+				log.Warningf("error in ValidatedGoStruct.Validate: %v", err)
+				return fmt.Errorf("Invalid key present in the node path: %v", gPath)
+			}
+		} else {
+			log.Warningf("could not validate the gnmi path: %v since casting to ValidatedGoStruct fails", gPath)
+			return fmt.Errorf("Invalid key present in the node path: %v", gPath)
+		}
+	}
+	return nil
+}
+
+func (pv *pathValidator) updateStructFieldVal() {
+	if log.V(4) {
+		log.Infof("updateStructFieldVal: struct field: %v; struct field type: %v", pv.sField, pv.sField.Type)
+	}
+	var sVal reflect.Value
+
+	if util.IsTypeMap(pv.sField.Type) {
+		if log.V(4) {
+			log.Info("updateStructFieldVal: field type is map")
+		}
+		sVal = reflect.New(pv.sField.Type.Elem().Elem())
+	} else if pv.sField.Type.Kind() == reflect.Ptr {
+		if log.V(4) {
+			log.Info("updateStructFieldVal: field type is pointer")
+		}
+		sVal = reflect.New(pv.sField.Type.Elem())
+	} else {
+		sVal = reflect.New(pv.sField.Type)
+	}
+	if log.V(4) {
+		log.Info("updateStructFieldVal: sVal", sVal)
+	}
+	pv.parentIntf = pv.sValIntf
+	pv.sValIntf = sVal.Interface()
+}
+
+// PathValidatorOpt is an interface used for any option to be supplied
+type PathValidatorOpt interface {
+	IsPathValidatorOpt()
+}
+
+// AppendModulePrefix is an PathValidator option that indicates that
+// the missing module prefix in the given gnmi path will be added
+// during the path validation
+type AppendModulePrefix struct{}
+
+// IsPathValidatorOpt marks AppendModulePrefix as a valid PathValidatorOpt.
+func (*AppendModulePrefix) IsPathValidatorOpt() {}
+
+// AddWildcardKeys is an PathValidator option that indicates that
+// the missing wild card keys in the given gnmi path will be added
+// during the path validation
+type AddWildcardKeys struct{}
+
+// IsPathValidatorOpt marks AddWildcardKeys as a valid PathValidatorOpt.
+func (*AddWildcardKeys) IsPathValidatorOpt() {}
+
+// IgnoreKeyValidation is an PathValidator option to indicate the
+// validator to ignore the key validation in the given gnmi path during the path validation
+type IgnoreKeyValidation struct{}
+
+// IsPathValidatorOpt marks IgnoreKeyValidation as a valid PathValidatorOpt.
+func (*IgnoreKeyValidation) IsPathValidatorOpt() {}
+
+func (pv *pathValidator) hasIgnoreKeyValidationOption() bool {
+	for _, o := range pv.opts {
+		if _, ok := o.(*IgnoreKeyValidation); ok {
+			return true
+		}
+	}
+	return false
+}
+
+func (pv *pathValidator) hasAppendModulePrefixOption() bool {
+	for _, o := range pv.opts {
+		if _, ok := o.(*AppendModulePrefix); ok {
+			return true
+		}
+	}
+	return false
+}
+
+func (pv *pathValidator) hasAddWildcardKeyOption() bool {
+	for _, o := range pv.opts {
+		if _, ok := o.(*AddWildcardKeys); ok {
+			return true
+		}
+	}
+	return false
+}

--- a/translib/path/path_validator_test.go
+++ b/translib/path/path_validator_test.go
@@ -1,0 +1,155 @@
+////////////////////////////////////////////////////////////////////////////////
+//                                                                            //
+//  Copyright 2021 Broadcom. The term Broadcom refers to Broadcom Inc. and/or //
+//  its subsidiaries.                                                         //
+//                                                                            //
+//  Licensed under the Apache License, Version 2.0 (the "License");           //
+//  you may not use this file except in compliance with the License.          //
+//  You may obtain a copy of the License at                                   //
+//                                                                            //
+//     http://www.apache.org/licenses/LICENSE-2.0                             //
+//                                                                            //
+//  Unless required by applicable law or agreed to in writing, software       //
+//  distributed under the License is distributed on an "AS IS" BASIS,         //
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  //
+//  See the License for the specific language governing permissions and       //
+//  limitations under the License.                                            //
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+
+package path
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/openconfig/ygot/ygot"
+)
+
+func TestNewPathValidator(t *testing.T) {
+	pathValdtor := NewPathValidator(&(AppendModulePrefix{}), &(AddWildcardKeys{}))
+	if pathValdtor != nil {
+		t.Log("reflect.ValueOf(pathValdtor.rootObj).Type().Name() ==> ", reflect.ValueOf(pathValdtor.rootObj).Elem().Type().Name())
+		if reflect.ValueOf(pathValdtor.rootObj).Elem().Type().Name() != "Device" || pathValdtor.hasIgnoreKeyValidationOption() ||
+			!pathValdtor.hasAppendModulePrefixOption() || !pathValdtor.hasAddWildcardKeyOption() {
+			t.Error("Error in creating the NewPathValidator")
+		}
+	}
+}
+
+func TestValidatePath(t *testing.T) {
+	tests := []struct {
+		tid       int
+		path      string
+		resPath   string
+		errPrefix string
+	}{{
+		tid:     1, // validate path and key value
+		path:    "/openconfig-acl:acl/acl-sets/acl-set[name=Sample][type=ACL_IPV4]/state/description",
+		resPath: "/openconfig-acl:acl/acl-sets/acl-set[name=Sample][type=ACL_IPV4]/state/description",
+	}, {
+		tid: 2, // fill key name and value as wild card for missing keys
+		path: "/openconfig-network-instance:network-instances/network-instance[name=default]/protocols/protocol[identifier=IGMP_SNOOPING][name=IGMP-SNOOPING]/" +
+			"openconfig-network-instance-deviation:igmp-snooping/interfaces/interface/config",
+		resPath: "/openconfig-network-instance:network-instances/network-instance[name=default]/protocols/protocol[identifier=IGMP_SNOOPING][name=IGMP-SNOOPING]/" +
+			"openconfig-network-instance-deviation:igmp-snooping/interfaces/interface[name=*]/config",
+	}, {
+		tid: 3, // append module prefix
+		path: "/openconfig-network-instance:network-instances/network-instance[name=default]/protocols/protocol[identifier=IGMP_SNOOPING][name=IGMP-SNOOPING]/" +
+			"igmp-snooping/interfaces",
+		resPath: "/openconfig-network-instance:network-instances/network-instance[name=default]/protocols/protocol[identifier=IGMP_SNOOPING][name=IGMP-SNOOPING]/" +
+			"openconfig-network-instance-deviation:igmp-snooping/interfaces",
+	}, {
+		tid:     4, // validate path and key value
+		path:    "/openconfig-interfaces:interfaces/interface[name=Ethernet8]/ethernet/switched-vlan/config/trunk-vlans",
+		resPath: "/openconfig-interfaces:interfaces/interface[name=Ethernet8]/openconfig-if-ethernet:ethernet/openconfig-vlan:switched-vlan/config/trunk-vlans",
+	}, {
+		tid:     5, // validate path and key value
+		path:    "/acl/acl-sets/acl-set[name=Sample][type=ACL_IPV4]/config/type",
+		resPath: "/openconfig-acl:acl/acl-sets/acl-set[name=Sample][type=ACL_IPV4]/config/type",
+	}, {
+		tid: 6, // negative - invalid module prefix
+		path: "/openconfig-network-instance:network-instances/network-instance[name=default]/protocols/protocol[identifier=IGMP_SNOOPING][name=IGMP-SNOOPING]/" +
+			"openconfig-network-instance-deviationxx:igmp-snooping/interfaces",
+		errPrefix: "Invalid yang module prefix in the path node openconfig-network-instance-deviationxx:igmp-snooping",
+	}, {
+		tid: 7, // negative - invalid path
+		path: "/openconfig-network-instance:network-instances/network-instance[name=default]/protocols/protocol[identifier=IGMP_SNOOPING][name=IGMP-SNOOPING]/" +
+			"openconfig-network-instance-deviation:igmp-snooping/interfacesxx",
+		errPrefix: "Node interfacesxx not found in the given gnmi path elem",
+	}, {
+		tid: 8, // negative - invalid key name
+		path: "/openconfig-network-instance:network-instances/network-instance[name=default]/protocols/protocol[identifier=IGMP_SNOOPING][name=IGMP-SNOOPING]/" +
+			"openconfig-network-instance-deviation:igmp-snooping/interfaces/interface[namexx=*]/config",
+		errPrefix: "Invalid key name: map[namexx:*] in the list node path: interface",
+	}, {
+		tid:       9, // negative - invalid path
+		path:      "/openconfig-system:system/config/hostname/invalid",
+		errPrefix: "Node invalid not found in the given gnmi path elem",
+	}, { // verify module prefix at list node path
+		tid:     10,
+		path:    "/openconfig-network-instance:network-instances/network-instance[name=*]/protocols/protocol[identifier=OSPF][name=ospfv2]/ospfv2/global/inter-area-propagation-policies/openconfig-ospfv2-ext:inter-area-policy[src-area=0.0.0.1]",
+		resPath: "/openconfig-network-instance:network-instances/network-instance[name=*]/protocols/protocol[identifier=OSPF][name=ospfv2]/ospfv2/global/inter-area-propagation-policies/openconfig-ospfv2-ext:inter-area-policy[src-area=0.0.0.1]",
+	}, { // append module prefix at list node path and verify
+		tid:     11,
+		path:    "/openconfig-network-instance:network-instances/network-instance[name=*]/protocols/protocol[identifier=OSPF][name=ospfv2]/ospfv2/global/inter-area-propagation-policies/inter-area-policy[src-area=0.0.0.1]",
+		resPath: "/openconfig-network-instance:network-instances/network-instance[name=*]/protocols/protocol[identifier=OSPF][name=ospfv2]/ospfv2/global/inter-area-propagation-policies/openconfig-ospfv2-ext:inter-area-policy[src-area=0.0.0.1]",
+	}, {
+		tid:     12,
+		path:    "/openconfig-network-instance:network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/rib/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]/openconfig-bgp-evpn-ext:l2vpn-evpn/loc-rib/routes/route[origin=6.6.6.2][path-id=0][prefix=[5\\]:[0\\]:[96\\]:[6601::\\]][route-distinguisher=120.1.1.1:5096]",
+		resPath: "/openconfig-network-instance:network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/rib/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]/openconfig-bgp-evpn-ext:l2vpn-evpn/loc-rib/routes/route[origin=6.6.6.2][path-id=0][prefix=[5\\]:[0\\]:[96\\]:[6601::\\]][route-distinguisher=120.1.1.1:5096]",
+	}}
+
+	pathValdtor := NewPathValidator(&(AppendModulePrefix{}), &(AddWildcardKeys{}))
+	for _, tt := range tests {
+		if gPath, err := ygot.StringToPath(tt.path, ygot.StructuredPath); err != nil {
+			t.Error("Error in uri to path conversion: ", err)
+			break
+		} else {
+			pathValdtor.init(gPath)
+			if err := pathValdtor.validatePath(); err != nil {
+				if !strings.HasPrefix(err.Error(), tt.errPrefix) {
+					t.Errorf("Testcase %v failed; error: %v", tt.tid, err)
+				}
+			} else if resPath, err := ygot.PathToString(gPath); resPath != tt.resPath {
+				t.Errorf("Testcase %v failed; error: %v; result path: %v", tt.tid, err, resPath)
+			}
+		}
+	}
+}
+
+func BenchmarkValidatePath1(b *testing.B) {
+	pathValdtor := NewPathValidator(&(AppendModulePrefix{}), &(AddWildcardKeys{}))
+	if gPath, err := ygot.StringToPath("/openconfig-tam:tam/flowgroups/flowgroup[name=*]/config/priority", ygot.StructuredPath); err != nil {
+		b.Error("Error in uri to path conversion: ", err)
+	} else {
+		for i := 0; i < b.N; i++ {
+			pathValdtor.Validate(gPath)
+		}
+	}
+}
+
+func BenchmarkValidatePath2(b *testing.B) {
+	pathValdtor := NewPathValidator(&(AppendModulePrefix{}), &(AddWildcardKeys{}))
+	if gPath, err := ygot.StringToPath("/openconfig-interfaces:interfaces/interface[name=*]/subinterfaces/subinterface[index=*]/openconfig-if-ip:ipv6/addresses/address[ip=*]/state", ygot.StructuredPath); err != nil {
+		b.Error("Error in uri to path conversion: ", err)
+	} else {
+		for i := 0; i < b.N; i++ {
+			pathValdtor.Validate(gPath)
+		}
+	}
+}
+
+func BenchmarkValidatePath3(b *testing.B) {
+	pathValdtor := NewPathValidator(&(AppendModulePrefix{}), &(AddWildcardKeys{}))
+	if gPath, err := ygot.StringToPath("/openconfig-network-instance:network-instances/network-instance[name=*]/protocols/protocol[identifier=*][name=*]"+
+		"/ospfv2/areas/area[identifier=*]/lsdb/lsa-types/lsa-type[type=*]/lsas/lsa-ext[link-state-id=*][advertising-router=*]"+
+		"/opaque-lsa/extended-prefix/tlvs/tlv/sid-label-binding/tlvs/tlv/ero-path/segments/segment/unnumbered-hop/state/router-id", ygot.StructuredPath); err != nil {
+		b.Error("Error in uri to path conversion: ", err)
+	} else {
+		for i := 0; i < b.N; i++ {
+			pathValdtor.Validate(gPath)
+		}
+	}
+}

--- a/translib/tlerr/tlerr.go
+++ b/translib/tlerr/tlerr.go
@@ -119,3 +119,10 @@ type TranslibXfmrRetError struct {
 func (e TranslibXfmrRetError) Error() string {
      return p.Sprintf("Translib transformer return %s", e.XlateFailDelReq)
 }
+
+type TranslibDBConnectionReset struct {
+}
+
+func (e TranslibDBConnectionReset) Error() string {
+	return p.Sprintf("Translib Redis Error: DB Connection Reset")
+}


### PR DESCRIPTION
Path validator API implementation to validate the gnmi path, and added following methods.

NewPathValidator() : to create pathValidator type to validate the gnmi path and add the missing module prefix and key names and wild card values in the gnmi path based on the given PathValidatorOpt

Validate() : to validate the path and add the module prefix / wild card keys in the gnmi path based on the given PathValidatorOpt while creating the path validator.

Required for the subscription enhancements as described in HLD https://github.com/sonic-net/SONiC/pull/1287