### PR TITLE
CVL error reporting enhancements

### DIFF
--- a/cvl/Makefile
+++ b/cvl/Makefile
@@ -58,7 +58,6 @@ schema: $(CVL_SCHEMA)
 
 $(CVL_SCHEMA): $(SONIC_YANG_FILES) | $$(@D)/.
 	$(TOP_DIR)/tools/pyang/generate_yin.py \
-		--no-err-prefix \
 		--path=$(SONIC_YANG_DIR) \
 		--path=$(YANG_SRC_DIR)/common \
 		--out-dir=$(@D)
@@ -69,7 +68,6 @@ test-schema: $(CVL_TEST_SCHEMA)
 
 $(CVL_TEST_SCHEMA): $(CVL_TEST_YANGS) | $$(@D)/.
 	$(TOP_DIR)/tools/pyang/generate_yin.py \
-		--no-err-prefix \
 		--path=testdata/schema \
 		--path=$(YANG_SRC_DIR)/common \
 		--path=$(YANG_SRC_DIR)/sonic/common \

--- a/cvl/cvl_api.go
+++ b/cvl/cvl_api.go
@@ -379,6 +379,8 @@ func (c *CVL) ValidateEditConfig(cfgData []CVLEditConfigData) (cvlErr CVLErrorIn
 			//Check max-element constraint 
 			if ret := c.checkMaxElemConstraint(OP_CREATE, tbl); ret != CVL_SUCCESS {
 				cvlErrObj.ErrCode = CVL_SYNTAX_ERROR
+				cvlErrObj.TableName = tbl
+				cvlErrObj.Keys = splitKeyComponents(tbl, key)
 				cvlErrObj.ErrAppTag = "too-many-elements"
 				cvlErrObj.Msg = "Max elements limit reached"
 				cvlErrObj.CVLErrDetails = cvlErrorMap[cvlErrObj.ErrCode]
@@ -399,6 +401,9 @@ func (c *CVL) ValidateEditConfig(cfgData []CVLEditConfigData) (cvlErr CVLErrorIn
 				for field := range cfgData[i].Data {
 					if (c.checkDeleteConstraint(cfgData, tbl, key, field) != CVL_SUCCESS) {
 						cvlErrObj.ErrCode = CVL_SEMANTIC_ERROR
+						cvlErrObj.TableName = tbl
+						cvlErrObj.Keys = splitKeyComponents(tbl, key)
+						cvlErrObj.Field = field
 						cvlErrObj.Msg = "Validation failed for Delete operation, given instance is in use"
 						cvlErrObj.CVLErrDetails = cvlErrorMap[cvlErrObj.ErrCode]
 						cvlErrObj.ErrAppTag = "instance-in-use"
@@ -411,6 +416,7 @@ func (c *CVL) ValidateEditConfig(cfgData []CVLEditConfigData) (cvlErr CVLErrorIn
 						cvlErrObj.ErrCode = CVL_SEMANTIC_ERROR
 						cvlErrObj.Msg = "Mandatory field getting deleted"
 						cvlErrObj.TableName = tbl
+						cvlErrObj.Keys = splitKeyComponents(tbl, key)
 						cvlErrObj.Field = field
 						cvlErrObj.CVLErrDetails = cvlErrorMap[cvlErrObj.ErrCode]
 						cvlErrObj.ErrAppTag = "mandatory-field-delete"
@@ -427,6 +433,8 @@ func (c *CVL) ValidateEditConfig(cfgData []CVLEditConfigData) (cvlErr CVLErrorIn
 				//Now check delete constraints
 				if (c.checkDeleteConstraint(cfgData, tbl, key, "") != CVL_SUCCESS) {
 					cvlErrObj.ErrCode = CVL_SEMANTIC_ERROR
+					cvlErrObj.TableName = tbl
+					cvlErrObj.Keys = splitKeyComponents(tbl, key)
 					cvlErrObj.Msg = "Validation failed for Delete operation, given instance is in use"
 					cvlErrObj.CVLErrDetails = cvlErrorMap[cvlErrObj.ErrCode]
 					cvlErrObj.ErrAppTag = "instance-in-use"
@@ -498,6 +506,8 @@ func (c *CVL) ValidateEditConfig(cfgData []CVLEditConfigData) (cvlErr CVLErrorIn
 					CVL_LOG(WARNING, "\nValidateEditConfig(): Key = %s already exists", cfgData[i].Key)
 					cvlErrObj.ErrCode = CVL_SEMANTIC_KEY_ALREADY_EXIST
 					cvlErrObj.CVLErrDetails = cvlErrorMap[cvlErrObj.ErrCode]
+					cvlErrObj.TableName = tbl
+					cvlErrObj.Keys = splitKeyComponents(tbl, key)
 					return cvlErrObj, CVL_SEMANTIC_KEY_ALREADY_EXIST
 
 				} else {
@@ -514,6 +524,8 @@ func (c *CVL) ValidateEditConfig(cfgData []CVLEditConfigData) (cvlErr CVLErrorIn
 				CVL_LOG(WARNING, "\nValidateEditConfig(): Key = %s does not exist", cfgData[i].Key)
 				cvlErrObj.ErrCode = CVL_SEMANTIC_KEY_NOT_EXIST
 				cvlErrObj.CVLErrDetails = cvlErrorMap[cvlErrObj.ErrCode]
+				cvlErrObj.TableName = tbl
+				cvlErrObj.Keys = splitKeyComponents(tbl, key)
 				return cvlErrObj, CVL_SEMANTIC_KEY_NOT_EXIST
 			}
 
@@ -530,6 +542,8 @@ func (c *CVL) ValidateEditConfig(cfgData []CVLEditConfigData) (cvlErr CVLErrorIn
 				CVL_LOG(WARNING, "\nValidateEditConfig(): Key = %s does not exist", cfgData[i].Key)
 				cvlErrObj.ErrCode = CVL_SEMANTIC_KEY_NOT_EXIST
 				cvlErrObj.CVLErrDetails = cvlErrorMap[cvlErrObj.ErrCode]
+				cvlErrObj.TableName = tbl
+				cvlErrObj.Keys = splitKeyComponents(tbl, key)
 				return cvlErrObj, CVL_SEMANTIC_KEY_NOT_EXIST
 			}
 

--- a/cvl/cvl_error_test.go
+++ b/cvl/cvl_error_test.go
@@ -1,0 +1,85 @@
+////////////////////////////////////////////////////////////////////////////////
+//                                                                            //
+//  Copyright 2023 Broadcom. The term Broadcom refers to Broadcom Inc. and/or //
+//  its subsidiaries.                                                         //
+//                                                                            //
+//  Licensed under the Apache License, Version 2.0 (the "License");           //
+//  you may not use this file except in compliance with the License.          //
+//  You may obtain a copy of the License at                                   //
+//                                                                            //
+//     http://www.apache.org/licenses/LICENSE-2.0                             //
+//                                                                            //
+//  Unless required by applicable law or agreed to in writing, software       //
+//  distributed under the License is distributed on an "AS IS" BASIS,         //
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  //
+//  See the License for the specific language governing permissions and       //
+//  limitations under the License.                                            //
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+
+package cvl_test
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/Azure/sonic-mgmt-common/cvl"
+)
+
+const (
+	CVL_SUCCESS                = cvl.CVL_SUCCESS
+	CVL_SYNTAX_ERROR           = cvl.CVL_SYNTAX_ERROR
+	CVL_SEMANTIC_ERROR         = cvl.CVL_SEMANTIC_ERROR
+	CVL_SYNTAX_MAXIMUM_INVALID = cvl.CVL_SYNTAX_MAXIMUM_INVALID
+	CVL_SYNTAX_MINIMUM_INVALID = cvl.CVL_SYNTAX_MINIMUM_INVALID
+)
+
+var Success = CVLErrorInfo{ErrCode: CVL_SUCCESS}
+
+func compareErr(val, exp CVLErrorInfo) bool {
+	return (val.ErrCode == exp.ErrCode) &&
+		(len(exp.TableName) == 0 || val.TableName == exp.TableName) &&
+		(len(exp.Keys) == 0 || reflect.DeepEqual(val.Keys, exp.Keys)) &&
+		(len(exp.Field) == 0 || val.Field == exp.Field) &&
+		(len(exp.Value) == 0 || val.Value == exp.Value) &&
+		(len(exp.Msg) == 0 || val.Msg == exp.Msg) &&
+		(len(exp.CVLErrDetails) == 0 || val.CVLErrDetails == exp.CVLErrDetails) &&
+		(len(exp.ConstraintErrMsg) == 0 || val.ConstraintErrMsg == exp.ConstraintErrMsg) &&
+		(len(exp.ErrAppTag) == 0 || val.ErrAppTag == exp.ErrAppTag)
+}
+
+func verifyErr(t *testing.T, res, exp CVLErrorInfo) {
+	t.Helper()
+	expandMessagePatterns(&exp)
+	if !compareErr(res, exp) {
+		t.Fatalf("CVLErrorInfo verification failed\nExpected: %#v\nReceived: %#v", exp, res)
+	}
+}
+
+func verifyValidateEditConfig(t *testing.T, data []CVLEditConfigData, exp CVLErrorInfo) {
+	t.Helper()
+	c := NewTestSession(t)
+	res, _ := c.ValidateEditConfig(data)
+	verifyErr(t, res, exp)
+}
+
+func expandMessagePatterns(ex *CVLErrorInfo) {
+	switch ex.Msg {
+	case invalidValueErrMessage:
+		ex.Msg = strings.ReplaceAll(ex.Msg, "{{field}}", ex.Field)
+		ex.Msg = strings.ReplaceAll(ex.Msg, "{{value}}", ex.Value)
+		ex.Msg = strings.TrimSuffix(ex.Msg, " \"\"") // if value is empty
+	case unknownFieldErrMessage:
+		ex.Msg = strings.ReplaceAll(ex.Msg, "{{field}}", ex.Field)
+	}
+}
+
+const (
+	invalidValueErrMessage   = "Field \"{{field}}\" has invalid value \"{{value}}\""
+	unknownFieldErrMessage   = "Unknown field \"{{field}}\""
+	genericValueErrMessage   = "Data validation failed"
+	mustExpressionErrMessage = "Must expression validation failed"
+	whenExpressionErrMessage = "When expression validation failed"
+	instanceInUseErrMessage  = "Validation failed for Delete operation, given instance is in use"
+)

--- a/cvl/cvl_syntax.go
+++ b/cvl/cvl_syntax.go
@@ -137,7 +137,7 @@ parent *yparser.YParserNode, multileaf *[]*yparser.YParserLeafValue) CVLErrorInf
 				jsonFieldNode.FirstChild.Data, &batchInnerListLeaf)
 
 				if errObj := c.yp.AddMultiLeafNodes(modelInfo.tableInfo[tableName].module, listNode, batchInnerListLeaf); errObj.ErrCode != yparser.YP_SUCCESS {
-					cvlErrObj = createCVLErrObj(errObj)
+					cvlErrObj = createCVLErrObj(errObj, jsonNode)
 					CVL_LOG(WARNING, "Failed to create innner list leaf nodes, data = %v", batchInnerListLeaf)
 					return cvlErrObj
 				}
@@ -266,7 +266,7 @@ func (c *CVL) generateTableData(config bool, jsonNode *jsonquery.Node)(*yparser.
 			TRACE_LOG(TRACE_CACHE, "Starting batch leaf creation - %v\n", c.batchLeaf)
 			//process batch leaf creation
 			if errObj := c.yp.AddMultiLeafNodes(modelInfo.tableInfo[tableName].module, listNode, c.batchLeaf); errObj.ErrCode != yparser.YP_SUCCESS {
-				cvlErrObj = createCVLErrObj(errObj)
+				cvlErrObj = createCVLErrObj(errObj, jsonNode)
 				CVL_LOG(WARNING, "Failed to create leaf nodes, data = %v", c.batchLeaf)
 				return nil, cvlErrObj
 			}

--- a/cvl/internal/util/util.go
+++ b/cvl/internal/util/util.go
@@ -30,7 +30,7 @@ static void customLogCb(LY_LOG_LEVEL level, const char* msg, const char* path) {
 }
 
 static void ly_set_log_callback(int enable) {
-	ly_set_log_clb(customLogCb, 0);
+	ly_set_log_clb(customLogCb, 1);
 	if (enable == 1) {
 		ly_verb(LY_LLDBG);
 	} else {

--- a/cvl/internal/yparser/ly_path.go
+++ b/cvl/internal/yparser/ly_path.go
@@ -1,0 +1,132 @@
+////////////////////////////////////////////////////////////////////////////////
+//                                                                            //
+//  Copyright 2023 Broadcom. The term Broadcom refers to Broadcom Inc. and/or //
+//  its subsidiaries.                                                         //
+//                                                                            //
+//  Licensed under the Apache License, Version 2.0 (the "License");           //
+//  you may not use this file except in compliance with the License.          //
+//  You may obtain a copy of the License at                                   //
+//                                                                            //
+//     http://www.apache.org/licenses/LICENSE-2.0                             //
+//                                                                            //
+//  Unless required by applicable law or agreed to in writing, software       //
+//  distributed under the License is distributed on an "AS IS" BASIS,         //
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  //
+//  See the License for the specific language governing permissions and       //
+//  limitations under the License.                                            //
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+
+package yparser
+
+import (
+	"regexp"
+	"strings"
+)
+
+// parseLyPath parses a libyang formatted path; extracts table name, key components
+// and field name from it. Path should represent a sonic yang node. Path elements
+// are interpreted as follows:
+//
+//	/sonic-port:sonic-port/PORT/PORT_LIST[name='Ethernet0']/mtu
+//	                       ↑                    ↑           ↑
+//	                    table name          key comp     field name
+//
+// Special case :- single elem path is considered as field name.
+// Libyang does not report the full path when a leaf creation fails. So, 1 elem path
+// can either represent a top container or a leaf node. But it cannot be the former
+// due to our usage.
+func parseLyPath(p string) (table string, keys []string, field string) {
+	var elem []lyPathElem
+	for i := 0; i < len(p); {
+		pe, n := parseFirstElem(p[i:])
+		elem = append(elem, pe)
+		i += n
+	}
+	// elem[1] is the container representing table name
+	if len(elem) > 1 {
+		table = elem[1].name
+	}
+	// elem[2] is the list node, with optional key predicates
+	if len(elem) > 2 {
+		keys = elem[2].vals
+	}
+	// Last elem represents db field. Single elem path is also considered as db field!
+	if len(elem) == 1 || len(elem) > 3 {
+		field = elem[len(elem)-1].name
+	}
+	return
+}
+
+// parseFirstElem parses the first element from a libyang path.
+func parseFirstElem(p string) (elem lyPathElem, n int) {
+	i, size := 0, len(p)
+	if n < size && p[n] == '/' {
+		i, n = 1, 1 // skip the optional '/' prefix
+	}
+	for n < size && p[n] != '[' && p[n] != '/' {
+		n++ // locate next predicate or path sep, whichever comes first
+	}
+	// Collect the element name..
+	elem.name = p[i:n]
+	if k := strings.IndexByte(elem.name, ':'); k >= 0 {
+		elem.name = elem.name[k+1:]
+	}
+	// Parse each predicate section `[name='value']` and collect the values
+	for n < size && p[n] == '[' {
+		m := lyPredicatePattern.FindStringSubmatch(p[n:])
+		if len(m) != 3 {
+			elem.vals = nil
+			return elem, size // invalid path, skip everything
+		}
+		if v := m[2]; len(v) >= 2 { // remove surrounding quotes
+			elem.vals = append(elem.vals, v[1:len(v)-1])
+		}
+		n += len(m[0])
+	}
+	// Next char must be a path separator
+	if n < size && p[n] != '/' {
+		n = size // invalid path, skip everything
+	}
+	return
+}
+
+// lyPathElem represents a path element
+type lyPathElem struct {
+	name string   // element name
+	vals []string // key values
+}
+
+// lyPredicatePattern is the regex to match a libyang formatted predicate section.
+// Expects either `[name='value']` or `[name="value"]` syntax.
+// Match group 1 will be the name and group 2 will be the quoted value.
+// Libyang uses single quotes if the value does not contain any single quotes;
+// otherwise uses double quotes. But, libyang does not insert escape chars when
+// value contains both single and double quotes, resulting in a vague format.
+// Such predicates cannot be parsed.
+var lyPredicatePattern = regexp.MustCompile(`^\[([^=]*)=('[^']*'|"[^"]*")]`)
+
+// Regex patterns to extract target node name and value from libyang error message.
+// Example messages:
+// - Invalid value "9999999" in "vlanid" element
+// - Missing required element "vlanid" in "VLAN_LIST"
+// - Value "xyz" does not satisfy the constraint "Ethernet([1-3][0-9]{3}|[1-9][0-9]{2}|[1-9][0-9]|[0-9])" (range, length, or pattern)
+// - Leafref "/sonic-port:sonic-port/sonic-port:PORT/sonic-port:ifname" of value "Ethernet668" points to a non-existing leaf
+// - Failed to find "extra" as a sibling to "sonic-acl:aclname"
+var (
+	lyBadValue    = regexp.MustCompile(`[Vv]alue "([^"]*)" `)
+	lyElemPrefix  = regexp.MustCompile(`[Ee]lement "([^"]*)"`)
+	lyElemSuffix  = regexp.MustCompile(`"([^"]*)" element`)
+	lyUnknownElem = regexp.MustCompile(`Failed to find "([^"]*)" `)
+)
+
+// parseLyMessage matches a libyang returned log message using given
+// regex patterns and returns the first matched group.
+func parseLyMessage(s string, regex ...*regexp.Regexp) string {
+	for _, ex := range regex {
+		if m := ex.FindStringSubmatch(s); len(m) > 1 {
+			return m[1]
+		}
+	}
+	return ""
+}

--- a/cvl/testdata/schema/sonic-acl.yang
+++ b/cvl/testdata/schema/sonic-acl.yang
@@ -149,6 +149,7 @@ module sonic-acl {
 						enum IPV4;
 						enum IPV4ANY;
 						enum NON_IPV4;
+						enum IPV6;
 						enum IPV6ANY;
 						enum NON_IPV6;
 					}


### PR DESCRIPTION
Issue:
When cvl validation fails it returns a `CVLErrorInfo` object, which is supposed to indicate the errored table, key and field info with user defined error-message if any. But cvl is not filling all these details in most of the cases.

Example: creation of a ACL_RULE entry without the PACKET_ACTION field (which is mandatory) returns `CVLErrorInfo{TableName: "", ErrCode: 1003, CVLErrDetails: "Required Field is Missing", Keys: []string(nil), Value: "", Field: "", Msg: " with keys[] has field  with invalid value ", ConstraintErrMsg: "", ErrAppTag: ""}`. Error info does not indicate what actually failed.

Fix:
This PR fixes the cvl error reporting logic to return consistent error response when data validation fails. All syntax errors will have table, keys, and error message filled. A validation error will also include errored field name and value. ConstraintErrMsg and ErrAppTag are filled if the sonic yang node has error-message and error-app-tag values.

Now, the error object returned in the previous example would be: `CVLErrorInfo{TableName: "ACL_RULE", ErrCode: 1003, CVLErrDetails: "Required Field is Missing", Keys: []string{"ACL1", "RULE1"}, Value: "", Field: "PACKET_ACTION", Msg: "Field \"PACKET_ACTION\" has invalid value", ConstraintErrMsg: "", ErrAppTag: ""}`