### PR TITLE
Remove Duplicates in topsort results

### DIFF
--- a/cvl/internal/util/util.go
+++ b/cvl/internal/util/util.go
@@ -577,7 +577,7 @@ func GetDbSock(dbName string) string {
 	return unix_socket_path.(string)
 }
 
-//GetDbPassword Get DB password
+// GetDbPassword Get DB password
 func GetDbPassword(dbName string) string {
 	inst := getDbInst(dbName)
 	password := ""

--- a/translib/pfm_app.go
+++ b/translib/pfm_app.go
@@ -212,7 +212,8 @@ func (app *PlatformApp) processAction(dbs [db.MaxDB]*db.DB) (ActionResponse, err
 
 ///////////////////////////
 
-/**
+/*
+*
 Structures to read syseeprom from redis-db
 */
 type EepromDb struct {

--- a/translib/transformer/testxfmryang_test.go
+++ b/translib/transformer/testxfmryang_test.go
@@ -818,8 +818,11 @@ func Test_OC_Sonic_OneOnOne_Composite_KeyMapping(t *testing.T) {
 	unloadDB(db.ConfigDB, parent_prereq)
 }
 
-/*Test OC List having config container with leaves, that are referenced by list key-leafs and have no annotation.
-  Also covers the list's state container that have leaves same as list keys */
+/*
+Test OC List having config container with leaves, that are referenced by list key-leafs and have no annotation.
+
+	Also covers the list's state container that have leaves same as list keys
+*/
 func Test_NodeWithListHavingConfigLeafRefByKey_OC_Yang(t *testing.T) {
 
 	t.Log("++++++++++++++  Test_set_on_OC_yang_node_with_list_having_config_leaf_referenced_by_list_key  +++++++++++++")

--- a/translib/transformer/xfmr_testxfmr_callbacks.go
+++ b/translib/transformer/xfmr_testxfmr_callbacks.go
@@ -719,7 +719,7 @@ func convertSonicTestSetTypeToOC(testSetType string) ocbinds.E_OpenconfigTestXfm
 	return testSetOrigType
 }
 
-//Sonic yang key transformer functions
+// Sonic yang key transformer functions
 var DbToYang_test_sensor_mode_key_xfmr SonicKeyXfmrDbToYang = func(inParams SonicXfmrParams) (map[string]interface{}, error) {
 	res_map := make(map[string]interface{})
 	/* from DB-key string(inParams.key) extract mode and id to fill into the res_map

--- a/translib/transformer/xlate_tbl_info.go
+++ b/translib/transformer/xlate_tbl_info.go
@@ -111,7 +111,7 @@ func ordTblListCreate(ordTblList map[string][]string, tnMap map[string]*gphNode)
 	}
 }
 
-//sort transformer result table list based on dependenciesi(using CVL API) tables to be used for CRUD operations
+// sort transformer result table list based on dependenciesi(using CVL API) tables to be used for CRUD operations
 func sortPerTblDeps(ordTblListMap map[string][]string) error {
 	var err error
 


### PR DESCRIPTION
When LISTs were converted back to tables, there is a possibility of having consecutive duplicate table names in the result if there exists a dependency between table lists. Added a mechanism to remove such entries. More comments in the code for the next steps