### PR TITLE
Adding subscription support for ethernet interfaces.

### DIFF
--- a/models/yang/annotations/openconfig-interfaces-annot.yang
+++ b/models/yang/annotations/openconfig-interfaces-annot.yang
@@ -19,6 +19,7 @@ module openconfig-interfaces-annot {
     deviation /oc-intf:interfaces/oc-intf:interface/oc-eth:ethernet/oc-eth:config {
         deviate add {
             sonic-ext:subtree-transformer "intf_eth_port_config_xfmr";
+            sonic-ext:path-transformer "intf_eth_port_config_path_xfmr";
         }
     }
 
@@ -110,6 +111,7 @@ module openconfig-interfaces-annot {
             sonic-ext:table-transformer "intf_subintfs_table_xfmr";
             sonic-ext:virtual-table "true";
             sonic-ext:key-transformer "intf_subintfs_xfmr";
+            sonic-ext:path-transformer "intf_ip_path_xfmr";
         }
     }
     

--- a/translib/transformer/xfmr_intf.go
+++ b/translib/transformer/xfmr_intf.go
@@ -2600,7 +2600,6 @@ var Subscribe_intf_ip_addr_xfmr = func(inParams XfmrSubscInParams) (XfmrSubscOut
 		result.nOpts.pType = OnChange
 		result.isVirtualTbl = false
 
-		//uriIfName := pathInfo.Var("name")
 		tableName := ""
 		ipKey := ""
 		ifKey := ""

--- a/translib/transformer/xfmr_intf.go
+++ b/translib/transformer/xfmr_intf.go
@@ -752,9 +752,9 @@ var DbToYang_intf_eth_port_config_xfmr SubTreeXfmrDbToYang = func(inParams XfmrP
 	intfsObj := getIntfsRoot(inParams.ygRoot)
 	pathInfo := NewPathInfo(inParams.uri)
 	uriIfName := pathInfo.Var("name")
-	ifName := *(&uriIfName)
+	ifName := uriIfName
 
-	log.Infof("DbToYang_intf_eth_port_config_xfmr: Interface name : %s ", ifName)
+	log.V(3).Infof("DbToYang_intf_eth_port_config_xfmr: Interface name : %s ", ifName)
 
 	intfType, _, err := getIntfTypeByName(ifName)
 	if err != nil {
@@ -835,13 +835,13 @@ var Subscribe_intf_eth_port_config_xfmr SubTreeXfmrSubscribe = func(inParams Xfm
 	var result XfmrSubscOutParams
 
 	if inParams.subscProc == TRANSLATE_SUBSCRIBE {
-		log.Info("Subscribe_intf_eth_port_config_xfmr: inParams.subscProc: ", inParams.subscProc)
+		log.V(3).Info("Subscribe_intf_eth_port_config_xfmr: inParams.subscProc: ", inParams.subscProc)
 
 		pathInfo := NewPathInfo(inParams.uri)
 		targetUriPath := pathInfo.YangPath
 
-		log.Infof("Subscribe_intf_eth_port_config_xfmr:- URI:%s pathinfo:%s ", inParams.uri, pathInfo.Path)
-		log.Infof("Subscribe_intf_eth_port_config_xfmr:- Target URI path:%s", targetUriPath)
+		log.V(3).Infof("Subscribe_intf_eth_port_config_xfmr:- URI:%s pathinfo:%s ", inParams.uri, pathInfo.Path)
+		log.V(3).Infof("Subscribe_intf_eth_port_config_xfmr:- Target URI path:%s", targetUriPath)
 
 		// to handle the TRANSLATE_SUBSCRIBE
 		result.nOpts = new(notificationOpts)
@@ -850,23 +850,20 @@ var Subscribe_intf_eth_port_config_xfmr SubTreeXfmrSubscribe = func(inParams Xfm
 		result.isVirtualTbl = false
 		result.needCache = true
 
-		ifName := pathInfo.Var("name")
 		log.Info("Subscribe_intf_eth_port_config_xfmr: ifName: ", ifName)
 
-		if ifName == "" {
-			ifName = "*"
-		}
+		ifName := pathInfo.StringVar("name", "*")
 
 		result.dbDataMap = RedisDbSubscribeMap{db.ConfigDB: {
 			"PORT": {ifName: {"autoneg": "auto-negotiate", "speed": "port-speed"}}}}
 
-		log.Info("Subscribe_intf_eth_port_config_xfmr: result ", result)
+		log.V(3).Info("Subscribe_intf_eth_port_config_xfmr: result ", result)
 	}
 	return result, err
 }
 
 var DbToYangPath_intf_eth_port_config_path_xfmr PathXfmrDbToYangFunc = func(params XfmrDbToYgPathParams) error {
-	log.Info("DbToYangPath_intf_eth_port_config_path_xfmr: params: ", params)
+	log.V(3).Info("DbToYangPath_intf_eth_port_config_path_xfmr: params: ", params)
 
 	intfRoot := "/openconfig-interfaces:interfaces/interface"
 
@@ -876,7 +873,7 @@ var DbToYangPath_intf_eth_port_config_path_xfmr PathXfmrDbToYangFunc = func(para
 	}
 
 	if (params.tblName == "PORT") && (len(params.tblKeyComp) > 0) {
-		params.ygPathKeys[intfRoot+"/name"] = *(&params.tblKeyComp[0])
+		params.ygPathKeys[intfRoot+"/name"] = params.tblKeyComp[0]
 	} else {
 		log.Info("DbToYangPath_intf_eth_port_config_path_xfmr, wrong param: tbl ", params.tblName, " key ", params.tblKeyComp)
 		return nil
@@ -1453,7 +1450,7 @@ var intf_subintfs_table_xfmr TableXfmrFunc = func(inParams XfmrParams) ([]string
 	if inParams.oper == SUBSCRIBE {
 		var _intfTypeList []E_InterfaceType
 
-		if idx == "*" || idx != "0" {
+		if idx != "*" && idx != "0" {
 			err_str := "Subinterfaces not supported"
 			return tblList, tlerr.NotSupported(err_str)
 		}
@@ -2603,17 +2600,12 @@ var Subscribe_intf_ip_addr_xfmr = func(inParams XfmrSubscInParams) (XfmrSubscOut
 		result.nOpts.pType = OnChange
 		result.isVirtualTbl = false
 
-		uriIfName := pathInfo.Var("name")
+		//uriIfName := pathInfo.Var("name")
 		tableName := ""
 		ipKey := ""
 		ifKey := ""
 
-		if uriIfName == "" || uriIfName == "*" {
-			ifKey = "*"
-		} else {
-			sonicIfName := &uriIfName
-			ifKey = *sonicIfName
-		}
+		ifKey := pathInfo.StringVar("name", "*")
 
 		addressConfigPath := "/address/config"
 		addressStatePath := "/address/state"

--- a/translib/transformer/xfmr_intf.go
+++ b/translib/transformer/xfmr_intf.go
@@ -850,9 +850,9 @@ var Subscribe_intf_eth_port_config_xfmr SubTreeXfmrSubscribe = func(inParams Xfm
 		result.isVirtualTbl = false
 		result.needCache = true
 
-		log.Info("Subscribe_intf_eth_port_config_xfmr: ifName: ", ifName)
-
 		ifName := pathInfo.StringVar("name", "*")
+
+		log.V(3).Info("Subscribe_intf_eth_port_config_xfmr: ifName: ", ifName)
 
 		result.dbDataMap = RedisDbSubscribeMap{db.ConfigDB: {
 			"PORT": {ifName: {"autoneg": "auto-negotiate", "speed": "port-speed"}}}}
@@ -2604,7 +2604,7 @@ var Subscribe_intf_ip_addr_xfmr = func(inParams XfmrSubscInParams) (XfmrSubscOut
 		ipKey := ""
 		ifKey := ""
 
-		ifKey := pathInfo.StringVar("name", "*")
+		ifKey = pathInfo.StringVar("name", "*")
 
 		addressConfigPath := "/address/config"
 		addressStatePath := "/address/state"


### PR DESCRIPTION
**What I did:**
Added gNMI subscription transformer support for OpenConfig Ethernet Interfaces.

**Why I did it?**
Replacing existing intf_app.go code with transformer code.

**How did I verify the changes?**
Verified by manually testing gNMI subscription.

**Log files for gNMI subscription manual run:**

[UT logs community subscription ON change IPv4v6.docx](https://github.com/sonic-net/sonic-mgmt-common/files/15395754/UT.logs.community.subscription.ON.change.IPv4v6.docx)
[UT logs Community subscription SAMPLE IPv4v6.docx](https://github.com/sonic-net/sonic-mgmt-common/files/15395755/UT.logs.Community.subscription.SAMPLE.IPv4v6.docx)
[UT logs Community subscription TARGET DEFINED IPv4v6.docx](https://github.com/sonic-net/sonic-mgmt-common/files/15395756/UT.logs.Community.subscription.TARGET.DEFINED.IPv4v6.docx)
[UT logs community subscription - onchange Eth.docx](https://github.com/sonic-net/sonic-mgmt-common/files/15395898/UT.logs.community.subscription.-.onchange.Eth.docx)
[UT logs community subscription TARGET DEFINED ETH.docx](https://github.com/sonic-net/sonic-mgmt-common/files/15396071/UT.logs.community.subscription.TARGET.DEFINED.ETH.docx)
[UT LOGS community subscription SAMPLE Eth.docx](https://github.com/sonic-net/sonic-mgmt-common/files/15396074/UT.LOGS.community.subscription.SAMPLE.Eth.docx)
[UT logs community gnmi subscription TARGET DEFINED intf top level.docx](https://github.com/sonic-net/sonic-mgmt-common/files/15495895/UT.logs.community.gnmi.subscription.TARGET.DEFINED.intf.top.level.docx)
[UT logs community ON CHANGE intf top level.docx](https://github.com/sonic-net/sonic-mgmt-common/files/15495896/UT.logs.community.ON.CHANGE.intf.top.level.docx)
[UT logs community subscription SAMPLE intf top level.docx](https://github.com/sonic-net/sonic-mgmt-common/files/15495897/UT.logs.community.subscription.SAMPLE.intf.top.level.docx)
