### PR TITLE
Upgrading openconfig-system.yang version from 0.7.0 to 2.1.0

### DIFF
--- a/models/yang/common/openconfig-aaa-radius.yang
+++ b/models/yang/common/openconfig-aaa-radius.yang
@@ -26,7 +26,19 @@ submodule openconfig-aaa-radius {
     related to the RADIUS protocol for authentication,
     authorization, and accounting.";
 
-  oc-ext:openconfig-version "0.4.1";
+  oc-ext:openconfig-version "1.0.0";
+
+  revision "2022-07-29" {
+    description
+      "Update user role to be mandatory.";
+      reference "1.0.0";
+  }
+
+  revision "2020-07-30" {
+    description
+      "Add secret-key-hashed.";
+    reference "0.5.0";
+  }
 
   revision "2018-11-21" {
     description
@@ -95,6 +107,13 @@ submodule openconfig-aaa-radius {
       type oc-types:routing-password;
       description
         "The unencrypted shared key used between the authentication
+        server and the device.";
+    }
+
+    leaf secret-key-hashed {
+      type oc-aaa-types:crypt-password-type;
+      description
+        "The hashed shared key used between the authentication
         server and the device.";
     }
 

--- a/models/yang/common/openconfig-aaa-tacacs.yang
+++ b/models/yang/common/openconfig-aaa-tacacs.yang
@@ -25,7 +25,19 @@ submodule openconfig-aaa-tacacs {
     related to the TACACS+ protocol for authentication,
     authorization, and accounting.";
 
-  oc-ext:openconfig-version "0.4.1";
+  oc-ext:openconfig-version "1.0.0";
+
+  revision "2022-07-29" {
+    description
+      "Update user role to be mandatory.";
+      reference "1.0.0";
+  }
+
+  revision "2020-07-30" {
+    description
+      "Add secret-key-hashed.";
+    reference "0.5.0";
+  }
 
   revision "2018-11-21" {
     description
@@ -88,6 +100,13 @@ submodule openconfig-aaa-tacacs {
       type oc-types:routing-password;
       description
         "The unencrypted shared key used between the authentication
+        server and the device.";
+    }
+
+    leaf secret-key-hashed {
+      type oc-aaa-types:crypt-password-type;
+      description
+        "The hashed shared key used between the authentication
         server and the device.";
     }
 

--- a/models/yang/common/openconfig-aaa.yang
+++ b/models/yang/common/openconfig-aaa.yang
@@ -32,7 +32,31 @@ module openconfig-aaa {
     Portions of this model reuse data definitions or structure from
     RFC 7317 - A YANG Data Model for System Management";
 
-  oc-ext:openconfig-version "0.4.1";
+  oc-ext:openconfig-version "1.0.0";
+
+  revision "2022-07-29" {
+    description
+      "Update user role to be mandatory.";
+      reference "1.0.0";
+  }
+
+  revision "2020-07-30" {
+    description
+      "Add secret-key-hashed for TACACS and RADIUS.";
+    reference "0.5.0";
+  }
+
+  revision "2019-10-28" {
+    description
+      "Fix bug in when statement path";
+    reference "0.4.3";
+  }
+
+  revision "2019-08-20" {
+    description
+      "Fix identity prefixes and when statement paths";
+    reference "0.4.2";
+  }
 
   revision "2018-11-21" {
     description
@@ -266,11 +290,11 @@ module openconfig-aaa {
         }
 
         uses aaa-tacacs-server-top {
-          when "../../config/type = 'oc-aaa-types:TACACS'";
+          when "../../config/type = 'oc-aaa:TACACS'";
         }
 
         uses aaa-radius-server-top {
-          when "../../config/type = 'oc-aaa-types:RADIUS'";
+          when "../../config/type = 'oc-aaa:RADIUS'";
         }
       }
     }
@@ -378,10 +402,11 @@ module openconfig-aaa {
           base oc-aaa-types:SYSTEM_DEFINED_ROLES;
         }
       }
+      mandatory true;
       description
-        "Role assigned to the user.  The role may be supplied
-        as a string or a role defined by the SYSTEM_DEFINED_ROLES
-        identity.";
+        "Role assigned to the user.  The role must be supplied
+        as a role defined by the SYSTEM_DEFINED_ROLES
+        identity or a string that matches a user defined role.";
     }
   }
 

--- a/models/yang/common/openconfig-alarms.yang
+++ b/models/yang/common/openconfig-alarms.yang
@@ -42,7 +42,13 @@ module openconfig-alarms {
     Section 4.c of the IETF Trust's Legal Provisions Relating
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
-  oc-ext:openconfig-version "0.3.1";
+  oc-ext:openconfig-version "0.3.2";
+
+  revision "2019-07-09" {
+    description
+      "Clarify relative base for leaves using timeticks64.";
+    reference "0.3.2";
+  }
 
   revision "2018-11-21" {
     description
@@ -119,7 +125,7 @@ module openconfig-alarms {
       type oc-types:timeticks64;
       description
         "The time at which the alarm was raised by the system.
-        This value is expressed as nanoseconds since the Unix Epoch";
+        This value is expressed relative to the Unix Epoch.";
     }
 
     leaf severity {

--- a/models/yang/common/openconfig-hashing.yang
+++ b/models/yang/common/openconfig-hashing.yang
@@ -1,0 +1,366 @@
+module openconfig-hashing {
+    yang-version "1";
+
+    // namespace
+    namespace "http://openconfig.net/yang/hashing";
+
+    prefix "oc-hashing";
+
+    // import some basic types
+    import openconfig-extensions { prefix oc-ext; }
+    import openconfig-system {prefix oc-sys;}
+    import openconfig-interfaces {prefix oc-intf;}
+
+    // meta
+    organization "OpenConfig working group";
+
+    contact
+        "OpenConfig working group
+        netopenconfig@googlegroups.com";
+
+    description
+        "Model for managing hashing policies that would be referenced by the
+        interfaces model.";
+
+
+    oc-ext:openconfig-version "0.1.0";
+
+    revision "2023-08-08" {
+        description "Initial hashing model.";
+        reference "0.1.0";
+    }
+
+    oc-ext:catalog-organization "openconfig";
+    oc-ext:origin "openconfig";
+
+    grouping hashing-inputs {
+        description
+            "Top level container for inputs to be used for hashing policies.";
+
+        leaf ingress-interface {
+            type boolean;
+            description
+                "Include the ingress subinterface identified in the
+                calculation of the hash.";
+        }
+        leaf ip-protocol-type {
+            type boolean;
+            description
+                "Include the IP protocol type in the calculation of the hash.";
+        }
+    }
+
+    grouping ipv4-ipv6-inputs-top {
+        description
+            "The top level container for ipv4 and ipv6 header
+            fields used for the hash computation.";
+
+        leaf src-addr {
+            type boolean;
+            description
+                "Use the source address in the calculation of the hash.";
+        }
+
+        leaf dst-addr {
+            type boolean;
+            description
+                "Use the destination address in the calculation of the hash.";
+        }
+
+        leaf src-port {
+            type boolean;
+            description
+                "Use the source port from the transport header in the calculation
+                of the hash.";
+        }
+
+        leaf dst-port {
+            type boolean;
+            description
+                "Use the destination port from the transport header in the
+                calculation of the hash.";
+        }
+    }
+
+    grouping ipv6-inputs-top {
+        description
+            "The top level container specifially for ipv6 header
+            fields used for the hash computation.";
+
+        leaf flow-label {
+            type boolean;
+            description
+                "Use the flow label in the IPv6 header
+                to calculate the hash.";
+        }
+    }
+
+    grouping hashing-policy-config {
+        description
+            "Configuration data for hashing policies.";
+
+        leaf name {
+            type string;
+            description
+                "The name of the hashing policy.
+                When a configured user-controlled policy is created by the
+                system, it is instantiated with the same name in the
+                /system/hashing-policies/hashing-policy/name list.";
+        }
+
+        leaf seed {
+            type uint64;
+            description
+                "The seed used to initialize the hash algorithm";
+        }
+
+        leaf algorithm {
+            type string;
+            description
+                "The name of hash algorithm. This algorithm MUST
+                be a supported algorithm";
+        }
+    }
+
+    grouping hashing-policy-top {
+        description
+            "Top level grouping for hashing configuration and operational state
+            data.";
+
+        container hashing-policies {
+            description
+                "Top level container for hashing, including configuration and
+                state data.";
+
+            list hashing-policy {
+                key "name";
+
+                description
+                    "The list of named policies to be used on the device.";
+
+                leaf name {
+                    type leafref {
+                        path "../config/name";
+                    }
+                    description
+                        "References the name of the hashing policy.";
+                }
+                container config {
+                    description
+                        "Configurable items at the global hash policy level.";
+
+                    uses hashing-policy-config;
+                }
+                container state {
+                    config false;
+                    description
+                        "Operational state data at the global hash policy
+                        level.";
+
+                    uses hashing-policy-config;
+                }
+
+                container hash-field-modes {
+                    description
+                        "Container for specifying inputs to be used when
+                        calculating the hash.";
+
+                    container config {
+                        description
+                            "Configurable items at the hashing inputs level.";
+                        uses hashing-inputs;
+                    }
+                    container state {
+                        config false;
+                        description
+                            "Operational state data at the hashing
+                            inputs level.";
+                        uses hashing-inputs;
+                    }
+
+                    container ipv4 {
+                        description
+                            "The IPv4 fields that should be used to
+                            compute the hash.";
+                        container config {
+                            description
+                                "Configurable data at the hashing
+                                inputs level for IPv4.";
+                            uses ipv4-ipv6-inputs-top;
+                        }
+
+                        container state {
+                            config false;
+                            description
+                                "Operational state data at the hashing
+                                inputs level for IPv4.";
+                            uses ipv4-ipv6-inputs-top;
+                        }
+                    }
+
+                    container ipv6 {
+                        description
+                            "The IPv6 fields that should be used to
+                            compute the hash.";
+
+                        container config {
+                            description
+                                "Configurable data at the hashing
+                                inputs level for IPv6.";
+
+                            uses ipv4-ipv6-inputs-top;
+                            uses ipv6-inputs-top;
+                        }
+
+                        container state {
+                            config false;
+                            description
+                                "Operational state data at the hashing
+                                inputs level for IPv6.";
+
+                            uses ipv4-ipv6-inputs-top;
+                            uses ipv6-inputs-top;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    grouping supported-algorithms-state {
+        description
+            "Top-level container for the supported algorithms.";
+        leaf name {
+            type string;
+            description
+                "Name of the supported algorithm.";
+        }
+        leaf description {
+            type string;
+            description
+                "Description of the supported algorithm.";
+        }
+    }
+    grouping supported-algorithms-top {
+        description
+            "Top-level container of the supported algorithms for supported
+            algorithms.  The list of algorithms are expected to be defined by
+            the target device.";
+        container algorithms {
+            description
+                "Container for vendor supported hashing algorithms.";
+            uses vendor-hashing-algorithms;
+        }
+    }
+
+    grouping hashing-algo-top {
+        description
+            "Top level container of the supported algorithms for supported
+            algorithms.";
+        container hashing-algorithms {
+            config false;
+            description
+                "Container of the supported algorithms for supported
+                algorithms.";
+            list hashing-algorithm {
+                key "name";
+
+                description
+                    "List of the supported algorithms for supported
+                    algorithms.";
+
+                leaf name {
+                    type leafref {
+                        path ../state/name;
+                    }
+                    description
+                        "Reference to the supported algorithm list key.";
+                }
+
+                container state {
+                    description
+                        "Operational data for the supported algorithm.";
+                    config false;
+
+                    leaf name {
+                        type string;
+                        description
+                            "Name of the supported algorithm.";
+                    }
+
+                    leaf description {
+                        type string;
+                        description
+                            "Description of the supported algorithm.";
+                    }
+                }
+            }
+        }
+    }
+
+    grouping vendor-hashing-algorithms {
+        description
+            "Supported hashing algorithms per vender.";
+        container vendor {
+            description
+                "Specify the vendor. Each vendor should have its own set of
+                supported algorithms. For each supported algorithm, a name
+                and a description should be defined. An implementation must
+                augment this model using the schema described in the
+                vendor_counter_guide reference.
+
+                e.g.
+                augment /system/hashing/vendor {
+                    container <vendor name> {
+                        container <platform name> {
+                            uses hashing-algo-top;
+                        }
+                    }
+                }";
+            reference
+                "https://github.com/openconfig/public/tree/master/doc/vendor_counter_guide.md";
+        }
+    }
+
+    grouping hashing-top {
+        description
+            "Top-level container for Hashing algorithms and hashing policies";
+        container hashing {
+            description
+                "Container for Hashing algorithms and hashing policies";
+            uses supported-algorithms-top;
+            uses hashing-policy-top;
+        }
+    }
+
+    augment "/oc-sys:system" {
+        description
+            "Augment for Hashing algorithms and hashing policies";
+
+        uses hashing-top;
+    }
+
+    augment "/oc-intf:interfaces/oc-intf:interface/oc-intf:config" {
+        description
+            "Augment for configuration data hashing policy on the interface.";
+        leaf hashing-policy {
+            type leafref {
+                path "/oc-sys:system/hashing/hashing-policies/hashing-policy/name";
+            }
+            description "The configuration data hashing policy to be used when
+                hashing packets coming in on the interface.";
+        }
+    }
+
+    augment "/oc-intf:interfaces/oc-intf:interface/oc-intf:state" {
+        description
+            "Augment for operational data hashing policy on the iinterface.";
+        leaf hashing-policy {
+            type leafref {
+                path "/oc-sys:system/hashing/hashing-policies/hashing-policy/name";
+            }
+            description "The operational data hashing policy to be used when
+                hashing packets coming in on the interface.";
+        }
+    }
+}

--- a/models/yang/common/openconfig-license.yang
+++ b/models/yang/common/openconfig-license.yang
@@ -1,0 +1,177 @@
+module openconfig-license {
+
+  yang-version "1";
+
+  namespace "http://openconfig.net/yang/license";
+
+  prefix "oc-license";
+
+  import openconfig-extensions { prefix oc-ext; }
+
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This module defines configuration and operational
+    state data for licenses.";
+
+  oc-ext:openconfig-version "0.2.0";
+
+  revision "2020-04-22" {
+    description
+      "Make license-data a union of a string or binary.";
+    reference "0.2.0";
+  }
+
+  revision "2020-01-07" {
+    description
+      "Initial revision";
+    reference "0.1.0";
+  }
+
+  // OpenConfig specific extensions for module metadata.
+  oc-ext:regexp-posix;
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+
+  grouping license-config {
+    description
+      "Configuration data for license";
+
+    leaf license-id {
+      type string;
+      description
+        "License ID. A string that uniquelly identifies the license. The
+         platform should list all the licenses it supports being activated.";
+    }
+
+    leaf license-data {
+      type union {
+        type binary;
+        type string;
+      }
+      description
+        "The contents of the licence (if required) - which may be
+         supplied as a binary blob, or a simple string value. If this
+         value is considered sensitive, it may be read as an empty value.";
+    }
+
+    leaf active {
+      type boolean;
+      default false;
+      description
+        "The activation state of the license.";
+    }
+
+  }
+
+  grouping license-state {
+    description
+    "State data for license";
+
+    leaf description {
+      type string;
+      description
+        "The license description.";
+    }
+
+    leaf issue-date {
+      type uint64;
+      description
+        "The date and time at which the license was issued, expressed as the
+         number of nanoseconds since the Unix Epoch
+         (January 1, 1970, 00:00 UTC).";
+    }
+
+    leaf expiration-date {
+      type uint64;
+      description
+        "The date and time at which the license will expire, expressed as the
+         number of nanoseconds since the Unix Epoch
+         (January 1, 1970, 00:00 UTC). Zero if it does not expire.";
+    }
+
+    leaf in-use {
+      type boolean;
+      description
+        "The license is in use. Different from active. This states that the
+         license is effectively being used in addition to being active. If
+         license for feature X was activated but feature X is not being used,
+         then this should be false.";
+    }
+
+    leaf expired {
+      type boolean;
+      description
+        "The license has expired.";
+    }
+
+    leaf valid {
+      type boolean;
+      description
+        "The license is valid. Can be activated in the system or platform.";
+    }
+
+  }
+
+  grouping licenses-top {
+    description
+      "Top-level grouping for licenses.";
+
+    container licenses {
+      description
+        "Enclosing container for list of licenses";
+
+      list license {
+        key "license-id";
+        description
+          "List of licenses.";
+
+        leaf license-id {
+          type leafref {
+            path "../config/license-id";
+          }
+          description
+            "Reference to license id list key";
+        }
+
+        container config {
+          description
+            "Configuration data for license";
+
+          uses license-config;
+        }
+
+        container state {
+
+          config false;
+
+          description
+            "Operational state data for license.";
+
+          uses license-config;
+          uses license-state;
+        }
+      }
+    }
+
+  }
+
+  grouping license-top {
+    description
+      "Top-level for the license model";
+
+    container license {
+      description
+        "Container for license model";
+
+      uses licenses-top;
+
+    }
+  }
+
+}

--- a/models/yang/common/openconfig-messages.yang
+++ b/models/yang/common/openconfig-messages.yang
@@ -32,12 +32,18 @@ module openconfig-messages {
     /yang/system/openconfig-system.yang model, rather it provies the
     Operator with an alternative method of consuming messages.";
 
-  oc-ext:openconfig-version "0.0.1";
+  oc-ext:openconfig-version "0.1.0";
+
+  revision 2024-07-15 {
+    description
+      "Remove unused top-level messages container.";
+    reference "0.1.0";
+  }
 
   revision "2018-08-13" {
-      description
-        "Initial draft.";
-      reference "0.0.1";
+    description
+      "Initial draft.";
+    reference "0.0.1";
   }
 
   // identity statements
@@ -217,5 +223,4 @@ module openconfig-messages {
     uses debug-messages-top;
     }
   }
-  uses messages-top;
 }

--- a/models/yang/common/openconfig-procmon.yang
+++ b/models/yang/common/openconfig-procmon.yang
@@ -11,6 +11,7 @@ module openconfig-procmon {
   // import some basic types
   import openconfig-extensions { prefix oc-ext; }
   import openconfig-types { prefix oc-types; }
+  import openconfig-yang-types { prefix oc-yang; }
 
 
   // meta
@@ -24,7 +25,16 @@ module openconfig-procmon {
     "This module provides data definitions for process health
     monitoring of one or more processes running on the system.";
 
-  oc-ext:openconfig-version "0.3.1";
+  oc-ext:openconfig-version "0.4.0";
+
+  revision "2019-03-15" {
+    description
+      "Update process start time to be an absolute timestamp,
+      ensure that the units for CPU time are expressed correctly.
+      Update cpu-usage leaves to commonly use counter64 for consumed
+      CPU time.";
+    reference "0.4.0";
+  }
 
   revision "2018-11-21" {
     description
@@ -119,30 +129,25 @@ module openconfig-procmon {
     }
 
     leaf start-time {
-      type uint64;
-      units "ns";
+      type oc-types:timeticks64;
       description
         "The time at which this process started,
-        reported as nanoseconds since the UNIX epoch.  The
-        system must be synchronized such that the start-time
-        can be reported accurately, otherwise it should not be
-        reported.";
+        relative to the UNIX epoch.  The system must be
+        synchronized such that the start-time can be
+        reported accurately, otherwise it should not be reported.";
      }
 
-    leaf uptime {
-      type oc-types:timeticks64;
-      description
-        "Amount of time elapsed since this process started.";
-    }
-
     leaf cpu-usage-user {
-      type oc-types:timeticks64;
+      type oc-yang:counter64;
+      units "nanoseconds";
       description
-        "CPU time consumed by this process in user mode.";
+        "CPU time consumed by this process in user mode in
+        nanoseconds.";
     }
 
     leaf cpu-usage-system {
-      type oc-types:timeticks64;
+      type oc-yang:counter64;
+      units "nanoseconds";
       description
         "CPU time consumed by this process in kernel mode.";
     }

--- a/models/yang/common/openconfig-system-bootz.yang
+++ b/models/yang/common/openconfig-system-bootz.yang
@@ -1,0 +1,115 @@
+module openconfig-system-bootz {
+  yang-version "1";
+
+  namespace "http://openconfig.net/yang/system-bootz";
+  prefix "oc-sys-bootz";
+
+  import openconfig-extensions { prefix oc-ext; }
+  import openconfig-system { prefix oc-sys; }
+  import openconfig-types { prefix oc-types; }
+  import openconfig-yang-types { prefix oc-yang; }
+
+  organization
+    "OpenConfig working group";
+  contact
+    "www.openconfig.net";
+
+  description
+    "This module adds configuration and operational state relating to bootz
+    service running on a network device.";
+
+
+  oc-ext:openconfig-version "1.0.0";
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  revision "2023-06-16" {
+    description
+      "Creation of bootz state paths needed for the service.";
+    reference "1.0.0";
+  }
+
+  grouping bootz-service-structural {
+    description
+      "Structural grouping for bootz service that can be enabled on
+      the system.";
+
+    container bootz {
+      description
+        "Bootz protocol container for management of bootz protocol state.";
+
+      container state {
+        config false;
+        description
+          "Operational state relating to the bootz service.";
+        uses bootz-state;
+      }
+    }
+  }
+
+  grouping bootz-state {
+    description
+      "State parameters required to monitor bootz service.";
+
+    leaf checksum {
+      type string;
+      default "";
+      description
+        "The current checksum of the bootz protocol buffer.
+
+        This value should refect the current sha-512 of the bootz
+        protocol buffer message BootstrapDataSigned. The protocol
+        buffer serialization must be done by tag value for each field
+        in the bootz protocol buffer. This will produce a
+        determintistic marshalled value which can be
+        checksummed.";
+    }
+
+    leaf error-count {
+      type oc-yang:counter64;
+      description
+        "Total count of all bootz errors.";
+    }
+
+    leaf status {
+      type enumeration {
+        enum BOOTZ_UNSPECIFIED;
+        enum BOOTZ_SENT;
+        enum BOOTZ_RECEIVED;
+        enum BOOTZ_CONFIGURATION_APPLIED;
+        enum BOOTZ_OK;
+        enum BOOTZ_OV_INVALID;
+        enum BOOTZ_OS_UPGRADE_IN_PROGRESS;
+        enum BOOTZ_OS_UPGRADE_COMPLETE;
+        enum BOOTZ_OS_INVALID_IMAGE;
+        enum BOOTZ_CONFIGURATION_INVALID;
+      }
+      description
+        "The status of the bootz service.
+
+        The general sequence for the flow would be:
+        BOOTZ_UNSPECIFIED            <- system initial state
+        BOOTZ_SENT                   <- bootz request sent
+        BOOTZ_RECEIVED               <- bootz response received
+        BOOTZ_OS_UPGRADE_IN_PROGRESS <- (if needed)
+        BOOTZ_OS_UPGRADE_COMPLETE    <- (if needed)
+        BOOTZ_CONFIGURATION_APPLIED  <- bootz configuration applied
+        BOOTZ_OK                     <- bootz process successful
+
+        If any error is encounter an error ENUM will be returned.";
+    }
+
+    leaf last-boot-attempt {
+      type oc-types:timeticks64;
+      description
+        "The timestamp of the last bootz attempt.";
+    }
+  }
+
+  augment "/oc-sys:system" {
+    description
+      "Add bootz service configuration to the openconfig-system model.";
+
+    uses bootz-service-structural;
+  }
+}

--- a/models/yang/common/openconfig-system-controlplane.yang
+++ b/models/yang/common/openconfig-system-controlplane.yang
@@ -1,0 +1,374 @@
+module openconfig-system-controlplane {
+    yang-version "1";
+
+    namespace "http://openconfig.net/yang/system-controlplane";
+    prefix "oc-sys-copp";
+
+    import openconfig-extensions {
+        prefix oc-ext;
+    }
+    import openconfig-system {
+        prefix oc-sys;
+    }
+    import openconfig-acl {
+        prefix oc-acl;
+    }
+    import openconfig-qos {
+        prefix oc-qos;
+    }
+
+    organization
+      "OpenConfig working group";
+    contact
+      "www.openconfig.net";
+
+    description
+      "This module adds configuration and operational state relating to
+       policies for traffic destined to the system's control-plane.
+       Particularly, it allows for mechanisms to:
+        - apply an ACL that forwards or drops traffic towards the control-plane.
+        - classify traffic that is destined to the control-plane according to
+          a QoS classifier.
+        - schedule traffic that has been forwarded towards the control-plane,
+          to allow for policies such as rate limits to be applied.
+       The configured policies apply generically to all control-planes that
+       exist within the system, and should be mapped to the internal interfaces
+       via which packets are forwarded to control-plane modules.
+       When a packet is received at an input interface - it is classified into a
+       forwarding group which drains to a specific queue. If this input mapping
+       is sufficient, the CPU-facing interface uses the specified scheduler
+       to determine how to drain queues. If more granular remapping is required
+       (e.g., to classify control-plane traffic more granularly), a user specifies
+       an alternate classifier that is used to reclassify traffic into
+       a new set of forwarding-groups (and hence queues) that can subsequently
+       be scheduled by the specified scheduler.
+       The specified control-plane ACL is applied to traffic received by the
+       control-plane of the system.";
+
+    oc-ext:openconfig-version "0.2.0";
+    oc-ext:catalog-organization "openconfig";
+    oc-ext:origin "openconfig";
+
+    revision "2023-03-03" {
+      description
+        "Add missing state container to ACL.";
+      reference "0.2.0";
+    }
+
+    revision "2021-08-02" {
+      description
+        "Initial revision.";
+      reference "0.1.0";
+    }
+
+    grouping system-controlplane-top {
+      description
+        "Top-level structural grouping for control-plane traffic policies.";
+
+      container control-plane-traffic {
+        description
+          "Policies and configuration relating to the traffic destined towards
+            the system control-plane.";
+
+        container ingress {
+          description
+            "Control-plane traffic parameters relating to ingress traffic.
+            This refers to traffic that is being received by the system's
+            control plane from external-to-the-controlplane sources.";
+
+          uses system-controlplane-acl-common-top;
+
+          container qos {
+            description
+              "Configuration and operational state relating to QoS policies
+              that are applied to control-plane traffic.";
+
+            container classifier {
+              description
+                "Configuration and state parameters relating to the QoS
+                classifier that is applied to control plane traffic. A QoS
+                classifier - defined in /qos/classifiers specifies how traffic
+                is mapped to QoS queues. The classifier specified in this
+                container and corresponding state allows for traffic towards
+                the control-plane to be classified.";
+
+              container config {
+                description
+                  "Configuration parameters relating to QoS classifier
+                  applied to match control plane traffic.";
+                uses system-controlplane-qos-classifier-config;
+              }
+
+              container state {
+                config false;
+                description
+                  "Operational state parameters relating to the QoS classifier
+                  applied to match control plane traffic.";
+                uses system-controlplane-qos-classifier-config;
+              }
+
+              container terms {
+                config false;
+                description
+                  "Operational state and counters relating to the classifier
+                  applied to control-plane traffic.";
+
+                list term {
+                  key "id";
+
+                  description
+                    "A list of the terms within the QoS classifier being
+                    applied for control-plane traffic. Each term has
+                    corresponding operational state parameters.";
+
+                  leaf id {
+                    type leafref {
+                      path "../state/id";
+                    }
+                    description
+                      "Reference to the identifier for the classifier term.";
+                  }
+
+                  container state {
+                    config false;
+                    description
+                      "Operational state parameters relating to a term within
+                      the applied control-plane classifier";
+
+                    uses system-controlplane-qos-classifier-term-state;
+                    uses oc-qos:qos-interface-classifier-match-counters-state;
+                  }
+                }
+              }
+            }
+
+            container scheduler-policy {
+              description
+                "Configuration and operational state relating to the QoS
+                scheduler policy that is applied to control-plane traffic.
+                The scheduler policy determines how traffic, classified by
+                the specified control-plane classifier is rate-limited towards
+                the control-plane. The scheduler policy is defined in
+                /qos/scheduler-policies.";
+
+              container config {
+                description
+                  "Configuration parameters relating to the scheduler-policy
+                  that is to be applied control-plane traffic.";
+
+                uses system-controlplane-qos-scheduler-config;
+              }
+
+              container state {
+                config false;
+                description
+                  "Operational state parameters relating to the scheduler policy
+                  applied to the control-plane traffic.";
+
+                uses system-controlplane-qos-scheduler-config;
+              }
+
+              container scheduler-statistics {
+                config false;
+                description
+                  "Operational state and counters relating to the
+                  scheduler-policy applied to control plane traffic.";
+
+                list scheduler {
+                  key "sequence";
+                  description
+                    "List of the schedulers that are part of the scheduler-policy
+                    specified.";
+
+                  leaf sequence {
+                    type leafref {
+                      path "../state/sequence";
+                    }
+                    description
+                      "Reference to the sequence ID for the scheduler.";
+                  }
+
+                  container state {
+                    description
+                      "Operational state parameters relating to the scheduler
+                      policy.";
+
+                    uses system-controlplane-qos-scheduler-seq-state;
+                  }
+                }
+              }
+            }
+          }
+        }
+
+        container egress {
+          description
+            "Control-plane traffic parameters relating to egress traffic.
+            This refers to traffic that is sent by the system's control
+            plane to external-to-the-controlplane destinations.";
+
+          uses system-controlplane-acl-common-top;
+        }
+      }
+    }
+
+    grouping system-controlplane-acl-common-top {
+      description
+        "Common structural grouping for ACL configuration and state for
+        control plane traffic.";
+
+      container acl {
+        description
+          "Configuration and operational state parameters relating to the
+          access control list applied to control-plane traffic.";
+
+        list acl-set {
+          key "set-name type";
+
+          description
+            "List of the ACL that is to be applied in the specific ingress
+            or egress context. The key of the list specifies the type of
+            traffic to be matched, along with a reference to an ACL
+            configured in the OpenConfig ACL model within the /acl hierarchy.";
+
+          leaf set-name {
+            type leafref {
+              path "../config/set-name";
+            }
+            description
+              "Reference to the name of the ACL-set to be applied.";
+          }
+
+          leaf type {
+            type leafref {
+              path "../config/type";
+            }
+            description
+              "Reference to the type of the ACL-set to be applied.";
+          }
+
+          container config {
+            description
+              "Configuration parameters relating to the ACL to be applied.";
+
+            uses system-controlplane-common-acl-config;
+          }
+
+          container state {
+            config false;
+            description
+              "Operational state parameters relating to the ACL to be applied.";
+            uses system-controlplane-common-acl-config;
+          }
+
+          uses oc-acl:interface-acl-entries-top;
+        }
+      }
+    }
+
+    grouping system-controlplane-common-acl-config {
+      description
+        "Grouping for ACL parameters relating to the system control-plane.";
+
+      leaf set-name {
+        type leafref {
+            path "/oc-acl:acl/oc-acl:acl-sets/oc-acl:acl-set/" +
+                  "oc-acl:config/oc-acl:name";
+        }
+        description
+          "Reference to the ACL to be applied to traffic
+          in the specified context (ingress or egress).";
+      }
+
+      leaf type {
+        type leafref {
+          path "/oc-acl:acl/oc-acl:acl-sets/oc-acl:acl-set" +
+              "[oc-acl:name=current()/../set-name]" +
+              "/oc-acl:config/oc-acl:type";
+        }
+        description
+          "Reference to the ACL set type applied to traffic
+          in the specified context (ingress or egress).";
+      }
+    }
+
+    grouping system-controlplane-qos-classifier-config {
+      description
+        "Grouping for configuration parameters relating to QoS classifiers
+        for the system control-plane.";
+
+      leaf name {
+          type leafref {
+              path "/oc-qos:qos/oc-qos:classifiers/oc-qos:classifier/" +
+              "oc-qos:config/oc-qos:name";
+          }
+          description
+            "Reference to a classifier that is used to classify traffic
+              destined to the control-plane of the system.
+              This classifier determines how packets that match each terms
+              are classified into forwarding groups, and subsequently into
+              queues to be forwarded.";
+      }
+    }
+
+    grouping system-controlplane-qos-classifier-term-state {
+      description
+        "Grouping for control-plane traffic specific leaves required for
+        each configuration term.";
+
+      leaf id {
+        // Current location /system/control-plane/ingress/qos/classifier/
+        // terms/term/state/id
+        type leafref {
+          path "/oc-qos:qos/oc-qos:classifiers/" +
+              "oc-qos:classifier[oc-qos:name=current()/../../../../config/name]" +
+              "/oc-qos:terms/oc-qos:term/oc-qos:config/oc-qos:id";
+        }
+        description
+          "Reference to a term identifier within the configured control-plane
+          classifier.";
+      }
+    }
+
+    grouping system-controlplane-qos-scheduler-config {
+      description
+        "Grouping for configuration parameters relating to the QoS scheduler
+        policy for control-plane traffic.";
+
+      leaf name {
+          type leafref {
+              path "/oc-qos:qos/oc-qos:scheduler-policies/oc-qos:scheduler-policy/" +
+              "oc-qos:config/oc-qos:name";
+          }
+          description
+            "Reference to a scheduler policy that determines rate limits, or
+            shaping of packets towards the control-plane.";
+      }
+    }
+
+    grouping system-controlplane-qos-scheduler-seq-state {
+      description
+        "Grouping for operational state parameters relating to indivual
+        schedulers within the applied scheduler policy.";
+
+      leaf sequence {
+        type leafref {
+          path "/oc-qos:qos/oc-qos:scheduler-policies/oc-qos:scheduler-policy" +
+             "[oc-qos:name=current()/../../../../config/name]" +
+             "/oc-qos:schedulers/oc-qos:scheduler/oc-qos:config/" +
+             "oc-qos:sequence";
+        }
+        description
+          "Reference to a scheduler within the configured scheduler policy.";
+      }
+
+      uses oc-qos:qos-scheduler-common-state;
+    }
+
+    augment "/oc-sys:system" {
+        description
+          "Add control-plane configuration and state to the system model.";
+
+        uses system-controlplane-top;
+    }
+}

--- a/models/yang/common/openconfig-system-grpc.yang
+++ b/models/yang/common/openconfig-system-grpc.yang
@@ -1,0 +1,310 @@
+module openconfig-system-grpc {
+  yang-version "1";
+
+  namespace "http://openconfig.net/yang/system-grpc";
+  prefix "oc-sys-grpc";
+
+  import openconfig-extensions { prefix oc-ext; }
+  import openconfig-system { prefix oc-sys; }
+  import openconfig-inet-types { prefix oc-inet; }
+  import openconfig-network-instance { prefix oc-ni; }
+  import openconfig-yang-types { prefix oc-yang; }
+
+  organization
+    "OpenConfig working group";
+  contact
+    "www.openconfig.net";
+
+  description
+    "This module adds configuration and operational state relating to gRPC
+    services running on a network device. The GRPC_SERVICE identity is used
+    to create an extensible list of services that can be instantiated, with
+    a base set defined in this module. New services can extend the identity
+    to be included in the list.";
+
+
+  oc-ext:openconfig-version "1.1.0";
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  revision "2024-05-29" {
+    description
+      "Add support for gRPC connections.";
+    reference "1.1.0";
+  }
+
+  revision "2022-04-19" {
+    description
+      "Description and default value updates for grpc-server
+      implementation guidance.";
+    reference "1.0.0";
+  }
+
+  revision "2021-06-16" {
+    description
+      "Remove trailing whitespace";
+    reference "0.1.1";
+  }
+
+  revision 2021-03-30 {
+    description
+      "Initial revision.";
+    reference "0.1.0";
+  }
+
+  identity GRPC_SERVICE {
+    description
+      "Base identity for a gRPC-based service.";
+  }
+
+  identity GNMI {
+    base GRPC_SERVICE;
+    description
+      "gNMI: gRPC Network Management Interface";
+  }
+
+  grouping grpc-service-structural {
+    description
+      "Structural grouping for gRPC services that can be enabled on
+      the system.";
+
+    container grpc-servers {
+      description
+        "List of gRPC servers that can be configured on the device.";
+
+      list grpc-server {
+        key "name";
+
+        description
+          "The list of gRPC servers that are running on the device. Each
+          instance within this list corresponds to an individual gRPC listener
+          that listens on a single TCP port on the specified addresses.
+          Where there are multiple services that run on a single port, these
+          are enabled through the service leaf-list which uses the GRPC_SERVICE
+          identity to list the supported service types.";
+
+        leaf name {
+          type leafref {
+            path "../config/name";
+          }
+          description
+            "Reference to the name of the service that is to be enabled.";
+        }
+
+        container config {
+          description
+            "Configuration parameters relating to the gRPC service.";
+
+          uses grpc-server-config;
+          }
+
+        container state {
+          config false;
+          description
+            "Operational state relating to the gRPC service.";
+          uses grpc-server-config;
+        }
+        uses connections-top;
+      }
+    }
+  }
+
+  grouping grpc-server-config {
+    description
+      "Configuration parameters corresponding to an individual gRPC
+      server.";
+
+    leaf name {
+      type string;
+      default "DEFAULT";
+      description
+        "The name of the gRPC server instance that is running on
+        the local system.
+
+        If the operator does not designate a name for the protocol
+        instance (e.g. config), the implementation should use the
+        name of 'DEFAULT' (e.g. state).  In addition, for
+        implementations that support a single gRPC server instance,
+        the default value is recommended for consistency.";
+    }
+
+    leaf-list services {
+      type identityref {
+        base GRPC_SERVICE;
+      }
+      description
+        "The gRPC service definitions that should be enabled for the
+        specified server. A target may support only specific
+        sets of services being enabled on the same server (e.g.,
+        it may be possible to run gNMI and gNOI services on the same
+        port, but not to run gRIBI and gNMI on the same port).
+
+        The set of gRPC services that are available to be configured is
+        defined through the GRPC_SERVICE identity, which can be extended
+        for each protocol that is based on gRPC that is available on the
+        device.";
+    }
+
+    leaf enable {
+      type boolean;
+      description
+        "When set to true, the gRPC server is enabled and runs on the
+        local device.";
+    }
+
+    leaf port {
+      type oc-inet:port-number;
+      description
+        "TCP port on which the gRPC server should listen.";
+    }
+
+    leaf transport-security {
+      type boolean;
+      default true;
+      description
+        "Use gRPC transport security (e.g., SSL or TLS). Enabled by default.
+        This leaf allows transport security to be disabled for use cases that
+        are not supported, such as lab testing.";
+    }
+
+    leaf certificate-id {
+      type string;
+      description
+        "Name of the certificate that is associated with the gRPC service. The
+        certificate ID is provisioned through other interfaces to the device, such
+        as the gNOI certificate management service.";
+    }
+
+    leaf metadata-authentication {
+      type boolean;
+      description
+        "When set to true, metadata authentication is enabled for the gRPC server.
+        In this mode of operation, gRPC metadata is used to carry authentication
+        credentials as per the specification in
+        https://github.com/openconfig/reference/blob/master/rpc/gnmi/gnmi-authentication.md#credentials-and-authentication.";
+    }
+
+    leaf-list listen-addresses {
+      type union {
+        type oc-inet:ip-address;
+        type enumeration {
+          enum ANY {
+            description
+              "The gRPC server should listen on any address bound to an interface
+              of the system.";
+          }
+        }
+      }
+      description
+        "The IP addresses that the gRPC server should listen on. This may be
+        an IPv4 or an IPv6 address (or both).";
+    }
+
+    leaf network-instance {
+      type oc-ni:network-instance-ref;
+      description
+        "The network instance within which the gRPC server is listening.
+        When unspecified, the DEFAULT_INSTANCE should be used.";
+    }
+  }
+
+  grouping grpc-counters {
+    description
+      "Top-level container for gRPC counters.";
+    container counters {
+      description
+        "Operational data for gRPC counters.";
+      uses grpc-counters-top;
+    }
+  }
+
+  grouping grpc-counters-top {
+    description
+      "Top-level container of operational data for gRPC counters.";
+
+    leaf bytes-sent {
+      type oc-yang:counter64;
+      description
+        "The total number of bytes sent to the client.";
+    }
+
+    leaf packets-sent {
+      type oc-yang:counter64;
+      description
+        "The total number of packets sent to the client.";
+    }
+
+    leaf data-send-error {
+      type oc-yang:counter64;
+      description
+        "A count of errors the gRPC server encountered when
+        sending data to a grpc client.";
+    }
+  }
+
+  grouping grpc-server-connections-state {
+    description
+      "Operational data for gRPC server connections.";
+
+    leaf address {
+      type oc-inet:ip-address;
+      description
+        "IPv4/IPv6 address of the gRPC server connection.";
+    }
+
+    leaf port {
+      type oc-inet:port-number;
+      description
+        "TCP/UDP port number for the gRPC server connection.";
+    }
+  }
+
+  grouping connections-top {
+    description
+      "Top-level grouping for data related to gRPC connections.";
+
+    container connections {
+      config false;
+      description
+        "Enclosing container for list of gRPC connections.";
+
+      list connection {
+        key "address port";
+        description
+          "List of gRPC connections";
+
+        leaf address {
+          type leafref {
+            path "../state/address";
+          }
+          description
+            "Reference to address list key.";
+        }
+
+        leaf port {
+          type leafref {
+            path "../state/port";
+          }
+          description
+            "Reference to port list key.";
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state data for gRPC connections.";
+
+          uses grpc-server-connections-state;
+          uses grpc-counters;
+        }
+      }
+    }
+  }
+
+  augment "/oc-sys:system" {
+    description
+      "Add gRPC service configuration to the openconfig-system model.";
+
+    uses grpc-service-structural;
+  }
+}

--- a/models/yang/common/openconfig-system-logging.yang
+++ b/models/yang/common/openconfig-system-logging.yang
@@ -10,7 +10,7 @@ module openconfig-system-logging {
   // import some basic types
   import openconfig-extensions { prefix oc-ext; }
   import openconfig-inet-types { prefix oc-inet; }
-
+  import openconfig-network-instance { prefix oc-ni; }
 
   // meta
   organization "OpenConfig working group";
@@ -23,7 +23,25 @@ module openconfig-system-logging {
     "This module defines configuration and operational state data
     for common logging facilities on network systems.";
 
-  oc-ext:openconfig-version "0.3.1";
+  oc-ext:openconfig-version "0.6.0";
+
+revision "2023-07-20" {
+    description
+      "adding VTY and local files as logging destinations";
+    reference "0.6.0";
+  }
+
+  revision "2023-05-04" {
+    description
+      "removing LOG_DESTINATION_TYPE identities";
+    reference "0.5.0";
+  }
+
+  revision "2022-12-29" {
+    description
+      "Add network-instance for remote logging servers";
+    reference "0.4.1";
+  }
 
   revision "2018-11-21" {
     description
@@ -220,35 +238,6 @@ module openconfig-system-logging {
       "IETF RFC 5424 - The Syslog Protocol";
   }
 
-  identity LOG_DESTINATION_TYPE {
-    description
-      "Base identity for destination for logging messages";
-  }
-
-  identity DEST_CONSOLE {
-    base LOG_DESTINATION_TYPE;
-    description
-      "Directs log messages to the console";
-  }
-
-  identity DEST_BUFFER {
-    base LOG_DESTINATION_TYPE;
-    description
-      "Directs log messages to and in-memory circular buffer";
-  }
-
-  identity DEST_FILE {
-    base LOG_DESTINATION_TYPE;
-    description
-      "Directs log messages to a local file";
-  }
-
-  identity DEST_REMOTE {
-    base LOG_DESTINATION_TYPE;
-    description
-      "Directs log messages to a remote syslog server";
-  }
-
   // typedef statements
 
     typedef syslog-severity {
@@ -371,12 +360,12 @@ module openconfig-system-logging {
 
   grouping logging-console-config {
     description
-      "Configuration data for console logging";
+      "Configuration data for console and vty logging";
   }
 
   grouping logging-console-state {
     description
-      "Operational state data for console logging";
+      "Operational state data for console and vty logging";
   }
 
   grouping logging-console-top {
@@ -426,6 +415,13 @@ module openconfig-system-logging {
         "Source IP address for packets to the log server";
     }
 
+    leaf network-instance {
+      type oc-ni:network-instance-ref;
+      description
+        "The network instance used to reach the log server.  If no
+        instance is specified, DEFAULT_INSTANCE is used.";
+    }
+
     leaf remote-port {
       type oc-inet:port-number;
       default 514;
@@ -446,7 +442,8 @@ module openconfig-system-logging {
 
     container remote-servers {
       description
-        "Enclosing container for the list of remote log servers";
+        "Enclosing container for the list of remote log
+         servers";
 
       list remote-server {
         key "host";
@@ -483,6 +480,154 @@ module openconfig-system-logging {
     }
   }
 
+  grouping logging-file-config {
+    description
+      "Configuration data for logfile";
+
+    leaf filename-prefix {
+      type string {
+        length 0..255;
+      }
+      description
+        "A name used for the file.  It is expected that an
+        implementation may append timestamp, serial-number or
+        other identifier to the filename.";
+    }
+
+    leaf path {
+      type string {
+        length 0..255;
+      }
+      description
+        "The fully specified path of the folder where the
+        logfile is stored.  The path is implementation specific
+        and may include attributes such as a drive identifier.";
+    }
+
+    leaf rotate {
+      type uint32;
+      default 0;
+      description
+        "Used for logfile rotation.
+         Log files are rotated the number of times defined by
+         this leaf.
+         The default value of 1 indicates that there will be one
+         rotation file and one active file.  A 0 value indicates
+         old versions are removed rather than rotated.";
+    }
+
+    leaf max-size {
+      type uint32;
+      default 1000;
+      description
+        "Used for logfile rotation.
+        Maximum size in Bytes, logfile may grow to. When logfile
+        reach this size it triggers log rotation. The log file need to
+        be save, closed, and new file open or future log storage.
+        If needed oldest logfile of same prefix shall be deleted to";
+    }
+
+    leaf max-open-time {
+      type uint32;
+      default 1440;
+      description
+        "Used for logfile rotation.
+        Maximum time, in minutes, the logfile can be open. When expires,
+        it triggers log rotation.
+        Actions are same ans when log file reaches its max-size.
+        it need to be closed, save, and new file open or future log
+        storage. If needed oldest logfile of same prefix shall be
+        deleted to ";
+    }
+  }
+
+  grouping logging-file-state {
+    description
+      "Operational state data for logfile";
+    leaf open-logfile {
+      type string{
+        length 0..511;
+      }
+      description
+        "the currently active/open filename prepended by folder path
+        and including suffix appended to filename-prefix by system";
+    }
+  }
+
+  grouping logging-files-top {
+    description
+      "Top-level grouping for local log files";
+
+    container files {
+      description
+        "Enclosing container for the list of log files";
+
+      list file {
+        key "path filename-prefix";
+        description
+          "List of logfiles";
+
+        leaf filename-prefix {
+          type leafref {
+            path "../config/filename-prefix";
+          }
+          description
+            "Reference to the logfiles list key";
+        }
+
+        leaf path {
+          type leafref {
+            path "../config/path";
+          }
+          description
+            "Reference to the logfiles list key";
+        }
+
+        container config {
+          description
+            "Configuration data for logfile";
+          uses logging-file-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state data for logfile servers";
+          uses logging-file-config;
+          uses logging-file-state;
+        }
+        uses logging-selectors-top;
+      }
+    }
+  }
+
+  grouping logging-vty-top {
+    description
+      "Top-level grouping for vty logging data";
+
+    container vty {
+      description
+        "Top-level container for data related to vty-based
+        logging (active sessions of ssh, telnet, etc )";
+
+      container config {
+        description
+          "Configuration data for vty logging";
+
+        uses logging-console-config;
+      }
+
+      container state {
+        config false;
+        description
+          "Operational state data for console logging";
+        uses logging-console-config;
+        uses logging-console-state;
+      }
+      uses logging-selectors-top;
+    }
+  }
+
   grouping logging-top {
     description
       "Top-level grouping for logging data";
@@ -493,6 +638,9 @@ module openconfig-system-logging {
 
       uses logging-console-top;
       uses logging-remote-top;
+      uses logging-files-top;
+      uses logging-vty-top;
+
     }
   }
   // data definition statements

--- a/models/yang/common/openconfig-system-utilization.yang
+++ b/models/yang/common/openconfig-system-utilization.yang
@@ -1,0 +1,115 @@
+module openconfig-system-utilization {
+  yang-version "1";
+
+  namespace "http://openconfig.net/yang/system-utilization";
+  prefix "oc-sys-util";
+
+  import openconfig-extensions { prefix oc-ext; }
+  import openconfig-system { prefix oc-sys; }
+  import openconfig-platform { prefix oc-platform; }
+
+  organization
+    "OpenConfig working group";
+  contact
+    "www.openconfig.net";
+
+  description
+    "This module adds configuration and operational state for
+    system wide resource utilization thresholds.";
+
+  oc-ext:openconfig-version "0.1.0";
+
+  revision "2023-02-13" {
+      description
+        "Add system wide utilization thresholds.";
+      reference
+        "0.1.0";
+  }
+
+  grouping system-resource-utilization-config {
+    description
+      "Configuration data for resource utilization. The configuration added here should
+      apply across all of the components that matches the respective resource.
+      /components/component/*/utilization/resources/resource/name";
+
+
+    leaf name {
+      type string;
+      description
+        "Resource name within the system.";
+    }
+
+    uses oc-platform:resource-utilization-threshold-common;
+  }
+
+  grouping system-resource-utilization-state {
+    description
+      "State data for resource utilization.";
+
+    leaf-list active-component-list {
+      type leafref {
+        path "/oc-platform:components/oc-platform:component/oc-platform:config/oc-platform:name";
+      }
+
+      description
+        "List of references to each component which has this resource.";
+    }
+  }
+
+  grouping system-resource-utilization-top {
+    description
+      "Top level grouping for system wide configuration of resources for
+      all components.";
+
+    container "utilization" {
+      description
+        "System wide resource utilization configuration.";
+
+      container "resources" {
+        description
+          "Enclosing container for the resources in the entire system. The system
+          resource names should be aggregated from the following collections:
+
+          * /components/component/chassis/utilization/resources/resource
+          * /components/component/integrate-circuit/utilization/resources/resource
+          * /components/component/linecard/utilization/resources/resource.";
+
+        list "resource" {
+          key "name";
+          description
+            "The list of all resources across all platform components keyed by
+            resource name.";
+
+          leaf name {
+            type leafref {
+              path "../config/name";
+            }
+            description
+              "References the resource name.";
+          }
+
+          container "config" {
+            description
+              "Configuration data for resource utilization.";
+            uses system-resource-utilization-config;
+          }
+
+          container "state" {
+            config false;
+            description
+              "Operational state data for resource utilization.";
+
+            uses system-resource-utilization-config;
+            uses system-resource-utilization-state;
+          }
+        }
+      }
+    }
+  }
+
+  augment "/oc-sys:system" {
+    description
+      "Add system resource utilization.";
+    uses system-resource-utilization-top;
+  }
+}

--- a/models/yang/openconfig-system.yang
+++ b/models/yang/openconfig-system.yang
@@ -14,11 +14,13 @@ module openconfig-system {
   import openconfig-extensions { prefix oc-ext; }
   import openconfig-aaa { prefix oc-aaa; }
   import openconfig-system-logging { prefix oc-log; }
-  import openconfig-system-management { prefix oc-sys-mgmt; }
   import openconfig-system-terminal { prefix oc-sys-term; }
   import openconfig-procmon { prefix oc-proc; }
+  import openconfig-platform { prefix oc-platform; }
   import openconfig-alarms { prefix oc-alarms; }
   import openconfig-messages { prefix oc-messages; }
+  import openconfig-license { prefix oc-license; }
+  import openconfig-network-instance { prefix oc-ni; }
 
   // meta
   organization "OpenConfig working group";
@@ -45,7 +47,119 @@ module openconfig-system {
     Section 4.c of the IETF Trust's Legal Provisions Relating
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
-  oc-ext:openconfig-version "0.7.0";
+  oc-ext:openconfig-version "2.1.0";
+
+  revision "2024-07-15" {
+    description
+      "Added auth key reference in ntp server configuration.";
+    reference "2.1.0";
+  }
+
+  revision "2023-12-20" {
+    description
+      "Change NTP offset, root-delay, and root-dispersion to int64 nanoseconds,
+      and update their descriptions for accuracy and clarity.";
+    reference "2.0.0";
+  }
+
+  revision "2023-10-26" {
+    description
+      "Add up-time leaf and promote module to version 1.0.";
+    reference "1.0.0";
+  }
+
+  revision "2023-06-16" {
+    description
+      "Reordered imports to be alphabetical.";
+    reference "0.17.1";
+  }
+
+  revision "2022-12-20" {
+    description
+      "Added network instance leaf to ntp client, and dropped
+      ntp-source-address from global to individual config. Removed ntp prefix.";
+    reference "0.17.0";
+  }
+
+  revision "2022-12-19" {
+    description
+      "Update last configuration timestamp documentation.";
+    reference "0.16.1";
+  }
+
+  revision "2022-09-28" {
+    description
+      "Add last configuration timestamp leaf.";
+    reference "0.16.0";
+  }
+
+  revision "2022-07-25" {
+    description
+      "Add system software version.";
+    reference "0.15.0";
+  }
+
+  revision "2022-07-20" {
+    description
+      "Added routing-mac system MAC address.";
+    reference "0.14.0";
+  }
+
+  revision "2022-07-12" {
+    description
+      "Modify ntp enabled description to reflect true and false case.";
+    reference "0.13.1";
+  }
+
+  revision "2021-07-20" {
+    description
+      "Adding list of mount points.";
+    reference "0.13.0";
+  }
+
+  revision "2021-07-14" {
+    description
+      "Support for additional RAM usage counters.";
+    reference "0.12.0";
+  }
+
+  revision "2021-06-28" {
+    description
+      "Adding system memory error counters.";
+    reference "0.11.1";
+  }
+
+  revision "2021-06-16" {
+    description
+      "Remove trailing whitespace";
+    reference "0.10.1";
+  }
+
+  revision "2020-04-13" {
+    description
+      "Remove the existing grpc-service, and add a new list
+      of the gRPC servers in a new module.";
+    reference "0.10.0";
+  }
+
+  revision "2020-03-25" {
+    description
+      "Fix typo in description statement for ipv4-address
+      list.";
+    reference "0.9.1";
+  }
+
+  revision "2020-01-07" {
+    description
+      "Add import of license management model.";
+    reference "0.9.0";
+  }
+
+  revision "2019-03-15" {
+    description
+      "Update boot time to be nanoseconds since epoch.";
+    reference "0.8.0";
+  }
 
   revision "2019-01-29" {
     description
@@ -217,6 +331,55 @@ module openconfig-system {
     }
   }
 
+  grouping mount-point-state {
+    description
+      "Operational state data for the mount point.";
+
+    leaf name {
+      type string;
+      description
+        "Mount point name.";
+    }
+
+    leaf storage-component {
+      type leafref {
+        path "/oc-platform:components/oc-platform:component/" +
+          "oc-platform:name";
+      }
+
+      description
+        "In the case that the filesystem that is mounted corresponds to a
+        physical or logical component within the system, this leaf provides
+        a reference to the hosting component within the /components
+        hierarchy.
+
+        The reference should be to the most specific component (e.g., if an
+        entry for /dev/sda1 exists, then this should be referred to,
+        otherwise a reference to /dev/sda may be provided.";
+    }
+
+    leaf size {
+      type uint64;
+      units megabytes;
+      description
+        "The total size of the initialised filesystem.";
+    }
+
+    leaf available {
+      type uint64;
+      units megabytes;
+      description
+        "The amount of unused space on the filesystem.";
+    }
+
+    leaf utilized {
+      type uint64;
+      units megabytes;
+      description
+        "The amount of space currently in use on the filesystem.";
+    }
+  }
+
   grouping system-global-state {
     description
       "Global operational state data for the system";
@@ -227,14 +390,77 @@ module openconfig-system {
           "The current system date and time.";
     }
 
+    leaf up-time {
+        type oc-types:timeticks64;
+        units "nanoseconds";
+        description
+          "The amount of time since the network operating system was
+          initialized.";
+    }
+
     leaf boot-time {
         type oc-types:timeticks64;
+        units "nanoseconds";
         description
           "This timestamp indicates the time that the system was last
-          restarted.  The value is the timestamp in seconds relative
+          restarted.  The value is the timestamp in nanoseconds relative
           to the Unix Epoch (Jan 1, 1970 00:00:00 UTC).";
     }
 
+    leaf software-version {
+        type string;
+        description
+          "Operating system version of the currently active controller
+          of the device.  It is required that this value matches the
+          value of the state/software-version leaf in the component
+          of type OPERATING_SYSTEM.";
+    }
+
+    leaf last-configuration-timestamp {
+      type oc-types:timeticks64;
+      units "nanoseconds";
+      description
+        "Indicates the monotonically increasing timestamp at which the
+        last configuration change was made. This may may be through CLI,
+        gNMI or some other mechanism. The value is the timestamp in
+        nanoseconds relative to the Unix Epoch (Jan 1, 1970 00:00:00 UTC).";
+    }
+  }
+
+  grouping mount-points-top {
+    description
+      "Top-level grouping for mount points data.";
+
+    container mount-points {
+      config false;
+      description
+        "When a system has a set of filesystems that are attached to a
+        directory (i.e., mounted on the system) they are expected to be
+        present in this list. If the system has the concept of mounting
+        physical or virtual resources to a mount point within the root
+        filesystem (/) they should also be included in this list.";
+
+      list mount-point {
+        key "name";
+        description
+          "List of mount points in the system.";
+
+        leaf name {
+          type leafref {
+            path "../state/name";
+          }
+          description
+            "Reference to the key for list of mount points.";
+        }
+
+        container state {
+          config false;
+          description
+            "State of system mount point.";
+          uses mount-point-state;
+        }
+      }
+    }
   }
 
   grouping system-dns-config {
@@ -252,7 +478,6 @@ module openconfig-system {
   grouping system-dns-state {
     description
       "Operational state data for system DNS resolver";
-
   }
 
   grouping system-dns-servers-config {
@@ -302,7 +527,7 @@ module openconfig-system {
     leaf-list ipv4-address {
       type oc-inet:ipv4-address;
       description
-        "List of IPv4 addressses for the host entry";
+        "List of IPv4 addresses for the host entry";
     }
 
     leaf-list ipv6-address {
@@ -346,9 +571,7 @@ module openconfig-system {
         }
 
         container state {
-
           config false;
-
           description
             "Operational state data for static host entries";
 
@@ -408,9 +631,7 @@ module openconfig-system {
         }
 
         container state {
-
           config false;
-
           description
             "Operational state data for each DNS resolver";
 
@@ -440,9 +661,7 @@ module openconfig-system {
       }
 
       container state {
-
         config false;
-
         description
           "Operational state data for the DNS resolver";
 
@@ -523,6 +742,26 @@ module openconfig-system {
         "Indicates whether this server should be preferred
         or not.";
     }
+
+    leaf network-instance {
+      type oc-ni:network-instance-ref;
+      description
+        "The network instance used to find this server.";
+    }
+
+    leaf source-address {
+      type oc-inet:ip-address;
+      description
+        "Source address to use on outgoing NTP packets";
+    }
+
+    leaf key-id {
+      type leafref {
+        path "../../../../ntp-keys/ntp-key/key-id";
+      }
+      description
+        "Reference to NTP authentication key for this server.";
+    }
   }
 
   grouping system-ntp-server-state {
@@ -549,39 +788,35 @@ module openconfig-system {
     }
 
     leaf root-delay {
-      type uint32;
-      // TODO: reconsider units for these values -- the spec defines
-      // rootdelay and rootdisperson as 2 16-bit integers for seconds
-      // and fractional seconds, respectively.  This gives a
-      // precision of ~15 us (2^-16).  Using milliseconds here based
-      // on what implementations typically provide and likely lack
-      // of utility for less than millisecond precision with NTP
-      // time sync.
-      units "milliseconds";
+      type int64;
+      units "nanoseconds";
       description
-        "The round-trip delay to the server, in milliseconds.";
+        "The total round-trip delay to the reference clock, in nanoseconds.";
       reference
         "RFC 5905 - Network Time Protocol Version 4: Protocol and
-        Algorithms Specification";
+        Algorithms Specification, Section 7.3";
     }
 
     leaf root-dispersion {
-      type uint64;
-      units "milliseconds";
+      type int64;
+      units "nanoseconds";
       description
-        "Dispersion (epsilon) represents the maximum error inherent
-        in the measurement";
+        "The maximum error inherent in the measurement, accumulated over the
+        stratum levels from the reference clock.";
       reference
         "RFC 5905 - Network Time Protocol Version 4: Protocol and
-        Algorithms Specification";
+        Algorithms Specification, Section 4";
     }
 
     leaf offset {
-      type uint64;
-      units "milliseconds";
+      type int64;
+      units "nanoseconds";
       description
         "Estimate of the current time offset from the peer.  This is
-        the time difference between the local and reference clock.";
+        the time difference of the peer's clock minus the local clock.";
+      reference
+        "RFC 5905 - Network Time Protocol Version 4: Protocol and
+        Algorithms Specification, Section 8";
     }
 
     leaf poll-interval {
@@ -625,16 +860,13 @@ module openconfig-system {
         }
 
         container state {
-
           config false;
-
           description
             "Operational state data for an NTP server.";
 
           uses system-ntp-server-config;
           uses system-ntp-server-state;
         }
-
       }
     }
   }
@@ -721,15 +953,9 @@ module openconfig-system {
       type boolean;
       default false;
       description
-        "Enables the NTP protocol and indicates that the system should
+        "Enables and disables the NTP protocol and indicates that the system should
         attempt to synchronize the system clock with an NTP server
         from the servers defined in the 'ntp/server' list.";
-    }
-
-    leaf ntp-source-address {
-      type oc-inet:ip-address;
-      description
-        "Source address to use on outgoing NTP packets";
     }
 
     leaf enable-ntp-auth {
@@ -782,6 +1008,52 @@ module openconfig-system {
     }
   }
 
+  grouping system-routing-macaddr-config {
+    description
+      "Configuration data for system's routing MAC addresses.";
+
+    leaf routing-mac {
+      type oc-yang:mac-address;
+      description
+        "Any packets destined to this MAC address must be sent through the
+        routing pipeline by the system. This MAC address is used to identify
+        routed packets in addition to any other MAC addresses that the system
+        may already have been using to perform routing.
+
+        It is not expected that this MAC address will be used as the
+        source MAC address of any routed packet, as the source MAC address of
+        any packets generated by the system, or a MAC address used in ARP
+        response. This MAC address may not be allocated from the block of
+        MAC address that system owns. For instance, it's allocation could
+        be managed by an external controller.";
+    }
+  }
+
+  grouping system-macaddr-top {
+    description
+      "Top-level grouping for configuration and state of system's MAC addresses.";
+
+    container mac-address {
+      description
+        "Top-level container for system's MAC address configuration and state";
+
+      container config {
+        description
+          "Configuration data for routing MAC address.";
+
+        uses system-routing-macaddr-config;
+      }
+
+      container state {
+        config false;
+        description
+          "Operational state data for routing MAC address.";
+
+        uses system-routing-macaddr-config;
+      }
+    }
+  }
+
   grouping system-memory-config {
     description
       "Configuration data for system memory";
@@ -806,6 +1078,47 @@ module openconfig-system {
       description
         "Memory reserved for system use";
     }
+
+    leaf used {
+      type uint64;
+      units bytes;
+      description
+        "Memory that has been used and not available for allocation.";
+    }
+
+    leaf free {
+      type uint64;
+      units bytes;
+      description
+        "Memory that is not used and is available for allocation.";
+    }
+  }
+
+  grouping system-memory-error-counters {
+    description
+      "Counters for system memory errors.";
+
+    leaf correctable-ecc-errors {
+      type uint64;
+      description
+        "Count of correctable ECC errors. Systems with ECC memory
+        are capable of correcting Single-bit ECC errors.";
+    }
+
+    leaf uncorrectable-ecc-errors {
+      type uint64;
+      description
+        "Count of uncorrectable ECC errors. Systems with ECC
+        memory are capable of detecting multi-bit ECC errors,
+        but cannot correct them.";
+    }
+
+    leaf total-ecc-errors {
+      type uint64;
+      description
+        "Count of total ECC errors, this includes both correctable
+        and uncorrectable ECC errors.";
+    }
   }
 
   grouping system-memory-top {
@@ -827,6 +1140,12 @@ module openconfig-system {
         config false;
         description
           "Operational state data for system memory";
+
+        container counters {
+          description
+            "Counters for tracking system memory errors";
+            uses system-memory-error-counters;
+        }
 
         uses system-memory-config;
         uses system-memory-state;
@@ -940,7 +1259,6 @@ module openconfig-system {
         }
 
         container state {
-
           description
             "Operational state data for the system CPU(s)";
 
@@ -963,7 +1281,6 @@ module openconfig-system {
         description "Global configuration data for the system";
 
         uses system-global-config;
-
       }
 
       container state {
@@ -974,24 +1291,24 @@ module openconfig-system {
         uses system-global-state;
       }
 
-      uses system-clock-top;
-      uses system-dns-top;
-      uses system-ntp-top;
-      uses oc-sys-mgmt:system-grpc-server-top;
+      uses mount-points-top;
+      uses oc-aaa:aaa-top;
+      uses oc-alarms:alarms-top;
+      uses oc-log:logging-top;
+      uses oc-proc:procmon-processes-top;
+      uses oc-messages:messages-top;
+      uses oc-license:license-top;
       uses oc-sys-term:system-ssh-server-top;
       uses oc-sys-term:system-telnet-server-top;
-      uses oc-log:logging-top;
-      uses oc-aaa:aaa-top;
-      uses system-memory-top;
+      uses system-clock-top;
       uses system-cpu-top;
-      uses oc-proc:procmon-processes-top;
-      uses oc-alarms:alarms-top;
-      uses oc-messages:messages-top;
+      uses system-dns-top;
+      uses system-macaddr-top;
+      uses system-memory-top;
+      uses system-ntp-top;
     }
   }
 
   // data definition statements
-
   uses system-top;
-
 }


### PR DESCRIPTION
Feature wise major changes -
system/state → uptime, software-version, last-configuration-timestamp nodes are added 
ntp → source-address moved to per server list from global container. Also network-instance is included per server.
            ntp key reference added for ntp servers
grpc-server → Restructured completely, multiple server provision is added. 
logging → For remote-server, network-instance support is added. Files & VTY containers are added newly 
memory → used and free leaves are added.
process → uptime leaf is removed

New features added in recent version -
license
mac-address
hashing
bootz
control-plane-traffic (copp)
resource utilization

Testing
======
Ensured no yang related error introduced, with pyang lint