### PR TITLE
CVL Sort issue in target TABLE with multi-list

### DIFF
--- a/cvl/cvl_test.go
+++ b/cvl/cvl_test.go
@@ -3339,6 +3339,46 @@ func TestSortDepTables(t *testing.T) {
 	cvl.ValidationSessClose(cvSess)
 }
 
+func TestSortDepTablesWithMultiListTargetRaw(t *testing.T) {
+	cvSess, _ := NewCvlSession()
+
+	result, _ := cvSess.SortDepList([]string{"VLAN_SUB_INTERFACE", "OSPFV2_INTERFACE"})
+
+	expectedResult := []string{"OSPFV2_INTERFACE", "VLAN_SUB_INTERFACE_IPADDR", "VLAN_SUB_INTERFACE"}
+
+	for i := 0; i < len(expectedResult); i++ {
+		if result[i] != expectedResult[i] {
+			t.Errorf("Validation failed, returned value = %v", result)
+			break
+		}
+	}
+
+	cvl.ValidationSessClose(cvSess)
+}
+
+func TestSortDepTablesWithMultiListTarget(t *testing.T) {
+	cvSess, _ := NewCvlSession()
+
+	result, _ := cvSess.SortDepTables([]string{"VLAN_SUB_INTERFACE", "OSPFV2_INTERFACE"})
+
+	expectedResult := []string{"OSPFV2_INTERFACE", "VLAN_SUB_INTERFACE"}
+
+	if len(expectedResult) != len(result) {
+		t.Errorf("Validation failed, returned value = %v", result)
+		return
+	}
+
+	for i := 0; i < len(expectedResult); i++ {
+		if result[i] != expectedResult[i] {
+			t.Errorf("Validation failed, returned value = %v", result)
+			break
+		}
+	}
+
+	cvl.ValidationSessClose(cvSess)
+
+}
+
 func TestGetOrderedTables(t *testing.T) {
 	cvSess, _ := NewCvlSession()
 

--- a/cvl/testdata/schema/sonic-ospfv2.yang
+++ b/cvl/testdata/schema/sonic-ospfv2.yang
@@ -1,0 +1,64 @@
+module sonic-ospfv2 {
+    namespace "http://github.com/Azure/sonic-ospfv2";
+    prefix sn-ospfv2;
+    yang-version 1.1;
+
+    import sonic-extension {
+        prefix sonic-ext;
+    }
+    import sonic-vlan-subinterface {
+        prefix svlansub;
+    }
+    organization
+        "SONiC";
+
+    contact
+        "SONiC";
+
+    description
+        "SONIC ospfv2 Global YANG";
+
+    revision 2020-03-21 {
+        description
+            "Added Yang definition for OSPFv2 features.";
+    }
+
+    typedef ospf-sub-vlan-interface {
+        type union {
+            type string {
+                pattern "vlansub";
+            }
+            type leafref {
+                path "/svlansub:sonic-vlan-subinterface/svlansub:VLAN_SUB_INTERFACE/svlansub:VLAN_SUB_INTERFACE_LIST/svlansub:id";
+            }
+        }
+    }
+
+    typedef ospf-interface {
+        type union {
+            type string {
+                pattern "null";
+            }
+            type ospf-sub-vlan-interface;
+        }
+        description
+            "OSPF Interface name";
+    }
+
+    container sonic-ospfv2 {
+        container OSPFV2_INTERFACE {
+            description
+                "OSPFv2 Interface Table.";
+            list OSPFV2_INTERFACE_LIST {
+                key "name";
+                leaf name {
+                    type ospf-interface;
+                    description
+                        "OSPF interface";
+                }
+            } //OSPFV2_INTERFACE_LIST
+        } //OSPFV2_INTERFACE
+    } //sonic-ospfv2
+
+}
+

--- a/cvl/testdata/schema/sonic-vlan-subinterface.yang
+++ b/cvl/testdata/schema/sonic-vlan-subinterface.yang
@@ -1,0 +1,48 @@
+module sonic-vlan-subinterface {
+    namespace "http://github.com/Azure/sonic-vlan-subinterface";
+    prefix svlansub;
+    yang-version 1.1;
+
+    organization
+        "SONiC";
+
+    contact
+        "SONiC";
+
+    description
+        "SONIC SUN INTERFACE VLAN";
+
+    revision 2024-03-10 {
+        description
+            "Initial revision.";
+    }
+
+    container sonic-vlan-subinterface {
+        container VLAN_SUB_INTERFACE {
+            list VLAN_SUB_INTERFACE_LIST {
+                key "id";
+
+                leaf id {
+                    type string {
+                        pattern '(Eth([1-3][0-9]{3}|[1-9][0-9]{2}|[1-9][0-9]|[0-9])' +
+                        '|Eth([1-9]/(([1-9][0-9]|[1-9])|([1-9][0-9]|[1-9])/([1-9][0-9]|[1-9])))' +
+                        '|Po([1-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-6])' +
+                        '|PortChannel([1-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-6]))\.' +
+                        '(6553[0-5]|655[0-2][0-9]|654[0-9]{2}|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[1-9][0-9]{1,3}|[0-9])' {
+                            error-message "Invalid sub-interface name";
+                            error-app-tag interface-name-invalid;
+                        }
+                    }
+                }
+            }
+            list VLAN_SUB_INTERFACE_IPADDR_LIST {
+                key "id";
+                leaf id {
+                    type leafref {
+                        path "/svlansub:sonic-vlan-subinterface/svlansub:VLAN_SUB_INTERFACE/svlansub:VLAN_SUB_INTERFACE_LIST/svlansub:id";
+                    }
+                }
+            }
+        }
+    }
+}

--- a/cvl/tools/generate_yin.py
+++ b/cvl/tools/generate_yin.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 ################################################################################
 #                                                                              #
-#  Copyright 2021 Broadcom. The term Broadcom refers to Broadcom Inc. and/or   #
+#  Copyright 2024 Broadcom. The term Broadcom refers to Broadcom Inc. and/or   #
 #  its subsidiaries.                                                           #
 #                                                                              #
 #  Licensed under the Apache License, Version 2.0 (the "License");             #
@@ -41,19 +41,125 @@ ns_indent_space = '' #replace with ' ' for indentation
 yin_namespace = "urn:ietf:params:xml:ns:yang:yin:1"
 err_prefix = '[Error]'
 TBL_KEY_EXT = "tbl-key"
+TBL_DEP_ON_EXT = "dependent-on"
 TBL_KEY_EXT_PREFIX = "sonic-ext"
 SONIC_EXTENSION_MOD = "sonic-extension"
 syntax.yin_map[f"{TBL_KEY_EXT_PREFIX}:{TBL_KEY_EXT}"] = ("value", False)
+syntax.yin_map[f"{TBL_KEY_EXT_PREFIX}:{TBL_DEP_ON_EXT}"] = ("value", False)
 revision_added = False
 mod_dict = dict()
 
-class ContainerToListPlugin():
-    def convert_singleton_to_list(self, ctx, modules):
+
+class ListDependencyPlugin:
+    """
+    Plugin which handle LIST dependency in case of multi-list target
+    """
+    def __init__(self, ctx):
+        self.ctx = ctx
+        # Holds list name as key and their sibling list names as values
+        self.list_siblings = dict()
+
+        # Holds list name as key and their dependent list names as values
+        self.list_depends = dict()
+
+        # List's Stmt cache stmt for injecting dependent-on statement
+        self.list_objs = dict()
+
+    def process(self, modules):
+        """
+        Main Function for Dependency handling
+        :param modules: List of YANG modules
+        :return: None
+        """
+        for module in modules:
+            if len(modules[module].search('container')) > 0:
+                self.process_children(modules[module].search('container')[0], level=1)
+        self.handle_list_dependency()
+
+    def add_to_list_depends(self, dep_list_node, list_node):
+        """
+        Util to add to list_depends
+        :param dep_list_node: Dependent List
+        :param list_node: List on which dep_list_node is dependent-on
+        :return: None
+        """
+        if list_node not in self.list_depends:
+            # just in case where module is processed late.
+            self.list_depends[list_node] = []
+        self.list_depends[list_node].append(dep_list_node)
+
+    def process_children(self, stmt, level):
+        """
+        1. collects siblings info for a LIST
+        2. collects dependent info for a LIST
+        :param stmt: data node
+        :param level: yang tree level
+        :return: None
+        """
+        if level == 3:
+            if stmt.keyword == "list":
+                self.list_objs[stmt.arg] = stmt
+                if stmt.arg not in self.list_depends:
+                    self.list_depends[stmt.arg] = []
+                # Getting the dependent-on dependency
+                for substmt in stmt.substmts:
+                    if "dependent-on" in substmt.keyword:
+                        self.add_to_list_depends(stmt.arg, substmt.arg)
+                # Getting the leafref dependency
+                for key_leaf in stmt.i_key:
+                    type_data = Utils.get_primitive_type(key_leaf)
+                    for data in type_data:
+                        key_type, type_obj = data
+                        if key_type == "leafref":
+                            try:
+                                target_node = type_obj.i_type_spec.i_target_node
+                            except:
+                                # This is due to union type, pyang does not set it by itself
+                                target_node = statements.validate_leafref_path(self.ctx, key_leaf, type_obj.i_type_spec.path_spec, type_obj.i_type_spec.path_, False)[0]
+                            target_list_node = target_node.parent
+                            self.add_to_list_depends(stmt.arg, target_list_node.arg)
+        if level < 3:
+            for child in stmt.substmts:
+                self.process_children(child, level + 1)
+            if level == 2:
+                self.collect_sibling_lists(stmt)
+
+    def collect_sibling_lists(self, container_stmt):
+        """
+        Iterate over all child statements of the container statement to find list statements
+        :param container_stmt: Table level container
+        :return: None
+        """
+        for list_stmt in [child for child in container_stmt.substmts if child.keyword == "list"]:
+            # Initialize the list of sibling names, excluding the current list statement itself
+            siblings_names = [sibling.arg for sibling in container_stmt.substmts if sibling.keyword == "list" and sibling != list_stmt]
+            # Store the sibling list names in the dictionary with the current list statement's name as the key
+            self.list_siblings[list_stmt.arg] = siblings_names
+
+    def handle_list_dependency(self):
+        """
+        Operates on the collected data. It adds dependent-on extension on the sibling of the target node(if not exists)
+        :return: None
+        """
+        for list_entry in self.list_depends:
+            for sibling in self.list_siblings[list_entry]:
+                for dep_list in self.list_depends[list_entry]:
+                    if sibling == dep_list:
+                        continue # Dependency between LISTs of same TABLE
+                    if dep_list not in self.list_depends[sibling]:
+                        Utils.use_sonic_extension(self.list_objs[dep_list], TBL_DEP_ON_EXT, sibling)
+
+
+class ContainerToListPlugin:
+
+    def __init__(self):
         self.refs = dict()
+
+    def convert_singleton_to_list(self, ctx, modules):
         for module in modules:
             self.process_children(modules[module], level=0)
             if module == SONIC_EXTENSION_MOD:
-                self.add_sonic_extension(modules[module], TBL_KEY_EXT)
+                Utils.add_sonic_extension(modules[module], TBL_KEY_EXT)
         for module in modules:
             self.replace_refs(modules[module])
 
@@ -78,45 +184,6 @@ class ContainerToListPlugin():
             for child in stmt.substmts:
                 self.process_children(child, level + 1)
 
-    def add_sonic_extension(self, module_stmt, ext):
-        # Check if the TBL_KEY_EXT extension already exists
-        for s in module_stmt.substmts:
-            if s.keyword == "extension" and s.arg == ext:
-                # Extension already exists, no need to add
-                return
-
-        # If not present, add the extension
-        ext_stmt = statements.Statement(module_stmt, module_stmt, module_stmt.pos, "extension", ext)
-        arg_stmt = statements.Statement(module_stmt, ext_stmt, ext_stmt.pos, "argument", "value")
-        ext_stmt.substmts.append(arg_stmt)
-        module_stmt.substmts.append(ext_stmt)
-
-    def use_sonic_extension(self, stmt, ext, key_name):
-        # Get the module statement using stmt.top
-        module_stmt = stmt.top
-
-        # Check if sonic-extensions.yang is already imported
-        sonic_ext_prefix = None
-        for s in module_stmt.substmts:
-            if s.keyword == "import" and s.arg == SONIC_EXTENSION_MOD:
-                for sub_s in s.substmts:
-                    if sub_s.keyword == "prefix":
-                        sonic_ext_prefix = sub_s.arg
-                        break
-                break
-
-        # If not imported, add the import statement and set the prefix
-        if sonic_ext_prefix is None:
-            sonic_ext_prefix = TBL_KEY_EXT_PREFIX
-            import_stmt = statements.Statement(module_stmt, module_stmt, module_stmt.pos, "import", SONIC_EXTENSION_MOD)
-            prefix_stmt = statements.Statement(module_stmt, import_stmt, import_stmt.pos, "prefix", sonic_ext_prefix)
-            import_stmt.substmts.append(prefix_stmt)
-            module_stmt.substmts.insert(4, import_stmt)
-
-        # Add the TBL_KEY_EXT extension statement using the extracted/defined prefix
-        tbl_key_stmt = statements.Statement(stmt.top, stmt, stmt.pos, f"{sonic_ext_prefix}:{ext}", key_name)
-        stmt.substmts.insert(2, tbl_key_stmt)
-
     def convert_container_to_list(self, stmt):
         key_name = stmt.arg
         parent_stmt = stmt.parent
@@ -139,6 +206,7 @@ class ContainerToListPlugin():
                 "enumeration",
             )
         )
