### PR TITLE
Release CString memory to fix memory leak

### DIFF
--- a/cvl/internal/yparser/yparser.go
+++ b/cvl/internal/yparser/yparser.go
@@ -358,7 +358,9 @@ func Debug(on bool) {
 
 func Initialize() {
 	if !yparserInitialized {
-		ypCtx = (*YParserCtx)(C.ly_ctx_new(C.CString(CVL_SCHEMA), 0))
+		cs := C.CString(CVL_SCHEMA)
+		defer C.free(unsafe.Pointer(cs))
+		ypCtx = (*YParserCtx)(C.ly_ctx_new(cs, 0))
 		C.ly_verb(C.LY_LLERR)
 		//	yparserInitialized = true
 	}


### PR DESCRIPTION
# Why I did it
We detect a memory leak in sonic-mgmt-common.

# How I did it
Use C.free to release CString memory.

# How to verify it
Run sonic-mgmt-common unit test.