### PR TITLE
Disallow duplicate dyamic field names

### DIFF
--- a/cvl/internal/yparser/yparser.go
+++ b/cvl/internal/yparser/yparser.go
@@ -711,9 +711,22 @@ func getModelChildInfo(l *YParserListInfo, node *C.struct_lys_node,
 		case C.LYS_LIST:
 			nodeInnerList := (*C.struct_lys_node_list)(unsafe.Pointer(sChild))
 			innerListkeys := (*[10]*C.struct_lys_node_leaf)(unsafe.Pointer(nodeInnerList.keys))
-			for idx := 0; idx < int(nodeInnerList.keys_size); idx++ {
-				keyName := C.GoString(innerListkeys[idx].name)
+			if nodeInnerList.keys_size == 1 {
+				keyName := C.GoString(innerListkeys[0].name)
 				l.MapLeaf = append(l.MapLeaf, keyName)
+				// Now, find and add the first non-key leaf.
+				for sChildInner := nodeInnerList.child; sChildInner != nil; sChildInner = sChildInner.next {
+					if sChildInner.nodetype == C.LYS_LEAF {
+						// Check if the leaf is not a key.
+						if name := C.GoString(sChildInner.name); name != keyName {
+							l.MapLeaf = append(l.MapLeaf, name)
+							break
+						}
+					}
+				}
+			} else { // should never hit here, as linter does the validation
+				listName := C.GoString(nodeInnerList.name)
+				TRACE_LOG(TRACE_YPARSER, "Inner List %s for Dynamic fields has %d keys", listName, nodeInnerList.keys_size)
 			}
 		case C.LYS_USES:
 			nodeUses := (*C.struct_lys_node_uses)(unsafe.Pointer(sChild))

--- a/cvl/testdata/schema/sonic-cablelength.yang
+++ b/cvl/testdata/schema/sonic-cablelength.yang
@@ -32,7 +32,7 @@ module sonic-cablelength {
 				}
 
 				list CABLE_LENGTH { //this is list inside list for storing mapping between two fields
-					key "port length";
+					key "port";
 
 					leaf port {
 						type leafref {

--- a/cvl/testdata/schema/sonic-dscp-tc-map.yang
+++ b/cvl/testdata/schema/sonic-dscp-tc-map.yang
@@ -28,7 +28,7 @@ module sonic-dscp-tc-map {
 				}
 
 				list DSCP_TO_TC_MAP { //this is list inside list for storing mapping between two fields
-					key "dscp tc_num";
+					key "dscp";
 
 					leaf tc_num {
 						type string {

--- a/cvl/testdata/schema/sonic-pfc-priority-queue-map.yang
+++ b/cvl/testdata/schema/sonic-pfc-priority-queue-map.yang
@@ -28,7 +28,7 @@ module sonic-pfc-priority-queue-map {
 				}
 
 				list MAP_PFC_PRIORITY_TO_QUEUE { //this is list inside list for storing mapping between two fields
-					key "pfc_priority qindex";
+					key "pfc_priority";
 
 					leaf pfc_priority {
 						type string {

--- a/cvl/testdata/schema/sonic-tc-priority-group-map.yang
+++ b/cvl/testdata/schema/sonic-tc-priority-group-map.yang
@@ -28,7 +28,7 @@ module sonic-tc-priority-group-map {
 				}
 
 				list TC_TO_PRIORITY_GROUP_MAP { //this is list inside list for storing mapping between two fields
-					key "tc_num pg_num";
+					key "tc_num";
 
 					leaf tc_num {
 						type string {

--- a/cvl/testdata/schema/sonic-tc-queue-map.yang
+++ b/cvl/testdata/schema/sonic-tc-queue-map.yang
@@ -28,7 +28,7 @@ module sonic-tc-queue-map {
 				}
 
 				list TC_TO_QUEUE_MAP { //this is list inside list for storing mapping between two fields
-					key "tc_num qindex";
+					key "tc_num";
 
 					leaf tc_num {
 						type string {


### PR DESCRIPTION
CVL relying on 2-key list to determine the mapping Instead it should rely on one key and one non-key leaf