+        key_id.substmts[-1].i_type_spec = True #set some valid value, just needed to determine primitiive type
         key_id.substmts[-1].substmts.append(
             statements.Statement(
                 stmt.top,
@@ -153,7 +221,10 @@ class ContainerToListPlugin():
             1,
             statements.Statement(stmt.top, stmt, stmt.pos, "key", "key_id"),
         )
-        self.use_sonic_extension(stmt, TBL_KEY_EXT, key_name)
+        if not hasattr(stmt, 'i_key'):
+            stmt.i_key = []
+        stmt.i_key.append(key_id)
+        Utils.use_sonic_extension(stmt, TBL_KEY_EXT, key_name)
         new_list_path = statements.mk_path_str(stmt, with_prefixes=False)
         new_xpath = statements.mk_path_str(stmt, with_prefixes=True, prefix_to_module=True)
         if stmt.i_module.arg not in self.refs:
@@ -177,21 +248,22 @@ class ContainerToListPlugin():
         return normalized_path.replace(old_substring, new_substring)
 
     def update_local_references(self, stmt, table_name, key_name, list_name, old_container_path, new_list_path):
-            refs = dict()
-            refs[f"../../{key_name}"] = f"../../{list_name}"
-            refs[f"../../{table_name}/{key_name}"] = f"../../{table_name}/{list_name}"
-            refs[f"../../../{table_name}/{key_name}"] = f"../../../{table_name}/{list_name}"
-            refs[f"../../../../{table_name}/{key_name}"] = f"../../../../{table_name}/{list_name}"
-            stmts = []
-            self.collect_statements(stmt.top, stmts)
-            # Replace relative References
-            for c_stmt in stmts:
-                if "../.." in c_stmt.arg:
-                    for ref in refs:
-                        if ref in c_stmt.arg:
-                            c_stmt.arg = self.replace_path_substring(c_stmt.arg, ref, refs[ref])
-                # Replace Absolute references
-                c_stmt.arg = self.replace_path_substring(c_stmt.arg, old_container_path, new_list_path)
+        refs = dict()
+        refs[f"../../{key_name}"] = f"../../{list_name}"
+        refs[f"../../{table_name}/{key_name}"] = f"../../{table_name}/{list_name}"
+        refs[f"../../../{table_name}/{key_name}"] = f"../../../{table_name}/{list_name}"
+        refs[f"../../../../{table_name}/{key_name}"] = f"../../../../{table_name}/{list_name}"
+        stmts = []
+        self.collect_statements(stmt.top, stmts)
+        # Replace relative References
+        for c_stmt in stmts:
+            if "../.." in c_stmt.arg:
+                for ref in refs:
+                    if ref in c_stmt.arg:
+                        c_stmt.arg = self.replace_path_substring(c_stmt.arg, ref, refs[ref])
+            # Replace Absolute references
+            c_stmt.arg = self.replace_path_substring(c_stmt.arg, old_container_path, new_list_path)
+
 
 def process(args):
     if args.no_err_prefix:
@@ -223,6 +295,7 @@ def process(args):
     ctx.validate()
     conv = ContainerToListPlugin()
     conv.convert_singleton_to_list(ctx,mod_dict)
+    ListDependencyPlugin(ctx).process(mod_dict)
     error_seen = False
     for (epos, etag, eargs) in ctx.errors:
         elevel = error.err_level(etag)
@@ -413,7 +486,87 @@ def emit_stmt(ctx, module, stmt, fd, indent, indentstep):
         fd.write(indent + '</' + tag + '>' + new_line)
 
 
-if __name__== "__main__":
+class Utils:
+    """
+    Utility class holds utility functions
+    """
+    @staticmethod
+    def get_primitive_type(stmt):
+        """Recurses through the typedefs and union types, returns
+        the most primitive YANG types defined, including for nested unions."""
+        type_obj = stmt if stmt.keyword == 'type' else stmt.search_one('type')
+        if not type_obj:
+            raise Exception("Statement has no 'type'")
+
+        # Handling union types
+        if type_obj.arg == 'union':
+            primitive_types = []
+            for union_member in type_obj.i_type_spec.types:
+                if union_member.keyword == 'type':  # Ensure it's a type statement
+                    # Recurse to get the primitive type for each member of the union
+                    member_primitive_types = Utils.get_primitive_type(union_member)
+                    primitive_types.extend(member_primitive_types)
+            return primitive_types
+
+        # Handling typedef recursion
+        typedef_obj = getattr(type_obj, 'i_typedef', None)
+        if typedef_obj:
+            return Utils.get_primitive_type(typedef_obj)
+
+        # Check for primitive type
+        if not Utils.check_primitive_type(type_obj):
+            raise Exception(f'{type_obj.arg} is not a primitive! Incomplete parse tree?')
+
+        return [(type_obj.arg, type_obj)]  # Return a list of tuples for consistency
+
+    @staticmethod
+    def check_primitive_type(stmt):
+        """Determines if a type is primitive based on the presence of i_type_spec."""
+        return hasattr(stmt, 'i_type_spec')
+
+    @staticmethod
+    def add_sonic_extension(module_stmt, ext):
+        # Check if the TBL_KEY_EXT extension already exists
+        for s in module_stmt.substmts:
+            if s.keyword == "extension" and s.arg == ext:
+                # Extension already exists, no need to add
+                return
+
+        # If not present, add the extension
+        ext_stmt = statements.Statement(module_stmt, module_stmt, module_stmt.pos, "extension", ext)
+        arg_stmt = statements.Statement(module_stmt, ext_stmt, ext_stmt.pos, "argument", "value")
+        ext_stmt.substmts.append(arg_stmt)
+        module_stmt.substmts.append(ext_stmt)
+
+    @staticmethod
+    def use_sonic_extension(stmt, ext, key_name):
+        # Get the module statement using stmt.top
+        module_stmt = stmt.top
+
+        # Check if sonic-extensions.yang is already imported
+        sonic_ext_prefix = None
+        for s in module_stmt.substmts:
+            if s.keyword == "import" and s.arg == SONIC_EXTENSION_MOD:
+                for sub_s in s.substmts:
+                    if sub_s.keyword == "prefix":
+                        sonic_ext_prefix = sub_s.arg
+                        break
+                break
+
+        # If not imported, add the import statement and set the prefix
+        if sonic_ext_prefix is None:
+            sonic_ext_prefix = TBL_KEY_EXT_PREFIX
+            import_stmt = statements.Statement(module_stmt, module_stmt, module_stmt.pos, "import", SONIC_EXTENSION_MOD)
+            prefix_stmt = statements.Statement(module_stmt, import_stmt, import_stmt.pos, "prefix", sonic_ext_prefix)
+            import_stmt.substmts.append(prefix_stmt)
+            module_stmt.substmts.insert(4, import_stmt)
+
+        # Add the TBL_KEY_EXT extension statement using the extracted/defined prefix
+        tbl_key_stmt = statements.Statement(stmt.top, stmt, stmt.pos, f"{sonic_ext_prefix}:{ext}", key_name)
+        stmt.substmts.insert(2, tbl_key_stmt)
+
+
+if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument('--path', action='append', help='Sonic yang lookup directory', required=True, type=pathlib.Path)
     parser.add_argument('--out-dir', dest='out_dir', help='Output directory for YIN files', required=True, type=pathlib.Path)


### PR DESCRIPTION
When dependent target TABLE has multiple lists, if there exists a partial dependency, the loosely hanging LIST was causing sorting issue.

Below are the fix implemented

1. Retained the last LIST entry instead of first.
2. Injected dependency on all target LISTs of the TABLE.