### PR TITLE
Remove invalid db type definitions: ERROR_DB, USER_DB

### DIFF
--- a/translib/db/db.go
+++ b/translib/db/db.go
@@ -140,8 +140,6 @@ const (
 	FlexCounterDB              // 5
 	StateDB                    // 6
 	SnmpDB                     // 7
-	ErrorDB                    // 8
-	UserDB                     // 9
 	// All DBs added above this line, please ----
 	MaxDB //  The Number of DBs
 )
@@ -322,10 +320,6 @@ func getDBInstName (dbNo DBNum) string {
 		return "STATE_DB"
 	case SnmpDB:
 		return "SNMP_OVERLAY_DB"
-	case ErrorDB:
-		return "ERROR_DB"
-	case UserDB:
-		return "USER_DB"
 	}
 	return ""
 }
@@ -345,8 +339,6 @@ func GetdbNameToIndex(dbName string) DBNum {
 		dbIndex = FlexCounterDB
 	case "STATE_DB":
 		dbIndex = StateDB
-	case "ERROR_DB":
-		dbIndex = ErrorDB
 	}
 	return dbIndex
 }
@@ -382,7 +374,9 @@ func NewDB(opt Options) (*DB, error) {
 			glog.Warning("Database instance not present for the Db name: ", dbInstName)
 		}
 	} else {
-		glog.Error(fmt.Errorf("Invalid database number %d", dbId))
+		glog.Errorf("NewDB: invalid database number: %d", dbId)
+		e = tlerr.TranslibDBCannotOpen{}
+		goto NewDBExit
 	}
 
 	if opt.IsOnChangeEnabled && !opt.IsWriteDisabled {
@@ -428,7 +422,7 @@ func NewDB(opt Options) (*DB, error) {
 
 	if len(d.Opts.InitIndicator) == 0 {
 
-		glog.Info("NewDB: Init indication not requested")
+		glog.V(5).Info("NewDB: Init indication not requested")
 
 	} else if init, _ := d.client.Get(d.Opts.InitIndicator).Int(); init != 1 {
 
@@ -450,6 +444,9 @@ NewDBExit:
 
 // DeleteDB is the gentle way to close the DB connection.
 func (d *DB) DeleteDB() error {
+	if d == nil {
+		return nil
+	}
 
 	if glog.V(3) {
 		glog.Info("DeleteDB: Begin: d: ", d)

--- a/translib/db/db_test.go
+++ b/translib/db/db_test.go
@@ -101,11 +101,6 @@ var dbConfig = `
             "id" : 7,
             "separator": "|",
             "instance" : "redis"
-        },
-        "ERROR_DB" : {
-            "id" : 8,
-            "separator": ":",
-            "instance" : "redis"
         }
     },
     "VERSION" : "1.0"

--- a/translib/transformer/transformer_test.go
+++ b/translib/transformer/transformer_test.go
@@ -48,7 +48,7 @@ func getDBOptions(dbNo db.DBNum, isWriteDisabled bool) db.Options {
 	case db.ApplDB, db.CountersDB, db.AsicDB, db.FlexCounterDB:
 		opt = getDBOptionsWithSeparator(dbNo, "", ":", ":", isWriteDisabled)
 		break
-	case db.ConfigDB, db.StateDB, db.ErrorDB:
+	case db.ConfigDB, db.StateDB:
 		opt = getDBOptionsWithSeparator(dbNo, "", "|", "|", isWriteDisabled)
 		break
 	}

--- a/translib/transformer/xlate_utils.go
+++ b/translib/transformer/xlate_utils.go
@@ -562,9 +562,9 @@ func getDBOptions(dbNo db.DBNum) db.Options {
 	var opt db.Options
 
 	switch dbNo {
-	case db.ApplDB, db.CountersDB:
+	case db.ApplDB, db.CountersDB, db.FlexCounterDB, db.AsicDB:
 		opt = getDBOptionsWithSeparator(dbNo, "", ":", ":")
-	case db.FlexCounterDB, db.AsicDB, db.ConfigDB, db.StateDB, db.ErrorDB, db.UserDB:
+	case db.ConfigDB, db.StateDB:
 		opt = getDBOptionsWithSeparator(dbNo, "", "|", "|")
 	}
 

--- a/translib/translib.go
+++ b/translib/translib.go
@@ -796,6 +796,9 @@ func getAllDbs(opts ...func(*db.Options)) ([db.MaxDB]*db.DB, error) {
 	var dbs [db.MaxDB]*db.DB
 	var err error
 	for dbNum := db.DBNum(0); dbNum < db.MaxDB; dbNum++ {
+		if len(dbNum.Name()) == 0 {
+			continue
+		}
 		dbs[dbNum], err = db.NewDB(getDBOptions(dbNum, opts...))
 		if err != nil {
 			closeAllDbs(dbs[:])


### PR DESCRIPTION
Translib DBAccess library defines ERROR_DB and USER_DB, which are not supported by the database docker. All REST or gNMI GET operation prints following warning logs.

```
E0619 06:17:57.258827      19 db.go:385] Invalid database number 3
I0619 06:17:57.258872      19 db.go:431] NewDB: Init indication not requested
W0619 06:17:57.258928      19 db.go:382] Database instance not present for the Db name: ERROR_DB
W0619 06:17:57.258960      19 db.go:382] Database instance not present for the Db name: USER_DB
```
Removed the invalid ERROR_DB and USER_DB DBNum definitions and their references. Also skipped creating db object for index 3 -- it used to be the LOGLEVEL_DB earlier, which has been retired now.