### PR TITLE
DB Access: OnChange cache

### DIFF
--- a/translib/db/db.go
+++ b/translib/db/db.go
@@ -157,7 +157,7 @@ type Options struct {
 	TableNameSeparator string //Overriden by the DB config file's separator.
 	KeySeparator       string //Overriden by the DB config file's separator.
 	IsWriteDisabled    bool   //Indicated if write is allowed
-	IsEnableOnChange   bool   // whether OnChange cache enabled
+	IsOnChangeEnabled  bool   // whether OnChange cache enabled
 
 	DisableCVLCheck bool
 }
@@ -360,7 +360,7 @@ func NewDB(opt Options) (*DB, error) {
 		glog.Error(fmt.Errorf("Invalid database number %d", dbId))
 	}
 
-	if opt.IsEnableOnChange && !opt.IsWriteDisabled {
+	if opt.IsOnChangeEnabled && !opt.IsWriteDisabled {
 		glog.Errorf("NewDB: IsEnableOnChange cannot be set on write enabled DB")
 		e = tlerr.TranslibDBCannotOpen{}
 		goto NewDBExit
@@ -390,7 +390,7 @@ func NewDB(opt Options) (*DB, error) {
 		goto NewDBExit
 	}
 
-	if opt.IsEnableOnChange {
+	if opt.IsOnChangeEnabled {
 		d.onCReg = dbOnChangeReg{CacheTables: make(map[string]bool)}
 	}
 
@@ -509,7 +509,7 @@ func (d *DB) getEntry(ts *TableSpec, key Key, forceReadDB bool) (Value, error) {
 	var e error
 
 	entry := d.key2redis(ts, key)
-	useCache := d.Opts.IsEnableOnChange && d.onCReg.isCacheTable(ts.Name)
+	useCache := d.Opts.IsOnChangeEnabled && d.onCReg.isCacheTable(ts.Name)
 
 	if !forceReadDB && useCache {
 		if table, ok := d.cache.Tables[ts.Name]; ok {

--- a/translib/db/db_onchangecache.go
+++ b/translib/db/db_onchangecache.go
@@ -36,13 +36,13 @@ type dbOnChangeReg struct {
 ////////////////////////////////////////////////////////////////////////////////
 
 func (d *DB) RegisterTableForOnChangeCaching(ts *TableSpec) error {
-	if glog.V(1) {
+	if glog.V(3) {
 		glog.Info("RegisterTableForOnChange: ts:", ts)
 	}
 	if !d.IsOpen() {
 		return ConnectionClosed
 	}
-	if !d.Opts.IsEnableOnChange {
+	if !d.Opts.IsOnChangeEnabled {
 		return OnChangeDisabled
 	}
 
@@ -61,7 +61,7 @@ func (d *DB) OnChangeCacheUpdate(ts *TableSpec, key Key) (Value, Value, error) {
 	if !d.IsOpen() {
 		return Value{}, Value{}, ConnectionClosed
 	}
-	if !d.Opts.IsEnableOnChange {
+	if !d.Opts.IsOnChangeEnabled {
 		return Value{}, Value{}, OnChangeDisabled
 	}
 
@@ -86,7 +86,7 @@ func (d *DB) OnChangeCacheDelete(ts *TableSpec, key Key) (Value, error) {
 	if !d.IsOpen() {
 		return Value{}, ConnectionClosed
 	}
-	if !d.Opts.IsEnableOnChange {
+	if !d.Opts.IsOnChangeEnabled {
 		return Value{}, OnChangeDisabled
 	}
 

--- a/translib/db/db_onchangecache.go
+++ b/translib/db/db_onchangecache.go
@@ -1,0 +1,123 @@
+////////////////////////////////////////////////////////////////////////////////
+//                                                                            //
+//  Copyright 2021 Broadcom. The term Broadcom refers to Broadcom Inc. and/or //
+//  its subsidiaries.                                                         //
+//                                                                            //
+//  Licensed under the Apache License, Version 2.0 (the "License");           //
+//  you may not use this file except in compliance with the License.          //
+//  You may obtain a copy of the License at                                   //
+//                                                                            //
+//     http://www.apache.org/licenses/LICENSE-2.0                             //
+//                                                                            //
+//  Unless required by applicable law or agreed to in writing, software       //
+//  distributed under the License is distributed on an "AS IS" BASIS,         //
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  //
+//  See the License for the specific language governing permissions and       //
+//  limitations under the License.                                            //
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+
+package db
+
+import (
+	"github.com/golang/glog"
+)
+
+////////////////////////////////////////////////////////////////////////////////
+//  Internal Types                                                            //
+////////////////////////////////////////////////////////////////////////////////
+
+type dbOnChangeReg struct {
+	CacheTables map[string]bool // Only cache these tables.
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//  Exported Functions                                                        //
+////////////////////////////////////////////////////////////////////////////////
+
+func (d *DB) RegisterTableForOnChangeCaching(ts *TableSpec) error {
+	if glog.V(1) {
+		glog.Info("RegisterTableForOnChange: ts:", ts)
+	}
+	if !d.IsOpen() {
+		return ConnectionClosed
+	}
+	if !d.Opts.IsEnableOnChange {
+		return OnChangeDisabled
+	}
+
+	d.onCReg.CacheTables[ts.Name] = true
+	return nil
+}
+
+// OnChangeCacheUpdate reads a db entry from redis and updates the on_change cache.
+// Returns both previously cached Value and current Value. Previous Value will be
+// empty if there was no such cache entry earlier. Returns an error if DB entry
+// does not exists or could not be read.
+func (d *DB) OnChangeCacheUpdate(ts *TableSpec, key Key) (Value, Value, error) {
+	if glog.V(3) {
+		glog.Info("OnChangeCacheUpdate: Begin: ", "ts: ", ts, " key: ", key)
+	}
+	if !d.IsOpen() {
+		return Value{}, Value{}, ConnectionClosed
+	}
+	if !d.Opts.IsEnableOnChange {
+		return Value{}, Value{}, OnChangeDisabled
+	}
+
+	var valueOrig Value
+	if _, ok := d.cache.Tables[ts.Name]; ok {
+		valueOrig = d.cache.Tables[ts.Name].entry[d.key2redis(ts, key)]
+	}
+
+	// Get New Value from the DB
+	value, e := d.getEntry(ts, key, true)
+
+	return valueOrig, value, e
+}
+
+// OnChangeCacheDelete deletes an entry from the on_change cache.
+// Returns the previously cached Value object; or an empty Value if there was
+// no such cache entry.
+func (d *DB) OnChangeCacheDelete(ts *TableSpec, key Key) (Value, error) {
+	if glog.V(3) {
+		glog.Info("OnChangeCacheDelete: Begin: ", "ts:", ts, " key:", key)
+	}
+	if !d.IsOpen() {
+		return Value{}, ConnectionClosed
+	}
+	if !d.Opts.IsEnableOnChange {
+		return Value{}, OnChangeDisabled
+	}
+
+	redisKey := d.key2redis(ts, key)
+	var valueOrig Value
+	_, ok := d.cache.Tables[ts.Name]
+	if ok {
+		valueOrig, ok = d.cache.Tables[ts.Name].entry[redisKey]
+	}
+
+	if ok {
+		glog.V(2).Info("OnChangeCacheDelete: Delete ts:", ts, " key:", key)
+		delete(d.cache.Tables[ts.Name].entry, redisKey)
+	} else {
+		glog.V(2).Info("OnChangeCacheDelete: Not found; ts:", ts, " key:", key)
+	}
+
+	return valueOrig, nil
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//  Internal Functions                                                        //
+////////////////////////////////////////////////////////////////////////////////
+
+func init() {
+}
+
+func (reg *dbOnChangeReg) isCacheTable(name string) bool {
+	return reg.CacheTables[name]
+}
+
+func (reg *dbOnChangeReg) size() int {
+	return len(reg.CacheTables)
+}

--- a/translib/db/db_onchangecache_test.go
+++ b/translib/db/db_onchangecache_test.go
@@ -1,0 +1,213 @@
+////////////////////////////////////////////////////////////////////////////////
+//                                                                            //
+//  Copyright 2023 Broadcom. The term Broadcom refers to Broadcom Inc. and/or //
+//  its subsidiaries.                                                         //
+//                                                                            //
+//  Licensed under the Apache License, Version 2.0 (the "License");           //
+//  you may not use this file except in compliance with the License.          //
+//  You may obtain a copy of the License at                                   //
+//                                                                            //
+//     http://www.apache.org/licenses/LICENSE-2.0                             //
+//                                                                            //
+//  Unless required by applicable law or agreed to in writing, software       //
+//  distributed under the License is distributed on an "AS IS" BASIS,         //
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  //
+//  See the License for the specific language governing permissions and       //
+//  limitations under the License.                                            //
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+
+package db
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/Azure/sonic-mgmt-common/translib/tlerr"
+)
+
+func newTestDB(t *testing.T, opts Options) *DB {
+	t.Helper()
+	d, err := NewDB(opts)
+	if err != nil {
+		t.Fatalf("NewDB() failed: %v", err)
+	}
+	t.Cleanup(func() { d.DeleteDB() })
+	return d
+}
+
+func TestOnChangeCacheReg(t *testing.T) {
+	ts := &TableSpec{Name: "PORT"}
+	t.Run("occDisable", func(t *testing.T) {
+		d := newTestDB(t, Options{
+			DBNo:            ConfigDB,
+			IsWriteDisabled: true,
+		})
+		if err := d.RegisterTableForOnChangeCaching(ts); err == nil {
+			t.Fatal("RegisterTableForOnChangeCaching should have failed when IsEnableOnChange=false")
+		}
+		if d.onCReg.isCacheTable(ts.Name) {
+			t.Fatalf("isCacheTable(%q) returned true", ts.Name)
+		}
+	})
+
+	t.Run("occEnable", func(t *testing.T) {
+		d := newTestDB(t, Options{
+			DBNo:             ConfigDB,
+			IsWriteDisabled:  true,
+			IsEnableOnChange: true,
+		})
+		if err := d.RegisterTableForOnChangeCaching(ts); err != nil {
+			t.Fatal("RegisterTableForOnChangeCaching failed; ", err)
+		}
+		if !d.onCReg.isCacheTable(ts.Name) {
+			t.Fatalf("isCacheTable(%q) returned false", ts.Name)
+		}
+		if name := "XYZ"; d.onCReg.isCacheTable(name) {
+			t.Fatalf("isCacheTable(%q) returned true", name)
+		}
+	})
+
+	t.Run("writeEnable", func(t *testing.T) {
+		_, err := NewDB(Options{
+			DBNo:             ConfigDB,
+			IsEnableOnChange: true,
+		})
+		if err == nil {
+			t.Error("NewDB should have failed")
+		}
+	})
+}
+
+func TestOnChangeCache(t *testing.T) {
+	// OnChange cache enabled db
+	d := newTestDB(t, Options{DBNo: ConfigDB, IsWriteDisabled: true, IsEnableOnChange: true})
+	// Writale db to write test keys
+	dw := newTestDB(t, Options{DBNo: ConfigDB, DisableCVLCheck: true})
+
+	tsA := &TableSpec{Name: "TESTOCC_A"}
+	tsB := &TableSpec{Name: "TESTOCC_B"}
+	key1 := Key{Comp: []string{"001"}}
+	key2 := Key{Comp: []string{"002"}}
+	key3 := Key{Comp: []string{"003"}}
+	val1 := Value{Field: map[string]string{"msg": "hello, world!"}}
+	val2 := Value{Field: map[string]string{"msg": "foo bar"}}
+	val3 := Value{Field: map[string]string{"NULL": "NULL"}}
+
+	// Create test entries in tables TESTOCC_A and TESTOCC_B
+	t.Cleanup(func() {
+		dw.DeleteEntry(tsA, key1)
+		dw.DeleteEntry(tsA, key2)
+		dw.DeleteEntry(tsA, key3)
+		dw.DeleteEntry(tsB, key1)
+	})
+	dw.CreateEntry(tsA, key1, val1)
+	dw.CreateEntry(tsA, key2, val2)
+	dw.CreateEntry(tsB, key1, val3)
+
+	// Enable OnChange cache for TESTOCC_A only
+	if err := d.RegisterTableForOnChangeCaching(tsA); err != nil {
+		t.Fatalf("RegisterTableForOnChangeCaching(%q) failed: %v", tsA.Name, err)
+	}
+
+	// Call GetEntry() for one key from table A and check OnChangecache contains only that entry
+	verifyGetEntry(t, d, tsA, key1, val1)
+	verifyOnChangeCache(t, d, tsA, map[string]Value{
+		d.key2redis(tsA, key1): val1,
+	})
+
+	// Call GetEntry() for other keys from both tables
+	verifyGetEntry(t, d, tsA, key1, val1)
+	verifyGetEntry(t, d, tsA, key2, val2)
+	verifyGetEntry(t, d, tsA, key3, tlerr.TranslibRedisClientEntryNotExist{})
+	verifyGetEntry(t, d, tsB, key1, val3)
+	verifyGetEntry(t, d, tsB, key3, tlerr.TranslibRedisClientEntryNotExist{})
+
+	// Verify OnChange cache contains entries from table A only
+	verifyOnChangeCache(t, d, tsA, map[string]Value{
+		d.key2redis(tsA, key1): val1,
+		d.key2redis(tsA, key2): val2,
+	})
+	verifyOnChangeCache(t, d, tsB, nil)
+
+	// Make few changes to both tables
+	dw.SetEntry(tsA, key1, val3)
+	dw.DeleteEntry(tsA, key2)
+	dw.CreateEntry(tsA, key3, val2)
+	dw.SetEntry(tsB, key1, val1)
+
+	// Verify that GetEntry() does not return updated values for table A (due to cache)
+	verifyGetEntry(t, d, tsA, key1, val1)
+	verifyGetEntry(t, d, tsA, key2, val2)
+
+	// But GetEntry() should return new values for table B immediately
+	verifyGetEntry(t, d, tsB, key1, val1)
+
+	// Update OnChange cache
+	verifyOnChangeCacheUpdate(t, d, tsA, key1, val1, val3)
+	verifyOnChangeCacheUpdate(t, d, tsA, key3, Value{}, val2)
+	verifyOnChangeCacheDelete(t, d, tsA, key2, val2)
+
+	// Verify cache contents
+	verifyOnChangeCache(t, d, tsA, map[string]Value{
+		d.key2redis(tsA, key1): val3,
+		d.key2redis(tsA, key3): val2,
+	})
+
+	// Verify GetEntry() calls
+	verifyGetEntry(t, d, tsA, key1, val3)
+	verifyGetEntry(t, d, tsA, key2, tlerr.TranslibRedisClientEntryNotExist{})
+	verifyGetEntry(t, d, tsA, key3, val2)
+
+}
+
+func verifyGetEntry(t *testing.T, d *DB, ts *TableSpec, k Key, exp interface{}) {
+	t.Helper()
+	v, err := d.GetEntry(ts, k)
+	switch exp := exp.(type) {
+	case tlerr.TranslibRedisClientEntryNotExist:
+		if _, ok := err.(tlerr.TranslibRedisClientEntryNotExist); !ok {
+			t.Errorf("GetEntry(%q) did not return %T", d.key2redis(ts, k), exp)
+			t.Fatalf("Received: v=%v, err=%T(%v)", v.Field, err, err)
+		}
+	case Value:
+		if err != nil {
+			t.Fatalf("GetEntry(%q) failed: %v", d.key2redis(ts, k), err)
+		} else if !reflect.DeepEqual(v, exp) {
+			t.Errorf("GetEntry(%q) returned unexpected values", d.key2redis(ts, k))
+			t.Errorf("Expected: %v", exp.Field)
+			t.Fatalf("Received: %v", v.Field)
+		}
+	default:
+		t.Fatalf("Invalid expValue type: %T", exp)
+	}
+}
+
+func verifyOnChangeCache(t *testing.T, d *DB, ts *TableSpec, exp map[string]Value) {
+	t.Helper()
+	if cached := d.cache.Tables[ts.Name]; !reflect.DeepEqual(cached.entry, exp) {
+		t.Errorf("OnChange cache comparson failed for table %s", ts.Name)
+		t.Errorf("Expected: %v", exp)
+		t.Fatalf("Found:    %v", cached.entry)
+	}
+}
+
+func verifyOnChangeCacheUpdate(t *testing.T, d *DB, ts *TableSpec, k Key, expOld, expNew Value) {
+	t.Helper()
+	old, new, err := d.OnChangeCacheUpdate(ts, k)
+	if err != nil || !reflect.DeepEqual(old, expOld) || !reflect.DeepEqual(new, expNew) {
+		t.Errorf("OnChangeCacheUpdate(%q) failed", d.key2redis(ts, k))
+		t.Errorf("Expected: old=%v, new=%v", expOld.Field, expNew.Field)
+		t.Fatalf("Received: old=%v, new=%v, err=%v", old.Field, new.Field, err)
+	}
+}
+
+func verifyOnChangeCacheDelete(t *testing.T, d *DB, ts *TableSpec, k Key, expOld Value) {
+	t.Helper()
+	old, err := d.OnChangeCacheDelete(ts, k)
+	if err != nil || !reflect.DeepEqual(old, expOld) {
+		t.Errorf("OnChangeCacheUpdate(%q) failed", d.key2redis(ts, k))
+		t.Errorf("Expected: %v", expOld.Field)
+		t.Fatalf("Received: %v, err=%v", old.Field, err)
+	}
+}

--- a/translib/db/db_onchangecache_test.go
+++ b/translib/db/db_onchangecache_test.go
@@ -53,9 +53,9 @@ func TestOnChangeCacheReg(t *testing.T) {
 
 	t.Run("occEnable", func(t *testing.T) {
 		d := newTestDB(t, Options{
-			DBNo:             ConfigDB,
-			IsWriteDisabled:  true,
-			IsEnableOnChange: true,
+			DBNo:              ConfigDB,
+			IsWriteDisabled:   true,
+			IsOnChangeEnabled: true,
 		})
 		if err := d.RegisterTableForOnChangeCaching(ts); err != nil {
 			t.Fatal("RegisterTableForOnChangeCaching failed; ", err)
@@ -70,8 +70,8 @@ func TestOnChangeCacheReg(t *testing.T) {
 
 	t.Run("writeEnable", func(t *testing.T) {
 		_, err := NewDB(Options{
-			DBNo:             ConfigDB,
-			IsEnableOnChange: true,
+			DBNo:              ConfigDB,
+			IsOnChangeEnabled: true,
 		})
 		if err == nil {
 			t.Error("NewDB should have failed")
@@ -81,7 +81,7 @@ func TestOnChangeCacheReg(t *testing.T) {
 
 func TestOnChangeCache(t *testing.T) {
 	// OnChange cache enabled db
-	d := newTestDB(t, Options{DBNo: ConfigDB, IsWriteDisabled: true, IsEnableOnChange: true})
+	d := newTestDB(t, Options{DBNo: ConfigDB, IsWriteDisabled: true, IsOnChangeEnabled: true})
 	// Writale db to write test keys
 	dw := newTestDB(t, Options{DBNo: ConfigDB, DisableCVLCheck: true})
 

--- a/translib/tlerr/tlerr.go
+++ b/translib/tlerr/tlerr.go
@@ -93,6 +93,12 @@ func (e TranslibDBSubscribeFail) Error() string {
 	return p.Sprintf("Translib Redis Error: DB Subscribe Fail")
 }
 
+type TranslibDBInvalidState string
+
+func (e TranslibDBInvalidState) Error() string {
+	return "DB error: " + string(e)
+}
+
 type TranslibSyntaxValidationError struct {
 	StatusCode int   // status code
 	ErrorStr   error // error message


### PR DESCRIPTION
1\) Introduced the OnChange cache in the DB object. Cache is maintained as map[string]db.Value, where map key is the redis key.

OnChange cache is not enabled by default. DB instance should be inited with IsEnableOnChange=true option and caching should be enabled for specific tables by calling DB.RegisterTableForOnChangeCaching(). DB.OnChangeCacheUpdate() and DB.OnChangeCacheDelete() functions should be used to refresh the cache contents.

2\) Enhanced DB.GetEntry() to return value from the OnChnage cahce if the key exists in the cache. Otherwise the value will be read from redis and cache will be updated.

Part of the subscription enhancements described in the HLD https://github.com/sonic-net/SONiC/pull/1287