### PR TITLE
Add 'AppTag' in translib app errors

### DIFF
--- a/translib/tlerr/app_errors.go
+++ b/translib/tlerr/app_errors.go
@@ -28,6 +28,7 @@ type errordata struct {
 	Format string        // message format string
 	Args   []interface{} // message format arguments
 	Path   string        // error path (optional)
+	AppTag string        // application specific error tag (optional)
 }
 
 // InvalidArgsError indicates bad request error.
@@ -63,6 +64,12 @@ func (e InvalidArgsError) Error() string {
 func InvalidArgs(msg string, args ...interface{}) InvalidArgsError {
 	return InvalidArgsError{Format: msg, Args: args}
 }
+
+// InvalidArgsErr creates an InvalidArgsError instance with given messae, app erorr tag and path
+func InvalidArgsErr(appTag, path, msg string, args ...interface{}) InvalidArgsError {
+	return InvalidArgsError{Format: msg, Args: args, AppTag: appTag, Path: path}
+}
+
 func (e NotFoundError) Error() string {
 	return p.Sprintf(e.Format, e.Args...)
 }
@@ -70,6 +77,11 @@ func (e NotFoundError) Error() string {
 // NotFound creates a NotFoundError
 func NotFound(msg string, args ...interface{}) NotFoundError {
 	return NotFoundError{Format: msg, Args: args}
+}
+
+// NotFoundErr creates a NotFoundError instance with given message, app error tag and path.
+func NotFoundErr(appTag, path, msg string, args ...interface{}) NotFoundError {
+	return NotFoundError{Format: msg, Args: args, AppTag: appTag, Path: path}
 }
 
 func (e AlreadyExistsError) Error() string {
@@ -81,6 +93,11 @@ func AlreadyExists(msg string, args ...interface{}) AlreadyExistsError {
 	return AlreadyExistsError{Format: msg, Args: args}
 }
 
+// AlreadyExistsErr creates an AlreadyExistsError instance with given message, app error tag and path.
+func AlreadyExistsErr(appTag, path, msg string, args ...interface{}) AlreadyExistsError {
+	return AlreadyExistsError{Format: msg, Args: args, AppTag: appTag, Path: path}
+}
+
 func (e NotSupportedError) Error() string {
 	return p.Sprintf(e.Format, e.Args...)
 }
@@ -88,6 +105,11 @@ func (e NotSupportedError) Error() string {
 // NotSupported creates a NotSupportedError
 func NotSupported(msg string, args ...interface{}) NotSupportedError {
 	return NotSupportedError{Format: msg, Args: args}
+}
+
+// NotSupportedErr creates a NotSupportedError instance with given message, app error tag and path.
+func NotSupportedErr(appTag, path, msg string, args ...interface{}) NotSupportedError {
+	return NotSupportedError{Format: msg, Args: args, AppTag: appTag, Path: path}
 }
 
 func (e InternalError) Error() string {
@@ -99,8 +121,17 @@ func New(msg string, args ...interface{}) InternalError {
 	return InternalError{Format: msg, Args: args}
 }
 
+// NewError creates an InternalError instance with given message, app error tag and path.
+func NewError(appTag, path, msg string, args ...interface{}) InternalError {
+	return InternalError{Format: msg, Args: args, AppTag: appTag, Path: path}
+}
+
 func (e AuthorizationError) Error() string {
 	return p.Sprintf(e.Format, e.Args...)
+}
+
+func TranslibXfmrRetErr(fail bool) TranslibXfmrRetError {
+	return TranslibXfmrRetError{XlateFailDelReq: fail}
 }
 
 func (e RequestContextCancelledError) Error() string {
@@ -110,4 +141,15 @@ func (e RequestContextCancelledError) Error() string {
 // RequestContextCancelled creates a RequestContextCancelledError
 func RequestContextCancelled(msg string, ctxErr error) RequestContextCancelledError {
 	return RequestContextCancelledError{msg, ctxErr}
+}
+
+//======= helper functions =======
+
+// IsNotFound return true if the given error represents a 'not found' condition
+func IsNotFound(err error) bool {
+	switch err.(type) {
+	case TranslibRedisClientEntryNotExist, NotFoundError:
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
Introduce a AppTag field to all error types defined in `app_errors.go` file. This will be an optional value. Can be used an app specific error code by apps. REST or gNMI servers can copy them in protocol specific error fields, like RESTCONF `error-app-tag`. REST server will be enhanced in a separate PR after this PR is merged.