### PR TITLE
Script to populate the test data to the simulator db

### DIFF
--- a/tools/test/dbinit.py
+++ b/tools/test/dbinit.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+
+import json
+import os
+import re
+import redis
+from argparse import ArgumentParser, Namespace as Obj
+
+redis_clients = {}
+
+ApplDB = 0
+CountersDB = 2
+ConfigDB = 4
+StateDB = 6
+
+overwrite = False
+
+
+def main():
+    p = ArgumentParser(
+        description="""Populates test data in essential tables like PORT,
+        DEVICE_METADATA, SWITCH_TABLE, USER_TABLE etc.
+        """,
+    )
+    p.add_argument("-p", "--port", help="Redis port number (default 6379)",
+                   type=int, default=6379)
+    p.add_argument("--platconf", help="""Path to a platform config file
+                   for reading PORT settings (default './platform.json')""",
+                   default=guess_platconf_file())
+    p.add_argument("--overwrite", help="Overwrite existing entry fields",
+                   action="store_true")
+    p.add_argument("--flushdb", help="Flush db entries first",
+                   action="store_true")
+
+    args = p.parse_args()
+
+    with open(args.platconf, "r") as f:
+        platconf = json.load(f)
+
+    if args.overwrite:
+        global overwrite
+        overwrite = args.overwrite
+
+    try:
+        for i in (ApplDB, CountersDB, ConfigDB, StateDB):
+            redis_clients[i] = redis.Redis(
+                host="localhost", port=args.port, db=i,
+                decode_responses=True,
+            )
+
+        if args.flushdb:
+            for n, db in redis_clients.items():
+                print(f"[{n}] flushdb")
+                db.flushdb()
+
+        for name, cfg in platconf.items():
+            create_confdb_entry(name, cfg)
+            create_appldb_entry(name, cfg)
+            create_intf_counter(name, cfg)
+            create_lldp_entry(name, cfg)
+
+        init_device_metadata()
+        init_feature_flags()
+        init_user_db()
+        set_config_db_inited()
+
+    finally:
+        for db in redis_clients.values():
+            db.close()
+
+
+def set_config_db_inited():
+    d = redis_clients[ConfigDB]
+    if not d.exists("CONFIG_DB_INITIALIZED"):
+        d.set("CONFIG_DB_INITIALIZED", "1")
+
+
+def init_device_metadata():
+    db_hmset(ConfigDB, "DEVICE_METADATA|localhost", {
+        "hwsku":    "generic",
+        "hostname": "sonic",
+        "platform": "generic",
+        "mac":      "00:01:02:03:04:05",
+    })
+
+
+def init_feature_flags():
+    db_hmset(ConfigDB, "HARDWARE|ACCESS_LIST", {
+        "COUNTER_MODE": "per-rule",
+        "LOOKUP_MODE":  "optimized",
+    })
+    db_hmset(ApplDB, "SWITCH_TABLE:switch", {
+        "subinterface_supported": "true",
+        "stp_supported":          "true",
+        "drop_monitor_supported": "true",
+        "vlan_mapping_supported": "true",
+    })
+    db_hmset(StateDB, "TUNNEL_FEATURE_TABLE|vxlan", {"state": "enable"})
+    db_hmset(StateDB, "TUNNEL_CAPABILITY_TABLE|vxlan", {"state": "enable"})
+    db_hmset(StateDB, "STP_TABLE|GLOBAL", {"max_stp_inst": "254"})
+
+
+def init_user_db():
+    user = os.getenv("USER")
+    db_hmset(StateDB, f"USER_TABLE|{user}", {"roles@": "admin"})
+
+
+def create_confdb_entry(name, cfg):
+    key = f"PORT|{name}"
+    values = {
+        "admin_status": "up",
+        "mtu": 9100,
+    }
+    if "index" in cfg:
+        values["index"] = at(cfg["index"], 0)
+    if "alias_at_lanes" in cfg:
+        values["alias"] = at(cfg["alias_at_lanes"], 0)
+    if "lanes" in cfg:
+        values["lanes"] = cfg["lanes"]
+    if "default_brkout_mode" in cfg:
+        values["speed"] = brkout_mode_to_speed(cfg["default_brkout_mode"])
+    db_hmset(ConfigDB, key, values)
+
+
+def create_appldb_entry(name, cfg):
+    key = f"PORT_TABLE:{name}"
+    values = {
+        "admin_status": "up",
+        "oper_status": "up",
+        "oper_status_change_uptime": 10000,
+        "mtu": 9100,
+    }
+    if "index" in cfg:
+        values["index"] = at(cfg["index"], 0)
+    if "lanes" in cfg:
+        values["lanes"] = cfg["lanes"]
+    if "default_brkout_mode" in cfg:
+        speed = brkout_mode_to_speed(cfg["default_brkout_mode"])
+        values["speed"] = speed
+        values["oper_speed"] = speed
+    db_hmset(ApplDB, key, values)
+
+
+def create_intf_counter(name, cfg):
+    oid = f"oid:0x{0x1000000000000+ifid(name):x}"
+    db_hmset(CountersDB, "COUNTERS_PORT_NAME_MAP", {name: oid})
+    db_hmset(CountersDB, f"COUNTERS:{oid}", {
+        "SAI_PORT_STAT_IF_IN_OCTETS":           0,
+        "SAI_PORT_STAT_IF_IN_UCAST_PKTS":       0,
+        "SAI_PORT_STAT_IF_IN_NON_UCAST_PKTS":   0,
+        "SAI_PORT_STAT_IF_IN_BROADCAST_PKTS":   0,
+        "SAI_PORT_STAT_IF_IN_MULTICAST_PKTS":   0,
+        "SAI_PORT_STAT_IF_IN_ERRORS":           0,
+        "SAI_PORT_STAT_IF_IN_DISCARDS":         0,
+        "SAI_PORT_STAT_IF_OUT_OCTETS":          0,
+        "SAI_PORT_STAT_IF_OUT_UCAST_PKTS":      0,
+        "SAI_PORT_STAT_IF_OUT_NON_UCAST_PKTS":  0,
+        "SAI_PORT_STAT_IF_OUT_BROADCAST_PKTS":  0,
+        "SAI_PORT_STAT_IF_OUT_MULTICAST_PKTS":  0,
+        "SAI_PORT_STAT_IF_OUT_ERRORS":          0,
+        "SAI_PORT_STAT_IF_OUT_DISCARDS":        0,
+    })
+
+
+# _lldp_config holds remaining LLDP_ENTRY_TABLE data to be created
+_lldp_config = [
+    Obj(switch=1, ports=[0, 1, 2], i=0),
+    Obj(switch=2, ports=[8, 12], i=0),
+]
+
+
+def create_lldp_entry(name, cfg):
+    if len(_lldp_config) == 0:
+        return
+    r = _lldp_config[0]
+    p = r.ports.pop(0)
+    r.i += 1
+    if len(r.ports) == 0:
+        _lldp_config.pop(0)
+
+    db_hmset(ApplDB, f"LLDP_ENTRY_TABLE:{name}", {
+        "lldp_rem_index":               r.switch,
+        "lldp_rem_chassis_id":          f"00:aa:00:00:00:{r.switch:02x}",
+        "lldp_rem_chassis_id_subtype":  "4",
+        "lldp_rem_man_addr":            f"172.17.2.{r.switch},fd00::{r.switch}",
+        "lldp_rem_port_id":             f"Ethernet{p}",
+        "lldp_rem_port_desc":           f"Port 1/{r.i}",
+        "lldp_rem_port_id_subtype":     "7",
+        "lldp_rem_sys_cap_enabled":     "28 00",
+        "lldp_rem_sys_cap_supported":   "28 00",
+        "lldp_rem_sys_desc":            f"SONiC simulator {r.switch}; Hwsku: generic",
+        "lldp_rem_sys_name":            f"sonic{r.switch}",
+        "lldp_rem_time_mark":           "5000",
+    })
+
+
+def ifid(name):
+    if name.startswith("Ethernet"):
+        return int(name[8:])
+    return None
+
+
+def at(v, index):
+    toks = v.split(",")
+    if index < len(toks):
+        return toks[index].strip()
+    return ""
+
+
+def brkout_mode_to_speed(mode):
+    speed = 0
+    m = re.search(r"(\d+)x(\d+)([MG])", mode)
+    try:
+        speed = int(m.group(2))
+        if m.group(3) == "G":
+            speed = speed * 1000
+    except:
+        print(f"[ERROR] invalid breakout mode: {mode}")
+    return speed
+
+
+def guess_platconf_file():
+    return os.path.join(os.path.dirname(__file__), "platform.json")
+
+
+def db_delete(index, pattern):
+    db = redis_clients[index]
+    keys = db.keys(pattern)
+    if keys:
+        [print(f"[{index}] DEL {k}") for k in sorted(keys)]
+        db.delete(*keys)
+
+
+def db_hmset(index, key, value):
+    if not overwrite:
+        current = redis_clients[index].hgetall(key)
+        [value.pop(k, None) for k in current]
+    if not value:
+        return  # no new values
+    toks = [f"{k} {repr(v)}" for k, v in value.items()]
+    print(f"[{index}] HMSET {repr(key)} {' '.join(toks)}")
+    redis_clients[index].hmset(key, value)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/test/platform.json
+++ b/tools/test/platform.json
@@ -1,0 +1,142 @@
+{
+    "Ethernet0": {
+        "index": "1,1,1,1",
+        "default_brkout_mode": "1x100G[40G]",
+        "lanes": "1,2,3,4",
+        "alias_at_lanes": "Eth1/1/1,Eth1/1/2,Eth1/1/3,Eth1/1/4",
+        "breakout_modes": "1x100G[40G],2x50G,1x50G,4x25G[10G],1x25G[10G]"
+    },
+    "Ethernet4": {
+        "index": "2,2,2,2",
+        "default_brkout_mode": "1x100G[40G]",
+        "lanes": "5,6,7,8",
+        "alias_at_lanes": "Eth1/2/1,Eth1/2/2,Eth1/2/3,Eth1/2/4",
+        "breakout_modes": "1x100G[40G],2x50G,1x50G,4x25G[10G],1x25G[10G]"
+    },
+    "Ethernet8": {
+        "index": "3,3,3,3",
+        "default_brkout_mode": "1x100G[40G]",
+        "lanes": "9,10,11,12",
+        "alias_at_lanes": "Eth1/3/1,Eth1/3/2,Eth1/3/3,Eth1/3/4",
+        "breakout_modes": "1x100G[40G],2x50G,1x50G,4x25G[10G],1x25G[10G]"
+    },
+    "Ethernet12": {
+        "index": "4,4,4,4",
+        "default_brkout_mode": "1x100G[40G]",
+        "lanes": "13,14,15,16",
+        "alias_at_lanes": "Eth1/4/1,Eth1/4/2,Eth1/4/3,Eth1/4/4",
+        "breakout_modes": "1x100G[40G],2x50G,1x50G,4x25G[10G],1x25G[10G]"
+    },
+    "Ethernet16": {
+        "index": "5,5,5,5",
+        "default_brkout_mode": "1x100G[40G]",
+        "lanes": "17,18,19,20",
+        "alias_at_lanes": "Eth1/5/1,Eth1/5/2,Eth1/5/3,Eth1/5/4",
+        "breakout_modes": "1x100G[40G],2x50G,1x50G,4x25G[10G],1x25G[10G]"
+    },
+    "Ethernet20": {
+        "index": "6,6,6,6",
+        "default_brkout_mode": "1x100G[40G]",
+        "lanes": "21,22,23,24",
+        "alias_at_lanes": "Eth1/6/1,Eth1/6/2,Eth1/6/3,Eth1/6/4",
+        "breakout_modes": "1x100G[40G],2x50G,1x50G,4x25G[10G],1x25G[10G]"
+    },
+    "Ethernet24": {
+        "index": "7,7,7,7",
+        "default_brkout_mode": "1x100G[40G]",
+        "lanes": "25,26,27,28",
+        "alias_at_lanes": "Eth1/7/1,Eth1/7/2,Eth1/7/3,Eth1/7/4",
+        "breakout_modes": "1x100G[40G],2x50G,1x50G,4x25G[10G],1x25G[10G]"
+    },
+    "Ethernet28": {
+        "index": "8,8,8,8",
+        "default_brkout_mode": "1x100G[40G]",
+        "lanes": "29,30,31,32",
+        "alias_at_lanes": "Eth1/8/1,Eth1/8/2,Eth1/8/3,Eth1/8/4",
+        "breakout_modes": "1x100G[40G],2x50G,1x50G,4x25G[10G],1x25G[10G]"
+    },
+    "Ethernet32": {
+        "index": "9,9,9,9",
+        "default_brkout_mode": "1x100G[40G]",
+        "lanes": "33,34,35,36",
+        "alias_at_lanes": "Eth1/9/1,Eth1/9/2,Eth1/9/3,Eth1/9/4",
+        "breakout_modes": "1x100G[40G],2x50G,1x50G,4x25G[10G],1x25G[10G]"
+    },
+    "Ethernet36": {
+        "index": "10,10,10,10",
+        "default_brkout_mode": "1x100G[40G]",
+        "lanes": "37,38,39,40",
+        "alias_at_lanes": "Eth1/10/1,Eth1/10/2,Eth1/10/3,Eth1/10/4",
+        "breakout_modes": "1x100G[40G],2x50G,1x50G,4x25G[10G],1x25G[10G]"
+    },
+    "Ethernet40": {
+        "index": "11,11,11,11",
+        "default_brkout_mode": "1x100G[40G]",
+        "lanes": "41,42,43,44",
+        "alias_at_lanes": "Eth1/11/1,Eth1/11/2,Eth1/11/3,Eth1/11/4",
+        "breakout_modes": "1x100G[40G],2x50G,1x50G,4x25G[10G],1x25G[10G]"
+    },
+    "Ethernet44": {
+        "index": "12,12,12,12",
+        "default_brkout_mode": "1x100G[40G]",
+        "lanes": "45,46,47,48",
+        "alias_at_lanes": "Eth1/12/1,Eth1/12/2,Eth1/12/3,Eth1/12/4",
+        "breakout_modes": "1x100G[40G],2x50G,1x50G,4x25G[10G],1x25G[10G]"
+    },
+    "Ethernet48": {
+        "index": "13,13,13,13",
+        "default_brkout_mode": "1x100G[40G]",
+        "lanes": "49,50,51,52",
+        "alias_at_lanes": "Eth1/13/1,Eth1/13/2,Eth1/13/3,Eth1/13/4",
+        "breakout_modes": "1x100G[40G],2x50G,1x50G,4x25G[10G],1x25G[10G]"
+    },
+    "Ethernet52": {
+        "index": "14,14,14,14",
+        "default_brkout_mode": "1x100G[40G]",
+        "lanes": "53,54,55,56",
+        "alias_at_lanes": "Eth1/14/1,Eth1/14/2,Eth1/14/3,Eth1/14/4",
+        "breakout_modes": "1x100G[40G],2x50G,1x50G,4x25G[10G],1x25G[10G]"
+    },
+    "Ethernet56": {
+        "index": "15,15,15,15",
+        "default_brkout_mode": "1x100G[40G]",
+        "lanes": "57,58,59,60",
+        "alias_at_lanes": "Eth1/15/1,Eth1/15/2,Eth1/15/3,Eth1/15/4",
+        "breakout_modes": "1x100G[40G],2x50G,1x50G,4x25G[10G],1x25G[10G]"
+    },
+    "Ethernet60": {
+        "index": "16,16,16,16",
+        "default_brkout_mode": "1x100G[40G]",
+        "lanes": "61,62,63,64",
+        "alias_at_lanes": "Eth1/16/1,Eth1/16/2,Eth1/16/3,Eth1/16/4",
+        "breakout_modes": "1x100G[40G],2x50G,1x50G,4x25G[10G],1x25G[10G]"
+    },
+    "Ethernet64": {
+        "index": "17,17,17,17",
+        "default_brkout_mode": "1x100G[40G]",
+        "lanes": "65,66,67,68",
+        "alias_at_lanes": "Eth1/17/1,Eth1/17/2,Eth1/17/3,Eth1/17/4",
+        "breakout_modes": "1x100G[40G],2x50G,1x50G,4x25G[10G],1x25G[10G]"
+    },
+    "Ethernet68": {
+        "index": "18",
+        "default_brkout_mode": "1x10G",
+        "lanes": "69",
+        "alias_at_lanes": "Eth1/18",
+        "breakout_modes": "1x10G"
+    },
+    "Ethernet69": {
+        "index": "19",
+        "default_brkout_mode": "1x10G",
+        "lanes": "70",
+        "alias_at_lanes": "Eth1/19",
+        "breakout_modes": "1x10G"
+    },
+    "Ethernet70": {
+        "index": "20",
+        "default_brkout_mode": "1x10G",
+        "lanes": "71",
+        "alias_at_lanes": "Eth1/20",
+        "breakout_modes": "1x10G"
+    }
+}


### PR DESCRIPTION
Add dbinit.py script, which pupulates test data into the essential tables like PORT, PORT_TABLE, COUNTERS, DEVICE_METADATA etc. Helps to verify REST and gNMI get/set operations on the build server itself.
**These scripts are not installed to the sonic switch.**