### PR TITLE
Query Parameters Pruning API and Tests

### DIFF
--- a/translib/transformer/xfmr_interface.go
+++ b/translib/transformer/xfmr_interface.go
@@ -52,6 +52,7 @@ type XfmrParams struct {
 	pCascadeDelTbl       *[]string //used to populate list of tables needed cascade delete by subtree overloaded methods
 	yangDefValMap        map[string]map[string]db.Value
 	queryParams          QueryParams
+	pruneDone            *bool
 	invokeCRUSubtreeOnce *bool
 }
 

--- a/translib/transformer/xlate_prune.go
+++ b/translib/transformer/xlate_prune.go
@@ -1,0 +1,480 @@
+////////////////////////////////////////////////////////////////////////////////
+//                                                                            //
+//  Copyright 2021 Broadcom. The term Broadcom refers to Broadcom Inc. and/or //
+//  its subsidiaries.                                                         //
+//                                                                            //
+//  Licensed under the Apache License, Version 2.0 (the "License");           //
+//  you may not use this file except in compliance with the License.          //
+//  You may obtain a copy of the License at                                   //
+//                                                                            //
+//     http://www.apache.org/licenses/LICENSE-2.0                             //
+//                                                                            //
+//  Unless required by applicable law or agreed to in writing, software       //
+//  distributed under the License is distributed on an "AS IS" BASIS,         //
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  //
+//  See the License for the specific language governing permissions and       //
+//  limitations under the License.                                            //
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+
+package transformer
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/Azure/sonic-mgmt-common/translib/ocbinds"
+	log "github.com/golang/glog"
+	"github.com/kylelemons/godebug/pretty"
+	"github.com/openconfig/goyang/pkg/yang"
+	ygutil "github.com/openconfig/ygot/util"
+	"github.com/openconfig/ygot/ygot"
+	"github.com/openconfig/ygot/ytypes"
+)
+
+func getPruneObjNode(ygRoot *ygot.GoStruct, uri string, requestUri string,
+	queryParams *QueryParams) ([]reflect.Value, int, string, error) {
+
+	var err error
+	var curValList []reflect.Value
+
+	log.V(3).Infof("getPruneObjNode: URI %s, requestUri %s, queryParams %s",
+		uri, requestUri, queryParams)
+
+	xpath, _, _ := XfmrRemoveXPATHPredicates(uri)
+
+	// Split (predicate-less)xpath, requestUri, and uri into element arrays
+	xpathList := strings.Split(xpath, "/")
+	ruList := strings.Split(requestUri, "/")
+
+	// The fields are w.r.t the requestUri. Thus while indexing into
+	// QueryParams.fields array, need to adjust the curDepth by depthDiff
+	depthDiff := len(xpathList) - len(ruList)
+	pruneXpath := xpath
+
+	path, err := ygot.StringToPath(uri, ygot.StructuredPath,
+		ygot.StringSlicePath)
+	if err != nil {
+		log.Errorf("getPruneObjNode: StringToPath err: %s", err)
+		return curValList, depthDiff, pruneXpath, err
+	}
+
+	for _, p := range path.Elem {
+		pathSlice := strings.Split(p.Name, ":")
+		p.Name = pathSlice[len(pathSlice)-1]
+	}
+
+	ygSchema, err := ocbinds.GetSchema()
+	if err != nil {
+		log.Errorf("getPruneObjNode: GetSchema err: %s", err)
+		return curValList, depthDiff, pruneXpath, err
+	}
+	treeNodeList, err := ytypes.GetNode(ygSchema.RootSchema(),
+		*ygRoot, path, &ytypes.GetPartialKeyMatch{})
+	if err != nil {
+		log.Errorf("getPruneObjNode: GetNode err: %s", err)
+		return curValList, depthDiff, pruneXpath, err
+	}
+
+	curValList = make([]reflect.Value, len(treeNodeList))
+	for i, tn := range treeNodeList {
+		curValList[i] = reflect.ValueOf(tn.Data)
+	}
+
+	if log.V(5) {
+		log.Infof("getPruneObjNode: depthDiff: %d pruneXpath: %s err: %s returns:\n%s",
+			depthDiff, pruneXpath, err, pretty.Sprint(curValList))
+	}
+
+	return curValList, depthDiff, pruneXpath, err
+}
+
+// Prune the ygRoot after running a subtree transformer.
+// ygRoot: as returned from GET subtree callback (I/O)
+// qp: QueryParams structure that was passed to GET subtree callback (I)
+// uri: uri path/point where GET subtree callback was called during GET traversal. (I)
+// requestUri: uri with which the North Bound Client side request was made (I)
+func xfmrPruneQP(ygRoot *ygot.GoStruct, queryParams QueryParams, uri string,
+	requestUri string) error {
+
+	ts := time.Now()
+
+	pruneObjs, depthDiff, pruneXpath, err := getPruneObjNode(
+		ygRoot, uri, requestUri, &queryParams)
+
+	if err != nil {
+		log.Errorf("xfmrPruneQP: Couldn't get prune Obj: uri(\"%v\")"+
+			"requestUri(\"%v\") error(\"%v\").", uri, requestUri, err)
+		return err
+	}
+
+	for _, val := range pruneObjs {
+		if log.V(8) {
+			log.Infof("xfmrPruneQP: B4: pruneObj:\n%s",
+				pretty.Sprint(val.Interface()))
+		}
+
+		err = pruneYGObj(val, pruneXpath, &queryParams, 1, depthDiff, nil)
+		if err != nil {
+			break
+		}
+
+		if log.V(8) {
+			log.Infof("xfmrPruneQP: After: pruneObj:\n%s",
+				pretty.Sprint(val.Interface()))
+		}
+	}
+
+	tt := time.Since(ts)
+	GetPruneQPStats().add(tt, uri)
+	log.Infof("xfmrPruneQP: URI %v, requestUri %v, TimeTaken %s",
+		uri, requestUri, tt)
+	log.Infof("xfmrPruneQP: Totals: %s", GetPruneQPStats())
+
+	return err
+}
+
+// Prunes Ygot.GoStruct
+func pruneYGObj(val reflect.Value, xpath string, queryParams *QueryParams,
+	pruneDepth uint, depthDiff int, ctxt context.Context) error {
+
+	// isReqContextCancelled(ctxt) is in a different PR
+	if ctxt != nil {
+		log.Warningf("pruneYGObj: Replace with isReqContextCancelled()")
+		return nil
+	}
+
+	if (pruneDepth == 1) || log.V(4) {
+		log.Infof("pruneYGObj: Pruning: xpath %v, pruneDepth %d depthDiff %d",
+			xpath, pruneDepth, depthDiff)
+	}
+
+	if ygutil.IsValueNil(val) {
+		log.Infof("pruneYGObj: Bypassing nil node: %s, %v", xpath, val)
+		return nil
+	}
+
+	if !val.IsValid() {
+		log.Infof("pruneYGObj: Bypassing !Valid node:%s", xpath)
+		return nil
+	}
+
+	if !ygutil.IsValueStructPtr(val) {
+		log.V(3).Infof("pruneYGObj: Keeping leaf(y) node: %s type: %v val: %v",
+			xpath, val.Kind(), val)
+		return nil
+	}
+
+	fvals := val.Elem()
+	ftypes := fvals.Type()
+
+	// Filters each member(child node) of the struct.
+	for i := 0; i < fvals.NumField(); i++ {
+		ft := ftypes.Field(i)
+
+		if ygutil.IsYgotAnnotation(ft) {
+			continue
+		}
+
+		pname, ok := ft.Tag.Lookup("path")
+		if !ok {
+			continue
+		}
+
+		fv := fvals.Field(i)
+		if !fv.IsValid() || fv.IsZero() {
+			log.V(6).Infof("pruneYGObj: Skipping zero value node:",
+				xpath, "/", pname)
+			continue
+		}
+
+		// Root node is special. All children are modules.
+		if xpath == "" {
+			mname, ok := ft.Tag.Lookup("module")
+			if !ok {
+				continue
+			}
+			// For root, the first level xpath is module-name:path.
+			mcPath := "/" + mname + ":" + pname
+			err := pruneYGObj(fv, mcPath, queryParams, pruneDepth+1, depthDiff, ctxt)
+			if err != nil {
+				return err
+			}
+			continue
+		}
+
+		chldXpath := xpath + "/" + pname
+
+		if keep, keepSubtree := matchQueryParametersByXpath(chldXpath,
+			queryParams, pruneDepth, depthDiff); !keep || keepSubtree {
+
+			if !keep {
+				log.V(3).Infof("pruneYGObj: Removing node: %s type: %v",
+					chldXpath, fv.Kind())
+				fv.Set(reflect.Zero(fv.Type()))
+			}
+
+			if keepSubtree {
+				log.V(3).Infof("pruneYGObj: Keeping subtree: %s type: %v",
+					chldXpath, fv.Kind())
+			}
+
+			continue
+		}
+
+		switch fv.Kind() {
+		case reflect.Map:
+			// If the depth pruning causes inclusion of just the key,
+			// but not the values, then the resultant map element will be
+			// nil, and not even include the key in the attributes.
+			// Eg(.../subinterfaces/subinterface[name=0]/, but
+			//    no .../subinterfaces/subinterface[name=0]/name)
+			// To avoid this situation, check the depth at the Map level
+			// itself, and delete all the MapIndex entirely.
+			// Empty Containers/Lists are not allowed in any case.
+			var deleteMapElements bool
+			if queryParams.isDepthEnabled() &&
+				(pruneDepth+1 >= queryParams.curDepth) {
+				log.V(3).Infof("pruneYGObj: Trim chldXpath: %s pruneDepth: %d",
+					chldXpath, pruneDepth)
+				deleteMapElements = true
+			}
+			for _, k := range fv.MapKeys() {
+				if deleteMapElements {
+					fv.SetMapIndex(k, reflect.Value{})
+					continue
+				}
+				v := fv.MapIndex(k)
+				err := pruneYGObj(v, chldXpath, queryParams, pruneDepth+1, depthDiff, ctxt)
+				if err != nil {
+					return err
+				}
+			}
+		case reflect.Slice:
+			for i, fvLen := 0, fv.Len(); i < fvLen; i++ {
+				v := fv.Index(i)
+				err := pruneYGObj(v, chldXpath, queryParams, pruneDepth+1, depthDiff, ctxt)
+				if err != nil {
+					return err
+				}
+			}
+		case reflect.Ptr:
+			err := pruneYGObj(fv, chldXpath, queryParams, pruneDepth+1, depthDiff, ctxt)
+			if err != nil {
+				return err
+			}
+		default:
+			log.V(3).Infof("pruneYGObj: Keeping node: %s type: %v",
+				chldXpath, fv.Kind())
+		}
+	}
+
+	if (pruneDepth == 1) || log.V(4) {
+		log.Infof("pruneYGObj: Done Pruning: xpath %v", xpath)
+	}
+	return nil
+}
+
+// matchQueryParametersByXpath is operating under the simplyfying
+// assumptions of transformer QP implementation: The only simultaneous
+// combination of query parameters allowed is Depth, and Content.
+// Note: Content=all with Fields is also allowed (because there is no
+// filtering when Content=all)
+// Return: keep, keepSubtree
+//
+//	keep        : bool : keep the node, or prune it.
+//	keepSubtree : bool : keep the entire subtree, i.e. stop pruning
+//	                     on this xpath.
+func matchQueryParametersByXpath(xpath string, queryParams *QueryParams,
+	pruneDepth uint, depthDiff int) (bool, bool) {
+
+	log.V(6).Infof("matchQueryParametersByXpath: xpath %v, qP %v,"+
+		"pruneDepth %d, depthDiff %d",
+		xpath, queryParams, pruneDepth, depthDiff)
+
+	yangNode, ok := xYangSpecMap[xpath]
+	if ok && yangNode.yangType == YANG_MODULE {
+		log.V(6).Infof("matchQueryParametersByXpath: Module: xpath %v", xpath)
+		return true, false
+	}
+
+	yangEntry := getYangEntryForXPath(xpath)
+	if yangEntry == nil {
+
+		// If the Yang Specification is not found, we are in uncharted
+		// water. Best to stop pruning.
+		log.Warningf("matchQueryParametersByXpath: not found: %s", xpath)
+		return true, true
+	}
+
+	if queryParams.isDepthEnabled() &&
+		!matchDepth(yangNode, yangEntry, queryParams.curDepth, pruneDepth) {
+
+		return false, false
+	}
+
+	if queryParams.isContentEnabled() &&
+		!matchContent(yangNode, yangEntry, queryParams.content) {
+
+		return false, false
+	}
+
+	if queryParams.isFieldsEnabled() {
+		if keep, keepSubtree := matchFields(yangNode, yangEntry, queryParams.fields,
+			pruneDepth, depthDiff); !keep || keepSubtree {
+			return keep, keepSubtree
+		}
+	}
+
+	return true, false
+}
+
+func matchDepth(yangNode *yangXpathInfo, yangEntry *yang.Entry, depth uint,
+	pruneDepth uint) bool {
+
+	log.V(6).Infof("matchDepth: Name %v, depth %d, pruneDepth %d",
+		yangEntry.Name, depth, pruneDepth)
+
+	return pruneDepth < depth
+}
+
+func isStateEntry(yangEntry *yang.Entry) bool {
+
+	if yangEntry == nil {
+		return false
+	}
+
+	if yangEntry.ReadOnly() {
+		return true
+	}
+
+	// leaf is writable, therefore not STATE entry.
+	if yangEntry.IsLeaf() {
+		return false
+	}
+
+	// writable "config" container is CONFIG.
+	if yangEntry.IsContainer() && yangEntry.Name == "config" {
+		return false
+	}
+
+	// Non-Leaf writable node could be STATE entry.
+	return true
+}
+
+func isOperationalEntry(yangEntry *yang.Entry) bool {
+
+	if !isStateEntry(yangEntry) {
+		log.V(6).Infof("isOperationalEntry: OPERATIONAL: Omit CONFIG path:")
+		return false
+	}
+
+	// Non-leaf writable could be OPERATIONAL
+	if !yangEntry.IsLeaf() {
+		return true
+	}
+
+	// Corresponding config path exists: it is not an operational node.
+	cfgEntry := yangEntry.Find("../../config/" + yangEntry.Name)
+	if cfgEntry != nil && cfgEntry.IsLeaf() && !cfgEntry.ReadOnly() {
+		log.V(6).Infof("matchContent: OPERATIONAL: Omit non-operational STATE path:")
+		return false
+	}
+
+	return true
+}
+
+// matchContent based on ContentType/GNMI Get (type) filter
+// TBD: It may be possible to optimise similar to matchFields()
+//
+//	using keep, keepSubtree prune control returns.
+func matchContent(yangNode *yangXpathInfo, yangEntry *yang.Entry,
+	content ContentType) bool {
+
+	if (yangNode != nil) && yangNode.isKey {
+		log.V(3).Infof("matchContent: path %v, isKey %v", yangNode.fieldName,
+			yangNode.isKey)
+		return true
+	}
+
+	path := yangEntry.Path()
+	log.V(6).Infof("matchContent path %v content %v", path, content)
+
+	switch content {
+	case QUERY_CONTENT_CONFIG:
+		if yangEntry.ReadOnly() {
+			log.V(6).Infof("matchContent: CONFIG: Omit STATE path: %v", path)
+			return false
+		}
+	case QUERY_CONTENT_NONCONFIG:
+		if !isStateEntry(yangEntry) {
+			log.V(6).Infof("matchContent: STATE: Omit CONFIG path: %v", path)
+			return false
+		}
+	case QUERY_CONTENT_OPERATIONAL:
+		if !isOperationalEntry(yangEntry) {
+			log.V(6).Infof("matchContent: OPERATIONAL: Omit CONFIG/STATE path: %v",
+				path)
+			return false
+		}
+	}
+
+	return true
+}
+
+// matchFields is operating under the simplyfying assumptions of transformer QP
+// implementation: FIELDS having list(with or without key) is not supported
+// Return: keep, keepSubtree
+//
+//	keep        : bool : keep the node(true), or prune it(false).
+//	keepSubtree : bool : keep the entire subtree, i.e. stop pruning(true)
+func matchFields(yangNode *yangXpathInfo, yangEntry *yang.Entry, fields []string,
+	pruneDepth uint, depthDiff int) (bool, bool) {
+
+	log.V(6).Infof("matchFields: yangEntry.Name %v, fields %v, pruneDepth %d, depthDiff %d",
+		yangEntry.Name, fields, pruneDepth, depthDiff)
+
+	var keep, keepSubtree bool
+
+	// Adjust depth into fields.
+	depth := int(pruneDepth) + depthDiff - 1
+
+	if (yangNode != nil) && yangNode.isKey {
+		log.V(3).Infof("matchFields: Name %v key %v", yangNode.fieldName, true)
+		return true, true
+	}
+
+	log.V(6).Infof("matchFields: Name %v", yangEntry.Name)
+
+	for _, field := range fields {
+
+		log.V(8).Infof("matchFields: field %v", field)
+		fieldList := strings.Split(field, "/")
+		if len(fieldList) <= depth {
+			continue
+		}
+
+		if yangEntry.Name == fieldList[depth] {
+
+			keep = true
+			keepSubtree = (depth == (len(fieldList) - 1))
+
+			log.V(8).Infof("matchFields: Match %v keepSubtree %v",
+				yangEntry.Name, keepSubtree)
+
+			if keepSubtree {
+				// Our pruning task is done for this path
+				break
+			}
+
+			// Evaluate whether pruning has ended after looking at all fields
+		}
+	}
+
+	log.V(6).Infof("matchFields: Name %v keep %v keepSubtree %v",
+		yangEntry.Name, keep, keepSubtree)
+
+	return keep, keepSubtree
+}

--- a/translib/transformer/xlate_prune_acl_test.go
+++ b/translib/transformer/xlate_prune_acl_test.go
@@ -1,0 +1,330 @@
+////////////////////////////////////////////////////////////////////////////////
+//                                                                            //
+//  Copyright 2019 Broadcom. The term Broadcom refers to Broadcom Inc. and/or //
+//  its subsidiaries.                                                         //
+//                                                                            //
+//  Licensed under the Apache License, Version 2.0 (the "License");           //
+//  you may not use this file except in compliance with the License.          //
+//  You may obtain a copy of the License at                                   //
+//                                                                            //
+//     http://www.apache.org/licenses/LICENSE-2.0                             //
+//                                                                            //
+//  Unless required by applicable law or agreed to in writing, software       //
+//  distributed under the License is distributed on an "AS IS" BASIS,         //
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  //
+//  See the License for the specific language governing permissions and       //
+//  limitations under the License.                                            //
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+//go:build prune_xfmrtest
+// +build prune_xfmrtest
+
+package transformer
+
+import (
+	"reflect"
+
+	"github.com/Azure/sonic-mgmt-common/translib/ocbinds"
+)
+
+func init() {
+	xp_tests = append(xp_tests, acl_xp_tests...)
+}
+
+var acl_xp_tests = []xpTests{
+	{ // ACL Identity Test Case (i.e. no QP)
+		tid:        "ACL Identity",
+		uri:        "/openconfig-acl:acl/acl-sets",
+		requestUri: "/openconfig-acl:acl/acl-sets",
+		payload: []byte(`
+            {
+               "acl-sets" : {
+               "acl-set" : [
+                  {
+                     "name" : "MyACL3",
+                     "config" : {
+                        "name" : "MyACL3",
+                        "type" : "ACL_IPV4",
+                        "description" : "Description for MyACL3"
+                     },
+                     "state" : {
+                        "name" : "MyACL3",
+                        "type" : "ACL_IPV4",
+                        "description" : "Description for MyACL3"
+                     },
+                     "type" : "ACL_IPV4"
+                  }
+               ]
+               }
+            }`),
+		appRootType: reflect.TypeOf(ocbinds.OpenconfigAcl_Acl{}),
+		queryParams: QueryParams{
+			depthEnabled:  false,
+			curDepth:      1,
+			content:       QUERY_CONTENT_ALL,
+			fields:        []string{},
+			fieldsFillAll: false,
+		},
+		prunedPayload: []byte(`
+            {
+               "acl-sets" : {
+               "acl-set" : [
+                  {
+                     "name" : "MyACL3",
+                     "config" : {
+                        "name" : "MyACL3",
+                        "type" : "ACL_IPV4",
+                        "description" : "Description for MyACL3"
+                     },
+                     "state" : {
+                        "name" : "MyACL3",
+                        "type" : "ACL_IPV4",
+                        "description" : "Description for MyACL3"
+                     },
+                     "type" : "ACL_IPV4"
+                  }
+               ]
+               }
+            }`),
+	},
+	{ // ACL depth = 3
+		tid:        "ACL Depth",
+		uri:        "/openconfig-acl:acl/acl-sets",
+		requestUri: "/openconfig-acl:acl/acl-sets",
+		payload: []byte(`
+            {
+               "acl-sets" : {
+               "acl-set" : [
+                  {
+                     "name" : "MyACL3",
+                     "config" : {
+                        "name" : "MyACL3",
+                        "type" : "ACL_IPV4",
+                        "description" : "Description for MyACL3"
+                     },
+                     "state" : {
+                        "name" : "MyACL3",
+                        "type" : "ACL_IPV4",
+                        "description" : "Description for MyACL3"
+                     },
+                     "type" : "ACL_IPV4"
+                  }
+               ]
+               }
+            }`),
+		appRootType: reflect.TypeOf(ocbinds.OpenconfigAcl_Acl{}),
+		queryParams: QueryParams{
+			depthEnabled:  true,
+			curDepth:      3,
+			content:       QUERY_CONTENT_ALL,
+			fields:        []string{},
+			fieldsFillAll: false,
+		},
+		prunedPayload: []byte(`
+            {
+               "acl-sets" : {
+               "acl-set" : [
+                  {
+                     "name" : "MyACL3",
+                     "config" : {
+                     },
+                     "state" : {
+                     },
+                     "type" : "ACL_IPV4"
+                  }
+               ]
+               }
+            }`),
+	},
+	{ // ACL content = QUERY_CONTENT_CONFIG
+		tid:        "ACL Content Config",
+		uri:        "/openconfig-acl:acl/acl-sets",
+		requestUri: "/openconfig-acl:acl/acl-sets",
+		payload: []byte(`
+            {
+               "acl-sets" : {
+               "acl-set" : [
+                  {
+                     "name" : "MyACL3",
+                     "config" : {
+                        "name" : "MyACL3",
+                        "type" : "ACL_IPV4",
+                        "description" : "Description for MyACL3"
+                     },
+                     "state" : {
+                        "name" : "MyACL3",
+                        "type" : "ACL_IPV4",
+                        "description" : "Description for MyACL3"
+                     },
+                     "type" : "ACL_IPV4"
+                  }
+               ]
+               }
+            }`),
+		appRootType: reflect.TypeOf(ocbinds.OpenconfigAcl_Acl{}),
+		queryParams: QueryParams{
+			depthEnabled:  false,
+			curDepth:      1,
+			content:       QUERY_CONTENT_CONFIG,
+			fields:        []string{},
+			fieldsFillAll: false,
+		},
+		prunedPayload: []byte(`
+            {
+               "acl-sets" : {
+               "acl-set" : [
+                  {
+                     "name" : "MyACL3",
+                     "config" : {
+                        "name" : "MyACL3",
+                        "type" : "ACL_IPV4",
+                        "description" : "Description for MyACL3"
+                     },
+                     "type" : "ACL_IPV4"
+                  }
+               ]
+               }
+            }`),
+	},
+	{ // ACL content = QUERY_CONTENT_NONCONFIG
+		tid:        "ACL Content Nonconfig",
+		uri:        "/openconfig-acl:acl/acl-sets",
+		requestUri: "/openconfig-acl:acl/acl-sets",
+		payload: []byte(`
+            {
+               "acl-sets" : {
+               "acl-set" : [
+                  {
+                     "name" : "MyACL3",
+                     "config" : {
+                        "name" : "MyACL3",
+                        "type" : "ACL_IPV4",
+                        "description" : "Description for MyACL3"
+                     },
+                     "state" : {
+                        "name" : "MyACL3",
+                        "type" : "ACL_IPV4",
+                        "description" : "Description for MyACL3"
+                     },
+                     "type" : "ACL_IPV4"
+                  }
+               ]
+               }
+            }`),
+		appRootType: reflect.TypeOf(ocbinds.OpenconfigAcl_Acl{}),
+		queryParams: QueryParams{
+			depthEnabled:  false,
+			curDepth:      1,
+			content:       QUERY_CONTENT_NONCONFIG,
+			fields:        []string{},
+			fieldsFillAll: false,
+		},
+		prunedPayload: []byte(`
+            {
+               "acl-sets" : {
+               "acl-set" : [
+                  {
+                     "name" : "MyACL3",
+                     "state" : {
+                        "name" : "MyACL3",
+                        "type" : "ACL_IPV4",
+                        "description" : "Description for MyACL3"
+                     },
+                     "type" : "ACL_IPV4"
+                  }
+               ]
+               }
+            }`),
+	},
+	{ // ACL fields
+		tid:        "ACL Fields",
+		uri:        "/openconfig-acl:acl/acl-sets/acl-set[name=MyACL3][type=ACL_IPV4]",
+		requestUri: "/openconfig-acl:acl/acl-sets/acl-set[name=MyACL3][type=ACL_IPV4]",
+		payload: []byte(`
+            {
+               "openconfig-acl:acl-set" : [
+                  {
+                     "name" : "MyACL3",
+                     "config" : {
+                        "name" : "MyACL3",
+                        "type" : "ACL_IPV4",
+                        "description" : "Description for MyACL3"
+                     },
+                     "state" : {
+                        "name" : "MyACL3",
+                        "type" : "ACL_IPV4",
+                        "description" : "Description for MyACL3"
+                     },
+                     "type" : "ACL_IPV4"
+                  }
+               ]
+            }`),
+		appRootType: reflect.TypeOf(ocbinds.OpenconfigAcl_Acl{}),
+		queryParams: QueryParams{
+			depthEnabled:  false,
+			curDepth:      1,
+			content:       QUERY_CONTENT_ALL,
+			fields:        []string{"config/description", "name", "type"},
+			fieldsFillAll: false,
+		},
+		prunedPayload: []byte(`
+            {
+               "openconfig-acl:acl-set" : [
+                  {
+                     "name" : "MyACL3",
+                     "config" : {
+                        "description" : "Description for MyACL3"
+                     },
+                     "type" : "ACL_IPV4"
+                  }
+               ]
+            }`),
+	},
+	{ // ACL depth = 3, content = QUERY_CONTENT_CONFIG
+		tid:        "ACL Depth and content",
+		uri:        "/openconfig-acl:acl/acl-sets",
+		requestUri: "/openconfig-acl:acl/acl-sets",
+		payload: []byte(`
+            {
+               "acl-sets" : {
+               "acl-set" : [
+                  {
+                     "name" : "MyACL3",
+                     "config" : {
+                        "name" : "MyACL3",
+                        "type" : "ACL_IPV4",
+                        "description" : "Description for MyACL3"
+                     },
+                     "state" : {
+                        "name" : "MyACL3",
+                        "type" : "ACL_IPV4",
+                        "description" : "Description for MyACL3"
+                     },
+                     "type" : "ACL_IPV4"
+                  }
+               ]
+               }
+            }`),
+		appRootType: reflect.TypeOf(ocbinds.OpenconfigAcl_Acl{}),
+		queryParams: QueryParams{
+			depthEnabled:  true,
+			curDepth:      3,
+			content:       QUERY_CONTENT_CONFIG,
+			fields:        []string{},
+			fieldsFillAll: false,
+		},
+		prunedPayload: []byte(`
+            {
+               "acl-sets" : {
+               "acl-set" : [
+                  {
+                     "name" : "MyACL3",
+                     "config" : {
+                     },
+                     "type" : "ACL_IPV4"
+                  }
+               ]
+               }
+            }`),
+	},
+}

--- a/translib/transformer/xlate_prune_interfaces_test.go
+++ b/translib/transformer/xlate_prune_interfaces_test.go
@@ -1,0 +1,556 @@
+////////////////////////////////////////////////////////////////////////////////
+//                                                                            //
+//  Copyright 2019 Broadcom. The term Broadcom refers to Broadcom Inc. and/or //
+//  its subsidiaries.                                                         //
+//                                                                            //
+//  Licensed under the Apache License, Version 2.0 (the "License");           //
+//  you may not use this file except in compliance with the License.          //
+//  You may obtain a copy of the License at                                   //
+//                                                                            //
+//     http://www.apache.org/licenses/LICENSE-2.0                             //
+//                                                                            //
+//  Unless required by applicable law or agreed to in writing, software       //
+//  distributed under the License is distributed on an "AS IS" BASIS,         //
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  //
+//  See the License for the specific language governing permissions and       //
+//  limitations under the License.                                            //
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+//go:build interfaces_prune_xfmrtest
+// +build interfaces_prune_xfmrtest
+
+package transformer
+
+import (
+	"reflect"
+
+	"github.com/Azure/sonic-mgmt-common/translib/ocbinds"
+)
+
+func init() {
+	xp_tests = append(xp_tests, interfaces_xp_tests...)
+}
+
+var interfaces_xp_tests = []xpTests{
+	{ // Interface Identity Test Case (i.e. no QP)
+		tid:        "Interface Identity",
+		uri:        "/openconfig-interfaces:interfaces/interface[name=Ethernet0]",
+		requestUri: "/openconfig-interfaces:interfaces/interface[name=Ethernet0]",
+		payload: []byte(`
+            {
+               "openconfig-interfaces:interface" : [
+                  {
+                     "openconfig-if-ethernet:ethernet" : {
+                        "config" : {
+                           "port-speed" : "openconfig-if-ethernet:SPEED_100GB"
+                        }
+                     },
+                     "subinterfaces" : {
+                        "subinterface" : [
+                           {
+                              "openconfig-if-ip:ipv6" : {
+                                 "config" : {
+                                    "enabled" : false
+                                 },
+                                 "state" : {
+                                    "enabled" : false
+                                 }
+                              },
+                              "index" : 0,
+                              "config" : {
+                                 "index" : 0
+                              },
+                              "state" : {
+                                 "index" : 0
+                              }
+                           }
+                        ]
+                     },
+                     "name" : "Ethernet0",
+                     "config" : {
+                        "name" : "Ethernet0",
+                        "type" : "iana-if-type:ethernetCsmacd",
+                        "enabled" : true
+                     },
+                     "state" : {
+                        "oper-status" : "DOWN",
+                        "mac-address" : "50:6b:8d:16:6e:8b",
+                        "name" : "Ethernet0"
+                     }
+                  }
+               ]
+            }
+            `),
+		appRootType: reflect.TypeOf(ocbinds.OpenconfigInterfaces_Interfaces{}),
+		queryParams: QueryParams{
+			depthEnabled:  false,
+			curDepth:      1,
+			content:       QUERY_CONTENT_ALL,
+			fields:        []string{},
+			fieldsFillAll: false,
+		},
+		prunedPayload: []byte(`
+            {
+               "openconfig-interfaces:interface" : [
+                  {
+                     "openconfig-if-ethernet:ethernet" : {
+                        "config" : {
+                           "port-speed" : "openconfig-if-ethernet:SPEED_100GB"
+                        }
+                     },
+                     "subinterfaces" : {
+                        "subinterface" : [
+                           {
+                              "openconfig-if-ip:ipv6" : {
+                                 "config" : {
+                                    "enabled" : false
+                                 },
+                                 "state" : {
+                                    "enabled" : false
+                                 }
+                              },
+                              "index" : 0,
+                              "config" : {
+                                 "index" : 0
+                              },
+                              "state" : {
+                                 "index" : 0
+                              }
+                           }
+                        ]
+                     },
+                     "name" : "Ethernet0",
+                     "config" : {
+                        "name" : "Ethernet0",
+                        "type" : "iana-if-type:ethernetCsmacd",
+                        "enabled" : true
+                     },
+                     "state" : {
+                        "oper-status" : "DOWN",
+                        "mac-address" : "50:6b:8d:16:6e:8b",
+                        "name" : "Ethernet0"
+                     }
+                  }
+               ]
+            }
+            `),
+	},
+	{ // Interface depth = 3
+		tid:        "Interface Depth",
+		uri:        "/openconfig-interfaces:interfaces/interface[name=Ethernet0]",
+		requestUri: "/openconfig-interfaces:interfaces/interface[name=Ethernet0]",
+		payload: []byte(`
+            {
+               "openconfig-interfaces:interface" : [
+                  {
+                     "openconfig-if-ethernet:ethernet" : {
+                        "config" : {
+                           "port-speed" : "openconfig-if-ethernet:SPEED_100GB"
+                        }
+                     },
+                     "subinterfaces" : {
+                        "subinterface" : [
+                           {
+                              "openconfig-if-ip:ipv6" : {
+                                 "config" : {
+                                    "enabled" : false
+                                 },
+                                 "state" : {
+                                    "enabled" : false
+                                 }
+                              },
+                              "index" : 0,
+                              "config" : {
+                                 "index" : 0
+                              },
+                              "state" : {
+                                 "index" : 0
+                              }
+                           }
+                        ]
+                     },
+                     "name" : "Ethernet0",
+                     "config" : {
+                        "name" : "Ethernet0",
+                        "type" : "iana-if-type:ethernetCsmacd",
+                        "enabled" : true
+                     },
+                     "state" : {
+                        "oper-status" : "DOWN",
+                        "mac-address" : "50:6b:8d:16:6e:8b",
+                        "name" : "Ethernet0"
+                     }
+                  }
+               ]
+            }
+            `),
+		appRootType: reflect.TypeOf(ocbinds.OpenconfigInterfaces_Interfaces{}),
+		queryParams: QueryParams{
+			depthEnabled:  true,
+			curDepth:      3,
+			content:       QUERY_CONTENT_ALL,
+			fields:        []string{},
+			fieldsFillAll: false,
+		},
+		prunedPayload: []byte(`
+            {
+               "openconfig-interfaces:interface" : [
+                  {
+                     "openconfig-if-ethernet:ethernet" : {
+                        "config" : {
+                        }
+                     },
+                     "subinterfaces" : {
+                        "subinterface" : [
+                        ]
+                     },
+                     "name" : "Ethernet0",
+                     "config" : {
+                        "name" : "Ethernet0",
+                        "type" : "iana-if-type:ethernetCsmacd",
+                        "enabled" : true
+                     },
+                     "state" : {
+                        "oper-status" : "DOWN",
+                        "mac-address" : "50:6b:8d:16:6e:8b",
+                        "name" : "Ethernet0"
+                     }
+                  }
+               ]
+            }
+            `),
+	},
+	{ // Interface Content QUERY_CONTENT_CONFIG
+		tid:        "Interface Content Config",
+		uri:        "/openconfig-interfaces:interfaces/interface[name=Ethernet0]",
+		requestUri: "/openconfig-interfaces:interfaces/interface[name=Ethernet0]",
+		payload: []byte(`
+            {
+               "openconfig-interfaces:interface" : [
+                  {
+                     "openconfig-if-ethernet:ethernet" : {
+                        "config" : {
+                           "port-speed" : "openconfig-if-ethernet:SPEED_100GB"
+                        }
+                     },
+                     "subinterfaces" : {
+                        "subinterface" : [
+                           {
+                              "openconfig-if-ip:ipv6" : {
+                                 "config" : {
+                                    "enabled" : false
+                                 },
+                                 "state" : {
+                                    "enabled" : false
+                                 }
+                              },
+                              "index" : 0,
+                              "config" : {
+                                 "index" : 0
+                              },
+                              "state" : {
+                                 "index" : 0
+                              }
+                           }
+                        ]
+                     },
+                     "name" : "Ethernet0",
+                     "config" : {
+                        "name" : "Ethernet0",
+                        "type" : "iana-if-type:ethernetCsmacd",
+                        "enabled" : true
+                     },
+                     "state" : {
+                        "oper-status" : "DOWN",
+                        "mac-address" : "50:6b:8d:16:6e:8b",
+                        "name" : "Ethernet0"
+                     }
+                  }
+               ]
+            }
+            `),
+		appRootType: reflect.TypeOf(ocbinds.OpenconfigInterfaces_Interfaces{}),
+		queryParams: QueryParams{
+			depthEnabled:  false,
+			curDepth:      1,
+			content:       QUERY_CONTENT_CONFIG,
+			fields:        []string{},
+			fieldsFillAll: false,
+		},
+		prunedPayload: []byte(`
+            {
+               "openconfig-interfaces:interface" : [
+                  {
+                     "openconfig-if-ethernet:ethernet" : {
+                        "config" : {
+                           "port-speed" : "openconfig-if-ethernet:SPEED_100GB"
+                        }
+                     },
+                     "subinterfaces" : {
+                        "subinterface" : [
+                           {
+                              "openconfig-if-ip:ipv6" : {
+                                 "config" : {
+                                    "enabled" : false
+                                 }
+                              },
+                              "index" : 0,
+                              "config" : {
+                                 "index" : 0
+                              }
+                           }
+                        ]
+                     },
+                     "name" : "Ethernet0",
+                     "config" : {
+                        "name" : "Ethernet0",
+                        "type" : "iana-if-type:ethernetCsmacd",
+                        "enabled" : true
+                     }
+                  }
+               ]
+            }
+            `),
+	},
+	{ // Interface Content QUERY_CONTENT_NONCONFIG
+		tid:        "Interface Content Nonconfig",
+		uri:        "/openconfig-interfaces:interfaces/interface[name=Ethernet0]",
+		requestUri: "/openconfig-interfaces:interfaces/interface[name=Ethernet0]",
+		payload: []byte(`
+            {
+               "openconfig-interfaces:interface" : [
+                  {
+                     "openconfig-if-ethernet:ethernet" : {
+                        "config" : {
+                           "port-speed" : "openconfig-if-ethernet:SPEED_100GB"
+                        }
+                     },
+                     "subinterfaces" : {
+                        "subinterface" : [
+                           {
+                              "openconfig-if-ip:ipv6" : {
+                                 "config" : {
+                                    "enabled" : false
+                                 },
+                                 "state" : {
+                                    "enabled" : false
+                                 }
+                              },
+                              "index" : 0,
+                              "config" : {
+                                 "index" : 0
+                              },
+                              "state" : {
+                                 "index" : 0
+                              }
+                           }
+                        ]
+                     },
+                     "name" : "Ethernet0",
+                     "config" : {
+                        "name" : "Ethernet0",
+                        "type" : "iana-if-type:ethernetCsmacd",
+                        "enabled" : true
+                     },
+                     "state" : {
+                        "oper-status" : "DOWN",
+                        "mac-address" : "50:6b:8d:16:6e:8b",
+                        "name" : "Ethernet0"
+                     }
+                  }
+               ]
+            }
+            `),
+		appRootType: reflect.TypeOf(ocbinds.OpenconfigInterfaces_Interfaces{}),
+		queryParams: QueryParams{
+			depthEnabled:  false,
+			curDepth:      1,
+			content:       QUERY_CONTENT_NONCONFIG,
+			fields:        []string{},
+			fieldsFillAll: false,
+		},
+		prunedPayload: []byte(`
+            {
+               "openconfig-interfaces:interface" : [
+                  {
+                     "openconfig-if-ethernet:ethernet" : {
+                     },
+                     "subinterfaces" : {
+                        "subinterface" : [
+                           {
+                              "openconfig-if-ip:ipv6" : {
+                                 "state" : {
+                                    "enabled" : false
+                                 }
+                              },
+                              "index" : 0,
+                              "state" : {
+                                 "index" : 0
+                              }
+                           }
+                        ]
+                     },
+                     "name" : "Ethernet0",
+                     "state" : {
+                        "oper-status" : "DOWN",
+                        "mac-address" : "50:6b:8d:16:6e:8b",
+                        "name" : "Ethernet0"
+                     }
+                  }
+               ]
+            }
+            `),
+	},
+	{ // Interface fields
+		tid:        "Interface fields",
+		uri:        "/openconfig-interfaces:interfaces/interface[name=Ethernet0]",
+		requestUri: "/openconfig-interfaces:interfaces/interface[name=Ethernet0]",
+		payload: []byte(`
+            {
+               "openconfig-interfaces:interface" : [
+                  {
+                     "openconfig-if-ethernet:ethernet" : {
+                        "config" : {
+                           "port-speed" : "openconfig-if-ethernet:SPEED_100GB"
+                        }
+                     },
+                     "subinterfaces" : {
+                        "subinterface" : [
+                           {
+                              "openconfig-if-ip:ipv6" : {
+                                 "config" : {
+                                    "enabled" : false
+                                 },
+                                 "state" : {
+                                    "enabled" : false
+                                 }
+                              },
+                              "index" : 0,
+                              "config" : {
+                                 "index" : 0
+                              },
+                              "state" : {
+                                 "index" : 0
+                              }
+                           }
+                        ]
+                     },
+                     "name" : "Ethernet0",
+                     "config" : {
+                        "name" : "Ethernet0",
+                        "type" : "iana-if-type:ethernetCsmacd",
+                        "enabled" : true
+                     },
+                     "state" : {
+                        "oper-status" : "DOWN",
+                        "mac-address" : "50:6b:8d:16:6e:8b",
+                        "name" : "Ethernet0"
+                     }
+                  }
+               ]
+            }
+            `),
+		appRootType: reflect.TypeOf(ocbinds.OpenconfigInterfaces_Interfaces{}),
+		queryParams: QueryParams{
+			depthEnabled:  false,
+			curDepth:      1,
+			content:       QUERY_CONTENT_ALL,
+			fields:        []string{"ethernet/config/port-speed", "name"},
+			fieldsFillAll: false,
+		},
+		prunedPayload: []byte(`
+            {
+               "openconfig-interfaces:interface" : [
+                  {
+                     "openconfig-if-ethernet:ethernet" : {
+                        "config" : {
+                           "port-speed" : "openconfig-if-ethernet:SPEED_100GB"
+                        }
+                     },
+                     "name" : "Ethernet0"
+                  }
+               ]
+            }
+            `),
+	},
+	{ // Interface depth = 3, content = CONFIG
+		tid:        "Interface Depth and Content",
+		uri:        "/openconfig-interfaces:interfaces/interface[name=Ethernet0]",
+		requestUri: "/openconfig-interfaces:interfaces/interface[name=Ethernet0]",
+		payload: []byte(`
+            {
+               "openconfig-interfaces:interface" : [
+                  {
+                     "openconfig-if-ethernet:ethernet" : {
+                        "config" : {
+                           "port-speed" : "openconfig-if-ethernet:SPEED_100GB"
+                        }
+                     },
+                     "subinterfaces" : {
+                        "subinterface" : [
+                           {
+                              "openconfig-if-ip:ipv6" : {
+                                 "config" : {
+                                    "enabled" : false
+                                 },
+                                 "state" : {
+                                    "enabled" : false
+                                 }
+                              },
+                              "index" : 0,
+                              "config" : {
+                                 "index" : 0
+                              },
+                              "state" : {
+                                 "index" : 0
+                              }
+                           }
+                        ]
+                     },
+                     "name" : "Ethernet0",
+                     "config" : {
+                        "name" : "Ethernet0",
+                        "type" : "iana-if-type:ethernetCsmacd",
+                        "enabled" : true
+                     },
+                     "state" : {
+                        "oper-status" : "DOWN",
+                        "mac-address" : "50:6b:8d:16:6e:8b",
+                        "name" : "Ethernet0"
+                     }
+                  }
+               ]
+            }
+            `),
+		appRootType: reflect.TypeOf(ocbinds.OpenconfigInterfaces_Interfaces{}),
+		queryParams: QueryParams{
+			depthEnabled:  true,
+			curDepth:      3,
+			content:       QUERY_CONTENT_CONFIG,
+			fields:        []string{},
+			fieldsFillAll: false,
+		},
+		prunedPayload: []byte(`
+            {
+               "openconfig-interfaces:interface" : [
+                  {
+                     "openconfig-if-ethernet:ethernet" : {
+                        "config" : {
+                        }
+                     },
+                     "subinterfaces" : {
+                        "subinterface" : [
+                        ]
+                     },
+                     "name" : "Ethernet0",
+                     "config" : {
+                        "name" : "Ethernet0",
+                        "type" : "iana-if-type:ethernetCsmacd",
+                        "enabled" : true
+                     }
+                  }
+               ]
+            }
+            `),
+	},
+}

--- a/translib/transformer/xlate_prune_ospf_test.go
+++ b/translib/transformer/xlate_prune_ospf_test.go
@@ -1,0 +1,7273 @@
+////////////////////////////////////////////////////////////////////////////////
+//                                                                            //
+//  Copyright 2019 Broadcom. The term Broadcom refers to Broadcom Inc. and/or //
+//  its subsidiaries.                                                         //
+//                                                                            //
+//  Licensed under the Apache License, Version 2.0 (the "License");           //
+//  you may not use this file except in compliance with the License.          //
+//  You may obtain a copy of the License at                                   //
+//                                                                            //
+//     http://www.apache.org/licenses/LICENSE-2.0                             //
+//                                                                            //
+//  Unless required by applicable law or agreed to in writing, software       //
+//  distributed under the License is distributed on an "AS IS" BASIS,         //
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  //
+//  See the License for the specific language governing permissions and       //
+//  limitations under the License.                                            //
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+//go:build ospf_prune_xfmrtest
+// +build ospf_prune_xfmrtest
+
+package transformer
+
+import (
+	"reflect"
+
+	"github.com/Azure/sonic-mgmt-common/translib/ocbinds"
+)
+
+func init() {
+	xp_tests = append(xp_tests, ni_ospf_tests...)
+}
+
+var ni_ospf_tests = []xpTests{
+	{ // OSPF Identity Test Case (i.e. no QP)
+		tid:        "OSPF Identity uri == requestUri",
+		uri:        "/openconfig-network-instance:network-instances/network-instance[name=default]/protocols/protocol[identifier=OSPF][name=ospfv2]",
+		requestUri: "/openconfig-network-instance:network-instances/network-instance[name=default]/protocols/protocol[identifier=OSPF][name=ospfv2]",
+		payload: []byte(`
+{
+   "protocol" : [
+      {
+         "identifier" : "openconfig-policy-types:OSPF",
+         "ospfv2" : {
+            "openconfig-ospfv2-ext:route-tables" : {
+               "route-table" : [
+                  {
+                     "routes" : {
+                        "route" : [
+                           {
+                              "next-hops" : {
+                                 "next-hop" : [
+                                    {
+                                       "area-id" : "0.0.0.0",
+                                       "address" : "32.1.0.1",
+                                       "state" : {
+                                          "area-id" : "0.0.0.0",
+                                          "address" : "32.1.0.1",
+                                          "out-interface" : "Vlan3719"
+                                       },
+                                       "out-interface" : "Vlan3719"
+                                    }
+                                 ]
+                              },
+                              "state" : {
+                                 "cost" : 4,
+                                 "sub-type" : "openconfig-ospfv2-ext:EXTERNAL_ROUTE_TYPE_2",
+                                 "type" : "openconfig-ospfv2-ext:EXTERNAL_ROUTE",
+                                 "prefix" : "10.193.80.0/20"
+                              },
+                              "prefix" : "10.193.80.0/20"
+                           }
+                        ]
+                     },
+                     "type" : "openconfig-ospfv2-ext:EXTERNAL_ROUTE_TABLE",
+                     "state" : {
+                        "type" : "openconfig-ospfv2-ext:EXTERNAL_ROUTE_TABLE"
+                     }
+                  },
+                  {
+                     "routes" : {
+                        "route" : [
+                           {
+                              "next-hops" : {
+                                 "next-hop" : [
+                                    {
+                                       "area-id" : "0.0.0.0",
+                                       "address" : "32.1.0.1",
+                                       "state" : {
+                                          "area-id" : "0.0.0.0",
+                                          "address" : "32.1.0.1",
+                                          "out-interface" : "Vlan3719"
+                                       },
+                                       "out-interface" : "Vlan3719"
+                                    }
+                                 ]
+                              },
+                              "state" : {
+                                 "cost" : 14,
+                                 "type" : "openconfig-ospfv2-ext:NETWORK_ROUTE",
+                                 "inter-area" : true,
+                                 "prefix" : "10.193.80.0/20"
+                              },
+                              "prefix" : "21.1.0.0/24"
+                           },
+                           {
+                              "next-hops" : {
+                                 "next-hop" : [
+                                    {
+                                       "area-id" : "0.0.0.0",
+                                       "address" : "0.0.0.0",
+                                       "state" : {
+                                          "area-id" : "0.0.0.0",
+                                          "address" : "32.1.0.1",
+                                          "out-interface" : "Vlan3719"
+                                       },
+                                       "out-interface" : "Vlan3719"
+                                    }
+                                 ]
+                              },
+                              "state" : {
+                                 "cost" : 4,
+                                 "type" : "openconfig-ospfv2-ext:NETWORK_ROUTE",
+                                 "prefix" : "10.193.80.0/20"
+                              },
+                              "prefix" : "32.1.0.0/24"
+                           },
+                           {
+                              "next-hops" : {
+                                 "next-hop" : [
+                                    {
+                                       "area-id" : "0.0.0.2",
+                                       "address" : "0.0.0.0",
+                                       "state" : {
+                                          "area-id" : "0.0.0.0",
+                                          "address" : "32.1.0.1",
+                                          "out-interface" : "Vlan3719"
+                                       },
+                                       "out-interface" : "Ethernet120"
+                                    }
+                                 ]
+                              },
+                              "state" : {
+                                 "cost" : 10,
+                                 "type" : "openconfig-ospfv2-ext:NETWORK_ROUTE",
+                                 "prefix" : "10.193.80.0/20"
+                              },
+                              "prefix" : "41.1.0.0/24"
+                           }
+                        ]
+                     },
+                     "type" : "openconfig-ospfv2-ext:NETWORK_ROUTE_TABLE",
+                     "state" : {
+                        "type" : "openconfig-ospfv2-ext:NETWORK_ROUTE_TABLE"
+                     }
+                  },
+                  {
+                     "routes" : {
+                        "route" : [
+                           {
+                              "next-hops" : {
+                                 "next-hop" : [
+                                    {
+                                       "area-id" : "0.0.0.0",
+                                       "address" : "32.1.0.1",
+                                       "state" : {
+                                          "area-id" : "0.0.0.0",
+                                          "address" : "32.1.0.1",
+                                          "out-interface" : "Vlan3719"
+                                       },
+                                       "out-interface" : "Vlan3719"
+                                    }
+                                 ]
+                              },
+                              "state" : {
+                                 "router-type" : "openconfig-ospfv2-ext:ABRASBR",
+                                 "cost" : 4,
+                                 "type" : "openconfig-ospfv2-ext:ROUTER_ROUTE",
+                                 "prefix" : "10.193.80.0/20"
+                              },
+                              "prefix" : "6.6.6.5"
+                           }
+                        ]
+                     },
+                     "type" : "openconfig-ospfv2-ext:ROUTER_ROUTE_TABLE",
+                     "state" : {
+                        "type" : "openconfig-ospfv2-ext:ROUTER_ROUTE_TABLE"
+                     }
+                  }
+               ]
+            },
+            "global" : {
+               "graceful-restart" : {
+                  "openconfig-ospfv2-ext:helpers" : {
+                     "helper" : [
+                        {
+                           "neighbour-id" : "5.5.5.4",
+                           "config" : {
+                              "vrf-name" : "default",
+                              "neighbour-id" : "5.5.5.4"
+                           },
+                           "state" : {
+                              "neighbour-id" : "5.5.5.4"
+                           }
+                        }
+                     ]
+                  },
+                  "config" : {
+                     "openconfig-ospfv2-ext:planned-only" : true,
+                     "helper-only" : true,
+                     "openconfig-ospfv2-ext:supported-grace-time" : 800,
+                     "openconfig-ospfv2-ext:strict-lsa-checking" : true
+                  },
+                  "state" : {
+                     "openconfig-ospfv2-ext:planned-only" : true,
+                     "helper-only" : true,
+                     "openconfig-ospfv2-ext:grace-period" : 0,
+                     "openconfig-ospfv2-ext:supported-grace-time" : 800,
+                     "openconfig-ospfv2-ext:strict-lsa-checking" : true
+                  }
+               },
+               "inter-area-propagation-policies" : {
+                  "openconfig-ospfv2-ext:inter-area-policy" : [
+                     {
+                        "config" : {
+                           "src-area" : "0.0.0.0"
+                        },
+                        "src-area" : "0.0.0.0",
+                        "state" : {
+                           "src-area" : "0.0.0.0"
+                        }
+                     },
+                     {
+                        "config" : {
+                           "src-area" : "0.0.0.2"
+                        },
+                        "src-area" : "0.0.0.2",
+                        "state" : {
+                           "src-area" : "0.0.0.2"
+                        }
+                     }
+                  ]
+               },
+               "config" : {
+                  "router-id" : "5.5.5.4",
+                  "openconfig-ospfv2-ext:opaque-lsa-capability" : true,
+                  "openconfig-ospfv2-ext:description" : "OSPFv2 Router",
+                  "openconfig-ospfv2-ext:enable" : true
+               },
+               "timers" : {
+                  "lsa-generation" : {
+                     "state" : {
+                        "openconfig-ospfv2-ext:refresh-timer" : 10000,
+                        "openconfig-ospfv2-ext:lsa-min-interval-timer" : 5000,
+                        "openconfig-ospfv2-ext:lsa-min-arrival-timer" : 1000
+                     }
+                  },
+                  "spf" : {
+                     "state" : {
+                        "maximum-delay" : 5000,
+                        "initial-delay" : 50,
+                        "openconfig-ospfv2-ext:throttle-delay" : 0,
+                        "openconfig-ospfv2-ext:spf-timer-due" : 0
+                     }
+                  }
+               },
+               "state" : {
+                  "openconfig-ospfv2-ext:area-count" : 2,
+                  "openconfig-ospfv2-ext:last-spf-duration" : 358,
+                  "openconfig-ospfv2-ext:hold-time-multiplier" : 1,
+                  "openconfig-ospfv2-ext:last-spf-execution-time" : "1187616",
+                  "openconfig-ospfv2-ext:opaque-lsa-count" : 0,
+                  "router-id" : "5.5.5.4",
+                  "openconfig-ospfv2-ext:abr-type" : "openconfig-ospfv2-ext:CISCO",
+                  "openconfig-ospfv2-ext:external-lsa-checksum" : "0x00016bcc",
+                  "openconfig-ospfv2-ext:opaque-lsa-checksum" : "0x00000000",
+                  "openconfig-ospfv2-ext:write-multiplier" : 20,
+                  "openconfig-ospfv2-ext:opaque-lsa-capability" : true,
+                  "openconfig-ospfv2-ext:external-lsa-count" : 2
+               }
+            },
+            "areas" : {
+               "area" : [
+                  {
+                     "lsdb" : {
+                        "lsa-types" : {
+                           "lsa-type" : [
+                              {
+                                 "type" : "openconfig-ospf-types:AS_EXTERNAL_LSA",
+                                 "state" : {
+                                    "type" : "openconfig-ospf-types:AS_EXTERNAL_LSA"
+                                 },
+                                 "lsas" : {
+                                    "openconfig-ospfv2-ext:lsa-ext" : [
+                                       {
+                                          "advertising-router" : "5.5.5.4",
+                                          "as-external-lsa" : {
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "forwarding-address" : "0.0.0.0",
+                                                         "external-route-tag" : 0,
+                                                         "metric" : 20
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "metric-type" : "TYPE_2",
+                                                "mask" : 20
+                                             }
+                                          },
+                                          "link-state-id" : "10.193.80.0",
+                                          "state" : {
+                                             "checksum" : 50393,
+                                             "length" : 36,
+                                             "flags" : 11,
+                                             "display-sequence-number" : "80000001",
+                                             "option" : 2,
+                                             "option-expanded" : "*||||||E|",
+                                             "age" : 1227
+                                          }
+                                       },
+                                       {
+                                          "advertising-router" : "6.6.6.5",
+                                          "as-external-lsa" : {
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "forwarding-address" : "0.0.0.0",
+                                                         "external-route-tag" : 0,
+                                                         "metric" : 20
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "metric-type" : "TYPE_2",
+                                                "mask" : 20
+                                             }
+                                          },
+                                          "link-state-id" : "10.193.80.0",
+                                          "state" : {
+                                             "checksum" : 42739,
+                                             "length" : 36,
+                                             "flags" : 6,
+                                             "display-sequence-number" : "80000001",
+                                             "option" : 2,
+                                             "option-expanded" : "*||||||E|",
+                                             "age" : 1228
+                                          }
+                                       }
+                                    ]
+                                 }
+                              },
+                              {
+                                 "type" : "openconfig-ospf-types:NETWORK_LSA",
+                                 "state" : {
+                                    "type" : "openconfig-ospf-types:NETWORK_LSA"
+                                 },
+                                 "lsas" : {
+                                    "openconfig-ospfv2-ext:lsa-ext" : [
+                                       {
+                                          "advertising-router" : "6.6.6.5",
+                                          "link-state-id" : "32.1.0.1",
+                                          "state" : {
+                                             "checksum" : 51756,
+                                             "length" : 32,
+                                             "flags" : 6,
+                                             "display-sequence-number" : "80000001",
+                                             "option" : 2,
+                                             "option-expanded" : "*|-|-|-|-|-|E|-",
+                                             "age" : 1198
+                                          },
+                                          "network-lsa" : {
+                                             "state" : {
+                                                "network-mask" : 24
+                                             }
+                                          }
+                                       }
+                                    ]
+                                 }
+                              },
+                              {
+                                 "type" : "openconfig-ospf-types:OSPFV2_LINK_SCOPE_OPAQUE_LSA"
+                              },
+                              {
+                                 "type" : "openconfig-ospf-types:ROUTER_LSA",
+                                 "state" : {
+                                    "type" : "openconfig-ospf-types:ROUTER_LSA"
+                                 },
+                                 "lsas" : {
+                                    "openconfig-ospfv2-ext:lsa-ext" : [
+                                       {
+                                          "advertising-router" : "5.5.5.4",
+                                          "link-state-id" : "5.5.5.4",
+                                          "state" : {
+                                             "checksum" : 5321,
+                                             "length" : 36,
+                                             "flags" : 3,
+                                             "display-sequence-number" : "80000005",
+                                             "option" : 2,
+                                             "option-expanded" : "*||||||E|",
+                                             "age" : 1197
+                                          },
+                                          "router-lsa" : {
+                                             "link-informations" : {
+                                                "link-information" : [
+                                                   {
+                                                      "state" : {
+                                                         "metric" : 4,
+                                                         "type" : "openconfig-ospf-types:ROUTER_LSA_TRANSIT_NETWORK",
+                                                         "number-tos-metrics" : 0
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "metric" : 4
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "flags-description" : " : ABR ASBR",
+                                                "flags" : 3,
+                                                "number-links" : 1
+                                             }
+                                          }
+                                       },
+                                       {
+                                          "advertising-router" : "6.6.6.5",
+                                          "link-state-id" : "6.6.6.5",
+                                          "state" : {
+                                             "checksum" : 47900,
+                                             "length" : 36,
+                                             "flags" : 6,
+                                             "display-sequence-number" : "80000004",
+                                             "option" : 2,
+                                             "option-expanded" : "*||||||E|",
+                                             "age" : 1197
+                                          },
+                                          "router-lsa" : {
+                                             "link-informations" : {
+                                                "link-information" : [
+                                                   {
+                                                      "state" : {
+                                                         "metric" : 4,
+                                                         "type" : "openconfig-ospf-types:ROUTER_LSA_TRANSIT_NETWORK",
+                                                         "number-tos-metrics" : 0
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "metric" : 4
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "flags-description" : " : ABR ASBR",
+                                                "flags" : 3,
+                                                "number-links" : 1
+                                             }
+                                          }
+                                       }
+                                    ]
+                                 }
+                              },
+                              {
+                                 "type" : "openconfig-ospf-types:SUMMARY_ASBR_LSA",
+                                 "state" : {
+                                    "type" : "openconfig-ospf-types:SUMMARY_ASBR_LSA"
+                                 }
+                              },
+                              {
+                                 "type" : "openconfig-ospf-types:SUMMARY_IP_NETWORK_LSA",
+                                 "state" : {
+                                    "type" : "openconfig-ospf-types:SUMMARY_IP_NETWORK_LSA"
+                                 },
+                                 "lsas" : {
+                                    "openconfig-ospfv2-ext:lsa-ext" : [
+                                       {
+                                          "advertising-router" : "6.6.6.5",
+                                          "link-state-id" : "21.1.0.0",
+                                          "summary-lsa" : {
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "metric" : 10
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "network-mask" : 24
+                                             }
+                                          },
+                                          "state" : {
+                                             "checksum" : 803,
+                                             "length" : 28,
+                                             "flags" : 6,
+                                             "display-sequence-number" : "80000001",
+                                             "option" : 2,
+                                             "option-expanded" : "*|-|-|-|-|-|E|-",
+                                             "age" : 1228
+                                          }
+                                       },
+                                       {
+                                          "advertising-router" : "5.5.5.4",
+                                          "link-state-id" : "41.1.0.0",
+                                          "summary-lsa" : {
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "metric" : 10
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "network-mask" : 24
+                                             }
+                                          },
+                                          "state" : {
+                                             "checksum" : 7417,
+                                             "length" : 28,
+                                             "flags" : 11,
+                                             "display-sequence-number" : "80000001",
+                                             "option" : 2,
+                                             "option-expanded" : "*|-|-|-|-|-|E|-",
+                                             "age" : 1227
+                                          }
+                                       }
+                                    ]
+                                 }
+                              }
+                           ]
+                        },
+                        "state" : {
+                           "identifier" : "0.0.0.0"
+                        }
+                     },
+                     "identifier" : "0.0.0.0",
+                     "interfaces" : {
+                        "interface" : [
+                           {
+                              "openconfig-ospfv2-ext:message-statistics" : {
+                                 "state" : {
+                                    "ls-update-transmit" : 4,
+                                    "ls-request-receive" : 1,
+                                    "ls-acknowledge-receive" : 2,
+                                    "ls-acknowledge-transmit" : 2,
+                                    "db-description-transmit" : 3,
+                                    "db-description-receive" : 2,
+                                    "hello-transmit" : 124,
+                                    "hello-receive" : 124,
+                                    "ls-request-transmit" : 1,
+                                    "ls-update-receive" : 3
+                                 }
+                              },
+                              "openconfig-ospfv2-ext:neighbours" : {
+                                 "neighbour" : [
+                                    {
+                                       "neighbor-id" : "6.6.6.5",
+                                       "neighbor-address" : "32.1.0.1",
+                                       "state" : {
+                                          "priority" : 1,
+                                          "option-value" : 66,
+                                          "gr-helper-status" : "None",
+                                          "state-changes" : 6,
+                                          "backup-designated-router" : "32.1.0.2",
+                                          "adjacency-state" : "openconfig-ospf-types:FULL",
+                                          "neighbor-id" : "6.6.6.5",
+                                          "optional-capabilities" : "*|O|-|-|-|-|E|-",
+                                          "thread-inactivity-timer" : true,
+                                          "thread-ls-request-retransmission" : true,
+                                          "thread-ls-update-retransmission" : true,
+                                          "retransmit-summary-queue-length" : 0,
+                                          "area-id" : "0.0.0.0",
+                                          "gr-active-helper" : false,
+                                          "interface-address" : "32.1.0.2",
+                                          "neighbor-address" : "32.1.0.1",
+                                          "last-established-time" : "1197595",
+                                          "designated-router" : "32.1.0.1",
+                                          "database-summary-queue-length" : 0,
+                                          "interface-name" : "Vlan3719",
+                                          "link-state-request-queue-length" : 0,
+                                          "dead-time" : "32410"
+                                       }
+                                    }
+                                 ]
+                              },
+                              "id" : "Vlan3719",
+                              "timers" : {
+                                 "state" : {
+                                    "retransmission-interval" : 5,
+                                    "dead-interval" : 40,
+                                    "openconfig-ospfv2-ext:wait-time" : 40,
+                                    "hello-interval" : 10000,
+                                    "openconfig-ospfv2-ext:hello-due" : 2409
+                                 }
+                              },
+                              "state" : {
+                                 "priority" : 1,
+                                 "openconfig-ospfv2-ext:member-of-ospf-all-routers" : true,
+                                 "openconfig-ospfv2-ext:index" : 310,
+                                 "openconfig-ospfv2-ext:mtu" : 9100,
+                                 "openconfig-ospfv2-ext:if-flags" : "<UP,BROADCAST,RUNNING,MULTICAST>",
+                                 "openconfig-ospfv2-ext:adjacency-count" : 1,
+                                 "openconfig-ospfv2-ext:address-len" : 24,
+                                 "openconfig-ospfv2-ext:ospf-enable" : true,
+                                 "openconfig-ospfv2-ext:cost" : 4,
+                                 "openconfig-ospfv2-ext:address" : "32.1.0.2",
+                                 "id" : "Vlan3719",
+                                 "openconfig-ospfv2-ext:adjacency-status" : "Backup",
+                                 "openconfig-ospfv2-ext:neighbor-count" : 1,
+                                 "openconfig-ospfv2-ext:backup-designated-router-id" : "5.5.5.4",
+                                 "openconfig-ospfv2-ext:member-of-ospf-designated-routers" : true,
+                                 "openconfig-ospfv2-ext:router-id" : "5.5.5.4",
+                                 "openconfig-ospfv2-ext:broadcast-address" : "32.1.0.255",
+                                 "openconfig-ospfv2-ext:bandwidth" : 25000,
+                                 "openconfig-ospfv2-ext:area-id" : "0.0.0.0",
+                                 "openconfig-ospfv2-ext:ospf-interface-type" : "Broadcast",
+                                 "openconfig-ospfv2-ext:backup-designated-router-address" : "32.1.0.2",
+                                 "network-type" : "openconfig-ospf-types:BROADCAST_NETWORK",
+                                 "openconfig-ospfv2-ext:transmit-delay" : 1,
+                                 "openconfig-ospfv2-ext:operational-state" : "Up"
+                              }
+                           }
+                        ]
+                     },
+                     "config" : {
+                        "identifier" : "0.0.0.0"
+                     },
+                     "openconfig-ospfv2-ext:networks" : {
+                        "network" : [
+                           {
+                              "address-prefix" : "31.1.0.0/24",
+                              "config" : {
+                                 "address-prefix" : "31.1.0.0/24",
+                                 "description" : "Network prefix"
+                              },
+                              "state" : {
+                                 "address-prefix" : "31.1.0.0/24",
+                                 "description" : "Network prefix"
+                              }
+                           },
+                           {
+                              "address-prefix" : "32.1.0.0/24",
+                              "config" : {
+                                 "address-prefix" : "32.1.0.0/24",
+                                 "description" : "Network prefix"
+                              },
+                              "state" : {
+                                 "address-prefix" : "32.1.0.0/24",
+                                 "description" : "Network prefix"
+                              }
+                           }
+                        ]
+                     },
+                     "state" : {
+                        "openconfig-ospfv2-ext:summary-lsa-count" : 2,
+                        "openconfig-ospfv2-ext:nssa-lsa-checksum" : "0x00000000",
+                        "openconfig-ospfv2-ext:authentication-type" : "no",
+                        "openconfig-ospfv2-ext:asbr-summary-lsa-count" : 0,
+                        "openconfig-ospfv2-ext:adjacency-count" : 1,
+                        "openconfig-ospfv2-ext:opaque-area-lsa-count" : 0,
+                        "openconfig-ospfv2-ext:opaque-area-lsa-checksum" : "0x00000000",
+                        "openconfig-ospfv2-ext:lsa-count" : 5,
+                        "openconfig-ospfv2-ext:opaque-link-lsa-checksum" : "0x00000000",
+                        "openconfig-ospfv2-ext:spf-execution-count" : 6,
+                        "openconfig-ospfv2-ext:interface-count" : 1,
+                        "openconfig-ospfv2-ext:network-lsa-count" : 1,
+                        "openconfig-ospfv2-ext:asbr-summary-lsa-checksum" : "0x00000000",
+                        "openconfig-ospfv2-ext:router-lsa-checksum" : "0x0000cfe5",
+                        "openconfig-ospfv2-ext:router-lsa-count" : 2,
+                        "openconfig-ospfv2-ext:nssa-lsa-count" : 0,
+                        "openconfig-ospfv2-ext:active-interface-count" : 1,
+                        "openconfig-ospfv2-ext:summary-lsa-checksum" : "0x0000201c",
+                        "openconfig-ospfv2-ext:network-lsa-checksum" : "0x0000ca2c",
+                        "openconfig-ospfv2-ext:opaque-link-lsa-count" : 0
+                     }
+                  },
+                  {
+                     "lsdb" : {
+                        "lsa-types" : {
+                           "lsa-type" : [
+                              {
+                                 "type" : "openconfig-ospf-types:AS_EXTERNAL_LSA",
+                                 "state" : {
+                                    "type" : "openconfig-ospf-types:AS_EXTERNAL_LSA"
+                                 },
+                                 "lsas" : {
+                                    "openconfig-ospfv2-ext:lsa-ext" : [
+                                       {
+                                          "advertising-router" : "5.5.5.4",
+                                          "as-external-lsa" : {
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "forwarding-address" : "0.0.0.0",
+                                                         "external-route-tag" : 0,
+                                                         "metric" : 20
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "metric-type" : "TYPE_2",
+                                                "mask" : 20
+                                             }
+                                          },
+                                          "link-state-id" : "10.193.80.0",
+                                          "state" : {
+                                             "checksum" : 50393,
+                                             "length" : 36,
+                                             "flags" : 11,
+                                             "display-sequence-number" : "80000001",
+                                             "option" : 2,
+                                             "option-expanded" : "*||||||E|",
+                                             "age" : 1227
+                                          }
+                                       },
+                                       {
+                                          "advertising-router" : "6.6.6.5",
+                                          "as-external-lsa" : {
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "forwarding-address" : "0.0.0.0",
+                                                         "external-route-tag" : 0,
+                                                         "metric" : 20
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "metric-type" : "TYPE_2",
+                                                "mask" : 20
+                                             }
+                                          },
+                                          "link-state-id" : "10.193.80.0",
+                                          "state" : {
+                                             "checksum" : 42739,
+                                             "length" : 36,
+                                             "flags" : 6,
+                                             "display-sequence-number" : "80000001",
+                                             "option" : 2,
+                                             "option-expanded" : "*||||||E|",
+                                             "age" : 1228
+                                          }
+                                       }
+                                    ]
+                                 }
+                              },
+                              {
+                                 "type" : "openconfig-ospf-types:NETWORK_LSA",
+                                 "state" : {
+                                    "type" : "openconfig-ospf-types:NETWORK_LSA"
+                                 },
+                                 "lsas" : {
+                                    "openconfig-ospfv2-ext:lsa-ext" : [
+                                       {
+                                          "advertising-router" : "5.5.5.4",
+                                          "link-state-id" : "41.1.0.2",
+                                          "state" : {
+                                             "checksum" : 1017,
+                                             "length" : 32,
+                                             "flags" : 3,
+                                             "display-sequence-number" : "80000001",
+                                             "option" : 2,
+                                             "option-expanded" : "*|-|-|-|-|-|E|-",
+                                             "age" : 1198
+                                          },
+                                          "network-lsa" : {
+                                             "state" : {
+                                                "network-mask" : 24
+                                             }
+                                          }
+                                       }
+                                    ]
+                                 }
+                              },
+                              {
+                                 "type" : "openconfig-ospf-types:OSPFV2_LINK_SCOPE_OPAQUE_LSA"
+                              },
+                              {
+                                 "type" : "openconfig-ospf-types:ROUTER_LSA",
+                                 "state" : {
+                                    "type" : "openconfig-ospf-types:ROUTER_LSA"
+                                 },
+                                 "lsas" : {
+                                    "openconfig-ospfv2-ext:lsa-ext" : [
+                                       {
+                                          "advertising-router" : "3.3.3.2",
+                                          "link-state-id" : "3.3.3.2",
+                                          "state" : {
+                                             "checksum" : 53771,
+                                             "length" : 36,
+                                             "flags" : 6,
+                                             "display-sequence-number" : "80000002",
+                                             "option" : 0,
+                                             "option-expanded" : "*|||||||-",
+                                             "age" : 1189
+                                          },
+                                          "router-lsa" : {
+                                             "link-informations" : {
+                                                "link-information" : [
+                                                   {
+                                                      "state" : {
+                                                         "metric" : 10,
+                                                         "type" : "openconfig-ospf-types:ROUTER_LSA_TRANSIT_NETWORK",
+                                                         "number-tos-metrics" : 0
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "metric" : 10
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "flags-description" : " :",
+                                                "flags" : 0,
+                                                "number-links" : 1
+                                             }
+                                          }
+                                       },
+                                       {
+                                          "advertising-router" : "5.5.5.4",
+                                          "link-state-id" : "5.5.5.4",
+                                          "state" : {
+                                             "checksum" : 12693,
+                                             "length" : 36,
+                                             "flags" : 3,
+                                             "display-sequence-number" : "80000003",
+                                             "option" : 2,
+                                             "option-expanded" : "*||||||E|",
+                                             "age" : 1198
+                                          },
+                                          "router-lsa" : {
+                                             "link-informations" : {
+                                                "link-information" : [
+                                                   {
+                                                      "state" : {
+                                                         "metric" : 10,
+                                                         "type" : "openconfig-ospf-types:ROUTER_LSA_TRANSIT_NETWORK",
+                                                         "number-tos-metrics" : 0
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "metric" : 10
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "flags-description" : " : ABR ASBR",
+                                                "flags" : 3,
+                                                "number-links" : 1
+                                             }
+                                          }
+                                       }
+                                    ]
+                                 }
+                              },
+                              {
+                                 "type" : "openconfig-ospf-types:SUMMARY_ASBR_LSA",
+                                 "state" : {
+                                    "type" : "openconfig-ospf-types:SUMMARY_ASBR_LSA"
+                                 },
+                                 "lsas" : {
+                                    "openconfig-ospfv2-ext:lsa-ext" : [
+                                       {
+                                          "advertising-router" : "5.5.5.4",
+                                          "link-state-id" : "6.6.6.5",
+                                          "summary-lsa" : {
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "metric" : 4
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "network-mask" : 0
+                                             }
+                                          },
+                                          "state" : {
+                                             "checksum" : 59716,
+                                             "length" : 28,
+                                             "flags" : 11,
+                                             "display-sequence-number" : "80000001",
+                                             "option" : 2,
+                                             "option-expanded" : "*|-|-|-|-|-|E|-",
+                                             "age" : 1187
+                                          }
+                                       }
+                                    ]
+                                 }
+                              },
+                              {
+                                 "type" : "openconfig-ospf-types:SUMMARY_IP_NETWORK_LSA",
+                                 "state" : {
+                                    "type" : "openconfig-ospf-types:SUMMARY_IP_NETWORK_LSA"
+                                 },
+                                 "lsas" : {
+                                    "openconfig-ospfv2-ext:lsa-ext" : [
+                                       {
+                                          "advertising-router" : "5.5.5.4",
+                                          "link-state-id" : "21.1.0.0",
+                                          "summary-lsa" : {
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "metric" : 14
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "network-mask" : 24
+                                             }
+                                          },
+                                          "state" : {
+                                             "checksum" : 18908,
+                                             "length" : 28,
+                                             "flags" : 11,
+                                             "display-sequence-number" : "80000001",
+                                             "option" : 2,
+                                             "option-expanded" : "*|-|-|-|-|-|E|-",
+                                             "age" : 1187
+                                          }
+                                       },
+                                       {
+                                          "advertising-router" : "5.5.5.4",
+                                          "link-state-id" : "32.1.0.0",
+                                          "summary-lsa" : {
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "metric" : 4
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "network-mask" : 24
+                                             }
+                                          },
+                                          "state" : {
+                                             "checksum" : 21967,
+                                             "length" : 28,
+                                             "flags" : 11,
+                                             "display-sequence-number" : "80000001",
+                                             "option" : 2,
+                                             "option-expanded" : "*|-|-|-|-|-|E|-",
+                                             "age" : 1229
+                                          }
+                                       }
+                                    ]
+                                 }
+                              }
+                           ]
+                        },
+                        "state" : {
+                           "identifier" : "0.0.0.2"
+                        }
+                     },
+                     "identifier" : "0.0.0.2",
+                     "interfaces" : {
+                        "interface" : [
+                           {
+                              "openconfig-ospfv2-ext:message-statistics" : {
+                                 "state" : {
+                                    "ls-update-transmit" : 3,
+                                    "ls-request-receive" : 0,
+                                    "ls-acknowledge-receive" : 3,
+                                    "ls-acknowledge-transmit" : 2,
+                                    "db-description-transmit" : 2,
+                                    "db-description-receive" : 6,
+                                    "hello-transmit" : 124,
+                                    "hello-receive" : 125,
+                                    "ls-request-transmit" : 1,
+                                    "ls-update-receive" : 2
+                                 }
+                              },
+                              "openconfig-ospfv2-ext:neighbours" : {
+                                 "neighbour" : [
+                                    {
+                                       "neighbor-id" : "3.3.3.2",
+                                       "neighbor-address" : "41.1.0.1",
+                                       "state" : {
+                                          "priority" : 0,
+                                          "option-value" : 66,
+                                          "gr-helper-status" : "None",
+                                          "state-changes" : 6,
+                                          "backup-designated-router" : "0.0.0.0",
+                                          "adjacency-state" : "openconfig-ospf-types:FULL",
+                                          "neighbor-id" : "6.6.6.5",
+                                          "optional-capabilities" : "*|O|-|-|-|-|E|-",
+                                          "thread-inactivity-timer" : true,
+                                          "thread-ls-request-retransmission" : true,
+                                          "thread-ls-update-retransmission" : true,
+                                          "retransmit-summary-queue-length" : 0,
+                                          "area-id" : "0.0.0.2",
+                                          "gr-active-helper" : false,
+                                          "interface-address" : "41.1.0.2",
+                                          "neighbor-address" : "41.1.0.1",
+                                          "last-established-time" : "1198302",
+                                          "designated-router" : "41.1.0.2",
+                                          "database-summary-queue-length" : 0,
+                                          "interface-name" : "Ethernet120",
+                                          "link-state-request-queue-length" : 0,
+                                          "dead-time" : "34872"
+                                       }
+                                    }
+                                 ]
+                              },
+                              "id" : "Ethernet120",
+                              "timers" : {
+                                 "state" : {
+                                    "retransmission-interval" : 5,
+                                    "dead-interval" : 40,
+                                    "openconfig-ospfv2-ext:wait-time" : 40,
+                                    "hello-interval" : 10000,
+                                    "openconfig-ospfv2-ext:hello-due" : 1711
+                                 }
+                              },
+                              "state" : {
+                                 "priority" : 1,
+                                 "openconfig-ospfv2-ext:member-of-ospf-all-routers" : true,
+                                 "openconfig-ospfv2-ext:index" : 299,
+                                 "openconfig-ospfv2-ext:mtu" : 9100,
+                                 "openconfig-ospfv2-ext:if-flags" : "<UP,BROADCAST,RUNNING,MULTICAST>",
+                                 "openconfig-ospfv2-ext:adjacency-count" : 1,
+                                 "openconfig-ospfv2-ext:address-len" : 24,
+                                 "openconfig-ospfv2-ext:ospf-enable" : true,
+                                 "openconfig-ospfv2-ext:cost" : 10,
+                                 "openconfig-ospfv2-ext:address" : "41.1.0.2",
+                                 "id" : "Ethernet120",
+                                 "openconfig-ospfv2-ext:adjacency-status" : "DR",
+                                 "openconfig-ospfv2-ext:member-of-ospf-designated-routers" : true,
+                                 "openconfig-ospfv2-ext:neighbor-count" : 1,
+                                 "openconfig-ospfv2-ext:router-id" : "5.5.5.4",
+                                 "openconfig-ospfv2-ext:broadcast-address" : "41.1.0.255",
+                                 "openconfig-ospfv2-ext:bandwidth" : 10000,
+                                 "openconfig-ospfv2-ext:area-id" : "0.0.0.2",
+                                 "openconfig-ospfv2-ext:ospf-interface-type" : "Broadcast",
+                                 "network-type" : "openconfig-ospf-types:BROADCAST_NETWORK",
+                                 "openconfig-ospfv2-ext:transmit-delay" : 1,
+                                 "openconfig-ospfv2-ext:operational-state" : "Up"
+                              }
+                           }
+                        ]
+                     },
+                     "config" : {
+                        "identifier" : "0.0.0.2"
+                     },
+                     "openconfig-ospfv2-ext:networks" : {
+                        "network" : [
+                           {
+                              "address-prefix" : "41.1.0.0/24",
+                              "config" : {
+                                 "address-prefix" : "41.1.0.0/24",
+                                 "description" : "Network prefix"
+                              },
+                              "state" : {
+                                 "address-prefix" : "41.1.0.0/24",
+                                 "description" : "Network prefix"
+                              }
+                           }
+                        ]
+                     },
+                     "state" : {
+                        "openconfig-ospfv2-ext:summary-lsa-count" : 2,
+                        "openconfig-ospfv2-ext:nssa-lsa-checksum" : "0x00000000",
+                        "openconfig-ospfv2-ext:authentication-type" : "no",
+                        "openconfig-ospfv2-ext:asbr-summary-lsa-count" : 1,
+                        "openconfig-ospfv2-ext:adjacency-count" : 1,
+                        "openconfig-ospfv2-ext:opaque-area-lsa-count" : 0,
+                        "openconfig-ospfv2-ext:opaque-area-lsa-checksum" : "0x00000000",
+                        "openconfig-ospfv2-ext:lsa-count" : 6,
+                        "openconfig-ospfv2-ext:opaque-link-lsa-checksum" : "0x00000000",
+                        "openconfig-ospfv2-ext:virtual-link-adjacency-count" : 0,
+                        "openconfig-ospfv2-ext:spf-execution-count" : 6,
+                        "openconfig-ospfv2-ext:interface-count" : 1,
+                        "openconfig-ospfv2-ext:network-lsa-count" : 1,
+                        "openconfig-ospfv2-ext:asbr-summary-lsa-checksum" : "0x0000e944",
+                        "openconfig-ospfv2-ext:router-lsa-checksum" : "0x000103a0",
+                        "openconfig-ospfv2-ext:router-lsa-count" : 2,
+                        "openconfig-ospfv2-ext:nssa-lsa-count" : 0,
+                        "openconfig-ospfv2-ext:active-interface-count" : 1,
+                        "openconfig-ospfv2-ext:shortcut" : "openconfig-ospfv2-ext:DEFAULT",
+                        "openconfig-ospfv2-ext:summary-lsa-checksum" : "0x00009fab",
+                        "openconfig-ospfv2-ext:network-lsa-checksum" : "0x000003f9",
+                        "openconfig-ospfv2-ext:opaque-link-lsa-count" : 0
+                     }
+                  }
+               ]
+            }
+         },
+         "name" : "ospfv2",
+         "config" : {
+            "identifier" : "openconfig-policy-types:OSPF",
+            "name" : "ospfv2"
+         },
+         "state" : {
+            "identifier" : "openconfig-policy-types:OSPF",
+            "name" : "ospfv2"
+         }
+      }
+   ]
+}
+            `),
+		appRootType: reflect.TypeOf(ocbinds.OpenconfigNetworkInstance_NetworkInstances{}),
+		queryParams: QueryParams{
+			depthEnabled:  false,
+			curDepth:      1,
+			content:       QUERY_CONTENT_ALL,
+			fields:        []string{},
+			fieldsFillAll: false,
+		},
+		prunedPayload: []byte(`
+{
+   "protocol" : [
+      {
+         "identifier" : "openconfig-policy-types:OSPF",
+         "ospfv2" : {
+            "openconfig-ospfv2-ext:route-tables" : {
+               "route-table" : [
+                  {
+                     "routes" : {
+                        "route" : [
+                           {
+                              "next-hops" : {
+                                 "next-hop" : [
+                                    {
+                                       "area-id" : "0.0.0.0",
+                                       "address" : "32.1.0.1",
+                                       "state" : {
+                                          "area-id" : "0.0.0.0",
+                                          "address" : "32.1.0.1",
+                                          "out-interface" : "Vlan3719"
+                                       },
+                                       "out-interface" : "Vlan3719"
+                                    }
+                                 ]
+                              },
+                              "state" : {
+                                 "cost" : 4,
+                                 "sub-type" : "openconfig-ospfv2-ext:EXTERNAL_ROUTE_TYPE_2",
+                                 "type" : "openconfig-ospfv2-ext:EXTERNAL_ROUTE",
+                                 "prefix" : "10.193.80.0/20"
+                              },
+                              "prefix" : "10.193.80.0/20"
+                           }
+                        ]
+                     },
+                     "type" : "openconfig-ospfv2-ext:EXTERNAL_ROUTE_TABLE",
+                     "state" : {
+                        "type" : "openconfig-ospfv2-ext:EXTERNAL_ROUTE_TABLE"
+                     }
+                  },
+                  {
+                     "routes" : {
+                        "route" : [
+                           {
+                              "next-hops" : {
+                                 "next-hop" : [
+                                    {
+                                       "area-id" : "0.0.0.0",
+                                       "address" : "32.1.0.1",
+                                       "state" : {
+                                          "area-id" : "0.0.0.0",
+                                          "address" : "32.1.0.1",
+                                          "out-interface" : "Vlan3719"
+                                       },
+                                       "out-interface" : "Vlan3719"
+                                    }
+                                 ]
+                              },
+                              "state" : {
+                                 "cost" : 14,
+                                 "type" : "openconfig-ospfv2-ext:NETWORK_ROUTE",
+                                 "inter-area" : true,
+                                 "prefix" : "10.193.80.0/20"
+                              },
+                              "prefix" : "21.1.0.0/24"
+                           },
+                           {
+                              "next-hops" : {
+                                 "next-hop" : [
+                                    {
+                                       "area-id" : "0.0.0.0",
+                                       "address" : "0.0.0.0",
+                                       "state" : {
+                                          "area-id" : "0.0.0.0",
+                                          "address" : "32.1.0.1",
+                                          "out-interface" : "Vlan3719"
+                                       },
+                                       "out-interface" : "Vlan3719"
+                                    }
+                                 ]
+                              },
+                              "state" : {
+                                 "cost" : 4,
+                                 "type" : "openconfig-ospfv2-ext:NETWORK_ROUTE",
+                                 "prefix" : "10.193.80.0/20"
+                              },
+                              "prefix" : "32.1.0.0/24"
+                           },
+                           {
+                              "next-hops" : {
+                                 "next-hop" : [
+                                    {
+                                       "area-id" : "0.0.0.2",
+                                       "address" : "0.0.0.0",
+                                       "state" : {
+                                          "area-id" : "0.0.0.0",
+                                          "address" : "32.1.0.1",
+                                          "out-interface" : "Vlan3719"
+                                       },
+                                       "out-interface" : "Ethernet120"
+                                    }
+                                 ]
+                              },
+                              "state" : {
+                                 "cost" : 10,
+                                 "type" : "openconfig-ospfv2-ext:NETWORK_ROUTE",
+                                 "prefix" : "10.193.80.0/20"
+                              },
+                              "prefix" : "41.1.0.0/24"
+                           }
+                        ]
+                     },
+                     "type" : "openconfig-ospfv2-ext:NETWORK_ROUTE_TABLE",
+                     "state" : {
+                        "type" : "openconfig-ospfv2-ext:NETWORK_ROUTE_TABLE"
+                     }
+                  },
+                  {
+                     "routes" : {
+                        "route" : [
+                           {
+                              "next-hops" : {
+                                 "next-hop" : [
+                                    {
+                                       "area-id" : "0.0.0.0",
+                                       "address" : "32.1.0.1",
+                                       "state" : {
+                                          "area-id" : "0.0.0.0",
+                                          "address" : "32.1.0.1",
+                                          "out-interface" : "Vlan3719"
+                                       },
+                                       "out-interface" : "Vlan3719"
+                                    }
+                                 ]
+                              },
+                              "state" : {
+                                 "router-type" : "openconfig-ospfv2-ext:ABRASBR",
+                                 "cost" : 4,
+                                 "type" : "openconfig-ospfv2-ext:ROUTER_ROUTE",
+                                 "prefix" : "10.193.80.0/20"
+                              },
+                              "prefix" : "6.6.6.5"
+                           }
+                        ]
+                     },
+                     "type" : "openconfig-ospfv2-ext:ROUTER_ROUTE_TABLE",
+                     "state" : {
+                        "type" : "openconfig-ospfv2-ext:ROUTER_ROUTE_TABLE"
+                     }
+                  }
+               ]
+            },
+            "global" : {
+               "graceful-restart" : {
+                  "openconfig-ospfv2-ext:helpers" : {
+                     "helper" : [
+                        {
+                           "neighbour-id" : "5.5.5.4",
+                           "config" : {
+                              "vrf-name" : "default",
+                              "neighbour-id" : "5.5.5.4"
+                           },
+                           "state" : {
+                              "neighbour-id" : "5.5.5.4"
+                           }
+                        }
+                     ]
+                  },
+                  "config" : {
+                     "openconfig-ospfv2-ext:planned-only" : true,
+                     "helper-only" : true,
+                     "openconfig-ospfv2-ext:supported-grace-time" : 800,
+                     "openconfig-ospfv2-ext:strict-lsa-checking" : true
+                  },
+                  "state" : {
+                     "openconfig-ospfv2-ext:planned-only" : true,
+                     "helper-only" : true,
+                     "openconfig-ospfv2-ext:grace-period" : 0,
+                     "openconfig-ospfv2-ext:supported-grace-time" : 800,
+                     "openconfig-ospfv2-ext:strict-lsa-checking" : true
+                  }
+               },
+               "inter-area-propagation-policies" : {
+                  "openconfig-ospfv2-ext:inter-area-policy" : [
+                     {
+                        "config" : {
+                           "src-area" : "0.0.0.0"
+                        },
+                        "src-area" : "0.0.0.0",
+                        "state" : {
+                           "src-area" : "0.0.0.0"
+                        }
+                     },
+                     {
+                        "config" : {
+                           "src-area" : "0.0.0.2"
+                        },
+                        "src-area" : "0.0.0.2",
+                        "state" : {
+                           "src-area" : "0.0.0.2"
+                        }
+                     }
+                  ]
+               },
+               "config" : {
+                  "router-id" : "5.5.5.4",
+                  "openconfig-ospfv2-ext:opaque-lsa-capability" : true,
+                  "openconfig-ospfv2-ext:description" : "OSPFv2 Router",
+                  "openconfig-ospfv2-ext:enable" : true
+               },
+               "timers" : {
+                  "lsa-generation" : {
+                     "state" : {
+                        "openconfig-ospfv2-ext:refresh-timer" : 10000,
+                        "openconfig-ospfv2-ext:lsa-min-interval-timer" : 5000,
+                        "openconfig-ospfv2-ext:lsa-min-arrival-timer" : 1000
+                     }
+                  },
+                  "spf" : {
+                     "state" : {
+                        "maximum-delay" : 5000,
+                        "initial-delay" : 50,
+                        "openconfig-ospfv2-ext:throttle-delay" : 0,
+                        "openconfig-ospfv2-ext:spf-timer-due" : 0
+                     }
+                  }
+               },
+               "state" : {
+                  "openconfig-ospfv2-ext:area-count" : 2,
+                  "openconfig-ospfv2-ext:last-spf-duration" : 358,
+                  "openconfig-ospfv2-ext:hold-time-multiplier" : 1,
+                  "openconfig-ospfv2-ext:last-spf-execution-time" : "1187616",
+                  "openconfig-ospfv2-ext:opaque-lsa-count" : 0,
+                  "router-id" : "5.5.5.4",
+                  "openconfig-ospfv2-ext:abr-type" : "openconfig-ospfv2-ext:CISCO",
+                  "openconfig-ospfv2-ext:external-lsa-checksum" : "0x00016bcc",
+                  "openconfig-ospfv2-ext:opaque-lsa-checksum" : "0x00000000",
+                  "openconfig-ospfv2-ext:write-multiplier" : 20,
+                  "openconfig-ospfv2-ext:opaque-lsa-capability" : true,
+                  "openconfig-ospfv2-ext:external-lsa-count" : 2
+               }
+            },
+            "areas" : {
+               "area" : [
+                  {
+                     "lsdb" : {
+                        "lsa-types" : {
+                           "lsa-type" : [
+                              {
+                                 "type" : "openconfig-ospf-types:AS_EXTERNAL_LSA",
+                                 "state" : {
+                                    "type" : "openconfig-ospf-types:AS_EXTERNAL_LSA"
+                                 },
+                                 "lsas" : {
+                                    "openconfig-ospfv2-ext:lsa-ext" : [
+                                       {
+                                          "advertising-router" : "5.5.5.4",
+                                          "as-external-lsa" : {
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "forwarding-address" : "0.0.0.0",
+                                                         "external-route-tag" : 0,
+                                                         "metric" : 20
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "metric-type" : "TYPE_2",
+                                                "mask" : 20
+                                             }
+                                          },
+                                          "link-state-id" : "10.193.80.0",
+                                          "state" : {
+                                             "checksum" : 50393,
+                                             "length" : 36,
+                                             "flags" : 11,
+                                             "display-sequence-number" : "80000001",
+                                             "option" : 2,
+                                             "option-expanded" : "*||||||E|",
+                                             "age" : 1227
+                                          }
+                                       },
+                                       {
+                                          "advertising-router" : "6.6.6.5",
+                                          "as-external-lsa" : {
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "forwarding-address" : "0.0.0.0",
+                                                         "external-route-tag" : 0,
+                                                         "metric" : 20
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "metric-type" : "TYPE_2",
+                                                "mask" : 20
+                                             }
+                                          },
+                                          "link-state-id" : "10.193.80.0",
+                                          "state" : {
+                                             "checksum" : 42739,
+                                             "length" : 36,
+                                             "flags" : 6,
+                                             "display-sequence-number" : "80000001",
+                                             "option" : 2,
+                                             "option-expanded" : "*||||||E|",
+                                             "age" : 1228
+                                          }
+                                       }
+                                    ]
+                                 }
+                              },
+                              {
+                                 "type" : "openconfig-ospf-types:NETWORK_LSA",
+                                 "state" : {
+                                    "type" : "openconfig-ospf-types:NETWORK_LSA"
+                                 },
+                                 "lsas" : {
+                                    "openconfig-ospfv2-ext:lsa-ext" : [
+                                       {
+                                          "advertising-router" : "6.6.6.5",
+                                          "link-state-id" : "32.1.0.1",
+                                          "state" : {
+                                             "checksum" : 51756,
+                                             "length" : 32,
+                                             "flags" : 6,
+                                             "display-sequence-number" : "80000001",
+                                             "option" : 2,
+                                             "option-expanded" : "*|-|-|-|-|-|E|-",
+                                             "age" : 1198
+                                          },
+                                          "network-lsa" : {
+                                             "state" : {
+                                                "network-mask" : 24
+                                             }
+                                          }
+                                       }
+                                    ]
+                                 }
+                              },
+                              {
+                                 "type" : "openconfig-ospf-types:OSPFV2_LINK_SCOPE_OPAQUE_LSA"
+                              },
+                              {
+                                 "type" : "openconfig-ospf-types:ROUTER_LSA",
+                                 "state" : {
+                                    "type" : "openconfig-ospf-types:ROUTER_LSA"
+                                 },
+                                 "lsas" : {
+                                    "openconfig-ospfv2-ext:lsa-ext" : [
+                                       {
+                                          "advertising-router" : "5.5.5.4",
+                                          "link-state-id" : "5.5.5.4",
+                                          "state" : {
+                                             "checksum" : 5321,
+                                             "length" : 36,
+                                             "flags" : 3,
+                                             "display-sequence-number" : "80000005",
+                                             "option" : 2,
+                                             "option-expanded" : "*||||||E|",
+                                             "age" : 1197
+                                          },
+                                          "router-lsa" : {
+                                             "link-informations" : {
+                                                "link-information" : [
+                                                   {
+                                                      "state" : {
+                                                         "metric" : 4,
+                                                         "type" : "openconfig-ospf-types:ROUTER_LSA_TRANSIT_NETWORK",
+                                                         "number-tos-metrics" : 0
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "metric" : 4
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "flags-description" : " : ABR ASBR",
+                                                "flags" : 3,
+                                                "number-links" : 1
+                                             }
+                                          }
+                                       },
+                                       {
+                                          "advertising-router" : "6.6.6.5",
+                                          "link-state-id" : "6.6.6.5",
+                                          "state" : {
+                                             "checksum" : 47900,
+                                             "length" : 36,
+                                             "flags" : 6,
+                                             "display-sequence-number" : "80000004",
+                                             "option" : 2,
+                                             "option-expanded" : "*||||||E|",
+                                             "age" : 1197
+                                          },
+                                          "router-lsa" : {
+                                             "link-informations" : {
+                                                "link-information" : [
+                                                   {
+                                                      "state" : {
+                                                         "metric" : 4,
+                                                         "type" : "openconfig-ospf-types:ROUTER_LSA_TRANSIT_NETWORK",
+                                                         "number-tos-metrics" : 0
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "metric" : 4
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "flags-description" : " : ABR ASBR",
+                                                "flags" : 3,
+                                                "number-links" : 1
+                                             }
+                                          }
+                                       }
+                                    ]
+                                 }
+                              },
+                              {
+                                 "type" : "openconfig-ospf-types:SUMMARY_ASBR_LSA",
+                                 "state" : {
+                                    "type" : "openconfig-ospf-types:SUMMARY_ASBR_LSA"
+                                 }
+                              },
+                              {
+                                 "type" : "openconfig-ospf-types:SUMMARY_IP_NETWORK_LSA",
+                                 "state" : {
+                                    "type" : "openconfig-ospf-types:SUMMARY_IP_NETWORK_LSA"
+                                 },
+                                 "lsas" : {
+                                    "openconfig-ospfv2-ext:lsa-ext" : [
+                                       {
+                                          "advertising-router" : "6.6.6.5",
+                                          "link-state-id" : "21.1.0.0",
+                                          "summary-lsa" : {
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "metric" : 10
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "network-mask" : 24
+                                             }
+                                          },
+                                          "state" : {
+                                             "checksum" : 803,
+                                             "length" : 28,
+                                             "flags" : 6,
+                                             "display-sequence-number" : "80000001",
+                                             "option" : 2,
+                                             "option-expanded" : "*|-|-|-|-|-|E|-",
+                                             "age" : 1228
+                                          }
+                                       },
+                                       {
+                                          "advertising-router" : "5.5.5.4",
+                                          "link-state-id" : "41.1.0.0",
+                                          "summary-lsa" : {
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "metric" : 10
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "network-mask" : 24
+                                             }
+                                          },
+                                          "state" : {
+                                             "checksum" : 7417,
+                                             "length" : 28,
+                                             "flags" : 11,
+                                             "display-sequence-number" : "80000001",
+                                             "option" : 2,
+                                             "option-expanded" : "*|-|-|-|-|-|E|-",
+                                             "age" : 1227
+                                          }
+                                       }
+                                    ]
+                                 }
+                              }
+                           ]
+                        },
+                        "state" : {
+                           "identifier" : "0.0.0.0"
+                        }
+                     },
+                     "identifier" : "0.0.0.0",
+                     "interfaces" : {
+                        "interface" : [
+                           {
+                              "openconfig-ospfv2-ext:message-statistics" : {
+                                 "state" : {
+                                    "ls-update-transmit" : 4,
+                                    "ls-request-receive" : 1,
+                                    "ls-acknowledge-receive" : 2,
+                                    "ls-acknowledge-transmit" : 2,
+                                    "db-description-transmit" : 3,
+                                    "db-description-receive" : 2,
+                                    "hello-transmit" : 124,
+                                    "hello-receive" : 124,
+                                    "ls-request-transmit" : 1,
+                                    "ls-update-receive" : 3
+                                 }
+                              },
+                              "openconfig-ospfv2-ext:neighbours" : {
+                                 "neighbour" : [
+                                    {
+                                       "neighbor-id" : "6.6.6.5",
+                                       "neighbor-address" : "32.1.0.1",
+                                       "state" : {
+                                          "priority" : 1,
+                                          "option-value" : 66,
+                                          "gr-helper-status" : "None",
+                                          "state-changes" : 6,
+                                          "backup-designated-router" : "32.1.0.2",
+                                          "adjacency-state" : "openconfig-ospf-types:FULL",
+                                          "neighbor-id" : "6.6.6.5",
+                                          "optional-capabilities" : "*|O|-|-|-|-|E|-",
+                                          "thread-inactivity-timer" : true,
+                                          "thread-ls-request-retransmission" : true,
+                                          "thread-ls-update-retransmission" : true,
+                                          "retransmit-summary-queue-length" : 0,
+                                          "area-id" : "0.0.0.0",
+                                          "gr-active-helper" : false,
+                                          "interface-address" : "32.1.0.2",
+                                          "neighbor-address" : "32.1.0.1",
+                                          "last-established-time" : "1197595",
+                                          "designated-router" : "32.1.0.1",
+                                          "database-summary-queue-length" : 0,
+                                          "interface-name" : "Vlan3719",
+                                          "link-state-request-queue-length" : 0,
+                                          "dead-time" : "32410"
+                                       }
+                                    }
+                                 ]
+                              },
+                              "id" : "Vlan3719",
+                              "timers" : {
+                                 "state" : {
+                                    "retransmission-interval" : 5,
+                                    "dead-interval" : 40,
+                                    "openconfig-ospfv2-ext:wait-time" : 40,
+                                    "hello-interval" : 10000,
+                                    "openconfig-ospfv2-ext:hello-due" : 2409
+                                 }
+                              },
+                              "state" : {
+                                 "priority" : 1,
+                                 "openconfig-ospfv2-ext:member-of-ospf-all-routers" : true,
+                                 "openconfig-ospfv2-ext:index" : 310,
+                                 "openconfig-ospfv2-ext:mtu" : 9100,
+                                 "openconfig-ospfv2-ext:if-flags" : "<UP,BROADCAST,RUNNING,MULTICAST>",
+                                 "openconfig-ospfv2-ext:adjacency-count" : 1,
+                                 "openconfig-ospfv2-ext:address-len" : 24,
+                                 "openconfig-ospfv2-ext:ospf-enable" : true,
+                                 "openconfig-ospfv2-ext:cost" : 4,
+                                 "openconfig-ospfv2-ext:address" : "32.1.0.2",
+                                 "id" : "Vlan3719",
+                                 "openconfig-ospfv2-ext:adjacency-status" : "Backup",
+                                 "openconfig-ospfv2-ext:neighbor-count" : 1,
+                                 "openconfig-ospfv2-ext:backup-designated-router-id" : "5.5.5.4",
+                                 "openconfig-ospfv2-ext:member-of-ospf-designated-routers" : true,
+                                 "openconfig-ospfv2-ext:router-id" : "5.5.5.4",
+                                 "openconfig-ospfv2-ext:broadcast-address" : "32.1.0.255",
+                                 "openconfig-ospfv2-ext:bandwidth" : 25000,
+                                 "openconfig-ospfv2-ext:area-id" : "0.0.0.0",
+                                 "openconfig-ospfv2-ext:ospf-interface-type" : "Broadcast",
+                                 "openconfig-ospfv2-ext:backup-designated-router-address" : "32.1.0.2",
+                                 "network-type" : "openconfig-ospf-types:BROADCAST_NETWORK",
+                                 "openconfig-ospfv2-ext:transmit-delay" : 1,
+                                 "openconfig-ospfv2-ext:operational-state" : "Up"
+                              }
+                           }
+                        ]
+                     },
+                     "config" : {
+                        "identifier" : "0.0.0.0"
+                     },
+                     "openconfig-ospfv2-ext:networks" : {
+                        "network" : [
+                           {
+                              "address-prefix" : "31.1.0.0/24",
+                              "config" : {
+                                 "address-prefix" : "31.1.0.0/24",
+                                 "description" : "Network prefix"
+                              },
+                              "state" : {
+                                 "address-prefix" : "31.1.0.0/24",
+                                 "description" : "Network prefix"
+                              }
+                           },
+                           {
+                              "address-prefix" : "32.1.0.0/24",
+                              "config" : {
+                                 "address-prefix" : "32.1.0.0/24",
+                                 "description" : "Network prefix"
+                              },
+                              "state" : {
+                                 "address-prefix" : "32.1.0.0/24",
+                                 "description" : "Network prefix"
+                              }
+                           }
+                        ]
+                     },
+                     "state" : {
+                        "openconfig-ospfv2-ext:summary-lsa-count" : 2,
+                        "openconfig-ospfv2-ext:nssa-lsa-checksum" : "0x00000000",
+                        "openconfig-ospfv2-ext:authentication-type" : "no",
+                        "openconfig-ospfv2-ext:asbr-summary-lsa-count" : 0,
+                        "openconfig-ospfv2-ext:adjacency-count" : 1,
+                        "openconfig-ospfv2-ext:opaque-area-lsa-count" : 0,
+                        "openconfig-ospfv2-ext:opaque-area-lsa-checksum" : "0x00000000",
+                        "openconfig-ospfv2-ext:lsa-count" : 5,
+                        "openconfig-ospfv2-ext:opaque-link-lsa-checksum" : "0x00000000",
+                        "openconfig-ospfv2-ext:spf-execution-count" : 6,
+                        "openconfig-ospfv2-ext:interface-count" : 1,
+                        "openconfig-ospfv2-ext:network-lsa-count" : 1,
+                        "openconfig-ospfv2-ext:asbr-summary-lsa-checksum" : "0x00000000",
+                        "openconfig-ospfv2-ext:router-lsa-checksum" : "0x0000cfe5",
+                        "openconfig-ospfv2-ext:router-lsa-count" : 2,
+                        "openconfig-ospfv2-ext:nssa-lsa-count" : 0,
+                        "openconfig-ospfv2-ext:active-interface-count" : 1,
+                        "openconfig-ospfv2-ext:summary-lsa-checksum" : "0x0000201c",
+                        "openconfig-ospfv2-ext:network-lsa-checksum" : "0x0000ca2c",
+                        "openconfig-ospfv2-ext:opaque-link-lsa-count" : 0
+                     }
+                  },
+                  {
+                     "lsdb" : {
+                        "lsa-types" : {
+                           "lsa-type" : [
+                              {
+                                 "type" : "openconfig-ospf-types:AS_EXTERNAL_LSA",
+                                 "state" : {
+                                    "type" : "openconfig-ospf-types:AS_EXTERNAL_LSA"
+                                 },
+                                 "lsas" : {
+                                    "openconfig-ospfv2-ext:lsa-ext" : [
+                                       {
+                                          "advertising-router" : "5.5.5.4",
+                                          "as-external-lsa" : {
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "forwarding-address" : "0.0.0.0",
+                                                         "external-route-tag" : 0,
+                                                         "metric" : 20
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "metric-type" : "TYPE_2",
+                                                "mask" : 20
+                                             }
+                                          },
+                                          "link-state-id" : "10.193.80.0",
+                                          "state" : {
+                                             "checksum" : 50393,
+                                             "length" : 36,
+                                             "flags" : 11,
+                                             "display-sequence-number" : "80000001",
+                                             "option" : 2,
+                                             "option-expanded" : "*||||||E|",
+                                             "age" : 1227
+                                          }
+                                       },
+                                       {
+                                          "advertising-router" : "6.6.6.5",
+                                          "as-external-lsa" : {
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "forwarding-address" : "0.0.0.0",
+                                                         "external-route-tag" : 0,
+                                                         "metric" : 20
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "metric-type" : "TYPE_2",
+                                                "mask" : 20
+                                             }
+                                          },
+                                          "link-state-id" : "10.193.80.0",
+                                          "state" : {
+                                             "checksum" : 42739,
+                                             "length" : 36,
+                                             "flags" : 6,
+                                             "display-sequence-number" : "80000001",
+                                             "option" : 2,
+                                             "option-expanded" : "*||||||E|",
+                                             "age" : 1228
+                                          }
+                                       }
+                                    ]
+                                 }
+                              },
+                              {
+                                 "type" : "openconfig-ospf-types:NETWORK_LSA",
+                                 "state" : {
+                                    "type" : "openconfig-ospf-types:NETWORK_LSA"
+                                 },
+                                 "lsas" : {
+                                    "openconfig-ospfv2-ext:lsa-ext" : [
+                                       {
+                                          "advertising-router" : "5.5.5.4",
+                                          "link-state-id" : "41.1.0.2",
+                                          "state" : {
+                                             "checksum" : 1017,
+                                             "length" : 32,
+                                             "flags" : 3,
+                                             "display-sequence-number" : "80000001",
+                                             "option" : 2,
+                                             "option-expanded" : "*|-|-|-|-|-|E|-",
+                                             "age" : 1198
+                                          },
+                                          "network-lsa" : {
+                                             "state" : {
+                                                "network-mask" : 24
+                                             }
+                                          }
+                                       }
+                                    ]
+                                 }
+                              },
+                              {
+                                 "type" : "openconfig-ospf-types:OSPFV2_LINK_SCOPE_OPAQUE_LSA"
+                              },
+                              {
+                                 "type" : "openconfig-ospf-types:ROUTER_LSA",
+                                 "state" : {
+                                    "type" : "openconfig-ospf-types:ROUTER_LSA"
+                                 },
+                                 "lsas" : {
+                                    "openconfig-ospfv2-ext:lsa-ext" : [
+                                       {
+                                          "advertising-router" : "3.3.3.2",
+                                          "link-state-id" : "3.3.3.2",
+                                          "state" : {
+                                             "checksum" : 53771,
+                                             "length" : 36,
+                                             "flags" : 6,
+                                             "display-sequence-number" : "80000002",
+                                             "option" : 0,
+                                             "option-expanded" : "*|||||||-",
+                                             "age" : 1189
+                                          },
+                                          "router-lsa" : {
+                                             "link-informations" : {
+                                                "link-information" : [
+                                                   {
+                                                      "state" : {
+                                                         "metric" : 10,
+                                                         "type" : "openconfig-ospf-types:ROUTER_LSA_TRANSIT_NETWORK",
+                                                         "number-tos-metrics" : 0
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "metric" : 10
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "flags-description" : " :",
+                                                "flags" : 0,
+                                                "number-links" : 1
+                                             }
+                                          }
+                                       },
+                                       {
+                                          "advertising-router" : "5.5.5.4",
+                                          "link-state-id" : "5.5.5.4",
+                                          "state" : {
+                                             "checksum" : 12693,
+                                             "length" : 36,
+                                             "flags" : 3,
+                                             "display-sequence-number" : "80000003",
+                                             "option" : 2,
+                                             "option-expanded" : "*||||||E|",
+                                             "age" : 1198
+                                          },
+                                          "router-lsa" : {
+                                             "link-informations" : {
+                                                "link-information" : [
+                                                   {
+                                                      "state" : {
+                                                         "metric" : 10,
+                                                         "type" : "openconfig-ospf-types:ROUTER_LSA_TRANSIT_NETWORK",
+                                                         "number-tos-metrics" : 0
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "metric" : 10
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "flags-description" : " : ABR ASBR",
+                                                "flags" : 3,
+                                                "number-links" : 1
+                                             }
+                                          }
+                                       }
+                                    ]
+                                 }
+                              },
+                              {
+                                 "type" : "openconfig-ospf-types:SUMMARY_ASBR_LSA",
+                                 "state" : {
+                                    "type" : "openconfig-ospf-types:SUMMARY_ASBR_LSA"
+                                 },
+                                 "lsas" : {
+                                    "openconfig-ospfv2-ext:lsa-ext" : [
+                                       {
+                                          "advertising-router" : "5.5.5.4",
+                                          "link-state-id" : "6.6.6.5",
+                                          "summary-lsa" : {
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "metric" : 4
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "network-mask" : 0
+                                             }
+                                          },
+                                          "state" : {
+                                             "checksum" : 59716,
+                                             "length" : 28,
+                                             "flags" : 11,
+                                             "display-sequence-number" : "80000001",
+                                             "option" : 2,
+                                             "option-expanded" : "*|-|-|-|-|-|E|-",
+                                             "age" : 1187
+                                          }
+                                       }
+                                    ]
+                                 }
+                              },
+                              {
+                                 "type" : "openconfig-ospf-types:SUMMARY_IP_NETWORK_LSA",
+                                 "state" : {
+                                    "type" : "openconfig-ospf-types:SUMMARY_IP_NETWORK_LSA"
+                                 },
+                                 "lsas" : {
+                                    "openconfig-ospfv2-ext:lsa-ext" : [
+                                       {
+                                          "advertising-router" : "5.5.5.4",
+                                          "link-state-id" : "21.1.0.0",
+                                          "summary-lsa" : {
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "metric" : 14
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "network-mask" : 24
+                                             }
+                                          },
+                                          "state" : {
+                                             "checksum" : 18908,
+                                             "length" : 28,
+                                             "flags" : 11,
+                                             "display-sequence-number" : "80000001",
+                                             "option" : 2,
+                                             "option-expanded" : "*|-|-|-|-|-|E|-",
+                                             "age" : 1187
+                                          }
+                                       },
+                                       {
+                                          "advertising-router" : "5.5.5.4",
+                                          "link-state-id" : "32.1.0.0",
+                                          "summary-lsa" : {
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "metric" : 4
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "network-mask" : 24
+                                             }
+                                          },
+                                          "state" : {
+                                             "checksum" : 21967,
+                                             "length" : 28,
+                                             "flags" : 11,
+                                             "display-sequence-number" : "80000001",
+                                             "option" : 2,
+                                             "option-expanded" : "*|-|-|-|-|-|E|-",
+                                             "age" : 1229
+                                          }
+                                       }
+                                    ]
+                                 }
+                              }
+                           ]
+                        },
+                        "state" : {
+                           "identifier" : "0.0.0.2"
+                        }
+                     },
+                     "identifier" : "0.0.0.2",
+                     "interfaces" : {
+                        "interface" : [
+                           {
+                              "openconfig-ospfv2-ext:message-statistics" : {
+                                 "state" : {
+                                    "ls-update-transmit" : 3,
+                                    "ls-request-receive" : 0,
+                                    "ls-acknowledge-receive" : 3,
+                                    "ls-acknowledge-transmit" : 2,
+                                    "db-description-transmit" : 2,
+                                    "db-description-receive" : 6,
+                                    "hello-transmit" : 124,
+                                    "hello-receive" : 125,
+                                    "ls-request-transmit" : 1,
+                                    "ls-update-receive" : 2
+                                 }
+                              },
+                              "openconfig-ospfv2-ext:neighbours" : {
+                                 "neighbour" : [
+                                    {
+                                       "neighbor-id" : "3.3.3.2",
+                                       "neighbor-address" : "41.1.0.1",
+                                       "state" : {
+                                          "priority" : 0,
+                                          "option-value" : 66,
+                                          "gr-helper-status" : "None",
+                                          "state-changes" : 6,
+                                          "backup-designated-router" : "0.0.0.0",
+                                          "adjacency-state" : "openconfig-ospf-types:FULL",
+                                          "neighbor-id" : "6.6.6.5",
+                                          "optional-capabilities" : "*|O|-|-|-|-|E|-",
+                                          "thread-inactivity-timer" : true,
+                                          "thread-ls-request-retransmission" : true,
+                                          "thread-ls-update-retransmission" : true,
+                                          "retransmit-summary-queue-length" : 0,
+                                          "area-id" : "0.0.0.2",
+                                          "gr-active-helper" : false,
+                                          "interface-address" : "41.1.0.2",
+                                          "neighbor-address" : "41.1.0.1",
+                                          "last-established-time" : "1198302",
+                                          "designated-router" : "41.1.0.2",
+                                          "database-summary-queue-length" : 0,
+                                          "interface-name" : "Ethernet120",
+                                          "link-state-request-queue-length" : 0,
+                                          "dead-time" : "34872"
+                                       }
+                                    }
+                                 ]
+                              },
+                              "id" : "Ethernet120",
+                              "timers" : {
+                                 "state" : {
+                                    "retransmission-interval" : 5,
+                                    "dead-interval" : 40,
+                                    "openconfig-ospfv2-ext:wait-time" : 40,
+                                    "hello-interval" : 10000,
+                                    "openconfig-ospfv2-ext:hello-due" : 1711
+                                 }
+                              },
+                              "state" : {
+                                 "priority" : 1,
+                                 "openconfig-ospfv2-ext:member-of-ospf-all-routers" : true,
+                                 "openconfig-ospfv2-ext:index" : 299,
+                                 "openconfig-ospfv2-ext:mtu" : 9100,
+                                 "openconfig-ospfv2-ext:if-flags" : "<UP,BROADCAST,RUNNING,MULTICAST>",
+                                 "openconfig-ospfv2-ext:adjacency-count" : 1,
+                                 "openconfig-ospfv2-ext:address-len" : 24,
+                                 "openconfig-ospfv2-ext:ospf-enable" : true,
+                                 "openconfig-ospfv2-ext:cost" : 10,
+                                 "openconfig-ospfv2-ext:address" : "41.1.0.2",
+                                 "id" : "Ethernet120",
+                                 "openconfig-ospfv2-ext:adjacency-status" : "DR",
+                                 "openconfig-ospfv2-ext:member-of-ospf-designated-routers" : true,
+                                 "openconfig-ospfv2-ext:neighbor-count" : 1,
+                                 "openconfig-ospfv2-ext:router-id" : "5.5.5.4",
+                                 "openconfig-ospfv2-ext:broadcast-address" : "41.1.0.255",
+                                 "openconfig-ospfv2-ext:bandwidth" : 10000,
+                                 "openconfig-ospfv2-ext:area-id" : "0.0.0.2",
+                                 "openconfig-ospfv2-ext:ospf-interface-type" : "Broadcast",
+                                 "network-type" : "openconfig-ospf-types:BROADCAST_NETWORK",
+                                 "openconfig-ospfv2-ext:transmit-delay" : 1,
+                                 "openconfig-ospfv2-ext:operational-state" : "Up"
+                              }
+                           }
+                        ]
+                     },
+                     "config" : {
+                        "identifier" : "0.0.0.2"
+                     },
+                     "openconfig-ospfv2-ext:networks" : {
+                        "network" : [
+                           {
+                              "address-prefix" : "41.1.0.0/24",
+                              "config" : {
+                                 "address-prefix" : "41.1.0.0/24",
+                                 "description" : "Network prefix"
+                              },
+                              "state" : {
+                                 "address-prefix" : "41.1.0.0/24",
+                                 "description" : "Network prefix"
+                              }
+                           }
+                        ]
+                     },
+                     "state" : {
+                        "openconfig-ospfv2-ext:summary-lsa-count" : 2,
+                        "openconfig-ospfv2-ext:nssa-lsa-checksum" : "0x00000000",
+                        "openconfig-ospfv2-ext:authentication-type" : "no",
+                        "openconfig-ospfv2-ext:asbr-summary-lsa-count" : 1,
+                        "openconfig-ospfv2-ext:adjacency-count" : 1,
+                        "openconfig-ospfv2-ext:opaque-area-lsa-count" : 0,
+                        "openconfig-ospfv2-ext:opaque-area-lsa-checksum" : "0x00000000",
+                        "openconfig-ospfv2-ext:lsa-count" : 6,
+                        "openconfig-ospfv2-ext:opaque-link-lsa-checksum" : "0x00000000",
+                        "openconfig-ospfv2-ext:virtual-link-adjacency-count" : 0,
+                        "openconfig-ospfv2-ext:spf-execution-count" : 6,
+                        "openconfig-ospfv2-ext:interface-count" : 1,
+                        "openconfig-ospfv2-ext:network-lsa-count" : 1,
+                        "openconfig-ospfv2-ext:asbr-summary-lsa-checksum" : "0x0000e944",
+                        "openconfig-ospfv2-ext:router-lsa-checksum" : "0x000103a0",
+                        "openconfig-ospfv2-ext:router-lsa-count" : 2,
+                        "openconfig-ospfv2-ext:nssa-lsa-count" : 0,
+                        "openconfig-ospfv2-ext:active-interface-count" : 1,
+                        "openconfig-ospfv2-ext:shortcut" : "openconfig-ospfv2-ext:DEFAULT",
+                        "openconfig-ospfv2-ext:summary-lsa-checksum" : "0x00009fab",
+                        "openconfig-ospfv2-ext:network-lsa-checksum" : "0x000003f9",
+                        "openconfig-ospfv2-ext:opaque-link-lsa-count" : 0
+                     }
+                  }
+               ]
+            }
+         },
+         "name" : "ospfv2",
+         "config" : {
+            "identifier" : "openconfig-policy-types:OSPF",
+            "name" : "ospfv2"
+         },
+         "state" : {
+            "identifier" : "openconfig-policy-types:OSPF",
+            "name" : "ospfv2"
+         }
+      }
+   ]
+}
+            `),
+	},
+	{ // OSPF Identity Test Case (i.e. no QP)
+		tid:        "OSPF Identity",
+		uri:        "/openconfig-network-instance:network-instances/network-instance[name=default]/protocols/protocol[identifier=OSPF][name=ospfv2]/ospfv2/areas/area[identifier=0.0.0.0]/lsdb",
+		requestUri: "/openconfig-network-instance:network-instances/network-instance[name=default]/protocols/protocol[identifier=OSPF][name=ospfv2]",
+		payload: []byte(`
+{
+   "protocol" : [
+      {
+         "identifier" : "openconfig-policy-types:OSPF",
+         "ospfv2" : {
+            "openconfig-ospfv2-ext:route-tables" : {
+               "route-table" : [
+                  {
+                     "routes" : {
+                        "route" : [
+                           {
+                              "next-hops" : {
+                                 "next-hop" : [
+                                    {
+                                       "area-id" : "0.0.0.0",
+                                       "address" : "32.1.0.1",
+                                       "state" : {
+                                          "area-id" : "0.0.0.0",
+                                          "address" : "32.1.0.1",
+                                          "out-interface" : "Vlan3719"
+                                       },
+                                       "out-interface" : "Vlan3719"
+                                    }
+                                 ]
+                              },
+                              "state" : {
+                                 "cost" : 4,
+                                 "sub-type" : "openconfig-ospfv2-ext:EXTERNAL_ROUTE_TYPE_2",
+                                 "type" : "openconfig-ospfv2-ext:EXTERNAL_ROUTE",
+                                 "prefix" : "10.193.80.0/20"
+                              },
+                              "prefix" : "10.193.80.0/20"
+                           }
+                        ]
+                     },
+                     "type" : "openconfig-ospfv2-ext:EXTERNAL_ROUTE_TABLE",
+                     "state" : {
+                        "type" : "openconfig-ospfv2-ext:EXTERNAL_ROUTE_TABLE"
+                     }
+                  },
+                  {
+                     "routes" : {
+                        "route" : [
+                           {
+                              "next-hops" : {
+                                 "next-hop" : [
+                                    {
+                                       "area-id" : "0.0.0.0",
+                                       "address" : "32.1.0.1",
+                                       "state" : {
+                                          "area-id" : "0.0.0.0",
+                                          "address" : "32.1.0.1",
+                                          "out-interface" : "Vlan3719"
+                                       },
+                                       "out-interface" : "Vlan3719"
+                                    }
+                                 ]
+                              },
+                              "state" : {
+                                 "cost" : 14,
+                                 "type" : "openconfig-ospfv2-ext:NETWORK_ROUTE",
+                                 "inter-area" : true,
+                                 "prefix" : "10.193.80.0/20"
+                              },
+                              "prefix" : "21.1.0.0/24"
+                           },
+                           {
+                              "next-hops" : {
+                                 "next-hop" : [
+                                    {
+                                       "area-id" : "0.0.0.0",
+                                       "address" : "0.0.0.0",
+                                       "state" : {
+                                          "area-id" : "0.0.0.0",
+                                          "address" : "32.1.0.1",
+                                          "out-interface" : "Vlan3719"
+                                       },
+                                       "out-interface" : "Vlan3719"
+                                    }
+                                 ]
+                              },
+                              "state" : {
+                                 "cost" : 4,
+                                 "type" : "openconfig-ospfv2-ext:NETWORK_ROUTE",
+                                 "prefix" : "10.193.80.0/20"
+                              },
+                              "prefix" : "32.1.0.0/24"
+                           },
+                           {
+                              "next-hops" : {
+                                 "next-hop" : [
+                                    {
+                                       "area-id" : "0.0.0.2",
+                                       "address" : "0.0.0.0",
+                                       "state" : {
+                                          "area-id" : "0.0.0.0",
+                                          "address" : "32.1.0.1",
+                                          "out-interface" : "Vlan3719"
+                                       },
+                                       "out-interface" : "Ethernet120"
+                                    }
+                                 ]
+                              },
+                              "state" : {
+                                 "cost" : 10,
+                                 "type" : "openconfig-ospfv2-ext:NETWORK_ROUTE",
+                                 "prefix" : "10.193.80.0/20"
+                              },
+                              "prefix" : "41.1.0.0/24"
+                           }
+                        ]
+                     },
+                     "type" : "openconfig-ospfv2-ext:NETWORK_ROUTE_TABLE",
+                     "state" : {
+                        "type" : "openconfig-ospfv2-ext:NETWORK_ROUTE_TABLE"
+                     }
+                  },
+                  {
+                     "routes" : {
+                        "route" : [
+                           {
+                              "next-hops" : {
+                                 "next-hop" : [
+                                    {
+                                       "area-id" : "0.0.0.0",
+                                       "address" : "32.1.0.1",
+                                       "state" : {
+                                          "area-id" : "0.0.0.0",
+                                          "address" : "32.1.0.1",
+                                          "out-interface" : "Vlan3719"
+                                       },
+                                       "out-interface" : "Vlan3719"
+                                    }
+                                 ]
+                              },
+                              "state" : {
+                                 "router-type" : "openconfig-ospfv2-ext:ABRASBR",
+                                 "cost" : 4,
+                                 "type" : "openconfig-ospfv2-ext:ROUTER_ROUTE",
+                                 "prefix" : "10.193.80.0/20"
+                              },
+                              "prefix" : "6.6.6.5"
+                           }
+                        ]
+                     },
+                     "type" : "openconfig-ospfv2-ext:ROUTER_ROUTE_TABLE",
+                     "state" : {
+                        "type" : "openconfig-ospfv2-ext:ROUTER_ROUTE_TABLE"
+                     }
+                  }
+               ]
+            },
+            "global" : {
+               "graceful-restart" : {
+                  "openconfig-ospfv2-ext:helpers" : {
+                     "helper" : [
+                        {
+                           "neighbour-id" : "5.5.5.4",
+                           "config" : {
+                              "vrf-name" : "default",
+                              "neighbour-id" : "5.5.5.4"
+                           },
+                           "state" : {
+                              "neighbour-id" : "5.5.5.4"
+                           }
+                        }
+                     ]
+                  },
+                  "config" : {
+                     "openconfig-ospfv2-ext:planned-only" : true,
+                     "helper-only" : true,
+                     "openconfig-ospfv2-ext:supported-grace-time" : 800,
+                     "openconfig-ospfv2-ext:strict-lsa-checking" : true
+                  },
+                  "state" : {
+                     "openconfig-ospfv2-ext:planned-only" : true,
+                     "helper-only" : true,
+                     "openconfig-ospfv2-ext:grace-period" : 0,
+                     "openconfig-ospfv2-ext:supported-grace-time" : 800,
+                     "openconfig-ospfv2-ext:strict-lsa-checking" : true
+                  }
+               },
+               "inter-area-propagation-policies" : {
+                  "openconfig-ospfv2-ext:inter-area-policy" : [
+                     {
+                        "config" : {
+                           "src-area" : "0.0.0.0"
+                        },
+                        "src-area" : "0.0.0.0",
+                        "state" : {
+                           "src-area" : "0.0.0.0"
+                        }
+                     },
+                     {
+                        "config" : {
+                           "src-area" : "0.0.0.2"
+                        },
+                        "src-area" : "0.0.0.2",
+                        "state" : {
+                           "src-area" : "0.0.0.2"
+                        }
+                     }
+                  ]
+               },
+               "config" : {
+                  "router-id" : "5.5.5.4",
+                  "openconfig-ospfv2-ext:opaque-lsa-capability" : true,
+                  "openconfig-ospfv2-ext:description" : "OSPFv2 Router",
+                  "openconfig-ospfv2-ext:enable" : true
+               },
+               "timers" : {
+                  "lsa-generation" : {
+                     "state" : {
+                        "openconfig-ospfv2-ext:refresh-timer" : 10000,
+                        "openconfig-ospfv2-ext:lsa-min-interval-timer" : 5000,
+                        "openconfig-ospfv2-ext:lsa-min-arrival-timer" : 1000
+                     }
+                  },
+                  "spf" : {
+                     "state" : {
+                        "maximum-delay" : 5000,
+                        "initial-delay" : 50,
+                        "openconfig-ospfv2-ext:throttle-delay" : 0,
+                        "openconfig-ospfv2-ext:spf-timer-due" : 0
+                     }
+                  }
+               },
+               "state" : {
+                  "openconfig-ospfv2-ext:area-count" : 2,
+                  "openconfig-ospfv2-ext:last-spf-duration" : 358,
+                  "openconfig-ospfv2-ext:hold-time-multiplier" : 1,
+                  "openconfig-ospfv2-ext:last-spf-execution-time" : "1187616",
+                  "openconfig-ospfv2-ext:opaque-lsa-count" : 0,
+                  "router-id" : "5.5.5.4",
+                  "openconfig-ospfv2-ext:abr-type" : "openconfig-ospfv2-ext:CISCO",
+                  "openconfig-ospfv2-ext:external-lsa-checksum" : "0x00016bcc",
+                  "openconfig-ospfv2-ext:opaque-lsa-checksum" : "0x00000000",
+                  "openconfig-ospfv2-ext:write-multiplier" : 20,
+                  "openconfig-ospfv2-ext:opaque-lsa-capability" : true,
+                  "openconfig-ospfv2-ext:external-lsa-count" : 2
+               }
+            },
+            "areas" : {
+               "area" : [
+                  {
+                     "lsdb" : {
+                        "lsa-types" : {
+                           "lsa-type" : [
+                              {
+                                 "type" : "openconfig-ospf-types:AS_EXTERNAL_LSA",
+                                 "state" : {
+                                    "type" : "openconfig-ospf-types:AS_EXTERNAL_LSA"
+                                 },
+                                 "lsas" : {
+                                    "openconfig-ospfv2-ext:lsa-ext" : [
+                                       {
+                                          "advertising-router" : "5.5.5.4",
+                                          "as-external-lsa" : {
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "forwarding-address" : "0.0.0.0",
+                                                         "external-route-tag" : 0,
+                                                         "metric" : 20
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "metric-type" : "TYPE_2",
+                                                "mask" : 20
+                                             }
+                                          },
+                                          "link-state-id" : "10.193.80.0",
+                                          "state" : {
+                                             "checksum" : 50393,
+                                             "length" : 36,
+                                             "flags" : 11,
+                                             "display-sequence-number" : "80000001",
+                                             "option" : 2,
+                                             "option-expanded" : "*||||||E|",
+                                             "age" : 1227
+                                          }
+                                       },
+                                       {
+                                          "advertising-router" : "6.6.6.5",
+                                          "as-external-lsa" : {
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "forwarding-address" : "0.0.0.0",
+                                                         "external-route-tag" : 0,
+                                                         "metric" : 20
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "metric-type" : "TYPE_2",
+                                                "mask" : 20
+                                             }
+                                          },
+                                          "link-state-id" : "10.193.80.0",
+                                          "state" : {
+                                             "checksum" : 42739,
+                                             "length" : 36,
+                                             "flags" : 6,
+                                             "display-sequence-number" : "80000001",
+                                             "option" : 2,
+                                             "option-expanded" : "*||||||E|",
+                                             "age" : 1228
+                                          }
+                                       }
+                                    ]
+                                 }
+                              },
+                              {
+                                 "type" : "openconfig-ospf-types:NETWORK_LSA",
+                                 "state" : {
+                                    "type" : "openconfig-ospf-types:NETWORK_LSA"
+                                 },
+                                 "lsas" : {
+                                    "openconfig-ospfv2-ext:lsa-ext" : [
+                                       {
+                                          "advertising-router" : "6.6.6.5",
+                                          "link-state-id" : "32.1.0.1",
+                                          "state" : {
+                                             "checksum" : 51756,
+                                             "length" : 32,
+                                             "flags" : 6,
+                                             "display-sequence-number" : "80000001",
+                                             "option" : 2,
+                                             "option-expanded" : "*|-|-|-|-|-|E|-",
+                                             "age" : 1198
+                                          },
+                                          "network-lsa" : {
+                                             "state" : {
+                                                "network-mask" : 24
+                                             }
+                                          }
+                                       }
+                                    ]
+                                 }
+                              },
+                              {
+                                 "type" : "openconfig-ospf-types:OSPFV2_LINK_SCOPE_OPAQUE_LSA"
+                              },
+                              {
+                                 "type" : "openconfig-ospf-types:ROUTER_LSA",
+                                 "state" : {
+                                    "type" : "openconfig-ospf-types:ROUTER_LSA"
+                                 },
+                                 "lsas" : {
+                                    "openconfig-ospfv2-ext:lsa-ext" : [
+                                       {
+                                          "advertising-router" : "5.5.5.4",
+                                          "link-state-id" : "5.5.5.4",
+                                          "state" : {
+                                             "checksum" : 5321,
+                                             "length" : 36,
+                                             "flags" : 3,
+                                             "display-sequence-number" : "80000005",
+                                             "option" : 2,
+                                             "option-expanded" : "*||||||E|",
+                                             "age" : 1197
+                                          },
+                                          "router-lsa" : {
+                                             "link-informations" : {
+                                                "link-information" : [
+                                                   {
+                                                      "state" : {
+                                                         "metric" : 4,
+                                                         "type" : "openconfig-ospf-types:ROUTER_LSA_TRANSIT_NETWORK",
+                                                         "number-tos-metrics" : 0
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "metric" : 4
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "flags-description" : " : ABR ASBR",
+                                                "flags" : 3,
+                                                "number-links" : 1
+                                             }
+                                          }
+                                       },
+                                       {
+                                          "advertising-router" : "6.6.6.5",
+                                          "link-state-id" : "6.6.6.5",
+                                          "state" : {
+                                             "checksum" : 47900,
+                                             "length" : 36,
+                                             "flags" : 6,
+                                             "display-sequence-number" : "80000004",
+                                             "option" : 2,
+                                             "option-expanded" : "*||||||E|",
+                                             "age" : 1197
+                                          },
+                                          "router-lsa" : {
+                                             "link-informations" : {
+                                                "link-information" : [
+                                                   {
+                                                      "state" : {
+                                                         "metric" : 4,
+                                                         "type" : "openconfig-ospf-types:ROUTER_LSA_TRANSIT_NETWORK",
+                                                         "number-tos-metrics" : 0
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "metric" : 4
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "flags-description" : " : ABR ASBR",
+                                                "flags" : 3,
+                                                "number-links" : 1
+                                             }
+                                          }
+                                       }
+                                    ]
+                                 }
+                              },
+                              {
+                                 "type" : "openconfig-ospf-types:SUMMARY_ASBR_LSA",
+                                 "state" : {
+                                    "type" : "openconfig-ospf-types:SUMMARY_ASBR_LSA"
+                                 }
+                              },
+                              {
+                                 "type" : "openconfig-ospf-types:SUMMARY_IP_NETWORK_LSA",
+                                 "state" : {
+                                    "type" : "openconfig-ospf-types:SUMMARY_IP_NETWORK_LSA"
+                                 },
+                                 "lsas" : {
+                                    "openconfig-ospfv2-ext:lsa-ext" : [
+                                       {
+                                          "advertising-router" : "6.6.6.5",
+                                          "link-state-id" : "21.1.0.0",
+                                          "summary-lsa" : {
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "metric" : 10
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "network-mask" : 24
+                                             }
+                                          },
+                                          "state" : {
+                                             "checksum" : 803,
+                                             "length" : 28,
+                                             "flags" : 6,
+                                             "display-sequence-number" : "80000001",
+                                             "option" : 2,
+                                             "option-expanded" : "*|-|-|-|-|-|E|-",
+                                             "age" : 1228
+                                          }
+                                       },
+                                       {
+                                          "advertising-router" : "5.5.5.4",
+                                          "link-state-id" : "41.1.0.0",
+                                          "summary-lsa" : {
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "metric" : 10
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "network-mask" : 24
+                                             }
+                                          },
+                                          "state" : {
+                                             "checksum" : 7417,
+                                             "length" : 28,
+                                             "flags" : 11,
+                                             "display-sequence-number" : "80000001",
+                                             "option" : 2,
+                                             "option-expanded" : "*|-|-|-|-|-|E|-",
+                                             "age" : 1227
+                                          }
+                                       }
+                                    ]
+                                 }
+                              }
+                           ]
+                        },
+                        "state" : {
+                           "identifier" : "0.0.0.0"
+                        }
+                     },
+                     "identifier" : "0.0.0.0",
+                     "interfaces" : {
+                        "interface" : [
+                           {
+                              "openconfig-ospfv2-ext:message-statistics" : {
+                                 "state" : {
+                                    "ls-update-transmit" : 4,
+                                    "ls-request-receive" : 1,
+                                    "ls-acknowledge-receive" : 2,
+                                    "ls-acknowledge-transmit" : 2,
+                                    "db-description-transmit" : 3,
+                                    "db-description-receive" : 2,
+                                    "hello-transmit" : 124,
+                                    "hello-receive" : 124,
+                                    "ls-request-transmit" : 1,
+                                    "ls-update-receive" : 3
+                                 }
+                              },
+                              "openconfig-ospfv2-ext:neighbours" : {
+                                 "neighbour" : [
+                                    {
+                                       "neighbor-id" : "6.6.6.5",
+                                       "neighbor-address" : "32.1.0.1",
+                                       "state" : {
+                                          "priority" : 1,
+                                          "option-value" : 66,
+                                          "gr-helper-status" : "None",
+                                          "state-changes" : 6,
+                                          "backup-designated-router" : "32.1.0.2",
+                                          "adjacency-state" : "openconfig-ospf-types:FULL",
+                                          "neighbor-id" : "6.6.6.5",
+                                          "optional-capabilities" : "*|O|-|-|-|-|E|-",
+                                          "thread-inactivity-timer" : true,
+                                          "thread-ls-request-retransmission" : true,
+                                          "thread-ls-update-retransmission" : true,
+                                          "retransmit-summary-queue-length" : 0,
+                                          "area-id" : "0.0.0.0",
+                                          "gr-active-helper" : false,
+                                          "interface-address" : "32.1.0.2",
+                                          "neighbor-address" : "32.1.0.1",
+                                          "last-established-time" : "1197595",
+                                          "designated-router" : "32.1.0.1",
+                                          "database-summary-queue-length" : 0,
+                                          "interface-name" : "Vlan3719",
+                                          "link-state-request-queue-length" : 0,
+                                          "dead-time" : "32410"
+                                       }
+                                    }
+                                 ]
+                              },
+                              "id" : "Vlan3719",
+                              "timers" : {
+                                 "state" : {
+                                    "retransmission-interval" : 5,
+                                    "dead-interval" : 40,
+                                    "openconfig-ospfv2-ext:wait-time" : 40,
+                                    "hello-interval" : 10000,
+                                    "openconfig-ospfv2-ext:hello-due" : 2409
+                                 }
+                              },
+                              "state" : {
+                                 "priority" : 1,
+                                 "openconfig-ospfv2-ext:member-of-ospf-all-routers" : true,
+                                 "openconfig-ospfv2-ext:index" : 310,
+                                 "openconfig-ospfv2-ext:mtu" : 9100,
+                                 "openconfig-ospfv2-ext:if-flags" : "<UP,BROADCAST,RUNNING,MULTICAST>",
+                                 "openconfig-ospfv2-ext:adjacency-count" : 1,
+                                 "openconfig-ospfv2-ext:address-len" : 24,
+                                 "openconfig-ospfv2-ext:ospf-enable" : true,
+                                 "openconfig-ospfv2-ext:cost" : 4,
+                                 "openconfig-ospfv2-ext:address" : "32.1.0.2",
+                                 "id" : "Vlan3719",
+                                 "openconfig-ospfv2-ext:adjacency-status" : "Backup",
+                                 "openconfig-ospfv2-ext:neighbor-count" : 1,
+                                 "openconfig-ospfv2-ext:backup-designated-router-id" : "5.5.5.4",
+                                 "openconfig-ospfv2-ext:member-of-ospf-designated-routers" : true,
+                                 "openconfig-ospfv2-ext:router-id" : "5.5.5.4",
+                                 "openconfig-ospfv2-ext:broadcast-address" : "32.1.0.255",
+                                 "openconfig-ospfv2-ext:bandwidth" : 25000,
+                                 "openconfig-ospfv2-ext:area-id" : "0.0.0.0",
+                                 "openconfig-ospfv2-ext:ospf-interface-type" : "Broadcast",
+                                 "openconfig-ospfv2-ext:backup-designated-router-address" : "32.1.0.2",
+                                 "network-type" : "openconfig-ospf-types:BROADCAST_NETWORK",
+                                 "openconfig-ospfv2-ext:transmit-delay" : 1,
+                                 "openconfig-ospfv2-ext:operational-state" : "Up"
+                              }
+                           }
+                        ]
+                     },
+                     "config" : {
+                        "identifier" : "0.0.0.0"
+                     },
+                     "openconfig-ospfv2-ext:networks" : {
+                        "network" : [
+                           {
+                              "address-prefix" : "31.1.0.0/24",
+                              "config" : {
+                                 "address-prefix" : "31.1.0.0/24",
+                                 "description" : "Network prefix"
+                              },
+                              "state" : {
+                                 "address-prefix" : "31.1.0.0/24",
+                                 "description" : "Network prefix"
+                              }
+                           },
+                           {
+                              "address-prefix" : "32.1.0.0/24",
+                              "config" : {
+                                 "address-prefix" : "32.1.0.0/24",
+                                 "description" : "Network prefix"
+                              },
+                              "state" : {
+                                 "address-prefix" : "32.1.0.0/24",
+                                 "description" : "Network prefix"
+                              }
+                           }
+                        ]
+                     },
+                     "state" : {
+                        "openconfig-ospfv2-ext:summary-lsa-count" : 2,
+                        "openconfig-ospfv2-ext:nssa-lsa-checksum" : "0x00000000",
+                        "openconfig-ospfv2-ext:authentication-type" : "no",
+                        "openconfig-ospfv2-ext:asbr-summary-lsa-count" : 0,
+                        "openconfig-ospfv2-ext:adjacency-count" : 1,
+                        "openconfig-ospfv2-ext:opaque-area-lsa-count" : 0,
+                        "openconfig-ospfv2-ext:opaque-area-lsa-checksum" : "0x00000000",
+                        "openconfig-ospfv2-ext:lsa-count" : 5,
+                        "openconfig-ospfv2-ext:opaque-link-lsa-checksum" : "0x00000000",
+                        "openconfig-ospfv2-ext:spf-execution-count" : 6,
+                        "openconfig-ospfv2-ext:interface-count" : 1,
+                        "openconfig-ospfv2-ext:network-lsa-count" : 1,
+                        "openconfig-ospfv2-ext:asbr-summary-lsa-checksum" : "0x00000000",
+                        "openconfig-ospfv2-ext:router-lsa-checksum" : "0x0000cfe5",
+                        "openconfig-ospfv2-ext:router-lsa-count" : 2,
+                        "openconfig-ospfv2-ext:nssa-lsa-count" : 0,
+                        "openconfig-ospfv2-ext:active-interface-count" : 1,
+                        "openconfig-ospfv2-ext:summary-lsa-checksum" : "0x0000201c",
+                        "openconfig-ospfv2-ext:network-lsa-checksum" : "0x0000ca2c",
+                        "openconfig-ospfv2-ext:opaque-link-lsa-count" : 0
+                     }
+                  },
+                  {
+                     "lsdb" : {
+                        "lsa-types" : {
+                           "lsa-type" : [
+                              {
+                                 "type" : "openconfig-ospf-types:AS_EXTERNAL_LSA",
+                                 "state" : {
+                                    "type" : "openconfig-ospf-types:AS_EXTERNAL_LSA"
+                                 },
+                                 "lsas" : {
+                                    "openconfig-ospfv2-ext:lsa-ext" : [
+                                       {
+                                          "advertising-router" : "5.5.5.4",
+                                          "as-external-lsa" : {
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "forwarding-address" : "0.0.0.0",
+                                                         "external-route-tag" : 0,
+                                                         "metric" : 20
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "metric-type" : "TYPE_2",
+                                                "mask" : 20
+                                             }
+                                          },
+                                          "link-state-id" : "10.193.80.0",
+                                          "state" : {
+                                             "checksum" : 50393,
+                                             "length" : 36,
+                                             "flags" : 11,
+                                             "display-sequence-number" : "80000001",
+                                             "option" : 2,
+                                             "option-expanded" : "*||||||E|",
+                                             "age" : 1227
+                                          }
+                                       },
+                                       {
+                                          "advertising-router" : "6.6.6.5",
+                                          "as-external-lsa" : {
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "forwarding-address" : "0.0.0.0",
+                                                         "external-route-tag" : 0,
+                                                         "metric" : 20
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "metric-type" : "TYPE_2",
+                                                "mask" : 20
+                                             }
+                                          },
+                                          "link-state-id" : "10.193.80.0",
+                                          "state" : {
+                                             "checksum" : 42739,
+                                             "length" : 36,
+                                             "flags" : 6,
+                                             "display-sequence-number" : "80000001",
+                                             "option" : 2,
+                                             "option-expanded" : "*||||||E|",
+                                             "age" : 1228
+                                          }
+                                       }
+                                    ]
+                                 }
+                              },
+                              {
+                                 "type" : "openconfig-ospf-types:NETWORK_LSA",
+                                 "state" : {
+                                    "type" : "openconfig-ospf-types:NETWORK_LSA"
+                                 },
+                                 "lsas" : {
+                                    "openconfig-ospfv2-ext:lsa-ext" : [
+                                       {
+                                          "advertising-router" : "5.5.5.4",
+                                          "link-state-id" : "41.1.0.2",
+                                          "state" : {
+                                             "checksum" : 1017,
+                                             "length" : 32,
+                                             "flags" : 3,
+                                             "display-sequence-number" : "80000001",
+                                             "option" : 2,
+                                             "option-expanded" : "*|-|-|-|-|-|E|-",
+                                             "age" : 1198
+                                          },
+                                          "network-lsa" : {
+                                             "state" : {
+                                                "network-mask" : 24
+                                             }
+                                          }
+                                       }
+                                    ]
+                                 }
+                              },
+                              {
+                                 "type" : "openconfig-ospf-types:OSPFV2_LINK_SCOPE_OPAQUE_LSA"
+                              },
+                              {
+                                 "type" : "openconfig-ospf-types:ROUTER_LSA",
+                                 "state" : {
+                                    "type" : "openconfig-ospf-types:ROUTER_LSA"
+                                 },
+                                 "lsas" : {
+                                    "openconfig-ospfv2-ext:lsa-ext" : [
+                                       {
+                                          "advertising-router" : "3.3.3.2",
+                                          "link-state-id" : "3.3.3.2",
+                                          "state" : {
+                                             "checksum" : 53771,
+                                             "length" : 36,
+                                             "flags" : 6,
+                                             "display-sequence-number" : "80000002",
+                                             "option" : 0,
+                                             "option-expanded" : "*|||||||-",
+                                             "age" : 1189
+                                          },
+                                          "router-lsa" : {
+                                             "link-informations" : {
+                                                "link-information" : [
+                                                   {
+                                                      "state" : {
+                                                         "metric" : 10,
+                                                         "type" : "openconfig-ospf-types:ROUTER_LSA_TRANSIT_NETWORK",
+                                                         "number-tos-metrics" : 0
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "metric" : 10
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "flags-description" : " :",
+                                                "flags" : 0,
+                                                "number-links" : 1
+                                             }
+                                          }
+                                       },
+                                       {
+                                          "advertising-router" : "5.5.5.4",
+                                          "link-state-id" : "5.5.5.4",
+                                          "state" : {
+                                             "checksum" : 12693,
+                                             "length" : 36,
+                                             "flags" : 3,
+                                             "display-sequence-number" : "80000003",
+                                             "option" : 2,
+                                             "option-expanded" : "*||||||E|",
+                                             "age" : 1198
+                                          },
+                                          "router-lsa" : {
+                                             "link-informations" : {
+                                                "link-information" : [
+                                                   {
+                                                      "state" : {
+                                                         "metric" : 10,
+                                                         "type" : "openconfig-ospf-types:ROUTER_LSA_TRANSIT_NETWORK",
+                                                         "number-tos-metrics" : 0
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "metric" : 10
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "flags-description" : " : ABR ASBR",
+                                                "flags" : 3,
+                                                "number-links" : 1
+                                             }
+                                          }
+                                       }
+                                    ]
+                                 }
+                              },
+                              {
+                                 "type" : "openconfig-ospf-types:SUMMARY_ASBR_LSA",
+                                 "state" : {
+                                    "type" : "openconfig-ospf-types:SUMMARY_ASBR_LSA"
+                                 },
+                                 "lsas" : {
+                                    "openconfig-ospfv2-ext:lsa-ext" : [
+                                       {
+                                          "advertising-router" : "5.5.5.4",
+                                          "link-state-id" : "6.6.6.5",
+                                          "summary-lsa" : {
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "metric" : 4
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "network-mask" : 0
+                                             }
+                                          },
+                                          "state" : {
+                                             "checksum" : 59716,
+                                             "length" : 28,
+                                             "flags" : 11,
+                                             "display-sequence-number" : "80000001",
+                                             "option" : 2,
+                                             "option-expanded" : "*|-|-|-|-|-|E|-",
+                                             "age" : 1187
+                                          }
+                                       }
+                                    ]
+                                 }
+                              },
+                              {
+                                 "type" : "openconfig-ospf-types:SUMMARY_IP_NETWORK_LSA",
+                                 "state" : {
+                                    "type" : "openconfig-ospf-types:SUMMARY_IP_NETWORK_LSA"
+                                 },
+                                 "lsas" : {
+                                    "openconfig-ospfv2-ext:lsa-ext" : [
+                                       {
+                                          "advertising-router" : "5.5.5.4",
+                                          "link-state-id" : "21.1.0.0",
+                                          "summary-lsa" : {
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "metric" : 14
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "network-mask" : 24
+                                             }
+                                          },
+                                          "state" : {
+                                             "checksum" : 18908,
+                                             "length" : 28,
+                                             "flags" : 11,
+                                             "display-sequence-number" : "80000001",
+                                             "option" : 2,
+                                             "option-expanded" : "*|-|-|-|-|-|E|-",
+                                             "age" : 1187
+                                          }
+                                       },
+                                       {
+                                          "advertising-router" : "5.5.5.4",
+                                          "link-state-id" : "32.1.0.0",
+                                          "summary-lsa" : {
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "metric" : 4
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "network-mask" : 24
+                                             }
+                                          },
+                                          "state" : {
+                                             "checksum" : 21967,
+                                             "length" : 28,
+                                             "flags" : 11,
+                                             "display-sequence-number" : "80000001",
+                                             "option" : 2,
+                                             "option-expanded" : "*|-|-|-|-|-|E|-",
+                                             "age" : 1229
+                                          }
+                                       }
+                                    ]
+                                 }
+                              }
+                           ]
+                        },
+                        "state" : {
+                           "identifier" : "0.0.0.2"
+                        }
+                     },
+                     "identifier" : "0.0.0.2",
+                     "interfaces" : {
+                        "interface" : [
+                           {
+                              "openconfig-ospfv2-ext:message-statistics" : {
+                                 "state" : {
+                                    "ls-update-transmit" : 3,
+                                    "ls-request-receive" : 0,
+                                    "ls-acknowledge-receive" : 3,
+                                    "ls-acknowledge-transmit" : 2,
+                                    "db-description-transmit" : 2,
+                                    "db-description-receive" : 6,
+                                    "hello-transmit" : 124,
+                                    "hello-receive" : 125,
+                                    "ls-request-transmit" : 1,
+                                    "ls-update-receive" : 2
+                                 }
+                              },
+                              "openconfig-ospfv2-ext:neighbours" : {
+                                 "neighbour" : [
+                                    {
+                                       "neighbor-id" : "3.3.3.2",
+                                       "neighbor-address" : "41.1.0.1",
+                                       "state" : {
+                                          "priority" : 0,
+                                          "option-value" : 66,
+                                          "gr-helper-status" : "None",
+                                          "state-changes" : 6,
+                                          "backup-designated-router" : "0.0.0.0",
+                                          "adjacency-state" : "openconfig-ospf-types:FULL",
+                                          "neighbor-id" : "6.6.6.5",
+                                          "optional-capabilities" : "*|O|-|-|-|-|E|-",
+                                          "thread-inactivity-timer" : true,
+                                          "thread-ls-request-retransmission" : true,
+                                          "thread-ls-update-retransmission" : true,
+                                          "retransmit-summary-queue-length" : 0,
+                                          "area-id" : "0.0.0.2",
+                                          "gr-active-helper" : false,
+                                          "interface-address" : "41.1.0.2",
+                                          "neighbor-address" : "41.1.0.1",
+                                          "last-established-time" : "1198302",
+                                          "designated-router" : "41.1.0.2",
+                                          "database-summary-queue-length" : 0,
+                                          "interface-name" : "Ethernet120",
+                                          "link-state-request-queue-length" : 0,
+                                          "dead-time" : "34872"
+                                       }
+                                    }
+                                 ]
+                              },
+                              "id" : "Ethernet120",
+                              "timers" : {
+                                 "state" : {
+                                    "retransmission-interval" : 5,
+                                    "dead-interval" : 40,
+                                    "openconfig-ospfv2-ext:wait-time" : 40,
+                                    "hello-interval" : 10000,
+                                    "openconfig-ospfv2-ext:hello-due" : 1711
+                                 }
+                              },
+                              "state" : {
+                                 "priority" : 1,
+                                 "openconfig-ospfv2-ext:member-of-ospf-all-routers" : true,
+                                 "openconfig-ospfv2-ext:index" : 299,
+                                 "openconfig-ospfv2-ext:mtu" : 9100,
+                                 "openconfig-ospfv2-ext:if-flags" : "<UP,BROADCAST,RUNNING,MULTICAST>",
+                                 "openconfig-ospfv2-ext:adjacency-count" : 1,
+                                 "openconfig-ospfv2-ext:address-len" : 24,
+                                 "openconfig-ospfv2-ext:ospf-enable" : true,
+                                 "openconfig-ospfv2-ext:cost" : 10,
+                                 "openconfig-ospfv2-ext:address" : "41.1.0.2",
+                                 "id" : "Ethernet120",
+                                 "openconfig-ospfv2-ext:adjacency-status" : "DR",
+                                 "openconfig-ospfv2-ext:member-of-ospf-designated-routers" : true,
+                                 "openconfig-ospfv2-ext:neighbor-count" : 1,
+                                 "openconfig-ospfv2-ext:router-id" : "5.5.5.4",
+                                 "openconfig-ospfv2-ext:broadcast-address" : "41.1.0.255",
+                                 "openconfig-ospfv2-ext:bandwidth" : 10000,
+                                 "openconfig-ospfv2-ext:area-id" : "0.0.0.2",
+                                 "openconfig-ospfv2-ext:ospf-interface-type" : "Broadcast",
+                                 "network-type" : "openconfig-ospf-types:BROADCAST_NETWORK",
+                                 "openconfig-ospfv2-ext:transmit-delay" : 1,
+                                 "openconfig-ospfv2-ext:operational-state" : "Up"
+                              }
+                           }
+                        ]
+                     },
+                     "config" : {
+                        "identifier" : "0.0.0.2"
+                     },
+                     "openconfig-ospfv2-ext:networks" : {
+                        "network" : [
+                           {
+                              "address-prefix" : "41.1.0.0/24",
+                              "config" : {
+                                 "address-prefix" : "41.1.0.0/24",
+                                 "description" : "Network prefix"
+                              },
+                              "state" : {
+                                 "address-prefix" : "41.1.0.0/24",
+                                 "description" : "Network prefix"
+                              }
+                           }
+                        ]
+                     },
+                     "state" : {
+                        "openconfig-ospfv2-ext:summary-lsa-count" : 2,
+                        "openconfig-ospfv2-ext:nssa-lsa-checksum" : "0x00000000",
+                        "openconfig-ospfv2-ext:authentication-type" : "no",
+                        "openconfig-ospfv2-ext:asbr-summary-lsa-count" : 1,
+                        "openconfig-ospfv2-ext:adjacency-count" : 1,
+                        "openconfig-ospfv2-ext:opaque-area-lsa-count" : 0,
+                        "openconfig-ospfv2-ext:opaque-area-lsa-checksum" : "0x00000000",
+                        "openconfig-ospfv2-ext:lsa-count" : 6,
+                        "openconfig-ospfv2-ext:opaque-link-lsa-checksum" : "0x00000000",
+                        "openconfig-ospfv2-ext:virtual-link-adjacency-count" : 0,
+                        "openconfig-ospfv2-ext:spf-execution-count" : 6,
+                        "openconfig-ospfv2-ext:interface-count" : 1,
+                        "openconfig-ospfv2-ext:network-lsa-count" : 1,
+                        "openconfig-ospfv2-ext:asbr-summary-lsa-checksum" : "0x0000e944",
+                        "openconfig-ospfv2-ext:router-lsa-checksum" : "0x000103a0",
+                        "openconfig-ospfv2-ext:router-lsa-count" : 2,
+                        "openconfig-ospfv2-ext:nssa-lsa-count" : 0,
+                        "openconfig-ospfv2-ext:active-interface-count" : 1,
+                        "openconfig-ospfv2-ext:shortcut" : "openconfig-ospfv2-ext:DEFAULT",
+                        "openconfig-ospfv2-ext:summary-lsa-checksum" : "0x00009fab",
+                        "openconfig-ospfv2-ext:network-lsa-checksum" : "0x000003f9",
+                        "openconfig-ospfv2-ext:opaque-link-lsa-count" : 0
+                     }
+                  }
+               ]
+            }
+         },
+         "name" : "ospfv2",
+         "config" : {
+            "identifier" : "openconfig-policy-types:OSPF",
+            "name" : "ospfv2"
+         },
+         "state" : {
+            "identifier" : "openconfig-policy-types:OSPF",
+            "name" : "ospfv2"
+         }
+      }
+   ]
+}
+            `),
+		appRootType: reflect.TypeOf(ocbinds.OpenconfigNetworkInstance_NetworkInstances{}),
+		queryParams: QueryParams{
+			depthEnabled:  false,
+			curDepth:      1,
+			content:       QUERY_CONTENT_ALL,
+			fields:        []string{},
+			fieldsFillAll: false,
+		},
+		prunedPayload: []byte(`
+{
+   "protocol" : [
+      {
+         "identifier" : "openconfig-policy-types:OSPF",
+         "ospfv2" : {
+            "openconfig-ospfv2-ext:route-tables" : {
+               "route-table" : [
+                  {
+                     "routes" : {
+                        "route" : [
+                           {
+                              "next-hops" : {
+                                 "next-hop" : [
+                                    {
+                                       "area-id" : "0.0.0.0",
+                                       "address" : "32.1.0.1",
+                                       "state" : {
+                                          "area-id" : "0.0.0.0",
+                                          "address" : "32.1.0.1",
+                                          "out-interface" : "Vlan3719"
+                                       },
+                                       "out-interface" : "Vlan3719"
+                                    }
+                                 ]
+                              },
+                              "state" : {
+                                 "cost" : 4,
+                                 "sub-type" : "openconfig-ospfv2-ext:EXTERNAL_ROUTE_TYPE_2",
+                                 "type" : "openconfig-ospfv2-ext:EXTERNAL_ROUTE",
+                                 "prefix" : "10.193.80.0/20"
+                              },
+                              "prefix" : "10.193.80.0/20"
+                           }
+                        ]
+                     },
+                     "type" : "openconfig-ospfv2-ext:EXTERNAL_ROUTE_TABLE",
+                     "state" : {
+                        "type" : "openconfig-ospfv2-ext:EXTERNAL_ROUTE_TABLE"
+                     }
+                  },
+                  {
+                     "routes" : {
+                        "route" : [
+                           {
+                              "next-hops" : {
+                                 "next-hop" : [
+                                    {
+                                       "area-id" : "0.0.0.0",
+                                       "address" : "32.1.0.1",
+                                       "state" : {
+                                          "area-id" : "0.0.0.0",
+                                          "address" : "32.1.0.1",
+                                          "out-interface" : "Vlan3719"
+                                       },
+                                       "out-interface" : "Vlan3719"
+                                    }
+                                 ]
+                              },
+                              "state" : {
+                                 "cost" : 14,
+                                 "type" : "openconfig-ospfv2-ext:NETWORK_ROUTE",
+                                 "inter-area" : true,
+                                 "prefix" : "10.193.80.0/20"
+                              },
+                              "prefix" : "21.1.0.0/24"
+                           },
+                           {
+                              "next-hops" : {
+                                 "next-hop" : [
+                                    {
+                                       "area-id" : "0.0.0.0",
+                                       "address" : "0.0.0.0",
+                                       "state" : {
+                                          "area-id" : "0.0.0.0",
+                                          "address" : "32.1.0.1",
+                                          "out-interface" : "Vlan3719"
+                                       },
+                                       "out-interface" : "Vlan3719"
+                                    }
+                                 ]
+                              },
+                              "state" : {
+                                 "cost" : 4,
+                                 "type" : "openconfig-ospfv2-ext:NETWORK_ROUTE",
+                                 "prefix" : "10.193.80.0/20"
+                              },
+                              "prefix" : "32.1.0.0/24"
+                           },
+                           {
+                              "next-hops" : {
+                                 "next-hop" : [
+                                    {
+                                       "area-id" : "0.0.0.2",
+                                       "address" : "0.0.0.0",
+                                       "state" : {
+                                          "area-id" : "0.0.0.0",
+                                          "address" : "32.1.0.1",
+                                          "out-interface" : "Vlan3719"
+                                       },
+                                       "out-interface" : "Ethernet120"
+                                    }
+                                 ]
+                              },
+                              "state" : {
+                                 "cost" : 10,
+                                 "type" : "openconfig-ospfv2-ext:NETWORK_ROUTE",
+                                 "prefix" : "10.193.80.0/20"
+                              },
+                              "prefix" : "41.1.0.0/24"
+                           }
+                        ]
+                     },
+                     "type" : "openconfig-ospfv2-ext:NETWORK_ROUTE_TABLE",
+                     "state" : {
+                        "type" : "openconfig-ospfv2-ext:NETWORK_ROUTE_TABLE"
+                     }
+                  },
+                  {
+                     "routes" : {
+                        "route" : [
+                           {
+                              "next-hops" : {
+                                 "next-hop" : [
+                                    {
+                                       "area-id" : "0.0.0.0",
+                                       "address" : "32.1.0.1",
+                                       "state" : {
+                                          "area-id" : "0.0.0.0",
+                                          "address" : "32.1.0.1",
+                                          "out-interface" : "Vlan3719"
+                                       },
+                                       "out-interface" : "Vlan3719"
+                                    }
+                                 ]
+                              },
+                              "state" : {
+                                 "router-type" : "openconfig-ospfv2-ext:ABRASBR",
+                                 "cost" : 4,
+                                 "type" : "openconfig-ospfv2-ext:ROUTER_ROUTE",
+                                 "prefix" : "10.193.80.0/20"
+                              },
+                              "prefix" : "6.6.6.5"
+                           }
+                        ]
+                     },
+                     "type" : "openconfig-ospfv2-ext:ROUTER_ROUTE_TABLE",
+                     "state" : {
+                        "type" : "openconfig-ospfv2-ext:ROUTER_ROUTE_TABLE"
+                     }
+                  }
+               ]
+            },
+            "global" : {
+               "graceful-restart" : {
+                  "openconfig-ospfv2-ext:helpers" : {
+                     "helper" : [
+                        {
+                           "neighbour-id" : "5.5.5.4",
+                           "config" : {
+                              "vrf-name" : "default",
+                              "neighbour-id" : "5.5.5.4"
+                           },
+                           "state" : {
+                              "neighbour-id" : "5.5.5.4"
+                           }
+                        }
+                     ]
+                  },
+                  "config" : {
+                     "openconfig-ospfv2-ext:planned-only" : true,
+                     "helper-only" : true,
+                     "openconfig-ospfv2-ext:supported-grace-time" : 800,
+                     "openconfig-ospfv2-ext:strict-lsa-checking" : true
+                  },
+                  "state" : {
+                     "openconfig-ospfv2-ext:planned-only" : true,
+                     "helper-only" : true,
+                     "openconfig-ospfv2-ext:grace-period" : 0,
+                     "openconfig-ospfv2-ext:supported-grace-time" : 800,
+                     "openconfig-ospfv2-ext:strict-lsa-checking" : true
+                  }
+               },
+               "inter-area-propagation-policies" : {
+                  "openconfig-ospfv2-ext:inter-area-policy" : [
+                     {
+                        "config" : {
+                           "src-area" : "0.0.0.0"
+                        },
+                        "src-area" : "0.0.0.0",
+                        "state" : {
+                           "src-area" : "0.0.0.0"
+                        }
+                     },
+                     {
+                        "config" : {
+                           "src-area" : "0.0.0.2"
+                        },
+                        "src-area" : "0.0.0.2",
+                        "state" : {
+                           "src-area" : "0.0.0.2"
+                        }
+                     }
+                  ]
+               },
+               "config" : {
+                  "router-id" : "5.5.5.4",
+                  "openconfig-ospfv2-ext:opaque-lsa-capability" : true,
+                  "openconfig-ospfv2-ext:description" : "OSPFv2 Router",
+                  "openconfig-ospfv2-ext:enable" : true
+               },
+               "timers" : {
+                  "lsa-generation" : {
+                     "state" : {
+                        "openconfig-ospfv2-ext:refresh-timer" : 10000,
+                        "openconfig-ospfv2-ext:lsa-min-interval-timer" : 5000,
+                        "openconfig-ospfv2-ext:lsa-min-arrival-timer" : 1000
+                     }
+                  },
+                  "spf" : {
+                     "state" : {
+                        "maximum-delay" : 5000,
+                        "initial-delay" : 50,
+                        "openconfig-ospfv2-ext:throttle-delay" : 0,
+                        "openconfig-ospfv2-ext:spf-timer-due" : 0
+                     }
+                  }
+               },
+               "state" : {
+                  "openconfig-ospfv2-ext:area-count" : 2,
+                  "openconfig-ospfv2-ext:last-spf-duration" : 358,
+                  "openconfig-ospfv2-ext:hold-time-multiplier" : 1,
+                  "openconfig-ospfv2-ext:last-spf-execution-time" : "1187616",
+                  "openconfig-ospfv2-ext:opaque-lsa-count" : 0,
+                  "router-id" : "5.5.5.4",
+                  "openconfig-ospfv2-ext:abr-type" : "openconfig-ospfv2-ext:CISCO",
+                  "openconfig-ospfv2-ext:external-lsa-checksum" : "0x00016bcc",
+                  "openconfig-ospfv2-ext:opaque-lsa-checksum" : "0x00000000",
+                  "openconfig-ospfv2-ext:write-multiplier" : 20,
+                  "openconfig-ospfv2-ext:opaque-lsa-capability" : true,
+                  "openconfig-ospfv2-ext:external-lsa-count" : 2
+               }
+            },
+            "areas" : {
+               "area" : [
+                  {
+                     "lsdb" : {
+                        "lsa-types" : {
+                           "lsa-type" : [
+                              {
+                                 "type" : "openconfig-ospf-types:AS_EXTERNAL_LSA",
+                                 "state" : {
+                                    "type" : "openconfig-ospf-types:AS_EXTERNAL_LSA"
+                                 },
+                                 "lsas" : {
+                                    "openconfig-ospfv2-ext:lsa-ext" : [
+                                       {
+                                          "advertising-router" : "5.5.5.4",
+                                          "as-external-lsa" : {
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "forwarding-address" : "0.0.0.0",
+                                                         "external-route-tag" : 0,
+                                                         "metric" : 20
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "metric-type" : "TYPE_2",
+                                                "mask" : 20
+                                             }
+                                          },
+                                          "link-state-id" : "10.193.80.0",
+                                          "state" : {
+                                             "checksum" : 50393,
+                                             "length" : 36,
+                                             "flags" : 11,
+                                             "display-sequence-number" : "80000001",
+                                             "option" : 2,
+                                             "option-expanded" : "*||||||E|",
+                                             "age" : 1227
+                                          }
+                                       },
+                                       {
+                                          "advertising-router" : "6.6.6.5",
+                                          "as-external-lsa" : {
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "forwarding-address" : "0.0.0.0",
+                                                         "external-route-tag" : 0,
+                                                         "metric" : 20
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "metric-type" : "TYPE_2",
+                                                "mask" : 20
+                                             }
+                                          },
+                                          "link-state-id" : "10.193.80.0",
+                                          "state" : {
+                                             "checksum" : 42739,
+                                             "length" : 36,
+                                             "flags" : 6,
+                                             "display-sequence-number" : "80000001",
+                                             "option" : 2,
+                                             "option-expanded" : "*||||||E|",
+                                             "age" : 1228
+                                          }
+                                       }
+                                    ]
+                                 }
+                              },
+                              {
+                                 "type" : "openconfig-ospf-types:NETWORK_LSA",
+                                 "state" : {
+                                    "type" : "openconfig-ospf-types:NETWORK_LSA"
+                                 },
+                                 "lsas" : {
+                                    "openconfig-ospfv2-ext:lsa-ext" : [
+                                       {
+                                          "advertising-router" : "6.6.6.5",
+                                          "link-state-id" : "32.1.0.1",
+                                          "state" : {
+                                             "checksum" : 51756,
+                                             "length" : 32,
+                                             "flags" : 6,
+                                             "display-sequence-number" : "80000001",
+                                             "option" : 2,
+                                             "option-expanded" : "*|-|-|-|-|-|E|-",
+                                             "age" : 1198
+                                          },
+                                          "network-lsa" : {
+                                             "state" : {
+                                                "network-mask" : 24
+                                             }
+                                          }
+                                       }
+                                    ]
+                                 }
+                              },
+                              {
+                                 "type" : "openconfig-ospf-types:OSPFV2_LINK_SCOPE_OPAQUE_LSA"
+                              },
+                              {
+                                 "type" : "openconfig-ospf-types:ROUTER_LSA",
+                                 "state" : {
+                                    "type" : "openconfig-ospf-types:ROUTER_LSA"
+                                 },
+                                 "lsas" : {
+                                    "openconfig-ospfv2-ext:lsa-ext" : [
+                                       {
+                                          "advertising-router" : "5.5.5.4",
+                                          "link-state-id" : "5.5.5.4",
+                                          "state" : {
+                                             "checksum" : 5321,
+                                             "length" : 36,
+                                             "flags" : 3,
+                                             "display-sequence-number" : "80000005",
+                                             "option" : 2,
+                                             "option-expanded" : "*||||||E|",
+                                             "age" : 1197
+                                          },
+                                          "router-lsa" : {
+                                             "link-informations" : {
+                                                "link-information" : [
+                                                   {
+                                                      "state" : {
+                                                         "metric" : 4,
+                                                         "type" : "openconfig-ospf-types:ROUTER_LSA_TRANSIT_NETWORK",
+                                                         "number-tos-metrics" : 0
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "metric" : 4
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "flags-description" : " : ABR ASBR",
+                                                "flags" : 3,
+                                                "number-links" : 1
+                                             }
+                                          }
+                                       },
+                                       {
+                                          "advertising-router" : "6.6.6.5",
+                                          "link-state-id" : "6.6.6.5",
+                                          "state" : {
+                                             "checksum" : 47900,
+                                             "length" : 36,
+                                             "flags" : 6,
+                                             "display-sequence-number" : "80000004",
+                                             "option" : 2,
+                                             "option-expanded" : "*||||||E|",
+                                             "age" : 1197
+                                          },
+                                          "router-lsa" : {
+                                             "link-informations" : {
+                                                "link-information" : [
+                                                   {
+                                                      "state" : {
+                                                         "metric" : 4,
+                                                         "type" : "openconfig-ospf-types:ROUTER_LSA_TRANSIT_NETWORK",
+                                                         "number-tos-metrics" : 0
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "metric" : 4
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "flags-description" : " : ABR ASBR",
+                                                "flags" : 3,
+                                                "number-links" : 1
+                                             }
+                                          }
+                                       }
+                                    ]
+                                 }
+                              },
+                              {
+                                 "type" : "openconfig-ospf-types:SUMMARY_ASBR_LSA",
+                                 "state" : {
+                                    "type" : "openconfig-ospf-types:SUMMARY_ASBR_LSA"
+                                 }
+                              },
+                              {
+                                 "type" : "openconfig-ospf-types:SUMMARY_IP_NETWORK_LSA",
+                                 "state" : {
+                                    "type" : "openconfig-ospf-types:SUMMARY_IP_NETWORK_LSA"
+                                 },
+                                 "lsas" : {
+                                    "openconfig-ospfv2-ext:lsa-ext" : [
+                                       {
+                                          "advertising-router" : "6.6.6.5",
+                                          "link-state-id" : "21.1.0.0",
+                                          "summary-lsa" : {
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "metric" : 10
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "network-mask" : 24
+                                             }
+                                          },
+                                          "state" : {
+                                             "checksum" : 803,
+                                             "length" : 28,
+                                             "flags" : 6,
+                                             "display-sequence-number" : "80000001",
+                                             "option" : 2,
+                                             "option-expanded" : "*|-|-|-|-|-|E|-",
+                                             "age" : 1228
+                                          }
+                                       },
+                                       {
+                                          "advertising-router" : "5.5.5.4",
+                                          "link-state-id" : "41.1.0.0",
+                                          "summary-lsa" : {
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "metric" : 10
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "network-mask" : 24
+                                             }
+                                          },
+                                          "state" : {
+                                             "checksum" : 7417,
+                                             "length" : 28,
+                                             "flags" : 11,
+                                             "display-sequence-number" : "80000001",
+                                             "option" : 2,
+                                             "option-expanded" : "*|-|-|-|-|-|E|-",
+                                             "age" : 1227
+                                          }
+                                       }
+                                    ]
+                                 }
+                              }
+                           ]
+                        },
+                        "state" : {
+                           "identifier" : "0.0.0.0"
+                        }
+                     },
+                     "identifier" : "0.0.0.0",
+                     "interfaces" : {
+                        "interface" : [
+                           {
+                              "openconfig-ospfv2-ext:message-statistics" : {
+                                 "state" : {
+                                    "ls-update-transmit" : 4,
+                                    "ls-request-receive" : 1,
+                                    "ls-acknowledge-receive" : 2,
+                                    "ls-acknowledge-transmit" : 2,
+                                    "db-description-transmit" : 3,
+                                    "db-description-receive" : 2,
+                                    "hello-transmit" : 124,
+                                    "hello-receive" : 124,
+                                    "ls-request-transmit" : 1,
+                                    "ls-update-receive" : 3
+                                 }
+                              },
+                              "openconfig-ospfv2-ext:neighbours" : {
+                                 "neighbour" : [
+                                    {
+                                       "neighbor-id" : "6.6.6.5",
+                                       "neighbor-address" : "32.1.0.1",
+                                       "state" : {
+                                          "priority" : 1,
+                                          "option-value" : 66,
+                                          "gr-helper-status" : "None",
+                                          "state-changes" : 6,
+                                          "backup-designated-router" : "32.1.0.2",
+                                          "adjacency-state" : "openconfig-ospf-types:FULL",
+                                          "neighbor-id" : "6.6.6.5",
+                                          "optional-capabilities" : "*|O|-|-|-|-|E|-",
+                                          "thread-inactivity-timer" : true,
+                                          "thread-ls-request-retransmission" : true,
+                                          "thread-ls-update-retransmission" : true,
+                                          "retransmit-summary-queue-length" : 0,
+                                          "area-id" : "0.0.0.0",
+                                          "gr-active-helper" : false,
+                                          "interface-address" : "32.1.0.2",
+                                          "neighbor-address" : "32.1.0.1",
+                                          "last-established-time" : "1197595",
+                                          "designated-router" : "32.1.0.1",
+                                          "database-summary-queue-length" : 0,
+                                          "interface-name" : "Vlan3719",
+                                          "link-state-request-queue-length" : 0,
+                                          "dead-time" : "32410"
+                                       }
+                                    }
+                                 ]
+                              },
+                              "id" : "Vlan3719",
+                              "timers" : {
+                                 "state" : {
+                                    "retransmission-interval" : 5,
+                                    "dead-interval" : 40,
+                                    "openconfig-ospfv2-ext:wait-time" : 40,
+                                    "hello-interval" : 10000,
+                                    "openconfig-ospfv2-ext:hello-due" : 2409
+                                 }
+                              },
+                              "state" : {
+                                 "priority" : 1,
+                                 "openconfig-ospfv2-ext:member-of-ospf-all-routers" : true,
+                                 "openconfig-ospfv2-ext:index" : 310,
+                                 "openconfig-ospfv2-ext:mtu" : 9100,
+                                 "openconfig-ospfv2-ext:if-flags" : "<UP,BROADCAST,RUNNING,MULTICAST>",
+                                 "openconfig-ospfv2-ext:adjacency-count" : 1,
+                                 "openconfig-ospfv2-ext:address-len" : 24,
+                                 "openconfig-ospfv2-ext:ospf-enable" : true,
+                                 "openconfig-ospfv2-ext:cost" : 4,
+                                 "openconfig-ospfv2-ext:address" : "32.1.0.2",
+                                 "id" : "Vlan3719",
+                                 "openconfig-ospfv2-ext:adjacency-status" : "Backup",
+                                 "openconfig-ospfv2-ext:neighbor-count" : 1,
+                                 "openconfig-ospfv2-ext:backup-designated-router-id" : "5.5.5.4",
+                                 "openconfig-ospfv2-ext:member-of-ospf-designated-routers" : true,
+                                 "openconfig-ospfv2-ext:router-id" : "5.5.5.4",
+                                 "openconfig-ospfv2-ext:broadcast-address" : "32.1.0.255",
+                                 "openconfig-ospfv2-ext:bandwidth" : 25000,
+                                 "openconfig-ospfv2-ext:area-id" : "0.0.0.0",
+                                 "openconfig-ospfv2-ext:ospf-interface-type" : "Broadcast",
+                                 "openconfig-ospfv2-ext:backup-designated-router-address" : "32.1.0.2",
+                                 "network-type" : "openconfig-ospf-types:BROADCAST_NETWORK",
+                                 "openconfig-ospfv2-ext:transmit-delay" : 1,
+                                 "openconfig-ospfv2-ext:operational-state" : "Up"
+                              }
+                           }
+                        ]
+                     },
+                     "config" : {
+                        "identifier" : "0.0.0.0"
+                     },
+                     "openconfig-ospfv2-ext:networks" : {
+                        "network" : [
+                           {
+                              "address-prefix" : "31.1.0.0/24",
+                              "config" : {
+                                 "address-prefix" : "31.1.0.0/24",
+                                 "description" : "Network prefix"
+                              },
+                              "state" : {
+                                 "address-prefix" : "31.1.0.0/24",
+                                 "description" : "Network prefix"
+                              }
+                           },
+                           {
+                              "address-prefix" : "32.1.0.0/24",
+                              "config" : {
+                                 "address-prefix" : "32.1.0.0/24",
+                                 "description" : "Network prefix"
+                              },
+                              "state" : {
+                                 "address-prefix" : "32.1.0.0/24",
+                                 "description" : "Network prefix"
+                              }
+                           }
+                        ]
+                     },
+                     "state" : {
+                        "openconfig-ospfv2-ext:summary-lsa-count" : 2,
+                        "openconfig-ospfv2-ext:nssa-lsa-checksum" : "0x00000000",
+                        "openconfig-ospfv2-ext:authentication-type" : "no",
+                        "openconfig-ospfv2-ext:asbr-summary-lsa-count" : 0,
+                        "openconfig-ospfv2-ext:adjacency-count" : 1,
+                        "openconfig-ospfv2-ext:opaque-area-lsa-count" : 0,
+                        "openconfig-ospfv2-ext:opaque-area-lsa-checksum" : "0x00000000",
+                        "openconfig-ospfv2-ext:lsa-count" : 5,
+                        "openconfig-ospfv2-ext:opaque-link-lsa-checksum" : "0x00000000",
+                        "openconfig-ospfv2-ext:spf-execution-count" : 6,
+                        "openconfig-ospfv2-ext:interface-count" : 1,
+                        "openconfig-ospfv2-ext:network-lsa-count" : 1,
+                        "openconfig-ospfv2-ext:asbr-summary-lsa-checksum" : "0x00000000",
+                        "openconfig-ospfv2-ext:router-lsa-checksum" : "0x0000cfe5",
+                        "openconfig-ospfv2-ext:router-lsa-count" : 2,
+                        "openconfig-ospfv2-ext:nssa-lsa-count" : 0,
+                        "openconfig-ospfv2-ext:active-interface-count" : 1,
+                        "openconfig-ospfv2-ext:summary-lsa-checksum" : "0x0000201c",
+                        "openconfig-ospfv2-ext:network-lsa-checksum" : "0x0000ca2c",
+                        "openconfig-ospfv2-ext:opaque-link-lsa-count" : 0
+                     }
+                  },
+                  {
+                     "lsdb" : {
+                        "lsa-types" : {
+                           "lsa-type" : [
+                              {
+                                 "type" : "openconfig-ospf-types:AS_EXTERNAL_LSA",
+                                 "state" : {
+                                    "type" : "openconfig-ospf-types:AS_EXTERNAL_LSA"
+                                 },
+                                 "lsas" : {
+                                    "openconfig-ospfv2-ext:lsa-ext" : [
+                                       {
+                                          "advertising-router" : "5.5.5.4",
+                                          "as-external-lsa" : {
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "forwarding-address" : "0.0.0.0",
+                                                         "external-route-tag" : 0,
+                                                         "metric" : 20
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "metric-type" : "TYPE_2",
+                                                "mask" : 20
+                                             }
+                                          },
+                                          "link-state-id" : "10.193.80.0",
+                                          "state" : {
+                                             "checksum" : 50393,
+                                             "length" : 36,
+                                             "flags" : 11,
+                                             "display-sequence-number" : "80000001",
+                                             "option" : 2,
+                                             "option-expanded" : "*||||||E|",
+                                             "age" : 1227
+                                          }
+                                       },
+                                       {
+                                          "advertising-router" : "6.6.6.5",
+                                          "as-external-lsa" : {
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "forwarding-address" : "0.0.0.0",
+                                                         "external-route-tag" : 0,
+                                                         "metric" : 20
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "metric-type" : "TYPE_2",
+                                                "mask" : 20
+                                             }
+                                          },
+                                          "link-state-id" : "10.193.80.0",
+                                          "state" : {
+                                             "checksum" : 42739,
+                                             "length" : 36,
+                                             "flags" : 6,
+                                             "display-sequence-number" : "80000001",
+                                             "option" : 2,
+                                             "option-expanded" : "*||||||E|",
+                                             "age" : 1228
+                                          }
+                                       }
+                                    ]
+                                 }
+                              },
+                              {
+                                 "type" : "openconfig-ospf-types:NETWORK_LSA",
+                                 "state" : {
+                                    "type" : "openconfig-ospf-types:NETWORK_LSA"
+                                 },
+                                 "lsas" : {
+                                    "openconfig-ospfv2-ext:lsa-ext" : [
+                                       {
+                                          "advertising-router" : "5.5.5.4",
+                                          "link-state-id" : "41.1.0.2",
+                                          "state" : {
+                                             "checksum" : 1017,
+                                             "length" : 32,
+                                             "flags" : 3,
+                                             "display-sequence-number" : "80000001",
+                                             "option" : 2,
+                                             "option-expanded" : "*|-|-|-|-|-|E|-",
+                                             "age" : 1198
+                                          },
+                                          "network-lsa" : {
+                                             "state" : {
+                                                "network-mask" : 24
+                                             }
+                                          }
+                                       }
+                                    ]
+                                 }
+                              },
+                              {
+                                 "type" : "openconfig-ospf-types:OSPFV2_LINK_SCOPE_OPAQUE_LSA"
+                              },
+                              {
+                                 "type" : "openconfig-ospf-types:ROUTER_LSA",
+                                 "state" : {
+                                    "type" : "openconfig-ospf-types:ROUTER_LSA"
+                                 },
+                                 "lsas" : {
+                                    "openconfig-ospfv2-ext:lsa-ext" : [
+                                       {
+                                          "advertising-router" : "3.3.3.2",
+                                          "link-state-id" : "3.3.3.2",
+                                          "state" : {
+                                             "checksum" : 53771,
+                                             "length" : 36,
+                                             "flags" : 6,
+                                             "display-sequence-number" : "80000002",
+                                             "option" : 0,
+                                             "option-expanded" : "*|||||||-",
+                                             "age" : 1189
+                                          },
+                                          "router-lsa" : {
+                                             "link-informations" : {
+                                                "link-information" : [
+                                                   {
+                                                      "state" : {
+                                                         "metric" : 10,
+                                                         "type" : "openconfig-ospf-types:ROUTER_LSA_TRANSIT_NETWORK",
+                                                         "number-tos-metrics" : 0
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "metric" : 10
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "flags-description" : " :",
+                                                "flags" : 0,
+                                                "number-links" : 1
+                                             }
+                                          }
+                                       },
+                                       {
+                                          "advertising-router" : "5.5.5.4",
+                                          "link-state-id" : "5.5.5.4",
+                                          "state" : {
+                                             "checksum" : 12693,
+                                             "length" : 36,
+                                             "flags" : 3,
+                                             "display-sequence-number" : "80000003",
+                                             "option" : 2,
+                                             "option-expanded" : "*||||||E|",
+                                             "age" : 1198
+                                          },
+                                          "router-lsa" : {
+                                             "link-informations" : {
+                                                "link-information" : [
+                                                   {
+                                                      "state" : {
+                                                         "metric" : 10,
+                                                         "type" : "openconfig-ospf-types:ROUTER_LSA_TRANSIT_NETWORK",
+                                                         "number-tos-metrics" : 0
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "metric" : 10
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "flags-description" : " : ABR ASBR",
+                                                "flags" : 3,
+                                                "number-links" : 1
+                                             }
+                                          }
+                                       }
+                                    ]
+                                 }
+                              },
+                              {
+                                 "type" : "openconfig-ospf-types:SUMMARY_ASBR_LSA",
+                                 "state" : {
+                                    "type" : "openconfig-ospf-types:SUMMARY_ASBR_LSA"
+                                 },
+                                 "lsas" : {
+                                    "openconfig-ospfv2-ext:lsa-ext" : [
+                                       {
+                                          "advertising-router" : "5.5.5.4",
+                                          "link-state-id" : "6.6.6.5",
+                                          "summary-lsa" : {
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "metric" : 4
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "network-mask" : 0
+                                             }
+                                          },
+                                          "state" : {
+                                             "checksum" : 59716,
+                                             "length" : 28,
+                                             "flags" : 11,
+                                             "display-sequence-number" : "80000001",
+                                             "option" : 2,
+                                             "option-expanded" : "*|-|-|-|-|-|E|-",
+                                             "age" : 1187
+                                          }
+                                       }
+                                    ]
+                                 }
+                              },
+                              {
+                                 "type" : "openconfig-ospf-types:SUMMARY_IP_NETWORK_LSA",
+                                 "state" : {
+                                    "type" : "openconfig-ospf-types:SUMMARY_IP_NETWORK_LSA"
+                                 },
+                                 "lsas" : {
+                                    "openconfig-ospfv2-ext:lsa-ext" : [
+                                       {
+                                          "advertising-router" : "5.5.5.4",
+                                          "link-state-id" : "21.1.0.0",
+                                          "summary-lsa" : {
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "metric" : 14
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "network-mask" : 24
+                                             }
+                                          },
+                                          "state" : {
+                                             "checksum" : 18908,
+                                             "length" : 28,
+                                             "flags" : 11,
+                                             "display-sequence-number" : "80000001",
+                                             "option" : 2,
+                                             "option-expanded" : "*|-|-|-|-|-|E|-",
+                                             "age" : 1187
+                                          }
+                                       },
+                                       {
+                                          "advertising-router" : "5.5.5.4",
+                                          "link-state-id" : "32.1.0.0",
+                                          "summary-lsa" : {
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "metric" : 4
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "network-mask" : 24
+                                             }
+                                          },
+                                          "state" : {
+                                             "checksum" : 21967,
+                                             "length" : 28,
+                                             "flags" : 11,
+                                             "display-sequence-number" : "80000001",
+                                             "option" : 2,
+                                             "option-expanded" : "*|-|-|-|-|-|E|-",
+                                             "age" : 1229
+                                          }
+                                       }
+                                    ]
+                                 }
+                              }
+                           ]
+                        },
+                        "state" : {
+                           "identifier" : "0.0.0.2"
+                        }
+                     },
+                     "identifier" : "0.0.0.2",
+                     "interfaces" : {
+                        "interface" : [
+                           {
+                              "openconfig-ospfv2-ext:message-statistics" : {
+                                 "state" : {
+                                    "ls-update-transmit" : 3,
+                                    "ls-request-receive" : 0,
+                                    "ls-acknowledge-receive" : 3,
+                                    "ls-acknowledge-transmit" : 2,
+                                    "db-description-transmit" : 2,
+                                    "db-description-receive" : 6,
+                                    "hello-transmit" : 124,
+                                    "hello-receive" : 125,
+                                    "ls-request-transmit" : 1,
+                                    "ls-update-receive" : 2
+                                 }
+                              },
+                              "openconfig-ospfv2-ext:neighbours" : {
+                                 "neighbour" : [
+                                    {
+                                       "neighbor-id" : "3.3.3.2",
+                                       "neighbor-address" : "41.1.0.1",
+                                       "state" : {
+                                          "priority" : 0,
+                                          "option-value" : 66,
+                                          "gr-helper-status" : "None",
+                                          "state-changes" : 6,
+                                          "backup-designated-router" : "0.0.0.0",
+                                          "adjacency-state" : "openconfig-ospf-types:FULL",
+                                          "neighbor-id" : "6.6.6.5",
+                                          "optional-capabilities" : "*|O|-|-|-|-|E|-",
+                                          "thread-inactivity-timer" : true,
+                                          "thread-ls-request-retransmission" : true,
+                                          "thread-ls-update-retransmission" : true,
+                                          "retransmit-summary-queue-length" : 0,
+                                          "area-id" : "0.0.0.2",
+                                          "gr-active-helper" : false,
+                                          "interface-address" : "41.1.0.2",
+                                          "neighbor-address" : "41.1.0.1",
+                                          "last-established-time" : "1198302",
+                                          "designated-router" : "41.1.0.2",
+                                          "database-summary-queue-length" : 0,
+                                          "interface-name" : "Ethernet120",
+                                          "link-state-request-queue-length" : 0,
+                                          "dead-time" : "34872"
+                                       }
+                                    }
+                                 ]
+                              },
+                              "id" : "Ethernet120",
+                              "timers" : {
+                                 "state" : {
+                                    "retransmission-interval" : 5,
+                                    "dead-interval" : 40,
+                                    "openconfig-ospfv2-ext:wait-time" : 40,
+                                    "hello-interval" : 10000,
+                                    "openconfig-ospfv2-ext:hello-due" : 1711
+                                 }
+                              },
+                              "state" : {
+                                 "priority" : 1,
+                                 "openconfig-ospfv2-ext:member-of-ospf-all-routers" : true,
+                                 "openconfig-ospfv2-ext:index" : 299,
+                                 "openconfig-ospfv2-ext:mtu" : 9100,
+                                 "openconfig-ospfv2-ext:if-flags" : "<UP,BROADCAST,RUNNING,MULTICAST>",
+                                 "openconfig-ospfv2-ext:adjacency-count" : 1,
+                                 "openconfig-ospfv2-ext:address-len" : 24,
+                                 "openconfig-ospfv2-ext:ospf-enable" : true,
+                                 "openconfig-ospfv2-ext:cost" : 10,
+                                 "openconfig-ospfv2-ext:address" : "41.1.0.2",
+                                 "id" : "Ethernet120",
+                                 "openconfig-ospfv2-ext:adjacency-status" : "DR",
+                                 "openconfig-ospfv2-ext:member-of-ospf-designated-routers" : true,
+                                 "openconfig-ospfv2-ext:neighbor-count" : 1,
+                                 "openconfig-ospfv2-ext:router-id" : "5.5.5.4",
+                                 "openconfig-ospfv2-ext:broadcast-address" : "41.1.0.255",
+                                 "openconfig-ospfv2-ext:bandwidth" : 10000,
+                                 "openconfig-ospfv2-ext:area-id" : "0.0.0.2",
+                                 "openconfig-ospfv2-ext:ospf-interface-type" : "Broadcast",
+                                 "network-type" : "openconfig-ospf-types:BROADCAST_NETWORK",
+                                 "openconfig-ospfv2-ext:transmit-delay" : 1,
+                                 "openconfig-ospfv2-ext:operational-state" : "Up"
+                              }
+                           }
+                        ]
+                     },
+                     "config" : {
+                        "identifier" : "0.0.0.2"
+                     },
+                     "openconfig-ospfv2-ext:networks" : {
+                        "network" : [
+                           {
+                              "address-prefix" : "41.1.0.0/24",
+                              "config" : {
+                                 "address-prefix" : "41.1.0.0/24",
+                                 "description" : "Network prefix"
+                              },
+                              "state" : {
+                                 "address-prefix" : "41.1.0.0/24",
+                                 "description" : "Network prefix"
+                              }
+                           }
+                        ]
+                     },
+                     "state" : {
+                        "openconfig-ospfv2-ext:summary-lsa-count" : 2,
+                        "openconfig-ospfv2-ext:nssa-lsa-checksum" : "0x00000000",
+                        "openconfig-ospfv2-ext:authentication-type" : "no",
+                        "openconfig-ospfv2-ext:asbr-summary-lsa-count" : 1,
+                        "openconfig-ospfv2-ext:adjacency-count" : 1,
+                        "openconfig-ospfv2-ext:opaque-area-lsa-count" : 0,
+                        "openconfig-ospfv2-ext:opaque-area-lsa-checksum" : "0x00000000",
+                        "openconfig-ospfv2-ext:lsa-count" : 6,
+                        "openconfig-ospfv2-ext:opaque-link-lsa-checksum" : "0x00000000",
+                        "openconfig-ospfv2-ext:virtual-link-adjacency-count" : 0,
+                        "openconfig-ospfv2-ext:spf-execution-count" : 6,
+                        "openconfig-ospfv2-ext:interface-count" : 1,
+                        "openconfig-ospfv2-ext:network-lsa-count" : 1,
+                        "openconfig-ospfv2-ext:asbr-summary-lsa-checksum" : "0x0000e944",
+                        "openconfig-ospfv2-ext:router-lsa-checksum" : "0x000103a0",
+                        "openconfig-ospfv2-ext:router-lsa-count" : 2,
+                        "openconfig-ospfv2-ext:nssa-lsa-count" : 0,
+                        "openconfig-ospfv2-ext:active-interface-count" : 1,
+                        "openconfig-ospfv2-ext:shortcut" : "openconfig-ospfv2-ext:DEFAULT",
+                        "openconfig-ospfv2-ext:summary-lsa-checksum" : "0x00009fab",
+                        "openconfig-ospfv2-ext:network-lsa-checksum" : "0x000003f9",
+                        "openconfig-ospfv2-ext:opaque-link-lsa-count" : 0
+                     }
+                  }
+               ]
+            }
+         },
+         "name" : "ospfv2",
+         "config" : {
+            "identifier" : "openconfig-policy-types:OSPF",
+            "name" : "ospfv2"
+         },
+         "state" : {
+            "identifier" : "openconfig-policy-types:OSPF",
+            "name" : "ospfv2"
+         }
+      }
+   ]
+}
+            `),
+	},
+	{ // OSPF TroubleShooting Test Case (i.e. no QP)
+		tid:        "OSPF Troubleshoot BareBones",
+		uri:        "/openconfig-network-instance:network-instances/network-instance[name=default]/protocols/protocol[identifier=OSPF][name=ospfv2]",
+		requestUri: "/openconfig-network-instance:network-instances/network-instance[name=default]/protocols/protocol[identifier=OSPF][name=ospfv2]",
+		payload: []byte(`
+{
+   "protocol" : [
+      {
+         "identifier" : "openconfig-policy-types:OSPF",
+         "name" : "ospfv2",
+         "config" : {
+            "identifier" : "openconfig-policy-types:OSPF",
+            "name" : "ospfv2"
+         },
+         "state" : {
+            "identifier" : "openconfig-policy-types:OSPF",
+            "name" : "ospfv2"
+         }
+      }
+   ]
+}
+            `),
+		appRootType: reflect.TypeOf(ocbinds.OpenconfigNetworkInstance_NetworkInstances{}),
+		queryParams: QueryParams{
+			depthEnabled:  false,
+			curDepth:      1,
+			content:       QUERY_CONTENT_ALL,
+			fields:        []string{},
+			fieldsFillAll: false,
+		},
+		prunedPayload: []byte(`
+{
+   "protocol" : [
+      {
+         "identifier" : "openconfig-policy-types:OSPF",
+         "name" : "ospfv2",
+         "config" : {
+            "identifier" : "openconfig-policy-types:OSPF",
+            "name" : "ospfv2"
+         },
+         "state" : {
+            "identifier" : "openconfig-policy-types:OSPF",
+            "name" : "ospfv2"
+         }
+      }
+   ]
+}
+            `),
+	},
+	{ // OSPF Identity Test Case (i.e. no QP)
+		tid:        "OSPF Troubleshoot No Areas",
+		uri:        "/openconfig-network-instance:network-instances/network-instance[name=default]/protocols/protocol[identifier=OSPF][name=ospfv2]",
+		requestUri: "/openconfig-network-instance:network-instances/network-instance[name=default]/protocols/protocol[identifier=OSPF][name=ospfv2]",
+		payload: []byte(`
+{
+   "protocol" : [
+      {
+         "identifier" : "openconfig-policy-types:OSPF",
+         "ospfv2" : {
+            "openconfig-ospfv2-ext:route-tables" : {
+               "route-table" : [
+                  {
+                     "routes" : {
+                        "route" : [
+                           {
+                              "next-hops" : {
+                                 "next-hop" : [
+                                    {
+                                       "area-id" : "0.0.0.0",
+                                       "address" : "32.1.0.1",
+                                       "state" : {
+                                          "area-id" : "0.0.0.0",
+                                          "address" : "32.1.0.1",
+                                          "out-interface" : "Vlan3719"
+                                       },
+                                       "out-interface" : "Vlan3719"
+                                    }
+                                 ]
+                              },
+                              "state" : {
+                                 "cost" : 4,
+                                 "sub-type" : "openconfig-ospfv2-ext:EXTERNAL_ROUTE_TYPE_2",
+                                 "type" : "openconfig-ospfv2-ext:EXTERNAL_ROUTE",
+                                 "prefix" : "10.193.80.0/20"
+                              },
+                              "prefix" : "10.193.80.0/20"
+                           }
+                        ]
+                     },
+                     "type" : "openconfig-ospfv2-ext:EXTERNAL_ROUTE_TABLE",
+                     "state" : {
+                        "type" : "openconfig-ospfv2-ext:EXTERNAL_ROUTE_TABLE"
+                     }
+                  },
+                  {
+                     "routes" : {
+                        "route" : [
+                           {
+                              "next-hops" : {
+                                 "next-hop" : [
+                                    {
+                                       "area-id" : "0.0.0.0",
+                                       "address" : "32.1.0.1",
+                                       "state" : {
+                                          "area-id" : "0.0.0.0",
+                                          "address" : "32.1.0.1",
+                                          "out-interface" : "Vlan3719"
+                                       },
+                                       "out-interface" : "Vlan3719"
+                                    }
+                                 ]
+                              },
+                              "state" : {
+                                 "cost" : 14,
+                                 "type" : "openconfig-ospfv2-ext:NETWORK_ROUTE",
+                                 "inter-area" : true,
+                                 "prefix" : "10.193.80.0/20"
+                              },
+                              "prefix" : "21.1.0.0/24"
+                           },
+                           {
+                              "next-hops" : {
+                                 "next-hop" : [
+                                    {
+                                       "area-id" : "0.0.0.0",
+                                       "address" : "0.0.0.0",
+                                       "state" : {
+                                          "area-id" : "0.0.0.0",
+                                          "address" : "32.1.0.1",
+                                          "out-interface" : "Vlan3719"
+                                       },
+                                       "out-interface" : "Vlan3719"
+                                    }
+                                 ]
+                              },
+                              "state" : {
+                                 "cost" : 4,
+                                 "type" : "openconfig-ospfv2-ext:NETWORK_ROUTE",
+                                 "prefix" : "10.193.80.0/20"
+                              },
+                              "prefix" : "32.1.0.0/24"
+                           },
+                           {
+                              "next-hops" : {
+                                 "next-hop" : [
+                                    {
+                                       "area-id" : "0.0.0.2",
+                                       "address" : "0.0.0.0",
+                                       "state" : {
+                                          "area-id" : "0.0.0.0",
+                                          "address" : "32.1.0.1",
+                                          "out-interface" : "Vlan3719"
+                                       },
+                                       "out-interface" : "Ethernet120"
+                                    }
+                                 ]
+                              },
+                              "state" : {
+                                 "cost" : 10,
+                                 "type" : "openconfig-ospfv2-ext:NETWORK_ROUTE",
+                                 "prefix" : "10.193.80.0/20"
+                              },
+                              "prefix" : "41.1.0.0/24"
+                           }
+                        ]
+                     },
+                     "type" : "openconfig-ospfv2-ext:NETWORK_ROUTE_TABLE",
+                     "state" : {
+                        "type" : "openconfig-ospfv2-ext:NETWORK_ROUTE_TABLE"
+                     }
+                  },
+                  {
+                     "routes" : {
+                        "route" : [
+                           {
+                              "next-hops" : {
+                                 "next-hop" : [
+                                    {
+                                       "area-id" : "0.0.0.0",
+                                       "address" : "32.1.0.1",
+                                       "state" : {
+                                          "area-id" : "0.0.0.0",
+                                          "address" : "32.1.0.1",
+                                          "out-interface" : "Vlan3719"
+                                       },
+                                       "out-interface" : "Vlan3719"
+                                    }
+                                 ]
+                              },
+                              "state" : {
+                                 "router-type" : "openconfig-ospfv2-ext:ABRASBR",
+                                 "cost" : 4,
+                                 "type" : "openconfig-ospfv2-ext:ROUTER_ROUTE",
+                                 "prefix" : "10.193.80.0/20"
+                              },
+                              "prefix" : "6.6.6.5"
+                           }
+                        ]
+                     },
+                     "type" : "openconfig-ospfv2-ext:ROUTER_ROUTE_TABLE",
+                     "state" : {
+                        "type" : "openconfig-ospfv2-ext:ROUTER_ROUTE_TABLE"
+                     }
+                  }
+               ]
+            },
+            "global" : {
+               "graceful-restart" : {
+                  "openconfig-ospfv2-ext:helpers" : {
+                     "helper" : [
+                        {
+                           "neighbour-id" : "5.5.5.4",
+                           "config" : {
+                              "vrf-name" : "default",
+                              "neighbour-id" : "5.5.5.4"
+                           },
+                           "state" : {
+                              "neighbour-id" : "5.5.5.4"
+                           }
+                        }
+                     ]
+                  },
+                  "config" : {
+                     "openconfig-ospfv2-ext:planned-only" : true,
+                     "helper-only" : true,
+                     "openconfig-ospfv2-ext:supported-grace-time" : 800,
+                     "openconfig-ospfv2-ext:strict-lsa-checking" : true
+                  },
+                  "state" : {
+                     "openconfig-ospfv2-ext:planned-only" : true,
+                     "helper-only" : true,
+                     "openconfig-ospfv2-ext:grace-period" : 0,
+                     "openconfig-ospfv2-ext:supported-grace-time" : 800,
+                     "openconfig-ospfv2-ext:strict-lsa-checking" : true
+                  }
+               },
+               "inter-area-propagation-policies" : {
+                  "openconfig-ospfv2-ext:inter-area-policy" : [
+                     {
+                        "config" : {
+                           "src-area" : "0.0.0.0"
+                        },
+                        "src-area" : "0.0.0.0",
+                        "state" : {
+                           "src-area" : "0.0.0.0"
+                        }
+                     },
+                     {
+                        "config" : {
+                           "src-area" : "0.0.0.2"
+                        },
+                        "src-area" : "0.0.0.2",
+                        "state" : {
+                           "src-area" : "0.0.0.2"
+                        }
+                     }
+                  ]
+               },
+               "config" : {
+                  "router-id" : "5.5.5.4",
+                  "openconfig-ospfv2-ext:opaque-lsa-capability" : true,
+                  "openconfig-ospfv2-ext:description" : "OSPFv2 Router",
+                  "openconfig-ospfv2-ext:enable" : true
+               },
+               "timers" : {
+                  "lsa-generation" : {
+                     "state" : {
+                        "openconfig-ospfv2-ext:refresh-timer" : 10000,
+                        "openconfig-ospfv2-ext:lsa-min-interval-timer" : 5000,
+                        "openconfig-ospfv2-ext:lsa-min-arrival-timer" : 1000
+                     }
+                  },
+                  "spf" : {
+                     "state" : {
+                        "maximum-delay" : 5000,
+                        "initial-delay" : 50,
+                        "openconfig-ospfv2-ext:throttle-delay" : 0,
+                        "openconfig-ospfv2-ext:spf-timer-due" : 0
+                     }
+                  }
+               },
+               "state" : {
+                  "openconfig-ospfv2-ext:area-count" : 2,
+                  "openconfig-ospfv2-ext:last-spf-duration" : 358,
+                  "openconfig-ospfv2-ext:hold-time-multiplier" : 1,
+                  "openconfig-ospfv2-ext:last-spf-execution-time" : "1187616",
+                  "openconfig-ospfv2-ext:opaque-lsa-count" : 0,
+                  "router-id" : "5.5.5.4",
+                  "openconfig-ospfv2-ext:abr-type" : "openconfig-ospfv2-ext:CISCO",
+                  "openconfig-ospfv2-ext:external-lsa-checksum" : "0x00016bcc",
+                  "openconfig-ospfv2-ext:opaque-lsa-checksum" : "0x00000000",
+                  "openconfig-ospfv2-ext:write-multiplier" : 20,
+                  "openconfig-ospfv2-ext:opaque-lsa-capability" : true,
+                  "openconfig-ospfv2-ext:external-lsa-count" : 2
+               }
+            }
+         },
+         "name" : "ospfv2",
+         "config" : {
+            "identifier" : "openconfig-policy-types:OSPF",
+            "name" : "ospfv2"
+         },
+         "state" : {
+            "identifier" : "openconfig-policy-types:OSPF",
+            "name" : "ospfv2"
+         }
+      }
+   ]
+}
+            `),
+		appRootType: reflect.TypeOf(ocbinds.OpenconfigNetworkInstance_NetworkInstances{}),
+		queryParams: QueryParams{
+			depthEnabled:  false,
+			curDepth:      1,
+			content:       QUERY_CONTENT_ALL,
+			fields:        []string{},
+			fieldsFillAll: false,
+		},
+		prunedPayload: []byte(`
+{
+   "protocol" : [
+      {
+         "identifier" : "openconfig-policy-types:OSPF",
+         "ospfv2" : {
+            "openconfig-ospfv2-ext:route-tables" : {
+               "route-table" : [
+                  {
+                     "routes" : {
+                        "route" : [
+                           {
+                              "next-hops" : {
+                                 "next-hop" : [
+                                    {
+                                       "area-id" : "0.0.0.0",
+                                       "address" : "32.1.0.1",
+                                       "state" : {
+                                          "area-id" : "0.0.0.0",
+                                          "address" : "32.1.0.1",
+                                          "out-interface" : "Vlan3719"
+                                       },
+                                       "out-interface" : "Vlan3719"
+                                    }
+                                 ]
+                              },
+                              "state" : {
+                                 "cost" : 4,
+                                 "sub-type" : "openconfig-ospfv2-ext:EXTERNAL_ROUTE_TYPE_2",
+                                 "type" : "openconfig-ospfv2-ext:EXTERNAL_ROUTE",
+                                 "prefix" : "10.193.80.0/20"
+                              },
+                              "prefix" : "10.193.80.0/20"
+                           }
+                        ]
+                     },
+                     "type" : "openconfig-ospfv2-ext:EXTERNAL_ROUTE_TABLE",
+                     "state" : {
+                        "type" : "openconfig-ospfv2-ext:EXTERNAL_ROUTE_TABLE"
+                     }
+                  },
+                  {
+                     "routes" : {
+                        "route" : [
+                           {
+                              "next-hops" : {
+                                 "next-hop" : [
+                                    {
+                                       "area-id" : "0.0.0.0",
+                                       "address" : "32.1.0.1",
+                                       "state" : {
+                                          "area-id" : "0.0.0.0",
+                                          "address" : "32.1.0.1",
+                                          "out-interface" : "Vlan3719"
+                                       },
+                                       "out-interface" : "Vlan3719"
+                                    }
+                                 ]
+                              },
+                              "state" : {
+                                 "cost" : 14,
+                                 "type" : "openconfig-ospfv2-ext:NETWORK_ROUTE",
+                                 "inter-area" : true,
+                                 "prefix" : "10.193.80.0/20"
+                              },
+                              "prefix" : "21.1.0.0/24"
+                           },
+                           {
+                              "next-hops" : {
+                                 "next-hop" : [
+                                    {
+                                       "area-id" : "0.0.0.0",
+                                       "address" : "0.0.0.0",
+                                       "state" : {
+                                          "area-id" : "0.0.0.0",
+                                          "address" : "32.1.0.1",
+                                          "out-interface" : "Vlan3719"
+                                       },
+                                       "out-interface" : "Vlan3719"
+                                    }
+                                 ]
+                              },
+                              "state" : {
+                                 "cost" : 4,
+                                 "type" : "openconfig-ospfv2-ext:NETWORK_ROUTE",
+                                 "prefix" : "10.193.80.0/20"
+                              },
+                              "prefix" : "32.1.0.0/24"
+                           },
+                           {
+                              "next-hops" : {
+                                 "next-hop" : [
+                                    {
+                                       "area-id" : "0.0.0.2",
+                                       "address" : "0.0.0.0",
+                                       "state" : {
+                                          "area-id" : "0.0.0.0",
+                                          "address" : "32.1.0.1",
+                                          "out-interface" : "Vlan3719"
+                                       },
+                                       "out-interface" : "Ethernet120"
+                                    }
+                                 ]
+                              },
+                              "state" : {
+                                 "cost" : 10,
+                                 "type" : "openconfig-ospfv2-ext:NETWORK_ROUTE",
+                                 "prefix" : "10.193.80.0/20"
+                              },
+                              "prefix" : "41.1.0.0/24"
+                           }
+                        ]
+                     },
+                     "type" : "openconfig-ospfv2-ext:NETWORK_ROUTE_TABLE",
+                     "state" : {
+                        "type" : "openconfig-ospfv2-ext:NETWORK_ROUTE_TABLE"
+                     }
+                  },
+                  {
+                     "routes" : {
+                        "route" : [
+                           {
+                              "next-hops" : {
+                                 "next-hop" : [
+                                    {
+                                       "area-id" : "0.0.0.0",
+                                       "address" : "32.1.0.1",
+                                       "state" : {
+                                          "area-id" : "0.0.0.0",
+                                          "address" : "32.1.0.1",
+                                          "out-interface" : "Vlan3719"
+                                       },
+                                       "out-interface" : "Vlan3719"
+                                    }
+                                 ]
+                              },
+                              "state" : {
+                                 "router-type" : "openconfig-ospfv2-ext:ABRASBR",
+                                 "cost" : 4,
+                                 "type" : "openconfig-ospfv2-ext:ROUTER_ROUTE",
+                                 "prefix" : "10.193.80.0/20"
+                              },
+                              "prefix" : "6.6.6.5"
+                           }
+                        ]
+                     },
+                     "type" : "openconfig-ospfv2-ext:ROUTER_ROUTE_TABLE",
+                     "state" : {
+                        "type" : "openconfig-ospfv2-ext:ROUTER_ROUTE_TABLE"
+                     }
+                  }
+               ]
+            },
+            "global" : {
+               "graceful-restart" : {
+                  "openconfig-ospfv2-ext:helpers" : {
+                     "helper" : [
+                        {
+                           "neighbour-id" : "5.5.5.4",
+                           "config" : {
+                              "vrf-name" : "default",
+                              "neighbour-id" : "5.5.5.4"
+                           },
+                           "state" : {
+                              "neighbour-id" : "5.5.5.4"
+                           }
+                        }
+                     ]
+                  },
+                  "config" : {
+                     "openconfig-ospfv2-ext:planned-only" : true,
+                     "helper-only" : true,
+                     "openconfig-ospfv2-ext:supported-grace-time" : 800,
+                     "openconfig-ospfv2-ext:strict-lsa-checking" : true
+                  },
+                  "state" : {
+                     "openconfig-ospfv2-ext:planned-only" : true,
+                     "helper-only" : true,
+                     "openconfig-ospfv2-ext:grace-period" : 0,
+                     "openconfig-ospfv2-ext:supported-grace-time" : 800,
+                     "openconfig-ospfv2-ext:strict-lsa-checking" : true
+                  }
+               },
+               "inter-area-propagation-policies" : {
+                  "openconfig-ospfv2-ext:inter-area-policy" : [
+                     {
+                        "config" : {
+                           "src-area" : "0.0.0.0"
+                        },
+                        "src-area" : "0.0.0.0",
+                        "state" : {
+                           "src-area" : "0.0.0.0"
+                        }
+                     },
+                     {
+                        "config" : {
+                           "src-area" : "0.0.0.2"
+                        },
+                        "src-area" : "0.0.0.2",
+                        "state" : {
+                           "src-area" : "0.0.0.2"
+                        }
+                     }
+                  ]
+               },
+               "config" : {
+                  "router-id" : "5.5.5.4",
+                  "openconfig-ospfv2-ext:opaque-lsa-capability" : true,
+                  "openconfig-ospfv2-ext:description" : "OSPFv2 Router",
+                  "openconfig-ospfv2-ext:enable" : true
+               },
+               "timers" : {
+                  "lsa-generation" : {
+                     "state" : {
+                        "openconfig-ospfv2-ext:refresh-timer" : 10000,
+                        "openconfig-ospfv2-ext:lsa-min-interval-timer" : 5000,
+                        "openconfig-ospfv2-ext:lsa-min-arrival-timer" : 1000
+                     }
+                  },
+                  "spf" : {
+                     "state" : {
+                        "maximum-delay" : 5000,
+                        "initial-delay" : 50,
+                        "openconfig-ospfv2-ext:throttle-delay" : 0,
+                        "openconfig-ospfv2-ext:spf-timer-due" : 0
+                     }
+                  }
+               },
+               "state" : {
+                  "openconfig-ospfv2-ext:area-count" : 2,
+                  "openconfig-ospfv2-ext:last-spf-duration" : 358,
+                  "openconfig-ospfv2-ext:hold-time-multiplier" : 1,
+                  "openconfig-ospfv2-ext:last-spf-execution-time" : "1187616",
+                  "openconfig-ospfv2-ext:opaque-lsa-count" : 0,
+                  "router-id" : "5.5.5.4",
+                  "openconfig-ospfv2-ext:abr-type" : "openconfig-ospfv2-ext:CISCO",
+                  "openconfig-ospfv2-ext:external-lsa-checksum" : "0x00016bcc",
+                  "openconfig-ospfv2-ext:opaque-lsa-checksum" : "0x00000000",
+                  "openconfig-ospfv2-ext:write-multiplier" : 20,
+                  "openconfig-ospfv2-ext:opaque-lsa-capability" : true,
+                  "openconfig-ospfv2-ext:external-lsa-count" : 2
+               }
+            }
+         },
+         "name" : "ospfv2",
+         "config" : {
+            "identifier" : "openconfig-policy-types:OSPF",
+            "name" : "ospfv2"
+         },
+         "state" : {
+            "identifier" : "openconfig-policy-types:OSPF",
+            "name" : "ospfv2"
+         }
+      }
+   ]
+}
+            `),
+	},
+	{ // OSPF Identity Test Case (i.e. no QP)
+		tid:        "OSPF Troubleshoot No Areas No Propagation Policies",
+		uri:        "/openconfig-network-instance:network-instances/network-instance[name=default]/protocols/protocol[identifier=OSPF][name=ospfv2]",
+		requestUri: "/openconfig-network-instance:network-instances/network-instance[name=default]/protocols/protocol[identifier=OSPF][name=ospfv2]",
+		payload: []byte(`
+{
+   "protocol" : [
+      {
+         "identifier" : "openconfig-policy-types:OSPF",
+         "ospfv2" : {
+            "global" : {
+               "graceful-restart" : {
+                  "openconfig-ospfv2-ext:helpers" : {
+                     "helper" : [
+                        {
+                           "neighbour-id" : "5.5.5.4",
+                           "config" : {
+                              "vrf-name" : "default",
+                              "neighbour-id" : "5.5.5.4"
+                           },
+                           "state" : {
+                              "neighbour-id" : "5.5.5.4"
+                           }
+                        }
+                     ]
+                  },
+                  "config" : {
+                     "openconfig-ospfv2-ext:planned-only" : true,
+                     "helper-only" : true,
+                     "openconfig-ospfv2-ext:supported-grace-time" : 800,
+                     "openconfig-ospfv2-ext:strict-lsa-checking" : true
+                  },
+                  "state" : {
+                     "openconfig-ospfv2-ext:planned-only" : true,
+                     "helper-only" : true,
+                     "openconfig-ospfv2-ext:grace-period" : 0,
+                     "openconfig-ospfv2-ext:supported-grace-time" : 800,
+                     "openconfig-ospfv2-ext:strict-lsa-checking" : true
+                  }
+               },
+               "config" : {
+                  "router-id" : "5.5.5.4",
+                  "openconfig-ospfv2-ext:opaque-lsa-capability" : true,
+                  "openconfig-ospfv2-ext:description" : "OSPFv2 Router",
+                  "openconfig-ospfv2-ext:enable" : true
+               },
+               "timers" : {
+                  "lsa-generation" : {
+                     "state" : {
+                        "openconfig-ospfv2-ext:refresh-timer" : 10000,
+                        "openconfig-ospfv2-ext:lsa-min-interval-timer" : 5000,
+                        "openconfig-ospfv2-ext:lsa-min-arrival-timer" : 1000
+                     }
+                  },
+                  "spf" : {
+                     "state" : {
+                        "maximum-delay" : 5000,
+                        "initial-delay" : 50,
+                        "openconfig-ospfv2-ext:throttle-delay" : 0,
+                        "openconfig-ospfv2-ext:spf-timer-due" : 0
+                     }
+                  }
+               },
+               "state" : {
+                  "openconfig-ospfv2-ext:area-count" : 2,
+                  "openconfig-ospfv2-ext:last-spf-duration" : 358,
+                  "openconfig-ospfv2-ext:hold-time-multiplier" : 1,
+                  "openconfig-ospfv2-ext:last-spf-execution-time" : "1187616",
+                  "openconfig-ospfv2-ext:opaque-lsa-count" : 0,
+                  "router-id" : "5.5.5.4",
+                  "openconfig-ospfv2-ext:abr-type" : "openconfig-ospfv2-ext:CISCO",
+                  "openconfig-ospfv2-ext:external-lsa-checksum" : "0x00016bcc",
+                  "openconfig-ospfv2-ext:opaque-lsa-checksum" : "0x00000000",
+                  "openconfig-ospfv2-ext:write-multiplier" : 20,
+                  "openconfig-ospfv2-ext:opaque-lsa-capability" : true,
+                  "openconfig-ospfv2-ext:external-lsa-count" : 2
+               }
+            }
+         },
+         "name" : "ospfv2",
+         "config" : {
+            "identifier" : "openconfig-policy-types:OSPF",
+            "name" : "ospfv2"
+         },
+         "state" : {
+            "identifier" : "openconfig-policy-types:OSPF",
+            "name" : "ospfv2"
+         }
+      }
+   ]
+}
+            `),
+		appRootType: reflect.TypeOf(ocbinds.OpenconfigNetworkInstance_NetworkInstances{}),
+		queryParams: QueryParams{
+			depthEnabled:  false,
+			curDepth:      1,
+			content:       QUERY_CONTENT_ALL,
+			fields:        []string{},
+			fieldsFillAll: false,
+		},
+		prunedPayload: []byte(`
+{
+   "protocol" : [
+      {
+         "identifier" : "openconfig-policy-types:OSPF",
+         "ospfv2" : {
+            "global" : {
+               "graceful-restart" : {
+                  "openconfig-ospfv2-ext:helpers" : {
+                     "helper" : [
+                        {
+                           "neighbour-id" : "5.5.5.4",
+                           "config" : {
+                              "vrf-name" : "default",
+                              "neighbour-id" : "5.5.5.4"
+                           },
+                           "state" : {
+                              "neighbour-id" : "5.5.5.4"
+                           }
+                        }
+                     ]
+                  },
+                  "config" : {
+                     "openconfig-ospfv2-ext:planned-only" : true,
+                     "helper-only" : true,
+                     "openconfig-ospfv2-ext:supported-grace-time" : 800,
+                     "openconfig-ospfv2-ext:strict-lsa-checking" : true
+                  },
+                  "state" : {
+                     "openconfig-ospfv2-ext:planned-only" : true,
+                     "helper-only" : true,
+                     "openconfig-ospfv2-ext:grace-period" : 0,
+                     "openconfig-ospfv2-ext:supported-grace-time" : 800,
+                     "openconfig-ospfv2-ext:strict-lsa-checking" : true
+                  }
+               },
+               "config" : {
+                  "router-id" : "5.5.5.4",
+                  "openconfig-ospfv2-ext:opaque-lsa-capability" : true,
+                  "openconfig-ospfv2-ext:description" : "OSPFv2 Router",
+                  "openconfig-ospfv2-ext:enable" : true
+               },
+               "timers" : {
+                  "lsa-generation" : {
+                     "state" : {
+                        "openconfig-ospfv2-ext:refresh-timer" : 10000,
+                        "openconfig-ospfv2-ext:lsa-min-interval-timer" : 5000,
+                        "openconfig-ospfv2-ext:lsa-min-arrival-timer" : 1000
+                     }
+                  },
+                  "spf" : {
+                     "state" : {
+                        "maximum-delay" : 5000,
+                        "initial-delay" : 50,
+                        "openconfig-ospfv2-ext:throttle-delay" : 0,
+                        "openconfig-ospfv2-ext:spf-timer-due" : 0
+                     }
+                  }
+               },
+               "state" : {
+                  "openconfig-ospfv2-ext:area-count" : 2,
+                  "openconfig-ospfv2-ext:last-spf-duration" : 358,
+                  "openconfig-ospfv2-ext:hold-time-multiplier" : 1,
+                  "openconfig-ospfv2-ext:last-spf-execution-time" : "1187616",
+                  "openconfig-ospfv2-ext:opaque-lsa-count" : 0,
+                  "router-id" : "5.5.5.4",
+                  "openconfig-ospfv2-ext:abr-type" : "openconfig-ospfv2-ext:CISCO",
+                  "openconfig-ospfv2-ext:external-lsa-checksum" : "0x00016bcc",
+                  "openconfig-ospfv2-ext:opaque-lsa-checksum" : "0x00000000",
+                  "openconfig-ospfv2-ext:write-multiplier" : 20,
+                  "openconfig-ospfv2-ext:opaque-lsa-capability" : true,
+                  "openconfig-ospfv2-ext:external-lsa-count" : 2
+               }
+            }
+         },
+         "name" : "ospfv2",
+         "config" : {
+            "identifier" : "openconfig-policy-types:OSPF",
+            "name" : "ospfv2"
+         },
+         "state" : {
+            "identifier" : "openconfig-policy-types:OSPF",
+            "name" : "ospfv2"
+         }
+      }
+   ]
+}
+            `),
+	},
+	{ // OSPF Identity Test Case (i.e. no QP)
+		tid:        "OSPF Identity Content CONFIG",
+		uri:        "/openconfig-network-instance:network-instances/network-instance[name=default]/protocols/protocol[identifier=OSPF][name=ospfv2]/ospfv2/areas/area[identifier=0.0.0.0]/lsdb",
+		requestUri: "/openconfig-network-instance:network-instances/network-instance[name=default]/protocols/protocol[identifier=OSPF][name=ospfv2]",
+		payload: []byte(`
+{
+   "protocol" : [
+      {
+         "identifier" : "openconfig-policy-types:OSPF",
+         "ospfv2" : {
+            "openconfig-ospfv2-ext:route-tables" : {
+               "route-table" : [
+                  {
+                     "routes" : {
+                        "route" : [
+                           {
+                              "next-hops" : {
+                                 "next-hop" : [
+                                    {
+                                       "area-id" : "0.0.0.0",
+                                       "address" : "32.1.0.1",
+                                       "state" : {
+                                          "area-id" : "0.0.0.0",
+                                          "address" : "32.1.0.1",
+                                          "out-interface" : "Vlan3719"
+                                       },
+                                       "out-interface" : "Vlan3719"
+                                    }
+                                 ]
+                              },
+                              "state" : {
+                                 "cost" : 4,
+                                 "sub-type" : "openconfig-ospfv2-ext:EXTERNAL_ROUTE_TYPE_2",
+                                 "type" : "openconfig-ospfv2-ext:EXTERNAL_ROUTE",
+                                 "prefix" : "10.193.80.0/20"
+                              },
+                              "prefix" : "10.193.80.0/20"
+                           }
+                        ]
+                     },
+                     "type" : "openconfig-ospfv2-ext:EXTERNAL_ROUTE_TABLE",
+                     "state" : {
+                        "type" : "openconfig-ospfv2-ext:EXTERNAL_ROUTE_TABLE"
+                     }
+                  },
+                  {
+                     "routes" : {
+                        "route" : [
+                           {
+                              "next-hops" : {
+                                 "next-hop" : [
+                                    {
+                                       "area-id" : "0.0.0.0",
+                                       "address" : "32.1.0.1",
+                                       "state" : {
+                                          "area-id" : "0.0.0.0",
+                                          "address" : "32.1.0.1",
+                                          "out-interface" : "Vlan3719"
+                                       },
+                                       "out-interface" : "Vlan3719"
+                                    }
+                                 ]
+                              },
+                              "state" : {
+                                 "cost" : 14,
+                                 "type" : "openconfig-ospfv2-ext:NETWORK_ROUTE",
+                                 "inter-area" : true,
+                                 "prefix" : "10.193.80.0/20"
+                              },
+                              "prefix" : "21.1.0.0/24"
+                           },
+                           {
+                              "next-hops" : {
+                                 "next-hop" : [
+                                    {
+                                       "area-id" : "0.0.0.0",
+                                       "address" : "0.0.0.0",
+                                       "state" : {
+                                          "area-id" : "0.0.0.0",
+                                          "address" : "32.1.0.1",
+                                          "out-interface" : "Vlan3719"
+                                       },
+                                       "out-interface" : "Vlan3719"
+                                    }
+                                 ]
+                              },
+                              "state" : {
+                                 "cost" : 4,
+                                 "type" : "openconfig-ospfv2-ext:NETWORK_ROUTE",
+                                 "prefix" : "10.193.80.0/20"
+                              },
+                              "prefix" : "32.1.0.0/24"
+                           },
+                           {
+                              "next-hops" : {
+                                 "next-hop" : [
+                                    {
+                                       "area-id" : "0.0.0.2",
+                                       "address" : "0.0.0.0",
+                                       "state" : {
+                                          "area-id" : "0.0.0.0",
+                                          "address" : "32.1.0.1",
+                                          "out-interface" : "Vlan3719"
+                                       },
+                                       "out-interface" : "Ethernet120"
+                                    }
+                                 ]
+                              },
+                              "state" : {
+                                 "cost" : 10,
+                                 "type" : "openconfig-ospfv2-ext:NETWORK_ROUTE",
+                                 "prefix" : "10.193.80.0/20"
+                              },
+                              "prefix" : "41.1.0.0/24"
+                           }
+                        ]
+                     },
+                     "type" : "openconfig-ospfv2-ext:NETWORK_ROUTE_TABLE",
+                     "state" : {
+                        "type" : "openconfig-ospfv2-ext:NETWORK_ROUTE_TABLE"
+                     }
+                  },
+                  {
+                     "routes" : {
+                        "route" : [
+                           {
+                              "next-hops" : {
+                                 "next-hop" : [
+                                    {
+                                       "area-id" : "0.0.0.0",
+                                       "address" : "32.1.0.1",
+                                       "state" : {
+                                          "area-id" : "0.0.0.0",
+                                          "address" : "32.1.0.1",
+                                          "out-interface" : "Vlan3719"
+                                       },
+                                       "out-interface" : "Vlan3719"
+                                    }
+                                 ]
+                              },
+                              "state" : {
+                                 "router-type" : "openconfig-ospfv2-ext:ABRASBR",
+                                 "cost" : 4,
+                                 "type" : "openconfig-ospfv2-ext:ROUTER_ROUTE",
+                                 "prefix" : "10.193.80.0/20"
+                              },
+                              "prefix" : "6.6.6.5"
+                           }
+                        ]
+                     },
+                     "type" : "openconfig-ospfv2-ext:ROUTER_ROUTE_TABLE",
+                     "state" : {
+                        "type" : "openconfig-ospfv2-ext:ROUTER_ROUTE_TABLE"
+                     }
+                  }
+               ]
+            },
+            "global" : {
+               "graceful-restart" : {
+                  "openconfig-ospfv2-ext:helpers" : {
+                     "helper" : [
+                        {
+                           "neighbour-id" : "5.5.5.4",
+                           "config" : {
+                              "vrf-name" : "default",
+                              "neighbour-id" : "5.5.5.4"
+                           },
+                           "state" : {
+                              "neighbour-id" : "5.5.5.4"
+                           }
+                        }
+                     ]
+                  },
+                  "config" : {
+                     "openconfig-ospfv2-ext:planned-only" : true,
+                     "helper-only" : true,
+                     "openconfig-ospfv2-ext:supported-grace-time" : 800,
+                     "openconfig-ospfv2-ext:strict-lsa-checking" : true
+                  },
+                  "state" : {
+                     "openconfig-ospfv2-ext:planned-only" : true,
+                     "helper-only" : true,
+                     "openconfig-ospfv2-ext:grace-period" : 0,
+                     "openconfig-ospfv2-ext:supported-grace-time" : 800,
+                     "openconfig-ospfv2-ext:strict-lsa-checking" : true
+                  }
+               },
+               "inter-area-propagation-policies" : {
+                  "openconfig-ospfv2-ext:inter-area-policy" : [
+                     {
+                        "config" : {
+                           "src-area" : "0.0.0.0"
+                        },
+                        "src-area" : "0.0.0.0",
+                        "state" : {
+                           "src-area" : "0.0.0.0"
+                        }
+                     },
+                     {
+                        "config" : {
+                           "src-area" : "0.0.0.2"
+                        },
+                        "src-area" : "0.0.0.2",
+                        "state" : {
+                           "src-area" : "0.0.0.2"
+                        }
+                     }
+                  ]
+               },
+               "config" : {
+                  "router-id" : "5.5.5.4",
+                  "openconfig-ospfv2-ext:opaque-lsa-capability" : true,
+                  "openconfig-ospfv2-ext:description" : "OSPFv2 Router",
+                  "openconfig-ospfv2-ext:enable" : true
+               },
+               "timers" : {
+                  "lsa-generation" : {
+                     "state" : {
+                        "openconfig-ospfv2-ext:refresh-timer" : 10000,
+                        "openconfig-ospfv2-ext:lsa-min-interval-timer" : 5000,
+                        "openconfig-ospfv2-ext:lsa-min-arrival-timer" : 1000
+                     }
+                  },
+                  "spf" : {
+                     "state" : {
+                        "maximum-delay" : 5000,
+                        "initial-delay" : 50,
+                        "openconfig-ospfv2-ext:throttle-delay" : 0,
+                        "openconfig-ospfv2-ext:spf-timer-due" : 0
+                     }
+                  }
+               },
+               "state" : {
+                  "openconfig-ospfv2-ext:area-count" : 2,
+                  "openconfig-ospfv2-ext:last-spf-duration" : 358,
+                  "openconfig-ospfv2-ext:hold-time-multiplier" : 1,
+                  "openconfig-ospfv2-ext:last-spf-execution-time" : "1187616",
+                  "openconfig-ospfv2-ext:opaque-lsa-count" : 0,
+                  "router-id" : "5.5.5.4",
+                  "openconfig-ospfv2-ext:abr-type" : "openconfig-ospfv2-ext:CISCO",
+                  "openconfig-ospfv2-ext:external-lsa-checksum" : "0x00016bcc",
+                  "openconfig-ospfv2-ext:opaque-lsa-checksum" : "0x00000000",
+                  "openconfig-ospfv2-ext:write-multiplier" : 20,
+                  "openconfig-ospfv2-ext:opaque-lsa-capability" : true,
+                  "openconfig-ospfv2-ext:external-lsa-count" : 2
+               }
+            },
+            "areas" : {
+               "area" : [
+                  {
+                     "lsdb" : {
+                        "lsa-types" : {
+                           "lsa-type" : [
+                              {
+                                 "type" : "openconfig-ospf-types:AS_EXTERNAL_LSA",
+                                 "state" : {
+                                    "type" : "openconfig-ospf-types:AS_EXTERNAL_LSA"
+                                 },
+                                 "lsas" : {
+                                    "openconfig-ospfv2-ext:lsa-ext" : [
+                                       {
+                                          "advertising-router" : "5.5.5.4",
+                                          "as-external-lsa" : {
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "forwarding-address" : "0.0.0.0",
+                                                         "external-route-tag" : 0,
+                                                         "metric" : 20
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "metric-type" : "TYPE_2",
+                                                "mask" : 20
+                                             }
+                                          },
+                                          "link-state-id" : "10.193.80.0",
+                                          "state" : {
+                                             "checksum" : 50393,
+                                             "length" : 36,
+                                             "flags" : 11,
+                                             "display-sequence-number" : "80000001",
+                                             "option" : 2,
+                                             "option-expanded" : "*||||||E|",
+                                             "age" : 1227
+                                          }
+                                       },
+                                       {
+                                          "advertising-router" : "6.6.6.5",
+                                          "as-external-lsa" : {
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "forwarding-address" : "0.0.0.0",
+                                                         "external-route-tag" : 0,
+                                                         "metric" : 20
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "metric-type" : "TYPE_2",
+                                                "mask" : 20
+                                             }
+                                          },
+                                          "link-state-id" : "10.193.80.0",
+                                          "state" : {
+                                             "checksum" : 42739,
+                                             "length" : 36,
+                                             "flags" : 6,
+                                             "display-sequence-number" : "80000001",
+                                             "option" : 2,
+                                             "option-expanded" : "*||||||E|",
+                                             "age" : 1228
+                                          }
+                                       }
+                                    ]
+                                 }
+                              },
+                              {
+                                 "type" : "openconfig-ospf-types:NETWORK_LSA",
+                                 "state" : {
+                                    "type" : "openconfig-ospf-types:NETWORK_LSA"
+                                 },
+                                 "lsas" : {
+                                    "openconfig-ospfv2-ext:lsa-ext" : [
+                                       {
+                                          "advertising-router" : "6.6.6.5",
+                                          "link-state-id" : "32.1.0.1",
+                                          "state" : {
+                                             "checksum" : 51756,
+                                             "length" : 32,
+                                             "flags" : 6,
+                                             "display-sequence-number" : "80000001",
+                                             "option" : 2,
+                                             "option-expanded" : "*|-|-|-|-|-|E|-",
+                                             "age" : 1198
+                                          },
+                                          "network-lsa" : {
+                                             "state" : {
+                                                "network-mask" : 24
+                                             }
+                                          }
+                                       }
+                                    ]
+                                 }
+                              },
+                              {
+                                 "type" : "openconfig-ospf-types:OSPFV2_LINK_SCOPE_OPAQUE_LSA"
+                              },
+                              {
+                                 "type" : "openconfig-ospf-types:ROUTER_LSA",
+                                 "state" : {
+                                    "type" : "openconfig-ospf-types:ROUTER_LSA"
+                                 },
+                                 "lsas" : {
+                                    "openconfig-ospfv2-ext:lsa-ext" : [
+                                       {
+                                          "advertising-router" : "5.5.5.4",
+                                          "link-state-id" : "5.5.5.4",
+                                          "state" : {
+                                             "checksum" : 5321,
+                                             "length" : 36,
+                                             "flags" : 3,
+                                             "display-sequence-number" : "80000005",
+                                             "option" : 2,
+                                             "option-expanded" : "*||||||E|",
+                                             "age" : 1197
+                                          },
+                                          "router-lsa" : {
+                                             "link-informations" : {
+                                                "link-information" : [
+                                                   {
+                                                      "state" : {
+                                                         "metric" : 4,
+                                                         "type" : "openconfig-ospf-types:ROUTER_LSA_TRANSIT_NETWORK",
+                                                         "number-tos-metrics" : 0
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "metric" : 4
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "flags-description" : " : ABR ASBR",
+                                                "flags" : 3,
+                                                "number-links" : 1
+                                             }
+                                          }
+                                       },
+                                       {
+                                          "advertising-router" : "6.6.6.5",
+                                          "link-state-id" : "6.6.6.5",
+                                          "state" : {
+                                             "checksum" : 47900,
+                                             "length" : 36,
+                                             "flags" : 6,
+                                             "display-sequence-number" : "80000004",
+                                             "option" : 2,
+                                             "option-expanded" : "*||||||E|",
+                                             "age" : 1197
+                                          },
+                                          "router-lsa" : {
+                                             "link-informations" : {
+                                                "link-information" : [
+                                                   {
+                                                      "state" : {
+                                                         "metric" : 4,
+                                                         "type" : "openconfig-ospf-types:ROUTER_LSA_TRANSIT_NETWORK",
+                                                         "number-tos-metrics" : 0
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "metric" : 4
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "flags-description" : " : ABR ASBR",
+                                                "flags" : 3,
+                                                "number-links" : 1
+                                             }
+                                          }
+                                       }
+                                    ]
+                                 }
+                              },
+                              {
+                                 "type" : "openconfig-ospf-types:SUMMARY_ASBR_LSA",
+                                 "state" : {
+                                    "type" : "openconfig-ospf-types:SUMMARY_ASBR_LSA"
+                                 }
+                              },
+                              {
+                                 "type" : "openconfig-ospf-types:SUMMARY_IP_NETWORK_LSA",
+                                 "state" : {
+                                    "type" : "openconfig-ospf-types:SUMMARY_IP_NETWORK_LSA"
+                                 },
+                                 "lsas" : {
+                                    "openconfig-ospfv2-ext:lsa-ext" : [
+                                       {
+                                          "advertising-router" : "6.6.6.5",
+                                          "link-state-id" : "21.1.0.0",
+                                          "summary-lsa" : {
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "metric" : 10
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "network-mask" : 24
+                                             }
+                                          },
+                                          "state" : {
+                                             "checksum" : 803,
+                                             "length" : 28,
+                                             "flags" : 6,
+                                             "display-sequence-number" : "80000001",
+                                             "option" : 2,
+                                             "option-expanded" : "*|-|-|-|-|-|E|-",
+                                             "age" : 1228
+                                          }
+                                       },
+                                       {
+                                          "advertising-router" : "5.5.5.4",
+                                          "link-state-id" : "41.1.0.0",
+                                          "summary-lsa" : {
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "metric" : 10
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "network-mask" : 24
+                                             }
+                                          },
+                                          "state" : {
+                                             "checksum" : 7417,
+                                             "length" : 28,
+                                             "flags" : 11,
+                                             "display-sequence-number" : "80000001",
+                                             "option" : 2,
+                                             "option-expanded" : "*|-|-|-|-|-|E|-",
+                                             "age" : 1227
+                                          }
+                                       }
+                                    ]
+                                 }
+                              }
+                           ]
+                        },
+                        "state" : {
+                           "identifier" : "0.0.0.0"
+                        }
+                     },
+                     "identifier" : "0.0.0.0",
+                     "interfaces" : {
+                        "interface" : [
+                           {
+                              "openconfig-ospfv2-ext:message-statistics" : {
+                                 "state" : {
+                                    "ls-update-transmit" : 4,
+                                    "ls-request-receive" : 1,
+                                    "ls-acknowledge-receive" : 2,
+                                    "ls-acknowledge-transmit" : 2,
+                                    "db-description-transmit" : 3,
+                                    "db-description-receive" : 2,
+                                    "hello-transmit" : 124,
+                                    "hello-receive" : 124,
+                                    "ls-request-transmit" : 1,
+                                    "ls-update-receive" : 3
+                                 }
+                              },
+                              "openconfig-ospfv2-ext:neighbours" : {
+                                 "neighbour" : [
+                                    {
+                                       "neighbor-id" : "6.6.6.5",
+                                       "neighbor-address" : "32.1.0.1",
+                                       "state" : {
+                                          "priority" : 1,
+                                          "option-value" : 66,
+                                          "gr-helper-status" : "None",
+                                          "state-changes" : 6,
+                                          "backup-designated-router" : "32.1.0.2",
+                                          "adjacency-state" : "openconfig-ospf-types:FULL",
+                                          "neighbor-id" : "6.6.6.5",
+                                          "optional-capabilities" : "*|O|-|-|-|-|E|-",
+                                          "thread-inactivity-timer" : true,
+                                          "thread-ls-request-retransmission" : true,
+                                          "thread-ls-update-retransmission" : true,
+                                          "retransmit-summary-queue-length" : 0,
+                                          "area-id" : "0.0.0.0",
+                                          "gr-active-helper" : false,
+                                          "interface-address" : "32.1.0.2",
+                                          "neighbor-address" : "32.1.0.1",
+                                          "last-established-time" : "1197595",
+                                          "designated-router" : "32.1.0.1",
+                                          "database-summary-queue-length" : 0,
+                                          "interface-name" : "Vlan3719",
+                                          "link-state-request-queue-length" : 0,
+                                          "dead-time" : "32410"
+                                       }
+                                    }
+                                 ]
+                              },
+                              "id" : "Vlan3719",
+                              "timers" : {
+                                 "state" : {
+                                    "retransmission-interval" : 5,
+                                    "dead-interval" : 40,
+                                    "openconfig-ospfv2-ext:wait-time" : 40,
+                                    "hello-interval" : 10000,
+                                    "openconfig-ospfv2-ext:hello-due" : 2409
+                                 }
+                              },
+                              "state" : {
+                                 "priority" : 1,
+                                 "openconfig-ospfv2-ext:member-of-ospf-all-routers" : true,
+                                 "openconfig-ospfv2-ext:index" : 310,
+                                 "openconfig-ospfv2-ext:mtu" : 9100,
+                                 "openconfig-ospfv2-ext:if-flags" : "<UP,BROADCAST,RUNNING,MULTICAST>",
+                                 "openconfig-ospfv2-ext:adjacency-count" : 1,
+                                 "openconfig-ospfv2-ext:address-len" : 24,
+                                 "openconfig-ospfv2-ext:ospf-enable" : true,
+                                 "openconfig-ospfv2-ext:cost" : 4,
+                                 "openconfig-ospfv2-ext:address" : "32.1.0.2",
+                                 "id" : "Vlan3719",
+                                 "openconfig-ospfv2-ext:adjacency-status" : "Backup",
+                                 "openconfig-ospfv2-ext:neighbor-count" : 1,
+                                 "openconfig-ospfv2-ext:backup-designated-router-id" : "5.5.5.4",
+                                 "openconfig-ospfv2-ext:member-of-ospf-designated-routers" : true,
+                                 "openconfig-ospfv2-ext:router-id" : "5.5.5.4",
+                                 "openconfig-ospfv2-ext:broadcast-address" : "32.1.0.255",
+                                 "openconfig-ospfv2-ext:bandwidth" : 25000,
+                                 "openconfig-ospfv2-ext:area-id" : "0.0.0.0",
+                                 "openconfig-ospfv2-ext:ospf-interface-type" : "Broadcast",
+                                 "openconfig-ospfv2-ext:backup-designated-router-address" : "32.1.0.2",
+                                 "network-type" : "openconfig-ospf-types:BROADCAST_NETWORK",
+                                 "openconfig-ospfv2-ext:transmit-delay" : 1,
+                                 "openconfig-ospfv2-ext:operational-state" : "Up"
+                              }
+                           }
+                        ]
+                     },
+                     "config" : {
+                        "identifier" : "0.0.0.0"
+                     },
+                     "openconfig-ospfv2-ext:networks" : {
+                        "network" : [
+                           {
+                              "address-prefix" : "31.1.0.0/24",
+                              "config" : {
+                                 "address-prefix" : "31.1.0.0/24",
+                                 "description" : "Network prefix"
+                              },
+                              "state" : {
+                                 "address-prefix" : "31.1.0.0/24",
+                                 "description" : "Network prefix"
+                              }
+                           },
+                           {
+                              "address-prefix" : "32.1.0.0/24",
+                              "config" : {
+                                 "address-prefix" : "32.1.0.0/24",
+                                 "description" : "Network prefix"
+                              },
+                              "state" : {
+                                 "address-prefix" : "32.1.0.0/24",
+                                 "description" : "Network prefix"
+                              }
+                           }
+                        ]
+                     },
+                     "state" : {
+                        "openconfig-ospfv2-ext:summary-lsa-count" : 2,
+                        "openconfig-ospfv2-ext:nssa-lsa-checksum" : "0x00000000",
+                        "openconfig-ospfv2-ext:authentication-type" : "no",
+                        "openconfig-ospfv2-ext:asbr-summary-lsa-count" : 0,
+                        "openconfig-ospfv2-ext:adjacency-count" : 1,
+                        "openconfig-ospfv2-ext:opaque-area-lsa-count" : 0,
+                        "openconfig-ospfv2-ext:opaque-area-lsa-checksum" : "0x00000000",
+                        "openconfig-ospfv2-ext:lsa-count" : 5,
+                        "openconfig-ospfv2-ext:opaque-link-lsa-checksum" : "0x00000000",
+                        "openconfig-ospfv2-ext:spf-execution-count" : 6,
+                        "openconfig-ospfv2-ext:interface-count" : 1,
+                        "openconfig-ospfv2-ext:network-lsa-count" : 1,
+                        "openconfig-ospfv2-ext:asbr-summary-lsa-checksum" : "0x00000000",
+                        "openconfig-ospfv2-ext:router-lsa-checksum" : "0x0000cfe5",
+                        "openconfig-ospfv2-ext:router-lsa-count" : 2,
+                        "openconfig-ospfv2-ext:nssa-lsa-count" : 0,
+                        "openconfig-ospfv2-ext:active-interface-count" : 1,
+                        "openconfig-ospfv2-ext:summary-lsa-checksum" : "0x0000201c",
+                        "openconfig-ospfv2-ext:network-lsa-checksum" : "0x0000ca2c",
+                        "openconfig-ospfv2-ext:opaque-link-lsa-count" : 0
+                     }
+                  },
+                  {
+                     "lsdb" : {
+                        "lsa-types" : {
+                           "lsa-type" : [
+                              {
+                                 "type" : "openconfig-ospf-types:AS_EXTERNAL_LSA",
+                                 "state" : {
+                                    "type" : "openconfig-ospf-types:AS_EXTERNAL_LSA"
+                                 },
+                                 "lsas" : {
+                                    "openconfig-ospfv2-ext:lsa-ext" : [
+                                       {
+                                          "advertising-router" : "5.5.5.4",
+                                          "as-external-lsa" : {
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "forwarding-address" : "0.0.0.0",
+                                                         "external-route-tag" : 0,
+                                                         "metric" : 20
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "metric-type" : "TYPE_2",
+                                                "mask" : 20
+                                             }
+                                          },
+                                          "link-state-id" : "10.193.80.0",
+                                          "state" : {
+                                             "checksum" : 50393,
+                                             "length" : 36,
+                                             "flags" : 11,
+                                             "display-sequence-number" : "80000001",
+                                             "option" : 2,
+                                             "option-expanded" : "*||||||E|",
+                                             "age" : 1227
+                                          }
+                                       },
+                                       {
+                                          "advertising-router" : "6.6.6.5",
+                                          "as-external-lsa" : {
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "forwarding-address" : "0.0.0.0",
+                                                         "external-route-tag" : 0,
+                                                         "metric" : 20
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "metric-type" : "TYPE_2",
+                                                "mask" : 20
+                                             }
+                                          },
+                                          "link-state-id" : "10.193.80.0",
+                                          "state" : {
+                                             "checksum" : 42739,
+                                             "length" : 36,
+                                             "flags" : 6,
+                                             "display-sequence-number" : "80000001",
+                                             "option" : 2,
+                                             "option-expanded" : "*||||||E|",
+                                             "age" : 1228
+                                          }
+                                       }
+                                    ]
+                                 }
+                              },
+                              {
+                                 "type" : "openconfig-ospf-types:NETWORK_LSA",
+                                 "state" : {
+                                    "type" : "openconfig-ospf-types:NETWORK_LSA"
+                                 },
+                                 "lsas" : {
+                                    "openconfig-ospfv2-ext:lsa-ext" : [
+                                       {
+                                          "advertising-router" : "5.5.5.4",
+                                          "link-state-id" : "41.1.0.2",
+                                          "state" : {
+                                             "checksum" : 1017,
+                                             "length" : 32,
+                                             "flags" : 3,
+                                             "display-sequence-number" : "80000001",
+                                             "option" : 2,
+                                             "option-expanded" : "*|-|-|-|-|-|E|-",
+                                             "age" : 1198
+                                          },
+                                          "network-lsa" : {
+                                             "state" : {
+                                                "network-mask" : 24
+                                             }
+                                          }
+                                       }
+                                    ]
+                                 }
+                              },
+                              {
+                                 "type" : "openconfig-ospf-types:OSPFV2_LINK_SCOPE_OPAQUE_LSA"
+                              },
+                              {
+                                 "type" : "openconfig-ospf-types:ROUTER_LSA",
+                                 "state" : {
+                                    "type" : "openconfig-ospf-types:ROUTER_LSA"
+                                 },
+                                 "lsas" : {
+                                    "openconfig-ospfv2-ext:lsa-ext" : [
+                                       {
+                                          "advertising-router" : "3.3.3.2",
+                                          "link-state-id" : "3.3.3.2",
+                                          "state" : {
+                                             "checksum" : 53771,
+                                             "length" : 36,
+                                             "flags" : 6,
+                                             "display-sequence-number" : "80000002",
+                                             "option" : 0,
+                                             "option-expanded" : "*|||||||-",
+                                             "age" : 1189
+                                          },
+                                          "router-lsa" : {
+                                             "link-informations" : {
+                                                "link-information" : [
+                                                   {
+                                                      "state" : {
+                                                         "metric" : 10,
+                                                         "type" : "openconfig-ospf-types:ROUTER_LSA_TRANSIT_NETWORK",
+                                                         "number-tos-metrics" : 0
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "metric" : 10
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "flags-description" : " :",
+                                                "flags" : 0,
+                                                "number-links" : 1
+                                             }
+                                          }
+                                       },
+                                       {
+                                          "advertising-router" : "5.5.5.4",
+                                          "link-state-id" : "5.5.5.4",
+                                          "state" : {
+                                             "checksum" : 12693,
+                                             "length" : 36,
+                                             "flags" : 3,
+                                             "display-sequence-number" : "80000003",
+                                             "option" : 2,
+                                             "option-expanded" : "*||||||E|",
+                                             "age" : 1198
+                                          },
+                                          "router-lsa" : {
+                                             "link-informations" : {
+                                                "link-information" : [
+                                                   {
+                                                      "state" : {
+                                                         "metric" : 10,
+                                                         "type" : "openconfig-ospf-types:ROUTER_LSA_TRANSIT_NETWORK",
+                                                         "number-tos-metrics" : 0
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "metric" : 10
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "flags-description" : " : ABR ASBR",
+                                                "flags" : 3,
+                                                "number-links" : 1
+                                             }
+                                          }
+                                       }
+                                    ]
+                                 }
+                              },
+                              {
+                                 "type" : "openconfig-ospf-types:SUMMARY_ASBR_LSA",
+                                 "state" : {
+                                    "type" : "openconfig-ospf-types:SUMMARY_ASBR_LSA"
+                                 },
+                                 "lsas" : {
+                                    "openconfig-ospfv2-ext:lsa-ext" : [
+                                       {
+                                          "advertising-router" : "5.5.5.4",
+                                          "link-state-id" : "6.6.6.5",
+                                          "summary-lsa" : {
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "metric" : 4
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "network-mask" : 0
+                                             }
+                                          },
+                                          "state" : {
+                                             "checksum" : 59716,
+                                             "length" : 28,
+                                             "flags" : 11,
+                                             "display-sequence-number" : "80000001",
+                                             "option" : 2,
+                                             "option-expanded" : "*|-|-|-|-|-|E|-",
+                                             "age" : 1187
+                                          }
+                                       }
+                                    ]
+                                 }
+                              },
+                              {
+                                 "type" : "openconfig-ospf-types:SUMMARY_IP_NETWORK_LSA",
+                                 "state" : {
+                                    "type" : "openconfig-ospf-types:SUMMARY_IP_NETWORK_LSA"
+                                 },
+                                 "lsas" : {
+                                    "openconfig-ospfv2-ext:lsa-ext" : [
+                                       {
+                                          "advertising-router" : "5.5.5.4",
+                                          "link-state-id" : "21.1.0.0",
+                                          "summary-lsa" : {
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "metric" : 14
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "network-mask" : 24
+                                             }
+                                          },
+                                          "state" : {
+                                             "checksum" : 18908,
+                                             "length" : 28,
+                                             "flags" : 11,
+                                             "display-sequence-number" : "80000001",
+                                             "option" : 2,
+                                             "option-expanded" : "*|-|-|-|-|-|E|-",
+                                             "age" : 1187
+                                          }
+                                       },
+                                       {
+                                          "advertising-router" : "5.5.5.4",
+                                          "link-state-id" : "32.1.0.0",
+                                          "summary-lsa" : {
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "metric" : 4
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "network-mask" : 24
+                                             }
+                                          },
+                                          "state" : {
+                                             "checksum" : 21967,
+                                             "length" : 28,
+                                             "flags" : 11,
+                                             "display-sequence-number" : "80000001",
+                                             "option" : 2,
+                                             "option-expanded" : "*|-|-|-|-|-|E|-",
+                                             "age" : 1229
+                                          }
+                                       }
+                                    ]
+                                 }
+                              }
+                           ]
+                        },
+                        "state" : {
+                           "identifier" : "0.0.0.2"
+                        }
+                     },
+                     "identifier" : "0.0.0.2",
+                     "interfaces" : {
+                        "interface" : [
+                           {
+                              "openconfig-ospfv2-ext:message-statistics" : {
+                                 "state" : {
+                                    "ls-update-transmit" : 3,
+                                    "ls-request-receive" : 0,
+                                    "ls-acknowledge-receive" : 3,
+                                    "ls-acknowledge-transmit" : 2,
+                                    "db-description-transmit" : 2,
+                                    "db-description-receive" : 6,
+                                    "hello-transmit" : 124,
+                                    "hello-receive" : 125,
+                                    "ls-request-transmit" : 1,
+                                    "ls-update-receive" : 2
+                                 }
+                              },
+                              "openconfig-ospfv2-ext:neighbours" : {
+                                 "neighbour" : [
+                                    {
+                                       "neighbor-id" : "3.3.3.2",
+                                       "neighbor-address" : "41.1.0.1",
+                                       "state" : {
+                                          "priority" : 0,
+                                          "option-value" : 66,
+                                          "gr-helper-status" : "None",
+                                          "state-changes" : 6,
+                                          "backup-designated-router" : "0.0.0.0",
+                                          "adjacency-state" : "openconfig-ospf-types:FULL",
+                                          "neighbor-id" : "6.6.6.5",
+                                          "optional-capabilities" : "*|O|-|-|-|-|E|-",
+                                          "thread-inactivity-timer" : true,
+                                          "thread-ls-request-retransmission" : true,
+                                          "thread-ls-update-retransmission" : true,
+                                          "retransmit-summary-queue-length" : 0,
+                                          "area-id" : "0.0.0.2",
+                                          "gr-active-helper" : false,
+                                          "interface-address" : "41.1.0.2",
+                                          "neighbor-address" : "41.1.0.1",
+                                          "last-established-time" : "1198302",
+                                          "designated-router" : "41.1.0.2",
+                                          "database-summary-queue-length" : 0,
+                                          "interface-name" : "Ethernet120",
+                                          "link-state-request-queue-length" : 0,
+                                          "dead-time" : "34872"
+                                       }
+                                    }
+                                 ]
+                              },
+                              "id" : "Ethernet120",
+                              "timers" : {
+                                 "state" : {
+                                    "retransmission-interval" : 5,
+                                    "dead-interval" : 40,
+                                    "openconfig-ospfv2-ext:wait-time" : 40,
+                                    "hello-interval" : 10000,
+                                    "openconfig-ospfv2-ext:hello-due" : 1711
+                                 }
+                              },
+                              "state" : {
+                                 "priority" : 1,
+                                 "openconfig-ospfv2-ext:member-of-ospf-all-routers" : true,
+                                 "openconfig-ospfv2-ext:index" : 299,
+                                 "openconfig-ospfv2-ext:mtu" : 9100,
+                                 "openconfig-ospfv2-ext:if-flags" : "<UP,BROADCAST,RUNNING,MULTICAST>",
+                                 "openconfig-ospfv2-ext:adjacency-count" : 1,
+                                 "openconfig-ospfv2-ext:address-len" : 24,
+                                 "openconfig-ospfv2-ext:ospf-enable" : true,
+                                 "openconfig-ospfv2-ext:cost" : 10,
+                                 "openconfig-ospfv2-ext:address" : "41.1.0.2",
+                                 "id" : "Ethernet120",
+                                 "openconfig-ospfv2-ext:adjacency-status" : "DR",
+                                 "openconfig-ospfv2-ext:member-of-ospf-designated-routers" : true,
+                                 "openconfig-ospfv2-ext:neighbor-count" : 1,
+                                 "openconfig-ospfv2-ext:router-id" : "5.5.5.4",
+                                 "openconfig-ospfv2-ext:broadcast-address" : "41.1.0.255",
+                                 "openconfig-ospfv2-ext:bandwidth" : 10000,
+                                 "openconfig-ospfv2-ext:area-id" : "0.0.0.2",
+                                 "openconfig-ospfv2-ext:ospf-interface-type" : "Broadcast",
+                                 "network-type" : "openconfig-ospf-types:BROADCAST_NETWORK",
+                                 "openconfig-ospfv2-ext:transmit-delay" : 1,
+                                 "openconfig-ospfv2-ext:operational-state" : "Up"
+                              }
+                           }
+                        ]
+                     },
+                     "config" : {
+                        "identifier" : "0.0.0.2"
+                     },
+                     "openconfig-ospfv2-ext:networks" : {
+                        "network" : [
+                           {
+                              "address-prefix" : "41.1.0.0/24",
+                              "config" : {
+                                 "address-prefix" : "41.1.0.0/24",
+                                 "description" : "Network prefix"
+                              },
+                              "state" : {
+                                 "address-prefix" : "41.1.0.0/24",
+                                 "description" : "Network prefix"
+                              }
+                           }
+                        ]
+                     },
+                     "state" : {
+                        "openconfig-ospfv2-ext:summary-lsa-count" : 2,
+                        "openconfig-ospfv2-ext:nssa-lsa-checksum" : "0x00000000",
+                        "openconfig-ospfv2-ext:authentication-type" : "no",
+                        "openconfig-ospfv2-ext:asbr-summary-lsa-count" : 1,
+                        "openconfig-ospfv2-ext:adjacency-count" : 1,
+                        "openconfig-ospfv2-ext:opaque-area-lsa-count" : 0,
+                        "openconfig-ospfv2-ext:opaque-area-lsa-checksum" : "0x00000000",
+                        "openconfig-ospfv2-ext:lsa-count" : 6,
+                        "openconfig-ospfv2-ext:opaque-link-lsa-checksum" : "0x00000000",
+                        "openconfig-ospfv2-ext:virtual-link-adjacency-count" : 0,
+                        "openconfig-ospfv2-ext:spf-execution-count" : 6,
+                        "openconfig-ospfv2-ext:interface-count" : 1,
+                        "openconfig-ospfv2-ext:network-lsa-count" : 1,
+                        "openconfig-ospfv2-ext:asbr-summary-lsa-checksum" : "0x0000e944",
+                        "openconfig-ospfv2-ext:router-lsa-checksum" : "0x000103a0",
+                        "openconfig-ospfv2-ext:router-lsa-count" : 2,
+                        "openconfig-ospfv2-ext:nssa-lsa-count" : 0,
+                        "openconfig-ospfv2-ext:active-interface-count" : 1,
+                        "openconfig-ospfv2-ext:shortcut" : "openconfig-ospfv2-ext:DEFAULT",
+                        "openconfig-ospfv2-ext:summary-lsa-checksum" : "0x00009fab",
+                        "openconfig-ospfv2-ext:network-lsa-checksum" : "0x000003f9",
+                        "openconfig-ospfv2-ext:opaque-link-lsa-count" : 0
+                     }
+                  }
+               ]
+            }
+         },
+         "name" : "ospfv2",
+         "config" : {
+            "identifier" : "openconfig-policy-types:OSPF",
+            "name" : "ospfv2"
+         },
+         "state" : {
+            "identifier" : "openconfig-policy-types:OSPF",
+            "name" : "ospfv2"
+         }
+      }
+   ]
+}
+            `),
+		appRootType: reflect.TypeOf(ocbinds.OpenconfigNetworkInstance_NetworkInstances{}),
+		queryParams: QueryParams{
+			depthEnabled:  false,
+			curDepth:      1,
+			content:       QUERY_CONTENT_CONFIG,
+			fields:        []string{},
+			fieldsFillAll: false,
+		},
+		prunedPayload: []byte(`
+{
+   "protocol" : [
+      {
+         "identifier" : "openconfig-policy-types:OSPF",
+         "ospfv2" : {
+            "openconfig-ospfv2-ext:route-tables" : {
+               "route-table" : [
+                  {
+                     "routes" : {
+                        "route" : [
+                           {
+                              "next-hops" : {
+                                 "next-hop" : [
+                                    {
+                                       "area-id" : "0.0.0.0",
+                                       "address" : "32.1.0.1",
+                                       "state" : {
+                                          "area-id" : "0.0.0.0",
+                                          "address" : "32.1.0.1",
+                                          "out-interface" : "Vlan3719"
+                                       },
+                                       "out-interface" : "Vlan3719"
+                                    }
+                                 ]
+                              },
+                              "state" : {
+                                 "cost" : 4,
+                                 "sub-type" : "openconfig-ospfv2-ext:EXTERNAL_ROUTE_TYPE_2",
+                                 "type" : "openconfig-ospfv2-ext:EXTERNAL_ROUTE",
+                                 "prefix" : "10.193.80.0/20"
+                              },
+                              "prefix" : "10.193.80.0/20"
+                           }
+                        ]
+                     },
+                     "type" : "openconfig-ospfv2-ext:EXTERNAL_ROUTE_TABLE",
+                     "state" : {
+                        "type" : "openconfig-ospfv2-ext:EXTERNAL_ROUTE_TABLE"
+                     }
+                  },
+                  {
+                     "routes" : {
+                        "route" : [
+                           {
+                              "next-hops" : {
+                                 "next-hop" : [
+                                    {
+                                       "area-id" : "0.0.0.0",
+                                       "address" : "32.1.0.1",
+                                       "state" : {
+                                          "area-id" : "0.0.0.0",
+                                          "address" : "32.1.0.1",
+                                          "out-interface" : "Vlan3719"
+                                       },
+                                       "out-interface" : "Vlan3719"
+                                    }
+                                 ]
+                              },
+                              "state" : {
+                                 "cost" : 14,
+                                 "type" : "openconfig-ospfv2-ext:NETWORK_ROUTE",
+                                 "inter-area" : true,
+                                 "prefix" : "10.193.80.0/20"
+                              },
+                              "prefix" : "21.1.0.0/24"
+                           },
+                           {
+                              "next-hops" : {
+                                 "next-hop" : [
+                                    {
+                                       "area-id" : "0.0.0.0",
+                                       "address" : "0.0.0.0",
+                                       "state" : {
+                                          "area-id" : "0.0.0.0",
+                                          "address" : "32.1.0.1",
+                                          "out-interface" : "Vlan3719"
+                                       },
+                                       "out-interface" : "Vlan3719"
+                                    }
+                                 ]
+                              },
+                              "state" : {
+                                 "cost" : 4,
+                                 "type" : "openconfig-ospfv2-ext:NETWORK_ROUTE",
+                                 "prefix" : "10.193.80.0/20"
+                              },
+                              "prefix" : "32.1.0.0/24"
+                           },
+                           {
+                              "next-hops" : {
+                                 "next-hop" : [
+                                    {
+                                       "area-id" : "0.0.0.2",
+                                       "address" : "0.0.0.0",
+                                       "state" : {
+                                          "area-id" : "0.0.0.0",
+                                          "address" : "32.1.0.1",
+                                          "out-interface" : "Vlan3719"
+                                       },
+                                       "out-interface" : "Ethernet120"
+                                    }
+                                 ]
+                              },
+                              "state" : {
+                                 "cost" : 10,
+                                 "type" : "openconfig-ospfv2-ext:NETWORK_ROUTE",
+                                 "prefix" : "10.193.80.0/20"
+                              },
+                              "prefix" : "41.1.0.0/24"
+                           }
+                        ]
+                     },
+                     "type" : "openconfig-ospfv2-ext:NETWORK_ROUTE_TABLE",
+                     "state" : {
+                        "type" : "openconfig-ospfv2-ext:NETWORK_ROUTE_TABLE"
+                     }
+                  },
+                  {
+                     "routes" : {
+                        "route" : [
+                           {
+                              "next-hops" : {
+                                 "next-hop" : [
+                                    {
+                                       "area-id" : "0.0.0.0",
+                                       "address" : "32.1.0.1",
+                                       "state" : {
+                                          "area-id" : "0.0.0.0",
+                                          "address" : "32.1.0.1",
+                                          "out-interface" : "Vlan3719"
+                                       },
+                                       "out-interface" : "Vlan3719"
+                                    }
+                                 ]
+                              },
+                              "state" : {
+                                 "router-type" : "openconfig-ospfv2-ext:ABRASBR",
+                                 "cost" : 4,
+                                 "type" : "openconfig-ospfv2-ext:ROUTER_ROUTE",
+                                 "prefix" : "10.193.80.0/20"
+                              },
+                              "prefix" : "6.6.6.5"
+                           }
+                        ]
+                     },
+                     "type" : "openconfig-ospfv2-ext:ROUTER_ROUTE_TABLE",
+                     "state" : {
+                        "type" : "openconfig-ospfv2-ext:ROUTER_ROUTE_TABLE"
+                     }
+                  }
+               ]
+            },
+            "global" : {
+               "graceful-restart" : {
+                  "openconfig-ospfv2-ext:helpers" : {
+                     "helper" : [
+                        {
+                           "neighbour-id" : "5.5.5.4",
+                           "config" : {
+                              "vrf-name" : "default",
+                              "neighbour-id" : "5.5.5.4"
+                           },
+                           "state" : {
+                              "neighbour-id" : "5.5.5.4"
+                           }
+                        }
+                     ]
+                  },
+                  "config" : {
+                     "openconfig-ospfv2-ext:planned-only" : true,
+                     "helper-only" : true,
+                     "openconfig-ospfv2-ext:supported-grace-time" : 800,
+                     "openconfig-ospfv2-ext:strict-lsa-checking" : true
+                  },
+                  "state" : {
+                     "openconfig-ospfv2-ext:planned-only" : true,
+                     "helper-only" : true,
+                     "openconfig-ospfv2-ext:grace-period" : 0,
+                     "openconfig-ospfv2-ext:supported-grace-time" : 800,
+                     "openconfig-ospfv2-ext:strict-lsa-checking" : true
+                  }
+               },
+               "inter-area-propagation-policies" : {
+                  "openconfig-ospfv2-ext:inter-area-policy" : [
+                     {
+                        "config" : {
+                           "src-area" : "0.0.0.0"
+                        },
+                        "src-area" : "0.0.0.0",
+                        "state" : {
+                           "src-area" : "0.0.0.0"
+                        }
+                     },
+                     {
+                        "config" : {
+                           "src-area" : "0.0.0.2"
+                        },
+                        "src-area" : "0.0.0.2",
+                        "state" : {
+                           "src-area" : "0.0.0.2"
+                        }
+                     }
+                  ]
+               },
+               "config" : {
+                  "router-id" : "5.5.5.4",
+                  "openconfig-ospfv2-ext:opaque-lsa-capability" : true,
+                  "openconfig-ospfv2-ext:description" : "OSPFv2 Router",
+                  "openconfig-ospfv2-ext:enable" : true
+               },
+               "timers" : {
+                  "lsa-generation" : {
+                     "state" : {
+                        "openconfig-ospfv2-ext:refresh-timer" : 10000,
+                        "openconfig-ospfv2-ext:lsa-min-interval-timer" : 5000,
+                        "openconfig-ospfv2-ext:lsa-min-arrival-timer" : 1000
+                     }
+                  },
+                  "spf" : {
+                     "state" : {
+                        "maximum-delay" : 5000,
+                        "initial-delay" : 50,
+                        "openconfig-ospfv2-ext:throttle-delay" : 0,
+                        "openconfig-ospfv2-ext:spf-timer-due" : 0
+                     }
+                  }
+               },
+               "state" : {
+                  "openconfig-ospfv2-ext:area-count" : 2,
+                  "openconfig-ospfv2-ext:last-spf-duration" : 358,
+                  "openconfig-ospfv2-ext:hold-time-multiplier" : 1,
+                  "openconfig-ospfv2-ext:last-spf-execution-time" : "1187616",
+                  "openconfig-ospfv2-ext:opaque-lsa-count" : 0,
+                  "router-id" : "5.5.5.4",
+                  "openconfig-ospfv2-ext:abr-type" : "openconfig-ospfv2-ext:CISCO",
+                  "openconfig-ospfv2-ext:external-lsa-checksum" : "0x00016bcc",
+                  "openconfig-ospfv2-ext:opaque-lsa-checksum" : "0x00000000",
+                  "openconfig-ospfv2-ext:write-multiplier" : 20,
+                  "openconfig-ospfv2-ext:opaque-lsa-capability" : true,
+                  "openconfig-ospfv2-ext:external-lsa-count" : 2
+               }
+            },
+            "areas" : {
+               "area" : [
+                  {
+                     "lsdb" : {
+                     },
+                     "identifier" : "0.0.0.0",
+                     "interfaces" : {
+                        "interface" : [
+                           {
+                              "openconfig-ospfv2-ext:message-statistics" : {
+                                 "state" : {
+                                    "ls-update-transmit" : 4,
+                                    "ls-request-receive" : 1,
+                                    "ls-acknowledge-receive" : 2,
+                                    "ls-acknowledge-transmit" : 2,
+                                    "db-description-transmit" : 3,
+                                    "db-description-receive" : 2,
+                                    "hello-transmit" : 124,
+                                    "hello-receive" : 124,
+                                    "ls-request-transmit" : 1,
+                                    "ls-update-receive" : 3
+                                 }
+                              },
+                              "openconfig-ospfv2-ext:neighbours" : {
+                                 "neighbour" : [
+                                    {
+                                       "neighbor-id" : "6.6.6.5",
+                                       "neighbor-address" : "32.1.0.1",
+                                       "state" : {
+                                          "priority" : 1,
+                                          "option-value" : 66,
+                                          "gr-helper-status" : "None",
+                                          "state-changes" : 6,
+                                          "backup-designated-router" : "32.1.0.2",
+                                          "adjacency-state" : "openconfig-ospf-types:FULL",
+                                          "neighbor-id" : "6.6.6.5",
+                                          "optional-capabilities" : "*|O|-|-|-|-|E|-",
+                                          "thread-inactivity-timer" : true,
+                                          "thread-ls-request-retransmission" : true,
+                                          "thread-ls-update-retransmission" : true,
+                                          "retransmit-summary-queue-length" : 0,
+                                          "area-id" : "0.0.0.0",
+                                          "gr-active-helper" : false,
+                                          "interface-address" : "32.1.0.2",
+                                          "neighbor-address" : "32.1.0.1",
+                                          "last-established-time" : "1197595",
+                                          "designated-router" : "32.1.0.1",
+                                          "database-summary-queue-length" : 0,
+                                          "interface-name" : "Vlan3719",
+                                          "link-state-request-queue-length" : 0,
+                                          "dead-time" : "32410"
+                                       }
+                                    }
+                                 ]
+                              },
+                              "id" : "Vlan3719",
+                              "timers" : {
+                                 "state" : {
+                                    "retransmission-interval" : 5,
+                                    "dead-interval" : 40,
+                                    "openconfig-ospfv2-ext:wait-time" : 40,
+                                    "hello-interval" : 10000,
+                                    "openconfig-ospfv2-ext:hello-due" : 2409
+                                 }
+                              },
+                              "state" : {
+                                 "priority" : 1,
+                                 "openconfig-ospfv2-ext:member-of-ospf-all-routers" : true,
+                                 "openconfig-ospfv2-ext:index" : 310,
+                                 "openconfig-ospfv2-ext:mtu" : 9100,
+                                 "openconfig-ospfv2-ext:if-flags" : "<UP,BROADCAST,RUNNING,MULTICAST>",
+                                 "openconfig-ospfv2-ext:adjacency-count" : 1,
+                                 "openconfig-ospfv2-ext:address-len" : 24,
+                                 "openconfig-ospfv2-ext:ospf-enable" : true,
+                                 "openconfig-ospfv2-ext:cost" : 4,
+                                 "openconfig-ospfv2-ext:address" : "32.1.0.2",
+                                 "id" : "Vlan3719",
+                                 "openconfig-ospfv2-ext:adjacency-status" : "Backup",
+                                 "openconfig-ospfv2-ext:neighbor-count" : 1,
+                                 "openconfig-ospfv2-ext:backup-designated-router-id" : "5.5.5.4",
+                                 "openconfig-ospfv2-ext:member-of-ospf-designated-routers" : true,
+                                 "openconfig-ospfv2-ext:router-id" : "5.5.5.4",
+                                 "openconfig-ospfv2-ext:broadcast-address" : "32.1.0.255",
+                                 "openconfig-ospfv2-ext:bandwidth" : 25000,
+                                 "openconfig-ospfv2-ext:area-id" : "0.0.0.0",
+                                 "openconfig-ospfv2-ext:ospf-interface-type" : "Broadcast",
+                                 "openconfig-ospfv2-ext:backup-designated-router-address" : "32.1.0.2",
+                                 "network-type" : "openconfig-ospf-types:BROADCAST_NETWORK",
+                                 "openconfig-ospfv2-ext:transmit-delay" : 1,
+                                 "openconfig-ospfv2-ext:operational-state" : "Up"
+                              }
+                           }
+                        ]
+                     },
+                     "config" : {
+                        "identifier" : "0.0.0.0"
+                     },
+                     "openconfig-ospfv2-ext:networks" : {
+                        "network" : [
+                           {
+                              "address-prefix" : "31.1.0.0/24",
+                              "config" : {
+                                 "address-prefix" : "31.1.0.0/24",
+                                 "description" : "Network prefix"
+                              },
+                              "state" : {
+                                 "address-prefix" : "31.1.0.0/24",
+                                 "description" : "Network prefix"
+                              }
+                           },
+                           {
+                              "address-prefix" : "32.1.0.0/24",
+                              "config" : {
+                                 "address-prefix" : "32.1.0.0/24",
+                                 "description" : "Network prefix"
+                              },
+                              "state" : {
+                                 "address-prefix" : "32.1.0.0/24",
+                                 "description" : "Network prefix"
+                              }
+                           }
+                        ]
+                     },
+                     "state" : {
+                        "openconfig-ospfv2-ext:summary-lsa-count" : 2,
+                        "openconfig-ospfv2-ext:nssa-lsa-checksum" : "0x00000000",
+                        "openconfig-ospfv2-ext:authentication-type" : "no",
+                        "openconfig-ospfv2-ext:asbr-summary-lsa-count" : 0,
+                        "openconfig-ospfv2-ext:adjacency-count" : 1,
+                        "openconfig-ospfv2-ext:opaque-area-lsa-count" : 0,
+                        "openconfig-ospfv2-ext:opaque-area-lsa-checksum" : "0x00000000",
+                        "openconfig-ospfv2-ext:lsa-count" : 5,
+                        "openconfig-ospfv2-ext:opaque-link-lsa-checksum" : "0x00000000",
+                        "openconfig-ospfv2-ext:spf-execution-count" : 6,
+                        "openconfig-ospfv2-ext:interface-count" : 1,
+                        "openconfig-ospfv2-ext:network-lsa-count" : 1,
+                        "openconfig-ospfv2-ext:asbr-summary-lsa-checksum" : "0x00000000",
+                        "openconfig-ospfv2-ext:router-lsa-checksum" : "0x0000cfe5",
+                        "openconfig-ospfv2-ext:router-lsa-count" : 2,
+                        "openconfig-ospfv2-ext:nssa-lsa-count" : 0,
+                        "openconfig-ospfv2-ext:active-interface-count" : 1,
+                        "openconfig-ospfv2-ext:summary-lsa-checksum" : "0x0000201c",
+                        "openconfig-ospfv2-ext:network-lsa-checksum" : "0x0000ca2c",
+                        "openconfig-ospfv2-ext:opaque-link-lsa-count" : 0
+                     }
+                  },
+                  {
+                     "lsdb" : {
+                        "lsa-types" : {
+                           "lsa-type" : [
+                              {
+                                 "type" : "openconfig-ospf-types:AS_EXTERNAL_LSA",
+                                 "state" : {
+                                    "type" : "openconfig-ospf-types:AS_EXTERNAL_LSA"
+                                 },
+                                 "lsas" : {
+                                    "openconfig-ospfv2-ext:lsa-ext" : [
+                                       {
+                                          "advertising-router" : "5.5.5.4",
+                                          "as-external-lsa" : {
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "forwarding-address" : "0.0.0.0",
+                                                         "external-route-tag" : 0,
+                                                         "metric" : 20
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "metric-type" : "TYPE_2",
+                                                "mask" : 20
+                                             }
+                                          },
+                                          "link-state-id" : "10.193.80.0",
+                                          "state" : {
+                                             "checksum" : 50393,
+                                             "length" : 36,
+                                             "flags" : 11,
+                                             "display-sequence-number" : "80000001",
+                                             "option" : 2,
+                                             "option-expanded" : "*||||||E|",
+                                             "age" : 1227
+                                          }
+                                       },
+                                       {
+                                          "advertising-router" : "6.6.6.5",
+                                          "as-external-lsa" : {
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "forwarding-address" : "0.0.0.0",
+                                                         "external-route-tag" : 0,
+                                                         "metric" : 20
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "metric-type" : "TYPE_2",
+                                                "mask" : 20
+                                             }
+                                          },
+                                          "link-state-id" : "10.193.80.0",
+                                          "state" : {
+                                             "checksum" : 42739,
+                                             "length" : 36,
+                                             "flags" : 6,
+                                             "display-sequence-number" : "80000001",
+                                             "option" : 2,
+                                             "option-expanded" : "*||||||E|",
+                                             "age" : 1228
+                                          }
+                                       }
+                                    ]
+                                 }
+                              },
+                              {
+                                 "type" : "openconfig-ospf-types:NETWORK_LSA",
+                                 "state" : {
+                                    "type" : "openconfig-ospf-types:NETWORK_LSA"
+                                 },
+                                 "lsas" : {
+                                    "openconfig-ospfv2-ext:lsa-ext" : [
+                                       {
+                                          "advertising-router" : "5.5.5.4",
+                                          "link-state-id" : "41.1.0.2",
+                                          "state" : {
+                                             "checksum" : 1017,
+                                             "length" : 32,
+                                             "flags" : 3,
+                                             "display-sequence-number" : "80000001",
+                                             "option" : 2,
+                                             "option-expanded" : "*|-|-|-|-|-|E|-",
+                                             "age" : 1198
+                                          },
+                                          "network-lsa" : {
+                                             "state" : {
+                                                "network-mask" : 24
+                                             }
+                                          }
+                                       }
+                                    ]
+                                 }
+                              },
+                              {
+                                 "type" : "openconfig-ospf-types:OSPFV2_LINK_SCOPE_OPAQUE_LSA"
+                              },
+                              {
+                                 "type" : "openconfig-ospf-types:ROUTER_LSA",
+                                 "state" : {
+                                    "type" : "openconfig-ospf-types:ROUTER_LSA"
+                                 },
+                                 "lsas" : {
+                                    "openconfig-ospfv2-ext:lsa-ext" : [
+                                       {
+                                          "advertising-router" : "3.3.3.2",
+                                          "link-state-id" : "3.3.3.2",
+                                          "state" : {
+                                             "checksum" : 53771,
+                                             "length" : 36,
+                                             "flags" : 6,
+                                             "display-sequence-number" : "80000002",
+                                             "option" : 0,
+                                             "option-expanded" : "*|||||||-",
+                                             "age" : 1189
+                                          },
+                                          "router-lsa" : {
+                                             "link-informations" : {
+                                                "link-information" : [
+                                                   {
+                                                      "state" : {
+                                                         "metric" : 10,
+                                                         "type" : "openconfig-ospf-types:ROUTER_LSA_TRANSIT_NETWORK",
+                                                         "number-tos-metrics" : 0
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "metric" : 10
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "flags-description" : " :",
+                                                "flags" : 0,
+                                                "number-links" : 1
+                                             }
+                                          }
+                                       },
+                                       {
+                                          "advertising-router" : "5.5.5.4",
+                                          "link-state-id" : "5.5.5.4",
+                                          "state" : {
+                                             "checksum" : 12693,
+                                             "length" : 36,
+                                             "flags" : 3,
+                                             "display-sequence-number" : "80000003",
+                                             "option" : 2,
+                                             "option-expanded" : "*||||||E|",
+                                             "age" : 1198
+                                          },
+                                          "router-lsa" : {
+                                             "link-informations" : {
+                                                "link-information" : [
+                                                   {
+                                                      "state" : {
+                                                         "metric" : 10,
+                                                         "type" : "openconfig-ospf-types:ROUTER_LSA_TRANSIT_NETWORK",
+                                                         "number-tos-metrics" : 0
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "metric" : 10
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "flags-description" : " : ABR ASBR",
+                                                "flags" : 3,
+                                                "number-links" : 1
+                                             }
+                                          }
+                                       }
+                                    ]
+                                 }
+                              },
+                              {
+                                 "type" : "openconfig-ospf-types:SUMMARY_ASBR_LSA",
+                                 "state" : {
+                                    "type" : "openconfig-ospf-types:SUMMARY_ASBR_LSA"
+                                 },
+                                 "lsas" : {
+                                    "openconfig-ospfv2-ext:lsa-ext" : [
+                                       {
+                                          "advertising-router" : "5.5.5.4",
+                                          "link-state-id" : "6.6.6.5",
+                                          "summary-lsa" : {
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "metric" : 4
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "network-mask" : 0
+                                             }
+                                          },
+                                          "state" : {
+                                             "checksum" : 59716,
+                                             "length" : 28,
+                                             "flags" : 11,
+                                             "display-sequence-number" : "80000001",
+                                             "option" : 2,
+                                             "option-expanded" : "*|-|-|-|-|-|E|-",
+                                             "age" : 1187
+                                          }
+                                       }
+                                    ]
+                                 }
+                              },
+                              {
+                                 "type" : "openconfig-ospf-types:SUMMARY_IP_NETWORK_LSA",
+                                 "state" : {
+                                    "type" : "openconfig-ospf-types:SUMMARY_IP_NETWORK_LSA"
+                                 },
+                                 "lsas" : {
+                                    "openconfig-ospfv2-ext:lsa-ext" : [
+                                       {
+                                          "advertising-router" : "5.5.5.4",
+                                          "link-state-id" : "21.1.0.0",
+                                          "summary-lsa" : {
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "metric" : 14
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "network-mask" : 24
+                                             }
+                                          },
+                                          "state" : {
+                                             "checksum" : 18908,
+                                             "length" : 28,
+                                             "flags" : 11,
+                                             "display-sequence-number" : "80000001",
+                                             "option" : 2,
+                                             "option-expanded" : "*|-|-|-|-|-|E|-",
+                                             "age" : 1187
+                                          }
+                                       },
+                                       {
+                                          "advertising-router" : "5.5.5.4",
+                                          "link-state-id" : "32.1.0.0",
+                                          "summary-lsa" : {
+                                             "types-of-service" : {
+                                                "type-of-service" : [
+                                                   {
+                                                      "tos" : 0,
+                                                      "state" : {
+                                                         "metric" : 4
+                                                      }
+                                                   }
+                                                ]
+                                             },
+                                             "state" : {
+                                                "network-mask" : 24
+                                             }
+                                          },
+                                          "state" : {
+                                             "checksum" : 21967,
+                                             "length" : 28,
+                                             "flags" : 11,
+                                             "display-sequence-number" : "80000001",
+                                             "option" : 2,
+                                             "option-expanded" : "*|-|-|-|-|-|E|-",
+                                             "age" : 1229
+                                          }
+                                       }
+                                    ]
+                                 }
+                              }
+                           ]
+                        },
+                        "state" : {
+                           "identifier" : "0.0.0.2"
+                        }
+                     },
+                     "identifier" : "0.0.0.2",
+                     "interfaces" : {
+                        "interface" : [
+                           {
+                              "openconfig-ospfv2-ext:message-statistics" : {
+                                 "state" : {
+                                    "ls-update-transmit" : 3,
+                                    "ls-request-receive" : 0,
+                                    "ls-acknowledge-receive" : 3,
+                                    "ls-acknowledge-transmit" : 2,
+                                    "db-description-transmit" : 2,
+                                    "db-description-receive" : 6,
+                                    "hello-transmit" : 124,
+                                    "hello-receive" : 125,
+                                    "ls-request-transmit" : 1,
+                                    "ls-update-receive" : 2
+                                 }
+                              },
+                              "openconfig-ospfv2-ext:neighbours" : {
+                                 "neighbour" : [
+                                    {
+                                       "neighbor-id" : "3.3.3.2",
+                                       "neighbor-address" : "41.1.0.1",
+                                       "state" : {
+                                          "priority" : 0,
+                                          "option-value" : 66,
+                                          "gr-helper-status" : "None",
+                                          "state-changes" : 6,
+                                          "backup-designated-router" : "0.0.0.0",
+                                          "adjacency-state" : "openconfig-ospf-types:FULL",
+                                          "neighbor-id" : "6.6.6.5",
+                                          "optional-capabilities" : "*|O|-|-|-|-|E|-",
+                                          "thread-inactivity-timer" : true,
+                                          "thread-ls-request-retransmission" : true,
+                                          "thread-ls-update-retransmission" : true,
+                                          "retransmit-summary-queue-length" : 0,
+                                          "area-id" : "0.0.0.2",
+                                          "gr-active-helper" : false,
+                                          "interface-address" : "41.1.0.2",
+                                          "neighbor-address" : "41.1.0.1",
+                                          "last-established-time" : "1198302",
+                                          "designated-router" : "41.1.0.2",
+                                          "database-summary-queue-length" : 0,
+                                          "interface-name" : "Ethernet120",
+                                          "link-state-request-queue-length" : 0,
+                                          "dead-time" : "34872"
+                                       }
+                                    }
+                                 ]
+                              },
+                              "id" : "Ethernet120",
+                              "timers" : {
+                                 "state" : {
+                                    "retransmission-interval" : 5,
+                                    "dead-interval" : 40,
+                                    "openconfig-ospfv2-ext:wait-time" : 40,
+                                    "hello-interval" : 10000,
+                                    "openconfig-ospfv2-ext:hello-due" : 1711
+                                 }
+                              },
+                              "state" : {
+                                 "priority" : 1,
+                                 "openconfig-ospfv2-ext:member-of-ospf-all-routers" : true,
+                                 "openconfig-ospfv2-ext:index" : 299,
+                                 "openconfig-ospfv2-ext:mtu" : 9100,
+                                 "openconfig-ospfv2-ext:if-flags" : "<UP,BROADCAST,RUNNING,MULTICAST>",
+                                 "openconfig-ospfv2-ext:adjacency-count" : 1,
+                                 "openconfig-ospfv2-ext:address-len" : 24,
+                                 "openconfig-ospfv2-ext:ospf-enable" : true,
+                                 "openconfig-ospfv2-ext:cost" : 10,
+                                 "openconfig-ospfv2-ext:address" : "41.1.0.2",
+                                 "id" : "Ethernet120",
+                                 "openconfig-ospfv2-ext:adjacency-status" : "DR",
+                                 "openconfig-ospfv2-ext:member-of-ospf-designated-routers" : true,
+                                 "openconfig-ospfv2-ext:neighbor-count" : 1,
+                                 "openconfig-ospfv2-ext:router-id" : "5.5.5.4",
+                                 "openconfig-ospfv2-ext:broadcast-address" : "41.1.0.255",
+                                 "openconfig-ospfv2-ext:bandwidth" : 10000,
+                                 "openconfig-ospfv2-ext:area-id" : "0.0.0.2",
+                                 "openconfig-ospfv2-ext:ospf-interface-type" : "Broadcast",
+                                 "network-type" : "openconfig-ospf-types:BROADCAST_NETWORK",
+                                 "openconfig-ospfv2-ext:transmit-delay" : 1,
+                                 "openconfig-ospfv2-ext:operational-state" : "Up"
+                              }
+                           }
+                        ]
+                     },
+                     "config" : {
+                        "identifier" : "0.0.0.2"
+                     },
+                     "openconfig-ospfv2-ext:networks" : {
+                        "network" : [
+                           {
+                              "address-prefix" : "41.1.0.0/24",
+                              "config" : {
+                                 "address-prefix" : "41.1.0.0/24",
+                                 "description" : "Network prefix"
+                              },
+                              "state" : {
+                                 "address-prefix" : "41.1.0.0/24",
+                                 "description" : "Network prefix"
+                              }
+                           }
+                        ]
+                     },
+                     "state" : {
+                        "openconfig-ospfv2-ext:summary-lsa-count" : 2,
+                        "openconfig-ospfv2-ext:nssa-lsa-checksum" : "0x00000000",
+                        "openconfig-ospfv2-ext:authentication-type" : "no",
+                        "openconfig-ospfv2-ext:asbr-summary-lsa-count" : 1,
+                        "openconfig-ospfv2-ext:adjacency-count" : 1,
+                        "openconfig-ospfv2-ext:opaque-area-lsa-count" : 0,
+                        "openconfig-ospfv2-ext:opaque-area-lsa-checksum" : "0x00000000",
+                        "openconfig-ospfv2-ext:lsa-count" : 6,
+                        "openconfig-ospfv2-ext:opaque-link-lsa-checksum" : "0x00000000",
+                        "openconfig-ospfv2-ext:virtual-link-adjacency-count" : 0,
+                        "openconfig-ospfv2-ext:spf-execution-count" : 6,
+                        "openconfig-ospfv2-ext:interface-count" : 1,
+                        "openconfig-ospfv2-ext:network-lsa-count" : 1,
+                        "openconfig-ospfv2-ext:asbr-summary-lsa-checksum" : "0x0000e944",
+                        "openconfig-ospfv2-ext:router-lsa-checksum" : "0x000103a0",
+                        "openconfig-ospfv2-ext:router-lsa-count" : 2,
+                        "openconfig-ospfv2-ext:nssa-lsa-count" : 0,
+                        "openconfig-ospfv2-ext:active-interface-count" : 1,
+                        "openconfig-ospfv2-ext:shortcut" : "openconfig-ospfv2-ext:DEFAULT",
+                        "openconfig-ospfv2-ext:summary-lsa-checksum" : "0x00009fab",
+                        "openconfig-ospfv2-ext:network-lsa-checksum" : "0x000003f9",
+                        "openconfig-ospfv2-ext:opaque-link-lsa-count" : 0
+                     }
+                  }
+               ]
+            }
+         },
+         "name" : "ospfv2",
+         "config" : {
+            "identifier" : "openconfig-policy-types:OSPF",
+            "name" : "ospfv2"
+         },
+         "state" : {
+            "identifier" : "openconfig-policy-types:OSPF",
+            "name" : "ospfv2"
+         }
+      }
+   ]
+}
+            `),
+	},
+}

--- a/translib/transformer/xlate_prune_radius_test.go
+++ b/translib/transformer/xlate_prune_radius_test.go
@@ -1,0 +1,513 @@
+////////////////////////////////////////////////////////////////////////////////
+//                                                                            //
+//  Copyright 2019 Broadcom. The term Broadcom refers to Broadcom Inc. and/or //
+//  its subsidiaries.                                                         //
+//                                                                            //
+//  Licensed under the Apache License, Version 2.0 (the "License");           //
+//  you may not use this file except in compliance with the License.          //
+//  You may obtain a copy of the License at                                   //
+//                                                                            //
+//     http://www.apache.org/licenses/LICENSE-2.0                             //
+//                                                                            //
+//  Unless required by applicable law or agreed to in writing, software       //
+//  distributed under the License is distributed on an "AS IS" BASIS,         //
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  //
+//  See the License for the specific language governing permissions and       //
+//  limitations under the License.                                            //
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+//go:build radius_prune_xfmrtest
+// +build radius_prune_xfmrtest
+
+package transformer
+
+import (
+	"reflect"
+
+	"github.com/Azure/sonic-mgmt-common/translib/ocbinds"
+)
+
+func init() {
+	xp_tests = append(xp_tests, radius_xp_tests...)
+}
+
+var radius_xp_tests = []xpTests{
+	{ // RADIUS Identity Test Case (i.e. no QP)
+		tid:        "RADIUS Identity",
+		uri:        "/openconfig-system:system/aaa/server-groups/server-group[name=RADIUS]/servers/server[address=10.10.10.10]",
+		requestUri: "/openconfig-system:system/aaa/server-groups/server-group[name=RADIUS]/servers/server[address=10.10.10.10]",
+		payload: []byte(`
+            {
+               "openconfig-system:server" : [
+                  {
+                     "tacacs" : {
+                        "config" : {
+                           "encrypted" : true,
+                           "secret-key" : ""
+                        }
+                     },
+                     "radius" : {
+                        "config" : {
+                           "openconfig-aaa-radius-ext:encrypted" : true,
+                           "secret-key" : "",
+                           "retransmit-attempts" : 1
+                        },
+                        "state" : {
+                           "retransmit-attempts" : 1,
+                           "counters" : {
+                              "access-rejects" : "1",
+                              "access-accepts" : "2",
+                              "openconfig-aaa-radius-ext:access-requests" : "3"
+                           }
+                        }
+                     },
+                     "config" : {
+                        "priority" : 1,
+                        "auth-type" : "chap",
+                        "address" : "10.10.10.10"
+                     },
+                     "address" : "10.10.10.10",
+                     "state" : {
+                        "priority" : 1,
+                        "auth-type" : "chap",
+                        "address" : "10.10.10.10"
+                     }
+                  }
+               ]
+            }
+            `),
+		appRootType: reflect.TypeOf(ocbinds.OpenconfigSystem_System{}),
+		queryParams: QueryParams{
+			depthEnabled:  false,
+			curDepth:      1,
+			content:       QUERY_CONTENT_ALL,
+			fields:        []string{},
+			fieldsFillAll: false,
+		},
+		prunedPayload: []byte(`
+            {
+               "openconfig-system:server" : [
+                  {
+                     "tacacs" : {
+                        "config" : {
+                           "encrypted" : true,
+                           "secret-key" : ""
+                        }
+                     },
+                     "radius" : {
+                        "config" : {
+                           "openconfig-aaa-radius-ext:encrypted" : true,
+                           "secret-key" : "",
+                           "retransmit-attempts" : 1
+                        },
+                        "state" : {
+                           "retransmit-attempts" : 1,
+                           "counters" : {
+                              "access-rejects" : "1",
+                              "access-accepts" : "2",
+                              "openconfig-aaa-radius-ext:access-requests" : "3"
+                           }
+                        }
+                     },
+                     "config" : {
+                        "priority" : 1,
+                        "auth-type" : "chap",
+                        "address" : "10.10.10.10"
+                     },
+                     "address" : "10.10.10.10",
+                     "state" : {
+                        "priority" : 1,
+                        "auth-type" : "chap",
+                        "address" : "10.10.10.10"
+                     }
+                  }
+               ]
+            }
+            `),
+	},
+	{ // RADIUS depth = 3
+		tid:        "RADIUS Depth",
+		uri:        "/openconfig-system:system/aaa/server-groups/server-group[name=RADIUS]/servers/server[address=10.10.10.10]",
+		requestUri: "/openconfig-system:system/aaa/server-groups/server-group[name=RADIUS]/servers/server[address=10.10.10.10]",
+		payload: []byte(`
+            {
+               "openconfig-system:server" : [
+                  {
+                     "tacacs" : {
+                        "config" : {
+                           "encrypted" : true,
+                           "secret-key" : ""
+                        }
+                     },
+                     "radius" : {
+                        "config" : {
+                           "openconfig-aaa-radius-ext:encrypted" : true,
+                           "secret-key" : "",
+                           "retransmit-attempts" : 1
+                        },
+                        "state" : {
+                           "retransmit-attempts" : 1,
+                           "counters" : {
+                              "access-rejects" : "1",
+                              "access-accepts" : "2",
+                              "openconfig-aaa-radius-ext:access-requests" : "3"
+                           }
+                        }
+                     },
+                     "config" : {
+                        "priority" : 1,
+                        "auth-type" : "chap",
+                        "address" : "10.10.10.10"
+                     },
+                     "address" : "10.10.10.10",
+                     "state" : {
+                        "priority" : 1,
+                        "auth-type" : "chap",
+                        "address" : "10.10.10.10"
+                     }
+                  }
+               ]
+            }
+            `),
+		appRootType: reflect.TypeOf(ocbinds.OpenconfigSystem_System{}),
+		queryParams: QueryParams{
+			depthEnabled:  true,
+			curDepth:      3,
+			content:       QUERY_CONTENT_ALL,
+			fields:        []string{},
+			fieldsFillAll: false,
+		},
+		prunedPayload: []byte(`
+            {
+               "openconfig-system:server" : [
+                  {
+                     "tacacs" : {
+                        "config" : {
+                        }
+                     },
+                     "radius" : {
+                        "config" : {
+                        },
+                        "state" : {
+                        }
+                     },
+                     "config" : {
+                        "priority" : 1,
+                        "auth-type" : "chap",
+                        "address" : "10.10.10.10"
+                     },
+                     "address" : "10.10.10.10",
+                     "state" : {
+                        "priority" : 1,
+                        "auth-type" : "chap",
+                        "address" : "10.10.10.10"
+                     }
+                  }
+               ]
+            }
+            `),
+	},
+	{ // RADIUS content = QUERY_CONTENT_CONFIG
+		tid:        "RADIUS Content Config",
+		uri:        "/openconfig-system:system/aaa/server-groups/server-group[name=RADIUS]/servers/server[address=10.10.10.10]",
+		requestUri: "/openconfig-system:system/aaa/server-groups/server-group[name=RADIUS]/servers/server[address=10.10.10.10]",
+		payload: []byte(`
+            {
+               "openconfig-system:server" : [
+                  {
+                     "tacacs" : {
+                        "config" : {
+                           "encrypted" : true,
+                           "secret-key" : ""
+                        }
+                     },
+                     "radius" : {
+                        "config" : {
+                           "openconfig-aaa-radius-ext:encrypted" : true,
+                           "secret-key" : "",
+                           "retransmit-attempts" : 1
+                        },
+                        "state" : {
+                           "retransmit-attempts" : 1,
+                           "counters" : {
+                              "access-rejects" : "1",
+                              "access-accepts" : "2",
+                              "openconfig-aaa-radius-ext:access-requests" : "3"
+                           }
+                        }
+                     },
+                     "config" : {
+                        "priority" : 1,
+                        "auth-type" : "chap",
+                        "address" : "10.10.10.10"
+                     },
+                     "address" : "10.10.10.10",
+                     "state" : {
+                        "priority" : 1,
+                        "auth-type" : "chap",
+                        "address" : "10.10.10.10"
+                     }
+                  }
+               ]
+            }
+            `),
+		appRootType: reflect.TypeOf(ocbinds.OpenconfigSystem_System{}),
+		queryParams: QueryParams{
+			depthEnabled:  false,
+			curDepth:      1,
+			content:       QUERY_CONTENT_CONFIG,
+			fields:        []string{},
+			fieldsFillAll: false,
+		},
+		prunedPayload: []byte(`
+            {
+               "openconfig-system:server" : [
+                  {
+                     "tacacs" : {
+                        "config" : {
+                           "encrypted" : true,
+                           "secret-key" : ""
+                        }
+                     },
+                     "radius" : {
+                        "config" : {
+                           "openconfig-aaa-radius-ext:encrypted" : true,
+                           "secret-key" : "",
+                           "retransmit-attempts" : 1
+                        }
+                     },
+                     "config" : {
+                        "priority" : 1,
+                        "auth-type" : "chap",
+                        "address" : "10.10.10.10"
+                     },
+                     "address" : "10.10.10.10"
+                  }
+               ]
+            }
+            `),
+	},
+	{ // RADIUS content = QUERY_CONTENT_NONCONFIG
+		tid:        "RADIUS Content Nonconfig",
+		uri:        "/openconfig-system:system/aaa/server-groups/server-group[name=RADIUS]/servers/server[address=10.10.10.10]",
+		requestUri: "/openconfig-system:system/aaa/server-groups/server-group[name=RADIUS]/servers/server[address=10.10.10.10]",
+		payload: []byte(`
+            {
+               "openconfig-system:server" : [
+                  {
+                     "tacacs" : {
+                        "config" : {
+                           "encrypted" : true,
+                           "secret-key" : ""
+                        }
+                     },
+                     "radius" : {
+                        "config" : {
+                           "openconfig-aaa-radius-ext:encrypted" : true,
+                           "secret-key" : "",
+                           "retransmit-attempts" : 1
+                        },
+                        "state" : {
+                           "retransmit-attempts" : 1,
+                           "counters" : {
+                              "access-rejects" : "1",
+                              "access-accepts" : "2",
+                              "openconfig-aaa-radius-ext:access-requests" : "3"
+                           }
+                        }
+                     },
+                     "config" : {
+                        "priority" : 1,
+                        "auth-type" : "chap",
+                        "address" : "10.10.10.10"
+                     },
+                     "address" : "10.10.10.10",
+                     "state" : {
+                        "priority" : 1,
+                        "auth-type" : "chap",
+                        "address" : "10.10.10.10"
+                     }
+                  }
+               ]
+            }
+            `),
+		appRootType: reflect.TypeOf(ocbinds.OpenconfigSystem_System{}),
+		queryParams: QueryParams{
+			depthEnabled:  false,
+			curDepth:      1,
+			content:       QUERY_CONTENT_NONCONFIG,
+			fields:        []string{},
+			fieldsFillAll: false,
+		},
+		prunedPayload: []byte(`
+            {
+               "openconfig-system:server" : [
+                  {
+                     "tacacs" : {
+                     },
+                     "radius" : {
+                        "state" : {
+                           "retransmit-attempts" : 1,
+                           "counters" : {
+                              "access-rejects" : "1",
+                              "access-accepts" : "2",
+                              "openconfig-aaa-radius-ext:access-requests" : "3"
+                           }
+                        }
+                     },
+                     "address" : "10.10.10.10",
+                     "state" : {
+                        "priority" : 1,
+                        "auth-type" : "chap",
+                        "address" : "10.10.10.10"
+                     }
+                  }
+               ]
+            }
+            `),
+	},
+	{ // RADIUS content = QUERY_CONTENT_OPERATIONAL
+		tid:        "RADIUS Content Operational",
+		uri:        "/openconfig-system:system/aaa/server-groups/server-group[name=RADIUS]/servers/server[address=10.10.10.10]",
+		requestUri: "/openconfig-system:system/aaa/server-groups/server-group[name=RADIUS]/servers/server[address=10.10.10.10]",
+		payload: []byte(`
+            {
+               "openconfig-system:server" : [
+                  {
+                     "tacacs" : {
+                        "config" : {
+                           "encrypted" : true,
+                           "secret-key" : ""
+                        }
+                     },
+                     "radius" : {
+                        "config" : {
+                           "openconfig-aaa-radius-ext:encrypted" : true,
+                           "secret-key" : "",
+                           "retransmit-attempts" : 1
+                        },
+                        "state" : {
+                           "retransmit-attempts" : 1,
+                           "counters" : {
+                              "access-rejects" : "1",
+                              "access-accepts" : "2",
+                              "openconfig-aaa-radius-ext:access-requests" : "3"
+                           }
+                        }
+                     },
+                     "config" : {
+                        "priority" : 1,
+                        "auth-type" : "chap",
+                        "address" : "10.10.10.10"
+                     },
+                     "address" : "10.10.10.10",
+                     "state" : {
+                        "priority" : 1,
+                        "auth-type" : "chap",
+                        "address" : "10.10.10.10"
+                     }
+                  }
+               ]
+            }
+            `),
+		appRootType: reflect.TypeOf(ocbinds.OpenconfigSystem_System{}),
+		queryParams: QueryParams{
+			depthEnabled:  false,
+			curDepth:      1,
+			content:       QUERY_CONTENT_OPERATIONAL,
+			fields:        []string{},
+			fieldsFillAll: false,
+		},
+		prunedPayload: []byte(`
+            {
+               "openconfig-system:server" : [
+                  {
+                     "tacacs" : {
+                     },
+                     "radius" : {
+                        "state" : {
+                           "counters" : {
+                              "access-rejects" : "1",
+                              "access-accepts" : "2",
+                              "openconfig-aaa-radius-ext:access-requests" : "3"
+                           }
+                        }
+                     },
+                     "address" : "10.10.10.10",
+                     "state" : {
+                     }
+                  }
+               ]
+            }
+            `),
+	},
+	{ // RADIUS fields
+		tid:        "RADIUS Fields",
+		uri:        "/openconfig-system:system/aaa/server-groups/server-group[name=RADIUS]/servers/server[address=10.10.10.10]",
+		requestUri: "/openconfig-system:system/aaa/server-groups/server-group[name=RADIUS]/servers/server[address=10.10.10.10]",
+		payload: []byte(`
+            {
+               "openconfig-system:server" : [
+                  {
+                     "tacacs" : {
+                        "config" : {
+                           "encrypted" : true,
+                           "secret-key" : ""
+                        }
+                     },
+                     "radius" : {
+                        "config" : {
+                           "openconfig-aaa-radius-ext:encrypted" : true,
+                           "secret-key" : "",
+                           "retransmit-attempts" : 1
+                        },
+                        "state" : {
+                           "retransmit-attempts" : 1,
+                           "counters" : {
+                              "access-rejects" : "1",
+                              "access-accepts" : "2",
+                              "openconfig-aaa-radius-ext:access-requests" : "3"
+                           }
+                        }
+                     },
+                     "config" : {
+                        "priority" : 1,
+                        "auth-type" : "chap",
+                        "address" : "10.10.10.10"
+                     },
+                     "address" : "10.10.10.10",
+                     "state" : {
+                        "priority" : 1,
+                        "auth-type" : "chap",
+                        "address" : "10.10.10.10"
+                     }
+                  }
+               ]
+            }
+            `),
+		appRootType: reflect.TypeOf(ocbinds.OpenconfigSystem_System{}),
+		queryParams: QueryParams{
+			depthEnabled:  false,
+			curDepth:      1,
+			content:       QUERY_CONTENT_ALL,
+			fields:        []string{"radius/state/counters/access-rejects", "address"},
+			fieldsFillAll: false,
+		},
+		prunedPayload: []byte(`
+            {
+               "openconfig-system:server" : [
+                  {
+                     "radius" : {
+                        "state" : {
+                           "counters" : {
+                              "access-rejects" : "1"
+                           }
+                        }
+                     },
+                     "address" : "10.10.10.10"
+                  }
+               ]
+            }
+            `),
+	},
+}

--- a/translib/transformer/xlate_prune_stats.go
+++ b/translib/transformer/xlate_prune_stats.go
@@ -1,0 +1,65 @@
+////////////////////////////////////////////////////////////////////////////////
+//                                                                            //
+//  Copyright 2021 Broadcom. The term Broadcom refers to Broadcom Inc. and/or //
+//  its subsidiaries.                                                         //
+//                                                                            //
+//  Licensed under the Apache License, Version 2.0 (the "License");           //
+//  you may not use this file except in compliance with the License.          //
+//  You may obtain a copy of the License at                                   //
+//                                                                            //
+//     http://www.apache.org/licenses/LICENSE-2.0                             //
+//                                                                            //
+//  Unless required by applicable law or agreed to in writing, software       //
+//  distributed under the License is distributed on an "AS IS" BASIS,         //
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  //
+//  See the License for the specific language governing permissions and       //
+//  limitations under the License.                                            //
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+
+package transformer
+
+import (
+	"fmt"
+	"time"
+)
+
+type PruneQPStats struct {
+	Hits uint `json:"hits"`
+
+	Time time.Duration `json:"total-time"`
+	Peak time.Duration `json:"peak-time"`
+	Last time.Duration `json:"last-time"`
+
+	PeakUri string `json:"peak-uri"`
+	LastUri string `json:"last-uri"`
+}
+
+var pruneQPStats PruneQPStats
+var zeroPruneQPStats = &PruneQPStats{}
+
+func GetPruneQPStats() *PruneQPStats {
+	return &pruneQPStats
+}
+
+func (pqps *PruneQPStats) ClearPruneQPStats() {
+	if pqps != nil {
+		*pqps = *zeroPruneQPStats
+	}
+}
+
+func (pqps *PruneQPStats) String() string {
+	return fmt.Sprintf("\tLastTime: %s LastUri: %s Hits: %d TotalTime: %s PeakTime: %s PeakUri: %s\n",
+		pqps.Last, pqps.LastUri, pqps.Hits, pqps.Time, pqps.Peak, pqps.PeakUri)
+}
+
+func (pqps *PruneQPStats) add(t time.Duration, uri string) {
+	pqps.Hits++
+	pqps.Last = t
+	pqps.LastUri = uri
+	pqps.Time += t
+	if t > pqps.Peak {
+		pqps.Peak = t
+		pqps.PeakUri = uri
+	}
+}

--- a/translib/transformer/xlate_prune_test.go
+++ b/translib/transformer/xlate_prune_test.go
@@ -1,0 +1,279 @@
+////////////////////////////////////////////////////////////////////////////////
+//                                                                            //
+//  Copyright 2019 Broadcom. The term Broadcom refers to Broadcom Inc. and/or //
+//  its subsidiaries.                                                         //
+//                                                                            //
+//  Licensed under the Apache License, Version 2.0 (the "License");           //
+//  you may not use this file except in compliance with the License.          //
+//  You may obtain a copy of the License at                                   //
+//                                                                            //
+//     http://www.apache.org/licenses/LICENSE-2.0                             //
+//                                                                            //
+//  Unless required by applicable law or agreed to in writing, software       //
+//  distributed under the License is distributed on an "AS IS" BASIS,         //
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  //
+//  See the License for the specific language governing permissions and       //
+//  limitations under the License.                                            //
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+//go:build prune_xfmrtest
+// +build prune_xfmrtest
+
+package transformer
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/Azure/sonic-mgmt-common/translib/ocbinds"
+	"github.com/kylelemons/godebug/pretty"
+	"github.com/openconfig/gnmi/proto/gnmi"
+	"github.com/openconfig/goyang/pkg/yang"
+	"github.com/openconfig/ygot/util"
+	"github.com/openconfig/ygot/ygot"
+	"github.com/openconfig/ygot/ytypes"
+)
+
+var ygSchema *ytypes.Schema
+
+// Modelled (largely taken from) request_binder.go
+// request_binder.go is in translib which is a parent package of transformer
+// so, to avoid circular dependencies for unit testing code, we use a copy
+// here.
+type rB struct {
+	uri                *string
+	payload            *[]byte
+	appRootNodeType    *reflect.Type
+	pathParent         *gnmi.Path
+	targetNodePath     *gnmi.Path
+	targetNodeSchema   *yang.Entry
+	targetNodeListInst bool
+	isSonicModel       bool
+}
+
+func getRB(uri *string, payload *[]byte, appRootNodeType *reflect.Type) *rB {
+	return &rB{uri, payload, appRootNodeType, nil, nil, nil, false, false}
+}
+
+// Modelled from request_binder.go for testing
+func (rb *rB) unMarshallUri(t *testing.T, deviceObj *ocbinds.Device) (*interface{}, error) {
+
+	var path *gnmi.Path
+	var err error
+
+	path, err = ygot.StringToPath(*rb.uri, ygot.StructuredPath,
+		ygot.StringSlicePath)
+	if err != nil {
+		t.Error("Error in uri to path conversion: ", err)
+		return nil, err
+	}
+
+	for _, p := range path.Elem {
+		pathSlice := strings.Split(p.Name, ":")
+		p.Name = pathSlice[len(pathSlice)-1]
+	}
+
+	targetPath := path
+	var pathList []*gnmi.PathElem = path.Elem
+	pathLen := len(pathList)
+
+	if len(pathList[pathLen-1].Key) > 0 {
+		rb.targetNodeListInst = true
+	}
+
+	gpath := &gnmi.Path{}
+	for i := 0; i < (pathLen - 1); i++ {
+		gpath.Elem = append(gpath.Elem, pathList[i])
+	}
+
+	rb.targetNodePath = &gnmi.Path{}
+	rb.targetNodePath.Elem = append(rb.targetNodePath.Elem, pathList[(pathLen-1)])
+	t.Logf("unMarshallUri: modified path is: %v\n", gpath)
+
+	rb.pathParent = gpath
+
+	if rb.targetNodeListInst {
+		targetPath = rb.pathParent
+	}
+
+	ygNode, ygEntry, errYg := ytypes.GetOrCreateNode(ygSchema.RootSchema(),
+		deviceObj, targetPath)
+	if errYg != nil {
+		t.Error("Error in creating the target object: ", errYg)
+		return nil, errYg
+	} else {
+		rb.targetNodeSchema = ygEntry
+	}
+
+	return &ygNode, nil
+}
+
+func (rb *rB) unMarshallPayload(t *testing.T, workObj *interface{}) error {
+	targetObj, ok := (*workObj).(ygot.GoStruct)
+	if !ok {
+		t.Error("Error in casting the target object")
+		return errors.New("Error in casting the target object")
+	}
+
+	if err := ocbinds.Unmarshal(*(rb.payload), targetObj); err != nil {
+		t.Error("ocbinds.Unmarshal: ", err)
+		return err
+	}
+
+	return nil
+}
+
+func getWorkObj(t *testing.T, uri *string, payload *[]byte,
+	appRootNodeType *reflect.Type) (*interface{}, *interface{}) {
+
+	var deviceObj ocbinds.Device = ocbinds.Device{}
+
+	rb := getRB(uri, payload, appRootNodeType)
+	workObj, _ := rb.unMarshallUri(t, &deviceObj)
+
+	rootIntf := reflect.ValueOf(&deviceObj).Interface()
+	// ygotObj := rootIntf.(ygot.GoStruct)
+	// var ygotRootObj *ygot.GoStruct = &ygotObj
+
+	var tmpTargetNode *interface{}
+	var ygEntry *yang.Entry
+
+	if rb.pathParent != nil && !rb.targetNodeListInst {
+		treeNodeList, err := ytypes.GetNode(ygSchema.RootSchema(), &deviceObj, rb.pathParent)
+		if err != nil {
+			t.Error("getWorkObj: ytype.GetNode() err: ", err)
+			return nil, nil
+		}
+
+		if len(treeNodeList) == 0 {
+			t.Error("getWorkObj: treeNodeList: empty")
+			return nil, nil
+		}
+
+		tmpTargetNode = &(treeNodeList[0].Data)
+		ygEntry = treeNodeList[0].Schema
+	} else {
+		tmpTargetNode = workObj
+		ygEntry = rb.targetNodeSchema
+	}
+
+	if err := rb.unMarshallPayload(t, tmpTargetNode); err != nil {
+		return nil, nil
+	}
+
+	if ygEntry != nil {
+		var workObjIntf interface{}
+		if ygEntry.IsContainer() && !rb.targetNodeListInst {
+			v := reflect.ValueOf(*tmpTargetNode).Elem()
+			for i := 0; i < v.NumField(); i++ {
+				ft := v.Type().Field(i)
+				tagVal, _ := ft.Tag.Lookup("path")
+				if len(rb.targetNodePath.Elem) > 0 && tagVal == rb.targetNodePath.Elem[0].Name {
+					fv := v.Field(i)
+					workObjIntf = fv.Interface()
+					break
+				}
+			}
+		} else if ygEntry.IsList() || rb.targetNodeListInst {
+			if treeNodeList, err := ytypes.GetNode(ygEntry, *tmpTargetNode, rb.targetNodePath); err != nil {
+				t.Error("getWorkObj: targetNodeList, treeNodeList: err: ", err)
+				return nil, nil
+			} else if len(treeNodeList) == 0 {
+				t.Error("getWorkObj: targetNodeList, treeNodeList: empty")
+				return nil, nil
+			} else {
+				workObjIntf = treeNodeList[0].Data
+			}
+		}
+
+		if workObjIntf != nil {
+			workObj = &workObjIntf
+		} else {
+			t.Error("getWorkObj: Target node not found.")
+		}
+	}
+
+	return workObj, &rootIntf
+}
+
+// areEqual is taken from common_app.go for testing purposes
+func areEqual(a, b interface{}) bool {
+	if util.IsValueNil(a) && util.IsValueNil(b) {
+		return true
+	}
+	if util.IsValueNil(a) || util.IsValueNil(b) {
+		return false
+	}
+	va, vb := reflect.ValueOf(a), reflect.ValueOf(b)
+	if va.Kind() == reflect.Ptr && vb.Kind() == reflect.Ptr {
+		return reflect.DeepEqual(va.Elem().Interface(), vb.Elem().Interface())
+	}
+
+	return reflect.DeepEqual(a, b)
+}
+
+// areEqual is taken from common_app.go for testing purposes
+func areEqualSprint(a, b interface{}) bool {
+	if util.IsValueNil(a) && util.IsValueNil(b) {
+		return true
+	}
+	if util.IsValueNil(a) || util.IsValueNil(b) {
+		return false
+	}
+	aSprint := pretty.Sprint(a)
+	bSprint := pretty.Sprint(b)
+	return aSprint == bSprint
+}
+
+type xpTests struct {
+	tid           string
+	uri           string
+	requestUri    string
+	payload       []byte
+	appRootType   reflect.Type
+	queryParams   QueryParams
+	prunedPayload []byte
+}
+
+var xp_tests []xpTests
+
+func TestXfmrPruneQP(t *testing.T) {
+
+	var err error
+	if ygSchema, err = ocbinds.GetSchema(); err != nil {
+		t.Error("Error in ocbinds.GetSchema(): ", err)
+	}
+
+	for _, tt := range xp_tests {
+
+		t.Logf("TestXfmrPruneQP: Test Case %s: Start\n", tt.tid)
+
+		workObj, rootObj := getWorkObj(t, &tt.requestUri, &tt.payload, &tt.appRootType)
+		if workObj == nil || rootObj == nil {
+			t.Error("Cannot retrieve workObj/rootObj for the request")
+			break
+		}
+		ygRootNode, ok := (*rootObj).(ygot.GoStruct)
+		if !ok {
+			t.Error("Cannot convert workObj to ygot.GoStruct")
+		}
+
+		if pruneQPErr := xfmrPruneQP(&ygRootNode, tt.queryParams, tt.uri,
+			tt.requestUri); pruneQPErr != nil {
+			t.Error("xfmrPruneQP: pruneQPErr: ", pruneQPErr)
+		}
+		prunedWorkObj, _ := getWorkObj(t, &tt.requestUri,
+			&tt.prunedPayload, &tt.appRootType)
+
+		// compare prunedWorkObj with workObj and print a diff?
+		if !areEqualSprint(workObj, prunedWorkObj) {
+			t.Logf("\nTestXfmrPruneQP: QP:", tt.queryParams)
+			t.Logf("\nTestXfmrPruneQP: Got:\n", pretty.Sprint(workObj))
+			t.Logf("\nTestXfmrPruneQP: Exp:\n", pretty.Sprint(prunedWorkObj))
+			t.Errorf("TestXfmrPruneQP: Test Case %s: Fail\n", tt.tid)
+		}
+		t.Logf("TestXfmrPruneQP: Test Case %s: End\n", tt.tid)
+	}
+}

--- a/translib/transformer/xlate_xfmr_handler.go
+++ b/translib/transformer/xlate_xfmr_handler.go
@@ -21,7 +21,6 @@ package transformer
 import (
 	"github.com/Azure/sonic-mgmt-common/translib/db"
 	log "github.com/golang/glog"
-	"github.com/openconfig/ygot/ygot"
 )
 
 func xfmrHandlerFunc(inParams XfmrParams, xfmrFuncNm string) error {
@@ -33,6 +32,7 @@ func xfmrHandlerFunc(inParams XfmrParams, xfmrFuncNm string) error {
 		}
 	}
 
+	inParams.pruneDone = new(bool)
 	xfmrLogDebug("Before calling dbToYang subtree xfmr %v, inParams %v", xfmrFuncNm, inParams)
 	ret, err := XlateFuncCall(dbToYangXfmrFunc(xfmrFuncNm), inParams)
 	xfmrLogDebug("After calling dbToYang subtree xfmr %v, inParams %v", xfmrFuncNm, inParams)
@@ -61,13 +61,6 @@ func xfmrHandlerFunc(inParams XfmrParams, xfmrFuncNm string) error {
 		}
 	}
 	return err
-}
-
-/*Place holder for xfmrPruneQP API */
-func xfmrPruneQP(ygRoot *ygot.GoStruct, queryParams QueryParams, uri string,
-	requestUri string) error {
-	// TODO
-	return nil
 }
 
 func leafXfmrHandlerFunc(inParams XfmrParams, xfmrFieldFuncNm string) (map[string]interface{}, error) {

--- a/translib/transformer/xlate_xfmr_handler.go
+++ b/translib/transformer/xlate_xfmr_handler.go
@@ -49,7 +49,7 @@ func xfmrHandlerFunc(inParams XfmrParams, xfmrFuncNm string) error {
 			}
 		}
 	}
-	if (err == nil) && inParams.queryParams.isEnabled() {
+	if (err == nil) && inParams.queryParams.isEnabled() && !(*inParams.pruneDone) {
 		log.Infof("xfmrPruneQP: func %v URI %v, requestUri %v",
 			xfmrFuncNm, inParams.uri, inParams.requestUri)
 		err = xfmrPruneQP(inParams.ygRoot, inParams.queryParams,


### PR DESCRIPTION
- Pruning API used by subtree transformers for Query Parameters.
- Tests. ( Only ACL is enabled currently, since the others need support from the corresponding feature teams )
- Updated the hooks to invoke the pruning API.
- The GET request cancelling context parameter is passed to some of the pruning functions, but is not implemented since that is appearing in a separate PR