### PR TITLE
Upgrading openconfig-system.yang version from 0.7.0 to 2.1.0

### DIFF
--- a/models/yang/common/openconfig-aaa-radius.yang
+++ b/models/yang/common/openconfig-aaa-radius.yang
@@ -26,7 +26,19 @@ submodule openconfig-aaa-radius {
     related to the RADIUS protocol for authentication,
     authorization, and accounting.";
 
-  oc-ext:openconfig-version "0.4.1";
+  oc-ext:openconfig-version "1.0.0";
+
+  revision "2022-07-29" {
+    description
+      "Update user role to be mandatory.";
+      reference "1.0.0";
+  }
+
+  revision "2020-07-30" {
+    description
+      "Add secret-key-hashed.";
+    reference "0.5.0";
+  }
 
   revision "2018-11-21" {
     description
@@ -95,6 +107,13 @@ submodule openconfig-aaa-radius {
       type oc-types:routing-password;
       description
         "The unencrypted shared key used between the authentication
+        server and the device.";
+    }
+
+    leaf secret-key-hashed {
+      type oc-aaa-types:crypt-password-type;
+      description
+        "The hashed shared key used between the authentication
         server and the device.";
     }
 

--- a/models/yang/common/openconfig-aaa-tacacs.yang
+++ b/models/yang/common/openconfig-aaa-tacacs.yang
@@ -25,7 +25,19 @@ submodule openconfig-aaa-tacacs {
     related to the TACACS+ protocol for authentication,
     authorization, and accounting.";
 
-  oc-ext:openconfig-version "0.4.1";
+  oc-ext:openconfig-version "1.0.0";
+
+  revision "2022-07-29" {
+    description
+      "Update user role to be mandatory.";
+      reference "1.0.0";
+  }
+
+  revision "2020-07-30" {
+    description
+      "Add secret-key-hashed.";
+    reference "0.5.0";
+  }
 
   revision "2018-11-21" {
     description
@@ -88,6 +100,13 @@ submodule openconfig-aaa-tacacs {
       type oc-types:routing-password;
       description
         "The unencrypted shared key used between the authentication
+        server and the device.";
+    }
+
+    leaf secret-key-hashed {
+      type oc-aaa-types:crypt-password-type;
+      description
+        "The hashed shared key used between the authentication
         server and the device.";
     }
 

--- a/models/yang/common/openconfig-aaa.yang
+++ b/models/yang/common/openconfig-aaa.yang
@@ -32,7 +32,31 @@ module openconfig-aaa {
     Portions of this model reuse data definitions or structure from
     RFC 7317 - A YANG Data Model for System Management";
 
-  oc-ext:openconfig-version "0.4.1";
+  oc-ext:openconfig-version "1.0.0";
+
+  revision "2022-07-29" {
+    description
+      "Update user role to be mandatory.";
+      reference "1.0.0";
+  }
+
+  revision "2020-07-30" {
+    description
+      "Add secret-key-hashed for TACACS and RADIUS.";
+    reference "0.5.0";
+  }
+
+  revision "2019-10-28" {
+    description
+      "Fix bug in when statement path";
+    reference "0.4.3";
+  }
+
+  revision "2019-08-20" {
+    description
+      "Fix identity prefixes and when statement paths";
+    reference "0.4.2";
+  }
 
   revision "2018-11-21" {
     description
@@ -266,11 +290,11 @@ module openconfig-aaa {
         }
 
         uses aaa-tacacs-server-top {
-          when "../../config/type = 'oc-aaa-types:TACACS'";
+          when "../../config/type = 'oc-aaa:TACACS'";
         }
 
         uses aaa-radius-server-top {
-          when "../../config/type = 'oc-aaa-types:RADIUS'";
+          when "../../config/type = 'oc-aaa:RADIUS'";
         }
       }
     }
@@ -378,10 +402,11 @@ module openconfig-aaa {
           base oc-aaa-types:SYSTEM_DEFINED_ROLES;
         }
       }
+      mandatory true;
       description
-        "Role assigned to the user.  The role may be supplied
-        as a string or a role defined by the SYSTEM_DEFINED_ROLES
-        identity.";
+        "Role assigned to the user.  The role must be supplied
+        as a role defined by the SYSTEM_DEFINED_ROLES
+        identity or a string that matches a user defined role.";
     }
   }
 

--- a/models/yang/common/openconfig-aft-common.yang
+++ b/models/yang/common/openconfig-aft-common.yang
@@ -1,0 +1,804 @@
+submodule openconfig-aft-common {
+  belongs-to "openconfig-aft" {
+    prefix "oc-aft";
+  }
+
+  import openconfig-interfaces { prefix "oc-if"; }
+  import openconfig-extensions { prefix "oc-ext"; }
+  import openconfig-yang-types { prefix "oc-yang"; }
+  import openconfig-inet-types { prefix "oc-inet"; }
+  import openconfig-mpls-types { prefix "oc-mplst"; }
+  import openconfig-policy-types { prefix "oc-pol-types"; }
+  import openconfig-aft-types { prefix "oc-aftt"; }
+  import openconfig-evpn-types { prefix "oc-evpn-types"; }
+
+  organization
+    "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "Submodule containing definitions of groupings that are re-used
+    across multiple contexts within the AFT model.";
+
+  oc-ext:openconfig-version "2.5.0";
+
+  revision "2024-01-26" {
+    description
+      "Add gre container under next-hops aft entry state.
+       Add src-ip, dst-ip and ttl under gre aft entry state
+       for telemetry. Updated description for
+       tunnel-src-ip-address properties under next-hops.";
+    reference "2.5.0";
+  }
+
+  revision "2023-09-26" {
+    description
+      "Add next-hop-group-name in NHG AFT entry state.";
+    reference "2.4.0";
+  }
+
+  revision "2023-04-19" {
+    description
+      "Add atomic attribute to AFT containers.";
+    reference "2.3.0";
+  }
+
+  revision "2022-06-16" {
+    description
+      "Add state-synced container under afts.";
+    reference "2.2.0";
+  }
+
+  revision "2022-06-15" {
+    description
+      "Add decapsulate-header in NH AFT entry state";
+    reference "2.1.0";
+  }
+
+  revision "2022-05-17" {
+    description
+      "Relocate next-hop-group/next-hop-group-network-instance
+      from openconfig-aft-common to resolve absolute path
+      leafref specific to network-instances";
+    reference "2.0.0";
+  }
+
+  revision "2022-01-27" {
+    description
+      "Add next hop counters and prefix counters.";
+    reference "1.0.0";
+  }
+
+  revision "2022-01-26" {
+    description
+      "Add vni-label and tunnel-src-ip-address properties under next-hops";
+    reference "0.10.0";
+  }
+
+  revision "2021-12-09" {
+    description
+      "Add pop-top-label in NH AFT entry state";
+    reference "0.9.0";
+  }
+
+  revision "2021-08-06" {
+    description
+      "Add references to the network instance within which to resolve
+      a next-hop-group; fix defect where NHG could not be an ID defined
+      outside the current NI; add metadata; add IP-in-IP encap.";
+    reference "0.8.0";
+  }
+
+  revision "2021-07-15" {
+    description
+      "NHG-ID and NH-ID space management.";
+    reference "0.7.0";
+  }
+
+  revision "2020-11-06" {
+    description
+      "Make AFT model read-only.";
+    reference "0.6.0";
+  }
+
+  revision "2020-09-09" {
+    description
+      "Remove leafs that are not used as keys from config containers as
+      AFT model is ready-only.
+      * next-hop/interface-ref/config.
+      * all leafs under policy-forwarding-entry/config except index.";
+    reference "0.5.0";
+  }
+
+  revision "2019-11-07" {
+    description
+      "Move lsp-name leaf out of aft-common-entry-nexthop-state group.";
+    reference "0.4.1";
+  }
+
+  revision "2019-08-02" {
+    description
+      "Add installing protocol for IPv[46] unicast entries.
+      Add the ability to describe conditional next-hop groups
+      outside of the policy forwarding module to allow for efficient
+      handling of CBTS, where many prefixes may share the same next-hop
+      criteria.";
+    reference "0.4.0";
+  }
+
+  revision "2019-08-01" {
+    description
+      "Add lsp-name leaf to AFT next-hop.";
+    reference "0.3.3";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "0.3.2";
+  }
+
+  revision 2017-08-24 {
+    description
+      "Formatting fixes";
+    reference "0.3.1";
+  }
+
+  revision 2017-05-10 {
+    description
+      "Refactor to provide concretised per-AF schemas per AFT.";
+    reference "0.3.0";
+  }
+
+  grouping aft-nhop-structural {
+    description
+      "Structural grouping describing a next-hop entry.";
+
+    container next-hops {
+      description
+        "The list of next-hops that are to be used for entry within
+        the AFT table. The structure of each next-hop is address
+        family independent, such that it is possible to resolve fully
+        how the next-hop is treated. For example:
+
+        - Where ingress IPv4 unicast packets are to be forwarded via
+          an MPLS LSP, the next-hop list should indicate the MPLS
+          label stack that is used to the next-hop.
+        - Where ingress MPLS labelled packets are to be forwarded to
+          an IPv6 nexthop (for example, a CE within a VPN, then the
+          popped label stack, and IPv6 next-hop address should be
+          indicated).";
+
+      list next-hop {
+        key "index";
+
+        oc-ext:telemetry-atomic;
+        description
+          "A next-hop associated with the forwarding instance.";
+
+        leaf index {
+          type leafref {
+            path "../state/index";
+          }
+          description
+            "A unique index identifying the next-hop entry for the
+            AFT entry";
+
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state parameters relating to the AFT
+            next-hop entry";
+
+          uses aft-common-entry-nexthop-state;
+          uses aft-labeled-entry-state;
+
+          container counters {
+            description
+              "Surrounding container for counters.";
+
+            uses aft-common-entry-counter-state;
+          }
+
+          uses aft-evpn-entry-state;
+
+        }
+
+        container ip-in-ip {
+          description
+            "When specified, the packet has an IP-in-IP header applied to it before
+            forwarding to the specified next-hop.";
+
+          container state {
+            config false;
+            description
+              "State parameters relating to IP-in-IP encapsulation.";
+            uses aft-common-entry-nexthop-ipip-state;
+          }
+        }
+
+        container gre {
+          description
+            "When specified, the packet has an GRE
+            (Generic Routing Encapsulation)header applied to
+            it before forwarding to the specified next-hop.
+            encapsulate-header leaf should be set to GRE for this
+            to apply";
+
+          container state {
+            config false;
+            description
+              "State parameters relating to GRE encapsulation.";
+            uses aft-common-entry-nexthop-gre-state;
+          }
+        }
+
+        uses oc-if:interface-ref-state;
+      }
+    }
+  }
+
+  grouping aft-common-entry-state {
+    description
+      "Operational state parameters relating to a forwarding entry";
+
+    container counters {
+      config false;
+      description
+        "Surrounding container for counters.";
+
+      uses aft-common-entry-counter-state;
+    }
+
+    leaf entry-metadata {
+      type binary {
+        length "0..8"; // 0 to 8 bytes
+      }
+      description
+        "Metadata persistently stored with the entry.";
+    }
+  }
+
+  grouping aft-labeled-entry-state {
+    description
+      "Operational state for LSP name in forwarding entry";
+
+    leaf lsp-name {
+      type string;
+      description
+        "Where applicable, the protocol name for the next-hop labelled
+        forwarding entry. This leaf is applicable only to next-hops
+        which include MPLS label information, and its value typically
+        corresponds to the RSVP-TE LSP name.";
+    }
+  }
+
+  grouping aft-evpn-entry-state {
+    description
+      "Operational state for evpn related information in forwarding entry";
+
+    leaf vni-label {
+      type oc-evpn-types:evi-id;
+      description
+        "Where applicable, the next hop label representing the virtual
+        network identifier (VNI) for the forwarding entry. This leaf is
+        applicable only to next-hops which include VXLAN encapsulation
+        header information";
+    }
+
+    leaf tunnel-src-ip-address {
+      type oc-inet:ip-address;
+      description
+        "Where applicable this represents the vxlan tunnel source ip address.
+        For VXLAN this represents the source VTEP ip address";
+    }
+  }
+
+  grouping aft-common-entry-nexthop-state {
+    description
+      "Parameters relating to a next-hop.";
+
+    leaf index {
+      type uint64;
+      description
+        "A unique entry for the next-hop.";
+    }
+
+    leaf programmed-index {
+      type uint64;
+      description
+        "In some routing protocols, or route injection mechanisms it
+        is possible to set the index of the next-hop via configuration
+        or the protocol itself. In some systems it may not be possible
+        to maintain the index provided by an external client when
+        advertising the same entry via telemetry.
+
+        This leaf reflects the configured or client-supplied index of
+        the next-hop. This allows a client to create an assocation or
+        mapping back to the original index pushed by the client, and
+        the ID used as a key in the next-hop AFT list.";
+    }
+
+    leaf ip-address {
+      type oc-inet:ip-address;
+      description
+        "The IP address of the next-hop system.";
+    }
+
+    leaf mac-address {
+      type oc-yang:mac-address;
+      description
+        "The MAC address of the next-hop if resolved by the local
+        network instance.";
+    }
+
+    leaf pop-top-label {
+      type boolean;
+      default false;
+      description
+        "Flag that controls pop action, i.e., the top-most MPLS label
+         should be popped from the packet when switched by the system.
+
+        The top-most MPLS label associated with pop action is equal to
+        the label key used in 'mpls' AFT 'label-entry' list.";
+    }
+
+    leaf-list pushed-mpls-label-stack {
+      type oc-mplst:mpls-label;
+      ordered-by user;
+      description
+        "The MPLS label stack imposed when forwarding packets to the
+        next-hop
+        - the stack is encoded as a leaf list whereby the order of the
+          entries is such that the first entry in the list is the
+          label at the bottom of the stack to be pushed.
+
+        To this end, a packet which is to forwarded to a device using
+        a service label of 42, and a transport label of 8072 will be
+        represented with a label stack list of [42, 8072].
+
+        The MPLS label stack list is ordered by the user, such that no
+        system re-ordering of leaves is permitted by the system.
+
+        A swap operation is reflected by entries in the
+        popped-mpls-label-stack and pushed-mpls-label-stack nodes.";
+
+    }
+
+    leaf encapsulate-header {
+      type oc-aftt:encapsulation-header-type;
+      description
+        "When forwarding a packet to the specified next-hop the local
+        system performs an encapsulation of the packet - adding the
+        specified header type.";
+    }
+
+    leaf decapsulate-header {
+      type oc-aftt:encapsulation-header-type;
+      description
+        "When forwarding a packet to the specified next-hop, the local
+         system performs a decapsulation of the packet - removing the
+         specified header type. In the case that no next-hop is
+         specified, the packet header is removed, and a subsequent
+         forwarding lookup is performed on the packet encapsulated
+         within the header, matched within the relevant AFT within the
+         specified network-instance.";
+    }
+
+    uses aft-common-install-protocol;
+  }
+
+  grouping aft-common-entry-nexthop-ipip-state {
+    description
+      "IP-in-IP encapsulation applied on a next-hop";
+
+    leaf src-ip {
+      type oc-inet:ip-address;
+      description
+        "Source IP address to use for the encapsulated packet.";
+    }
+
+    leaf dst-ip {
+      type oc-inet:ip-address;
+      description
+        "Destination IP address to use for the encapsulated packet.";
+    }
+  }
+
+  grouping aft-common-entry-nexthop-gre-state {
+    description
+      "GRE encapsulation applied on a IPv4 and IPv6 next-hop.";
+
+    leaf src-ip {
+      type oc-inet:ip-address;
+      description
+        "The source IP address for the GRE encapsulation may be expressed
+        using this leaf (src-ip) or if may be derived from
+        '../../interface-ref/state/subinterface'";
+    }
+
+    leaf dst-ip {
+      type oc-inet:ip-address;
+      description
+        "Destination IP address to use for the encapsulated packet.";
+    }
+
+    leaf ttl {
+      type uint8;
+      description
+        "This leaf reflects the configured/default TTL value that is used in the
+         outer header during packet encapsulation. When this leaf is not set,
+         the TTL value of the inner packet is copied over as the outer packet's
+         TTL value during encapsulation.";
+    }
+  }
+
+  grouping aft-common-install-protocol {
+    description
+      "Grouping for a common reference to the protocol which
+      installed an entry.";
+
+    leaf origin-protocol {
+      type identityref {
+        base "oc-pol-types:INSTALL_PROTOCOL_TYPE";
+      }
+      description
+        "The protocol from which the AFT entry was learned.";
+    }
+
+  }
+
+  grouping aft-common-ip-state {
+    description
+      "Common parameters across IP address families";
+
+    uses aft-common-install-protocol;
+
+    leaf decapsulate-header {
+      type oc-aftt:encapsulation-header-type;
+      description
+        "When forwarding a packet to the specified next-hop, the local
+        system performs a decapsulation of the packet - removing the
+        specified header type. In the case that no next-hop is
+        specified, the packet header is removed, and a subsequent
+        forwarding lookup is performed on the packet encapsulated
+        within the header, matched within the relevant AFT within the
+        specified network-instance.";
+    }
+  }
+
+  grouping aft-next-hop-groups-structural {
+    description
+      "Logical grouping for groups of next-hops.";
+
+    container next-hop-groups {
+      description
+        "Surrounding container for groups of next-hops.";
+
+      list next-hop-group {
+        key "id";
+
+        oc-ext:telemetry-atomic;
+        description
+          "An individual set of next-hops grouped into a common group.
+          Each entry within an abstract forwarding table points to a
+          next-hop-group. Entries in the next-hop-group are forwarded to
+          according to the weights specified for each next-hop group.
+
+          If an entry within the next-hop group becomes unusable, for
+          example due to an interface failure, the remaining entries
+          are used until all entries become unusable - at which point
+          the backup next-hop-group (if specified) is used.";
+
+        leaf id {
+          type leafref {
+            path "../state/id";
+          }
+          description
+            "A reference to a unique identifier for the next-hop-group.";
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state parameters relating to next-hop-groups.";
+
+          uses aft-nhg-state;
+        }
+
+        container next-hops {
+          description
+            "Surrounding container for the list of next-hops within
+            the next-hop-group.";
+
+          list next-hop {
+            key "index";
+
+            description
+              "An individual next-hop within the next-hop-group. Each
+              next-hop is a reference to an entry within the next-hop
+              list.";
+
+            leaf index {
+              type leafref {
+                path "../state/index";
+              }
+              description
+                "A reference to the index for the next-hop within the
+                the next-hop-group.";
+            }
+
+            container state {
+              config false;
+              description
+                "Operational state parameters related to a next-hop
+                within the next-hop-group.";
+              uses aft-nhg-nh-state;
+            }
+          }
+        }
+
+        container conditional {
+          description
+            "When a system selects a next-hop-group based on conditions
+            in addition to those specified in the referencing table entries
+            (for example, DSCP is used in addition to the IPv4 destination
+            prefix), these conditions are specified in the conditions list.
+            Where such conditions exist, the next-hop-group MUST only
+            specify next-hop-groups under the conditional list, and therefore
+            MUST NOT specify any corresponding next-hops. The
+            next-hop-groups that are referenced by any conditions MUST
+            reference only next-hops and therefore MUST NOT be conditional
+            themselves.";
+
+          list condition {
+            key "id";
+
+            description
+              "A conditional next-hop-group that is used by the AFT
+              entry. The conditions that are specified within the
+              group are logically ANDed together. If a condition
+              is a leaf-list field its contents are logically ORed.";
+
+            leaf id {
+              type leafref {
+                path "../state/id";
+              }
+              description
+                "A reference to the identifier for the condition.";
+            }
+
+            container state {
+              config false;
+              description
+                "Operational state parameters related to the conditional
+                next-hop selection.";
+              uses aft-nhg-conditional-state;
+            }
+
+            container input-interfaces {
+              description
+                "The set of input interfaces that are required to be matched for
+                the next-hop-group condition to be met. Each non-interface condition
+                is logically ANDed with each member of the list -- i.e., interfaces in
+                the list are logically ORed.
+
+                If the input-interface list is empty, the condition applies to ALL input
+                interfaces.";
+
+              list input-interface {
+                key "id";
+
+                description
+                  "The input interface that must be matched for the condition to be met.";
+
+                leaf id {
+                  type leafref {
+                    path "../state/id";
+                  }
+                  description
+                    "Reference to the unique ID assigned to the input interface within
+                    the conditions list.";
+                }
+
+                container state {
+                  config false;
+                  description
+                    "Operational state parameters that relate to the input interface.";
+                  uses aft-nhg-conditional-interface-state;
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  grouping aft-nhg-state {
+    description
+      "Operational state parameters related to a next-hop-group.";
+
+    leaf id {
+      type uint64;
+      description
+        "A unique identifier for the next-hop-group. This index
+        is not expected to be consistent across reboots, or
+        reprogramming of the next-hop-group. When updating
+        a next-hop-group, if the group is removed by the system
+        or assigned an alternate identifier, the system should
+        send telemetry notifications deleting the previous
+        identifier. If the identifier of the next-hop-group
+        is changed, all AFT entries that reference it must
+        also be updated.";
+    }
+
+    leaf next-hop-group-name {
+      type string;
+      description
+        "Where applicable, this leaf is a unique identifier string for the
+        next-hop-group. It is an arbitrary name for the group, that is
+        supported by vendors and is exposed for telemetry.";
+    }
+
+    leaf programmed-id {
+      type uint64;
+      description
+        "In some routing protocols or route injection mechanisms it
+        is possible to supply the ID of the next-hop-group via
+        configuration or the protocol itself. In some systems, it
+        may not be possible to use this same ID when returning the
+        NHG via telemetry.
+
+        This leaf reflects the ID of the next-hop group that was
+        used by the original programming mechanism.
+
+        This leaf allows a client to create an association between
+        a programmed next-hop's original ID, and the ID that is
+        extracted via telemetry as a key in the next-hop-group AFT
+        list.";
+    }
+
+    leaf color {
+      type uint64;
+      description
+        "An arbitrary colour that is used as an identifier for the next-hop
+        group. Some next-hop resolutions may utilise the colour to select
+        the particular next-hop-group that a routing entry should be resolved
+        to. In this case, next-hop-group selection may be based on colour
+        matches rather than the protocol specified next-hop.
+
+        Regardless of whether the next-hop-group's specified colour is
+        used to select an AFT's active forwarding entry, the next-hop-group
+        referenced by an entry should be the currently active value.
+
+        Next-hop-groups that are installed on the system through a protocol
+        that allows injection of such entries (e.g., BGP using the SR-TE
+        Policy SAFI, or gRPC-based RIB programming) should have the colour
+        specified in the injecting protocol within this leaf.";
+    }
+
+    leaf backup-next-hop-group {
+      // We are at afts/next-hop-groups/next-hop-group/state/backup-next-hop-group
+      type leafref {
+        path "../../../next-hop-group/state/id";
+      }
+      description
+        "The backup next-hop-group for the current group. When all
+        entries within the next-hop group become unusable, the backup
+        next-hop group is used if specified.";
+    }
+  }
+
+  grouping aft-nhg-nh-state {
+    description
+      "Operational state parameters relating to an individual next-hop
+      within the next-hop-group.";
+
+    leaf index {
+      type leafref {
+        // We are at afts/next-hop-groups/next-hop-group/next-hops/next-hop/state/id
+        path "../../../../../../next-hops/next-hop/state/index";
+      }
+      description
+        "A reference to the identifier for the next-hop to which
+        the entry in the next-hop group corresponds.";
+    }
+
+    leaf weight {
+      type uint64;
+      description
+        "The weight applied to the next-hop within the group. Traffic
+        is balanced across the next-hops within the group in the
+        proportion of weight/(sum of weights of the next-hops within
+        the next-hop group).";
+    }
+  }
+
+  grouping aft-nhg-conditional-state {
+    description
+      "Operational state parameters relating to the conditional selection
+      of a next-hop group for an AFT entry.";
+
+    leaf id {
+      type uint64;
+      description
+        "A unique identifier for the conditional criteria.";
+    }
+
+    leaf-list dscp {
+      type oc-inet:dscp;
+      description
+        "A set of DSCP values that must be matched by an input packet for
+        the next-hop-group specified to be selected. A logical OR is applied
+        across the DSCP values.";
+    }
+
+    leaf next-hop-group {
+      type leafref {
+        // we are at afts/next-hop-groups/next-hop-group/conditions/condition/state/next-hop-group
+        path "../../../../../next-hop-group/state/id";
+      }
+      description
+        "The next-hop-group that is used by the system for packets that match
+        the criteria specified.";
+    }
+  }
+
+  grouping aft-nhg-conditional-interface-state {
+    description
+      "Operational state parameters relating to the input-interface condition
+      for a next-hop-group.";
+
+    leaf id {
+      type string;
+      description
+        "A unique reference for the input interface.";
+    }
+
+    uses oc-if:interface-ref-common;
+  }
+
+  grouping aft-common-entry-counter-state {
+    description
+      "Counters relating to a forwarding entry";
+
+    leaf packets-forwarded {
+      type oc-yang:counter64;
+      description
+        "The number of packets which have matched, and been forwarded,
+         based on the AFT entry.";
+    }
+
+    leaf octets-forwarded {
+      type oc-yang:counter64;
+      description
+        "The number of octets which have matched, and been forwarded,
+         based on the AFT entry";
+    }
+  }
+
+  grouping aft-common-backup-entry-counter-state {
+    description
+      "Counters relating to a backup forwarding entry";
+
+    leaf packets-forwarded-backup {
+      type oc-yang:counter64;
+      description
+        "The number of packets which have matched, and been forwarded,
+         based on the AFT backup entry.";
+    }
+
+    leaf octets-forwarded-backup {
+      type oc-yang:counter64;
+      description
+        "The number of octets which have matched, and been forwarded,
+         based on the AFT backup entry";
+    }
+  }
+}

--- a/models/yang/common/openconfig-aft-ethernet.yang
+++ b/models/yang/common/openconfig-aft-ethernet.yang
@@ -1,0 +1,198 @@
+submodule openconfig-aft-ethernet {
+  belongs-to "openconfig-aft" {
+    prefix "oc-aft";
+  }
+
+  import openconfig-extensions { prefix "oc-ext"; }
+  import openconfig-yang-types { prefix "oc-yang"; }
+
+  // Include common cross-AFT groupings from the common submodule.
+  include openconfig-aft-common;
+
+  organization
+    "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "Submodule containing definitions of groupings for the abstract
+    forwarding tables for Ethernet.";
+
+  oc-ext:openconfig-version "2.5.0";
+
+  revision "2024-01-26" {
+    description
+      "Add gre container under next-hops aft entry state.
+      Add src-ip, dst-ip and ttl under gre aft entry state
+      for telemetry.";
+    reference "2.5.0";
+  }
+
+  revision "2023-09-26" {
+    description
+      "Add next-hop-group-name in NHG AFT entry state.";
+    reference "2.4.0";
+  }
+
+  revision "2023-04-19" {
+    description
+      "Add atomic attribute to AFT containers.";
+    reference "2.3.0";
+  }
+
+  revision "2022-06-16" {
+    description
+      "Add state-synced container under afts.";
+    reference "2.2.0";
+  }
+
+  revision "2022-06-15" {
+    description
+      "Add network-instance and decapsulate-header in NH AFT entry state";
+    reference "2.1.0";
+  }
+
+  revision "2022-05-17" {
+    description
+      "Relocate next-hop-group/next-hop-group-network-instance
+      from openconfig-aft-common to resolve absolute path
+      leafref specific to network-instances";
+    reference "2.0.0";
+  }
+
+  revision "2022-01-27" {
+    description
+      "Add next hop counters and prefix counters.";
+    reference "1.0.0";
+  }
+
+  revision "2022-01-26" {
+    description
+      "Add vni-label and tunnel-src-ip-address properties under next-hops";
+    reference "0.10.0";
+  }
+
+  revision "2021-12-09" {
+    description
+      "Add pop-top-label in NH AFT entry state";
+    reference "0.9.0";
+  }
+
+  revision "2021-08-06" {
+    description
+      "Add references to the network instance within which to resolve
+      a next-hop-group; fix defect where NHG could not be an ID defined
+      outside the current NI; add metadata; add IP-in-IP encap.";
+    reference "0.8.0";
+  }
+
+  revision "2021-07-15" {
+    description
+      "NHG-ID and NH-ID space management.";
+    reference "0.7.0";
+  }
+
+  revision "2020-11-06" {
+    description
+      "Make AFT model read-only.";
+    reference "0.6.0";
+  }
+
+  revision "2020-09-09" {
+    description
+      "Remove leafs that are not used as keys from config containers as
+      AFT model is ready-only.
+      * next-hop/interface-ref/config.
+      * all leafs under policy-forwarding-entry/config except index.";
+    reference "0.5.0";
+  }
+
+  revision "2019-11-07" {
+    description
+      "Move lsp-name leaf out of aft-common-entry-nexthop-state group.";
+    reference "0.4.1";
+  }
+
+  revision "2019-08-02" {
+    description
+      "Add installing protocol for IPv[46] unicast entries.
+      Add the ability to describe conditional next-hop groups
+      outside of the policy forwarding module to allow for efficient
+      handling of CBTS, where many prefixes may share the same next-hop
+      criteria.";
+    reference "0.4.0";
+  }
+
+  revision "2019-08-01" {
+    description
+      "Add lsp-name leaf to AFT next-hop.";
+    reference "0.3.3";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "0.3.2";
+  }
+
+  revision 2017-08-24 {
+    description
+      "Formatting fixes";
+    reference "0.3.1";
+  }
+
+  revision 2017-05-10 {
+    description
+      "Refactor to provide concretised per-AF schemas per AFT.";
+    reference "0.3.0";
+  }
+
+  grouping aft-ethernet-structural {
+    description
+      "Structural grouping defining the schema for the Ethernet
+      abstract forwarding table.";
+
+    list mac-entry {
+      key "mac-address";
+
+      oc-ext:telemetry-atomic;
+      description
+        "List of the Ethernet entries within the abstract
+        forwarding table. This list is keyed by the outer MAC address
+        of the Ethernet frame.";
+
+      leaf mac-address {
+        type leafref {
+          path "../state/mac-address";
+        }
+        description
+          "Reference to the outer MAC address matched by the
+          entry.";
+      }
+
+      container state {
+        config false;
+        description
+          "Operational state parameters for the Ethernet AFT
+          entry.";
+        uses aft-ethernet-entry-state;
+      }
+    }
+  }
+
+  grouping aft-ethernet-entry-state {
+    description
+      "Operational state parameters for the Ethernet AFT entry.";
+
+    leaf mac-address {
+        type oc-yang:mac-address;
+        description
+          "The outer MAC address of the Ethernet frame that must
+          be matched for the AFT entry to be utilised.";
+    }
+
+    uses aft-common-entry-state;
+  }
+}

--- a/models/yang/common/openconfig-aft-ipv4.yang
+++ b/models/yang/common/openconfig-aft-ipv4.yang
@@ -1,0 +1,204 @@
+submodule openconfig-aft-ipv4 {
+  belongs-to "openconfig-aft" {
+    prefix "oc-aft";
+  }
+
+  import openconfig-extensions { prefix "oc-ext"; }
+  import openconfig-inet-types { prefix "oc-inet"; }
+
+  // Include common cross-AFT groupings from the common submodule.
+  include openconfig-aft-common;
+
+  organization
+    "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "Submodule containing definitions of groupings for the abstract
+    forwarding tables for IPv4.";
+
+  oc-ext:openconfig-version "2.5.0";
+
+  revision "2024-01-26" {
+    description
+      "Add gre container under next-hops aft entry state.
+      Add src-ip, dst-ip and ttl under gre aft entry state
+      for telemetry.";
+    reference "2.5.0";
+  }
+
+  revision "2023-09-26" {
+    description
+      "Add next-hop-group-name in NHG AFT entry state.";
+    reference "2.4.0";
+  }
+
+  revision "2023-04-19" {
+    description
+      "Add atomic attribute to AFT containers.";
+    reference "2.3.0";
+  }
+
+  revision "2022-06-16" {
+    description
+      "Add state-synced container under afts.";
+    reference "2.2.0";
+  }
+
+  revision "2022-06-15" {
+    description
+      "Add decapsulate-header in NH AFT entry state";
+    reference "2.1.0";
+  }
+
+  revision "2022-05-17" {
+    description
+      "Relocate next-hop-group/next-hop-group-network-instance
+      from openconfig-aft-common to resolve absolute path
+      leafref specific to network-instances";
+    reference "2.0.0";
+  }
+
+  revision "2022-01-27" {
+    description
+      "Add next hop counters and prefix counters.";
+    reference "1.0.0";
+  }
+  revision "2022-01-26" {
+    description
+      "Add vni-label and tunnel-src-ip-address properties under next-hops";
+    reference "0.10.0";
+  }
+
+  revision "2021-12-09" {
+    description
+      "Add pop-top-label in NH AFT entry state";
+    reference "0.9.0";
+  }
+
+  revision "2021-08-06" {
+    description
+      "Add references to the network instance within which to resolve
+      a next-hop-group; fix defect where NHG could not be an ID defined
+      outside the current NI; add metadata; add IP-in-IP encap.";
+    reference "0.8.0";
+  }
+
+  revision "2021-07-15" {
+    description
+      "NHG-ID and NH-ID space management.";
+    reference "0.7.0";
+  }
+
+  revision "2020-11-06" {
+    description
+      "Make AFT model read-only.";
+    reference "0.6.0";
+  }
+
+  revision "2020-09-09" {
+    description
+      "Remove leafs that are not used as keys from config containers as
+      AFT model is ready-only.
+      * next-hop/interface-ref/config.
+      * all leafs under policy-forwarding-entry/config except index.";
+    reference "0.5.0";
+  }
+
+  revision "2019-11-07" {
+    description
+      "Move lsp-name leaf out of aft-common-entry-nexthop-state group.";
+    reference "0.4.1";
+  }
+
+  revision "2019-08-02" {
+    description
+      "Add installing protocol for IPv[46] unicast entries.
+      Add the ability to describe conditional next-hop groups
+      outside of the policy forwarding module to allow for efficient
+      handling of CBTS, where many prefixes may share the same next-hop
+      criteria.";
+    reference "0.4.0";
+  }
+
+  revision "2019-08-01" {
+    description
+      "Add lsp-name leaf to AFT next-hop.";
+    reference "0.3.3";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "0.3.2";
+  }
+
+  revision 2017-08-24 {
+    description
+      "Formatting fixes";
+    reference "0.3.1";
+  }
+
+  revision 2017-05-10 {
+    description
+      "Refactor to provide concretised per-AF schemas per AFT.";
+    reference "0.3.0";
+  }
+
+  grouping aft-ipv4-unicast-structural {
+    description
+      "Structural grouping defining the schema for the IPv4 unicast
+      abstract forwarding table.";
+
+    list ipv4-entry {
+      key "prefix";
+
+      oc-ext:telemetry-atomic;
+      description
+        "List of the IPv4 unicast entries within the abstract
+        forwarding table. This list is keyed by the destination IPv4
+        prefix.";
+
+      leaf prefix {
+        type leafref {
+          path "../state/prefix";
+        }
+        description
+          "Reference to the IPv4 unicast destination prefix which
+          must be matched to utilise the AFT entry.";
+      }
+
+      container state {
+        config false;
+        description
+          "Operational state parameters for the IPv4 unicast AFT
+          entry.";
+        uses aft-ipv4-unicast-entry-state;
+      }
+    }
+  }
+
+  grouping aft-ipv4-unicast-entry-state {
+    description
+      "Operational state parameters for the IPv4 unicast entry.";
+    leaf prefix {
+        type oc-inet:ipv4-prefix;
+        description
+          "The IPv4 destination prefix that should be matched to
+          utilise the AFT entry.";
+    }
+    uses aft-common-entry-state {
+      augment counters {
+        description
+          "The number of packets and octets matched the AFT entry
+          and routed to next-hops within the backup next-hop-group";
+
+        uses aft-common-backup-entry-counter-state;
+      }
+    }
+    uses aft-common-ip-state;
+  }
+}

--- a/models/yang/common/openconfig-aft-ipv6.yang
+++ b/models/yang/common/openconfig-aft-ipv6.yang
@@ -1,0 +1,205 @@
+submodule openconfig-aft-ipv6 {
+  belongs-to "openconfig-aft" {
+    prefix "oc-aft";
+  }
+
+  import openconfig-extensions { prefix "oc-ext"; }
+  import openconfig-inet-types { prefix "oc-inet"; }
+
+  // Include common cross-AFT groupings from the common submodule.
+  include openconfig-aft-common;
+
+  organization
+    "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "Submodule containing definitions of groupings for the abstract
+    forwarding tables for IPv6.";
+
+  oc-ext:openconfig-version "2.5.0";
+
+  revision "2024-01-26" {
+    description
+      "Add gre container under next-hops aft entry state.
+      Add src-ip, dst-ip and ttl under gre aft entry state
+      for telemetry.";
+    reference "2.5.0";
+  }
+
+  revision "2023-09-26" {
+    description
+      "Add next-hop-group-name in NHG AFT entry state.";
+    reference "2.4.0";
+  }
+
+  revision "2023-04-19" {
+    description
+      "Add atomic attribute to AFT containers.";
+    reference "2.3.0";
+  }
+
+  revision "2022-06-16" {
+    description
+      "Add state-synced container under afts.";
+    reference "2.2.0";
+  }
+
+  revision "2022-06-15" {
+    description
+      "Add decapsulate-header in NH AFT entry state";
+    reference "2.1.0";
+  }
+
+  revision "2022-05-17" {
+    description
+      "Relocate next-hop-group/next-hop-group-network-instance
+      from openconfig-aft-common to resolve absolute path
+      leafref specific to network-instances";
+    reference "2.0.0";
+  }
+
+  revision "2022-01-27" {
+    description
+      "Add next hop counters and prefix counters.";
+    reference "1.0.0";
+  }
+
+  revision "2022-01-26" {
+    description
+      "Add vni-label and tunnel-src-ip-address properties under next-hops";
+    reference "0.10.0";
+  }
+
+  revision "2021-12-09" {
+    description
+      "Add pop-top-label in NH AFT entry state";
+    reference "0.9.0";
+  }
+
+  revision "2021-08-06" {
+    description
+      "Add references to the network instance within which to resolve
+      a next-hop-group; fix defect where NHG could not be an ID defined
+      outside the current NI; add metadata; add IP-in-IP encap.";
+    reference "0.8.0";
+  }
+
+  revision "2021-07-15" {
+    description
+      "NHG-ID and NH-ID space management.";
+    reference "0.7.0";
+  }
+
+  revision "2020-11-06" {
+    description
+      "Make AFT model read-only.";
+    reference "0.6.0";
+  }
+
+  revision "2020-09-09" {
+    description
+      "Remove leafs that are not used as keys from config containers as
+      AFT model is ready-only.
+      * next-hop/interface-ref/config.
+      * all leafs under policy-forwarding-entry/config except index.";
+    reference "0.5.0";
+  }
+
+  revision "2019-11-07" {
+    description
+      "Move lsp-name leaf out of aft-common-entry-nexthop-state group.";
+    reference "0.4.1";
+  }
+
+  revision "2019-08-02" {
+    description
+      "Add installing protocol for IPv[46] unicast entries.
+      Add the ability to describe conditional next-hop groups
+      outside of the policy forwarding module to allow for efficient
+      handling of CBTS, where many prefixes may share the same next-hop
+      criteria.";
+    reference "0.4.0";
+  }
+
+  revision "2019-08-01" {
+    description
+      "Add lsp-name leaf to AFT next-hop.";
+    reference "0.3.3";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "0.3.2";
+  }
+
+  revision 2017-08-24 {
+    description
+      "Formatting fixes";
+    reference "0.3.1";
+  }
+
+  revision 2017-05-10 {
+    description
+      "Refactor to provide concretised per-AF schemas per AFT.";
+    reference "0.3.0";
+  }
+
+  grouping aft-ipv6-unicast-structural {
+    description
+      "Structural grouping defining the schema for the IPv6 unicast
+      abstract forwarding table.";
+
+    list ipv6-entry {
+      key "prefix";
+
+      oc-ext:telemetry-atomic;
+      description
+        "List of the IPv6 unicast entries within the abstract
+        forwarding table. This list is keyed by the destination IPv6
+        prefix.";
+
+      leaf prefix {
+        type leafref {
+          path "../state/prefix";
+        }
+        description
+          "Reference to the IPv6 unicast destination prefix which
+          must be matched to utilise the AFT entry.";
+      }
+
+      container state {
+        config false;
+        description
+          "Operational state parameters for the IPv6 unicast AFT
+          entry.";
+        uses aft-ipv6-unicast-entry-state;
+      }
+    }
+  }
+
+  grouping aft-ipv6-unicast-entry-state {
+    description
+      "Operational state parameters for the IPv6 unicast entry.";
+    leaf prefix {
+        type oc-inet:ipv6-prefix;
+        description
+          "The IPv6 destination prefix that should be matched to
+          utilise the AFT entry.";
+    }
+    uses aft-common-entry-state {
+      augment counters {
+        description
+          "The number of packets and octets matched the AFT entry
+          and routed to next-hops within the backup next-hop-group";
+
+        uses aft-common-backup-entry-counter-state;
+      }
+    }
+    uses aft-common-ip-state;
+  }
+}

--- a/models/yang/common/openconfig-aft-mpls.yang
+++ b/models/yang/common/openconfig-aft-mpls.yang
@@ -1,0 +1,216 @@
+submodule openconfig-aft-mpls {
+  belongs-to "openconfig-aft" {
+    prefix "oc-aft";
+  }
+
+  import openconfig-extensions { prefix "oc-ext"; }
+  import openconfig-mpls-types { prefix "oc-mplst"; }
+
+  // Include common cross-AFT groupings from the common submodule.
+  include openconfig-aft-common;
+
+
+  organization
+    "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "Submodule containing definitions of groupings for the abstract
+    forwarding table for MPLS label forwarding.";
+
+  oc-ext:openconfig-version "2.5.0";
+
+  revision "2024-01-26" {
+    description
+      "Add gre container under next-hops aft entry state.
+      Add src-ip, dst-ip and ttl under gre aft entry state
+      for telemetry.";
+    reference "2.5.0";
+  }
+
+  revision "2023-09-26" {
+    description
+      "Add next-hop-group-name in NHG AFT entry state.";
+    reference "2.4.0";
+  }
+
+  revision "2023-04-19" {
+    description
+      "Add atomic attribute to AFT containers.";
+    reference "2.3.0";
+  }
+
+  revision "2022-06-16" {
+    description
+      "Add state-synced container under afts.";
+    reference "2.2.0";
+  }
+
+  revision "2022-06-15" {
+    description
+      "Add decapsulate-header in NH AFT entry state";
+    reference "2.1.0";
+  }
+
+  revision "2022-05-17" {
+    description
+      "Relocate next-hop-group/next-hop-group-network-instance
+      from openconfig-aft-common to resolve absolute path
+      leafref specific to network-instances";
+    reference "2.0.0";
+  }
+
+  revision "2022-01-27" {
+    description
+      "Add next hop counters and prefix counters.";
+    reference "1.0.0";
+  }
+
+  revision "2022-01-26" {
+    description
+      "Add vni-label and tunnel-src-ip-address properties under next-hops";
+    reference "0.10.0";
+  }
+
+  revision "2021-12-09" {
+    description
+      "Add pop-top-label in NH AFT entry state";
+    reference "0.9.0";
+  }
+
+  revision "2021-08-06" {
+    description
+      "Add references to the network instance within which to resolve
+      a next-hop-group; fix defect where NHG could not be an ID defined
+      outside the current NI; add metadata; add IP-in-IP encap.";
+    reference "0.8.0";
+  }
+
+  revision "2021-07-15" {
+    description
+      "NHG-ID and NH-ID space management.";
+    reference "0.7.0";
+  }
+
+  revision "2020-11-06" {
+    description
+      "Make AFT model read-only.";
+    reference "0.6.0";
+  }
+
+  revision "2020-09-09" {
+    description
+      "Remove leafs that are not used as keys from config containers as
+      AFT model is ready-only.
+      * next-hop/interface-ref/config.
+      * all leafs under policy-forwarding-entry/config except index.";
+    reference "0.5.0";
+  }
+
+  revision "2019-11-07" {
+    description
+      "Move lsp-name leaf out of aft-common-entry-nexthop-state group.";
+    reference "0.4.1";
+  }
+
+  revision "2019-08-02" {
+    description
+      "Add installing protocol for IPv[46] unicast entries.
+      Add the ability to describe conditional next-hop groups
+      outside of the policy forwarding module to allow for efficient
+      handling of CBTS, where many prefixes may share the same next-hop
+      criteria.";
+    reference "0.4.0";
+  }
+
+  revision "2019-08-01" {
+    description
+      "Add lsp-name leaf to AFT next-hop.";
+    reference "0.3.3";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "0.3.2";
+  }
+
+  revision 2017-08-24 {
+    description
+      "Formatting fixes";
+    reference "0.3.1";
+  }
+
+  revision 2017-05-10 {
+    description
+      "Refactor to provide concretised per-AF schemas per AFT.";
+    reference "0.3.0";
+  }
+
+  grouping aft-mpls-structural {
+    description
+      "Structural grouping defining the schema for the MPLS
+      abstract forwarding table.";
+
+    list label-entry {
+      key "label";
+
+      oc-ext:telemetry-atomic;
+      description
+        "List of the MPLS entries within the abstract
+        forwarding table. This list is keyed by the top-most MPLS
+        label.";
+
+      leaf label {
+        type leafref {
+          path "../state/label";
+        }
+        description
+          "Reference to the top-most MPLS label matched by the
+          entry.";
+      }
+
+      container state {
+        config false;
+        description
+          "Operational state parameters for the MPLS AFT
+          entry.";
+        uses aft-mpls-entry-state;
+      }
+    }
+  }
+
+  grouping aft-mpls-entry-state {
+    description
+      "Operational state parameters for the MPLS entry.";
+
+    leaf label {
+      type oc-mplst:mpls-label;
+      description
+        "The top-most MPLS label that should be matched to
+        utilise the AFT entry.";
+    }
+
+    uses aft-common-entry-state;
+
+    leaf-list popped-mpls-label-stack {
+      type oc-mplst:mpls-label;
+      description
+        "The MPLS label stack to be popped from the packet when
+        switched by the system. The stack is encoded as a leaf-list
+        such that the first entry is the label that is outer-most (i.e.,
+        furthest from the bottom of the stack).
+
+        If the local system pops the outer-most label 400, then the
+        value of this list is [400,]. If the local system removes two
+        labels, the outer-most being 500, and the second of which is
+        400, then the value of the list is [500, 400].
+
+        A swap operation is reflected by entries in the
+        popped-mpls-label-stack and pushed-mpls-label-stack nodes.";
+    }
+  }
+}

--- a/models/yang/common/openconfig-aft-network-instance.yang
+++ b/models/yang/common/openconfig-aft-network-instance.yang
@@ -1,0 +1,182 @@
+module openconfig-aft-network-instance {
+  yang-version "1";
+
+  namespace "http://openconfig.net/yang/aft/ni";
+  prefix "oc-aftni";
+
+  import openconfig-extensions { prefix "oc-ext"; }
+  import openconfig-network-instance { prefix "oc-ni"; }
+
+  organization
+    "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+     www.openconfig.net";
+
+  description
+    "This module provides augmentations that are utilized
+     when building the OpenConfig network instance model to
+     add per-NI AFTs.";
+
+  oc-ext:openconfig-version "0.3.1";
+
+  revision "2023-04-25" {
+    description
+      "Clarify use of the interface-ref type.";
+    reference "0.3.1";
+  }
+
+  revision "2022-03-29" {
+    description
+      "Relocate next-hop-group/next-hop-group-network-instance
+      from openconfig-aft-common to resolve absolute path
+      leafref specific to network-instances";
+    reference "0.3.0";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "0.2.3";
+  }
+
+  revision 2017-08-24 {
+    description
+      "Formatting fixes";
+    reference "0.2.2";
+  }
+
+  revision 2017-01-13 {
+    description
+      "Updated revision for external review";
+    reference "0.2.1";
+  }
+
+  // OpenConfig specific extensions for module metadata.
+  oc-ext:regexp-posix;
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  grouping aft-nexthop-ni-state {
+    description
+      "Operational state parameters relating to a next-hop which reference a
+      network instance.";
+
+    leaf network-instance {
+      type oc-ni:network-instance-ref;
+      description
+        "The network-instance within which the next-hop should be resolved.
+         When this leaf is unspecified, the next-hop is resolved within
+         the local instance.";
+    }
+  }
+
+  grouping aft-entry-ni-state {
+    description
+      "Operational state parameters relating to an AFT entry which reference
+      a network instance.";
+
+    leaf origin-network-instance {
+      type oc-ni:network-instance-ref;
+      description
+        "If the AFT entry was imported from another network instance (e.g., it
+        corresponds to a L3 forwarding entry which was learned within another
+        network-instance), the value of this leaf reflects the network-instance
+        from which it was learned.
+
+        For example, if the local network-instance corresponds to a L3VRF, and
+        routes are imported from the VPNv4 address-family of the BGP instance
+        in the DEFAULT_INSTANCE, then this value would reflect the
+        DEFAULT_INSTANCE as the origin-network-instance.";
+    }
+  }
+
+  grouping aft-entry-nexthop-group-state {
+    description
+      "Operational state nexthop group parameters relating to an AFT entry
+      which reference a network instance.";
+
+    leaf next-hop-group {
+      type leafref {
+        path "/oc-ni:network-instances/oc-ni:network-instance/oc-ni:afts/" +
+             "oc-ni:next-hop-groups/oc-ni:next-hop-group/oc-ni:state/oc-ni:id";
+      }
+      description
+        "A reference to the next-hop-group that is in use for the entry within
+        the AFT. Traffic is distributed across the set of next-hops within the
+        next-hop group according to the weight. This node needs to refer to any
+        network-instance on the system hence must be absolute.";
+    }
+
+    leaf next-hop-group-network-instance {
+      type oc-ni:network-instance-ref;
+      description
+        "The network instance to look up the next-hop-group in. If unspecified,
+        the next hop group is in the local network instance. The referenced
+        network-instance must be an existing network instance on the device and
+        have corresponding entries in the /network-instances/network-instance
+        list.";
+    }
+  }
+
+  augment "/oc-ni:network-instances/oc-ni:network-instance/" +
+          "oc-ni:afts/oc-ni:next-hops/oc-ni:next-hop/oc-ni:state" {
+
+    description
+      "Add leaves that require referencing of a network instance to the
+      operational state parameters of a next-hop within the AFT for IPv4
+      unicast.";
+
+    uses aft-nexthop-ni-state;
+  }
+
+  augment "/oc-ni:network-instances/oc-ni:network-instance/" +
+          "oc-ni:afts/oc-ni:ipv4-unicast/oc-ni:ipv4-entry/oc-ni:state" {
+    description
+      "Add leaves that require referencing of a network instance to the
+      operational state parameters of an entry within the IPv4 unicast AFT.";
+
+    uses aft-entry-nexthop-group-state;
+    uses aft-entry-ni-state;
+  }
+
+  augment "/oc-ni:network-instances/oc-ni:network-instance/" +
+          "oc-ni:afts/oc-ni:ipv6-unicast/oc-ni:ipv6-entry/oc-ni:state" {
+    description
+      "Add leaves that require referencing of a network instance to the
+      operational state parameters of an entry within the IPv6 unicast AFT.";
+
+    uses aft-entry-nexthop-group-state;
+    uses aft-entry-ni-state;
+  }
+
+  augment "/oc-ni:network-instances/oc-ni:network-instance/" +
+          "oc-ni:afts/oc-ni:policy-forwarding/oc-ni:policy-forwarding-entry/" +
+          "oc-ni:state" {
+    description
+      "Add leaves that require referencing of a network instance to the
+      operational state parameters of an entry within the Policy Forwarding
+      AFT.";
+
+    uses aft-entry-nexthop-group-state;
+  }
+
+  augment "/oc-ni:network-instances/oc-ni:network-instance/" +
+          "oc-ni:afts/oc-ni:mpls/oc-ni:label-entry/oc-ni:state" {
+    description
+      "Add leaves that require referencing of a network instance to the
+      operational state parameters of an entry within the MPLS AFT.";
+
+    uses aft-entry-nexthop-group-state;
+  }
+
+  augment "/oc-ni:network-instances/oc-ni:network-instance/" +
+          "oc-ni:afts/oc-ni:ethernet/oc-ni:mac-entry/oc-ni:state" {
+    description
+      "Add leaves that require referencing of a network instance to the
+      operational state parameters of an entry within the Ethernet AFT.";
+
+    uses aft-entry-nexthop-group-state;
+  }
+}

--- a/models/yang/common/openconfig-aft-pf.yang
+++ b/models/yang/common/openconfig-aft-pf.yang
@@ -1,0 +1,275 @@
+submodule openconfig-aft-pf {
+  belongs-to "openconfig-aft" {
+    prefix "oc-aft";
+  }
+
+  import openconfig-extensions { prefix "oc-ext"; }
+  import openconfig-inet-types { prefix "oc-inet"; }
+  import openconfig-yang-types { prefix "oc-yang"; }
+  import openconfig-mpls-types { prefix "oc-mplst"; }
+  import openconfig-packet-match-types {
+    prefix "oc-pkt-match-types";
+  }
+
+  // Include common cross-AFT groupings from the common submodule.
+  include openconfig-aft-common;
+
+  organization
+    "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "Submodule containing definitions of groupings for the abstract
+    forwarding table(s) for policy forwarding entries. These are
+    defined to be forwarding tables that allow matches on
+    fields other than the destination address that is used in
+    other forwarding tables.";
+
+  oc-ext:openconfig-version "2.5.0";
+
+  revision "2024-01-26" {
+    description
+      "Add gre container under next-hops aft entry state.
+      Add src-ip, dst-ip and ttl under gre aft entry state
+      for telemetry.";
+    reference "2.5.0";
+  }
+
+  revision "2023-09-26" {
+    description
+      "Add next-hop-group-name in NHG AFT entry state.";
+    reference "2.4.0";
+  }
+
+  revision "2023-04-19" {
+    description
+      "Add atomic attribute to AFT containers.";
+    reference "2.3.0";
+  }
+
+  revision "2022-06-16" {
+    description
+      "Add state-synced container under afts.";
+    reference "2.2.0";
+  }
+
+  revision "2022-06-15" {
+    description
+      "Add decapsulate-header in NH AFT entry state";
+    reference "2.1.0";
+  }
+
+  revision "2022-05-17" {
+    description
+      "Relocate next-hop-group/next-hop-group-network-instance
+      from openconfig-aft-common to resolve absolute path
+      leafref specific to network-instances";
+    reference "2.0.0";
+  }
+
+  revision "2022-01-27" {
+    description
+      "Add next hop counters and prefix counters.";
+    reference "1.0.0";
+  }
+
+  revision "2022-01-26" {
+    description
+      "Add vni-label and tunnel-src-ip-address properties under next-hops";
+    reference "0.10.0";
+  }
+
+  revision "2021-12-09" {
+    description
+      "Add pop-top-label in NH AFT entry state";
+    reference "0.9.0";
+  }
+
+  revision "2021-08-06" {
+    description
+      "Add references to the network instance within which to resolve
+      a next-hop-group; fix defect where NHG could not be an ID defined
+      outside the current NI; add metadata; add IP-in-IP encap.";
+    reference "0.8.0";
+  }
+
+  revision "2021-07-15" {
+    description
+      "NHG-ID and NH-ID space management.";
+    reference "0.7.0";
+  }
+
+  revision "2020-11-06" {
+    description
+      "Make AFT model read only.";
+    reference "0.6.0";
+  }
+
+  revision "2020-09-09" {
+    description
+      "Remove leafs that are not used as keys from config containers as
+      AFT model is ready-only.
+      * next-hop/interface-ref/config.
+      * all leafs under policy-forwarding-entry/config except index.";
+    reference "0.5.0";
+  }
+
+  revision "2019-11-07" {
+    description
+      "Move lsp-name leaf out of aft-common-entry-nexthop-state group.";
+    reference "0.4.1";
+  }
+
+  revision "2019-08-02" {
+    description
+      "Add installing protocol for IPv[46] unicast entries.
+      Add the ability to describe conditional next-hop groups
+      outside of the policy forwarding module to allow for efficient
+      handling of CBTS, where many prefixes may share the same next-hop
+      criteria.";
+    reference "0.4.0";
+  }
+
+  revision "2019-08-01" {
+    description
+      "Add lsp-name leaf to AFT next-hop.";
+    reference "0.3.3";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "0.3.2";
+  }
+
+  revision 2017-08-24 {
+    description
+      "Formatting fixes";
+    reference "0.3.1";
+  }
+
+  revision 2017-05-10 {
+    description
+      "Refactor to provide concretised per-AF schemas per AFT.";
+    reference "0.3.0";
+  }
+
+  grouping aft-pf-structural {
+    description
+      "Structural grouping defining the schema for the policy
+      forwarding abstract forwarding table.";
+
+    list policy-forwarding-entry {
+      key "index";
+
+      oc-ext:telemetry-atomic;
+      description
+        "List of the policy forwarding entries within the abstract
+        forwarding table. Each entry is uniquely identified by an
+        index on the system, due to the arbitrary match conditions
+        that may be implemented within the policy forwarding AFT.
+        The index may change upon changes of the entry if, and only
+        if, the device exporting the AFT replaces the entire entry
+        by removing the previous entry and replacing it with a
+        subsequent updated version.";
+
+      leaf index {
+        type leafref {
+          path "../state/index";
+        }
+        description
+          "Reference to the arbitary index for the policy forwarding
+          AFT entry.";
+      }
+
+      container state {
+        config false;
+        description
+          "Operational state parameters for the Policy Forwarding
+          AFT entry.";
+        uses aft-pf-entry-state;
+      }
+    }
+  }
+
+  grouping aft-pf-entry-state {
+    description
+      "Operational state parameters for the Policy Forwarding
+      AFT entry.";
+
+    leaf index {
+      type uint64;
+      description
+        "An arbitrary 64-bit index identifying the policy forwarding
+        AFT entry.";
+    }
+
+    leaf ip-prefix {
+      type oc-inet:ip-prefix;
+      description
+        "The IP prefix that the forwarding entry matches.";
+    }
+
+    leaf mac-address {
+      type oc-yang:mac-address;
+      description
+         "The MAC address that the forwarding entry matches. Used for
+         Layer 2 forwarding entries, e.g., within a VSI instance.";
+    }
+
+    leaf mpls-label {
+      type oc-mplst:mpls-label;
+      description
+        "The MPLS label that the forwarding entry matches. Used for
+        MPLS forwarding entries, whereby the local device acts as an
+        LSR.";
+    }
+
+    leaf mpls-tc {
+      type oc-mplst:mpls-tc;
+      description
+        "The value of the MPLS Traffic Class bits (formerly known as
+        the MPLS experimental bits) that are to be matched by the AFT
+        entry.";
+      reference
+        "RFC5462: Multiprotocol Label Switching (MPLS) Label Stack
+        Entry: 'EXP' Field Renamed to 'Traffic Class' Field"; }
+
+    leaf ip-dscp {
+      type oc-inet:dscp;
+      description
+        "The value of the differentiated services code point (DSCP) to
+        be matched for the forwarding entry. The value is specified in
+        cases where specific class-based forwarding based on IP is
+        implemented by the device.";
+    }
+
+    leaf ip-protocol {
+      type oc-pkt-match-types:ip-protocol-type;
+      description
+        "The value of the IP protocol field of an IPv4 packet, or the
+        next-header field of an IPv6 packet which is to be matched by
+        the AFT entry. This field is utilised where forwarding is
+        performed based on L4 information.";
+    }
+
+    leaf l4-src-port {
+      type oc-inet:port-number;
+      description
+        "The value of the source port field of the transport header
+        that is to be matched by the AFT entry.";
+    }
+
+    leaf l4-dst-port {
+      type oc-inet:port-number;
+      description
+        "The value of the destination port field of the transport
+        header that is to be matched by the AFT entry.";
+    }
+
+    uses aft-common-entry-state;
+  }
+}

--- a/models/yang/common/openconfig-aft-state-synced.yang
+++ b/models/yang/common/openconfig-aft-state-synced.yang
@@ -1,0 +1,81 @@
+submodule openconfig-aft-state-synced {
+  belongs-to "openconfig-aft" {
+    prefix "oc-aft";
+  }
+
+  import openconfig-extensions { prefix "oc-ext"; }
+
+  organization
+    "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "Submodule containing definitions of groupings for the state
+    synced signals corresponding to various abstract forwarding tables.";
+
+  oc-ext:openconfig-version "2.5.0";
+
+  revision "2024-01-26" {
+    description
+      "Add gre container under next-hops aft entry state.
+      Add src-ip, dst-ip and ttl under gre aft entry state
+      for telemetry.";
+    reference "2.5.0";
+  }
+
+  revision "2023-09-26" {
+    description
+      "Add next-hop-group-name in NHG AFT entry state.";
+    reference "2.4.0";
+  }
+
+  revision "2023-04-19" {
+    description
+      "Add atomic attribute to AFT containers.";
+    reference "2.3.0";
+  }
+
+  revision "2022-06-16" {
+    description
+      "Add state-synced container under afts.";
+    reference "2.2.0";
+  }
+
+  grouping aft-state-synced-structural {
+    description
+      "Structural grouping defining the schema for the state synced signals
+      of various abstract forwarding table.";
+
+    container state {
+      config false;
+      description
+        "Operational state parameters relating to the state
+        synced signals of various AFTs.";
+
+      leaf ipv4-unicast {
+        type boolean;
+        default false;
+        description
+          "State synced signal indicating consistent device snapshot of
+          IPv4 unicast AFT entries. Before setting this flag to true
+          next-hop-groups and next-hops AFT entries, associated with
+          ipv4-unicast AFT entries, are expected to be consistent with
+          device snapshot.";
+      }
+
+      leaf ipv6-unicast {
+        type boolean;
+        default false;
+        description
+          "State synced signal indicating consistent device snapshot of
+          IPv6 unicast AFT entries. Before setting this flag to true
+          next-hop-groups and next-hops AFT entries, associated with
+          ipv6-unicast AFT entries, are expected to be consistent with
+          device snapshot.";
+      }
+    }
+  }
+}

--- a/models/yang/common/openconfig-aft-summary.yang
+++ b/models/yang/common/openconfig-aft-summary.yang
@@ -1,0 +1,125 @@
+module openconfig-aft-summary {
+  yang-version "1";
+
+  namespace "http://openconfig.net/yang/aft-summary";
+
+  prefix "oc-aftsummary";
+
+  import openconfig-extensions { prefix "oc-ext"; }
+  import openconfig-policy-types { prefix "oc-pol-types"; }
+  import openconfig-network-instance { prefix "oc-ni"; }
+
+  organization
+    "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This module provides summary of aft entry counts per protocol type for each network
+    instance.";
+
+  oc-ext:openconfig-version "0.2.0";
+
+  revision "2024-01-12" {
+    description
+      "Change count of entries from counter64 to uint64.";
+    reference "0.2.0";
+  }
+
+  revision "2023-11-09" {
+    description
+      "Initial version.";
+    reference "0.1.0";
+  }
+
+  grouping protocols-state {
+    description
+      "Grouping for protocol type state.";
+
+    leaf origin-protocol {
+      description
+        "Protocol type that keys the protocol list.";
+
+      type identityref {
+        base "oc-pol-types:INSTALL_PROTOCOL_TYPE";
+      }
+    }
+
+    container counters {
+      description
+      "Enclosing container for aft entry counters";
+
+      leaf aft-entries {
+        description
+          "Total number of entries in the aft.";
+        type uint64;
+      }
+    }
+  }
+
+  grouping aft-summary {
+    description
+      "A summary of aft entries by protocol type.";
+
+    container protocols {
+      description
+        "Enclosing container for a list of protocols";
+      list protocol {
+        key "origin-protocol";
+
+        description
+          "Protocol type that keys the aft entry count list.";
+
+        leaf origin-protocol {
+          type leafref {
+            path "../state/origin-protocol";
+          }
+          description
+            "Reference to the protocol type which added the aft entry.";
+        }
+
+        container state {
+          description
+            "State parameters for the aft entry list.";
+          uses protocols-state;
+        }
+      }
+    }
+  }
+
+  grouping aft-summary-ipv4 {
+    description
+      "Grouping of all aft summaries for ipv4.";
+      container ipv4-unicast {
+        description
+          "Container for ipv4 unicast aft summary by protocol type.";
+        uses aft-summary;
+      }
+  }
+
+  grouping aft-summary-ipv6 {
+    description
+      "Grouping of all aft summaries for ipv6.";
+      container ipv6-unicast {
+        description
+          "Container for ipv6 aft counts by protocol type.";
+        uses aft-summary;
+      }
+  }
+
+  augment "/oc-ni:network-instances/oc-ni:network-instance/oc-ni:afts" {
+    description
+      "Augment the afts model with the aft summary container.";
+
+    container aft-summaries {
+      uses aft-summary-ipv4;
+      uses aft-summary-ipv6;
+
+      description
+        "Aft summary for the network instance.";
+    }
+  }
+
+}

--- a/models/yang/common/openconfig-aft-types.yang
+++ b/models/yang/common/openconfig-aft-types.yang
@@ -1,0 +1,97 @@
+module openconfig-aft-types {
+
+  namespace "http://openconfig.net/yang/fib-types";
+  prefix "oc-aftt";
+
+  import openconfig-extensions { prefix "oc-ext"; }
+
+  organization
+    "OpenConfig Working Group";
+
+  contact
+    "OpenConfig Working Group
+    www.openconfig.net";
+
+  description
+    "Types related to the OpenConfig Abstract Forwarding
+    Table (AFT) model";
+
+  oc-ext:openconfig-version "1.1.0";
+
+  revision "2022-05-05" {
+    description
+        "Add network-instance and decapsulate-header in NH AFT entry state";
+      reference "1.1.0";
+  }
+
+  revision "2021-08-24" {
+    description
+      "Add vxlan to next-hops encapsulation-header-type.";
+    reference "0.3.5";
+  }
+
+  revision "2019-11-07" {
+    description
+      "Move lsp-name leaf out of aft-common-entry-nexthop-state group.";
+    reference "0.3.4";
+  }
+
+  revision "2019-08-01" {
+    description
+      "Add lsp-name leaf to AFT next-hop.";
+    reference "0.3.3";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "0.3.2";
+  }
+
+  revision 2017-08-24 {
+    description
+      "Formatting fixes";
+    reference "0.3.1";
+  }
+
+  revision 2017-05-10 {
+    description
+      "Refactor to provide concretised per-AF schemas per AFT.";
+    reference "0.3.0";
+  }
+
+  // OpenConfig specific extensions for module metadata.
+  oc-ext:regexp-posix;
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  typedef encapsulation-header-type {
+    type enumeration {
+      enum GRE {
+        description
+          "The encapsulation header is a Generic Routing Encapsulation
+          header.";
+      }
+      enum IPV4 {
+        description
+          "The encapsulation header is an IPv4 packet header";
+      }
+      enum IPV6 {
+        description
+          "The encapsulation header is an IPv6 packet header";
+      }
+      enum MPLS {
+        description
+          "The encapsulation header is one or more MPLS labels indicated
+          by the pushed and popped label stack lists.";
+      }
+      enum VXLAN {
+        description
+          "The encapsulation header is a VXLAN packet header";
+      }
+    }
+    description
+      "Types of tunnel encapsulation that are supported by systems as either
+      head- or tail-end.";
+  }
+}

--- a/models/yang/common/openconfig-aft.yang
+++ b/models/yang/common/openconfig-aft.yang
@@ -1,0 +1,289 @@
+module openconfig-aft {
+
+  yang-version "1";
+
+  namespace "http://openconfig.net/yang/aft";
+
+  prefix "oc-aft";
+
+  import openconfig-extensions { prefix "oc-ext"; }
+
+  // Include IPv4 AFT submodule.
+  include openconfig-aft-ipv4;
+  // Include IPv6 AFT submodule.
+  include openconfig-aft-ipv6;
+  // Include MPLS AFT submodule.
+  include openconfig-aft-mpls;
+  // Include policy forwarding AFT submodule.
+  include openconfig-aft-pf;
+  // Include the ethernet AFT submodule.
+  include openconfig-aft-ethernet;
+  // Include the common cross-AFT entities.
+  include openconfig-aft-common;
+  // Include the state synced submodule.
+  include openconfig-aft-state-synced;
+
+  organization
+    "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "A model describing the forwarding entries installed on a network
+    element. It should be noted that this model is not expected to
+    align 1:1 with the underlying structure used directly by a
+    forwarding element (e.g., linecard), but rather provide an
+    abstraction that can be consumed by an NMS to observe, and in some
+    cases manipulate, the internal forwarding database in a simplified
+    manner. Since the underlying model of the forwarding table is not
+    expected to align with this model, the structure described herein
+    is referred to as an Abstract Forwarding Table (AFT), rather than
+    the FIB.";
+
+  oc-ext:openconfig-version "2.5.0";
+
+  revision "2024-01-26" {
+    description
+      "Add gre container under next-hops aft entry state.
+      Add src-ip, dst-ip and ttl under gre aft entry state
+      for telemetry.";
+    reference "2.5.0";
+  }
+
+  revision "2023-09-26" {
+    description
+      "Add next-hop-group-name in NHG AFT entry state.";
+    reference "2.4.0";
+  }
+
+  revision "2023-04-19" {
+    description
+      "Add atomic attribute to AFT containers.";
+    reference "2.3.0";
+  }
+
+  revision "2022-06-16" {
+    description
+      "Add state-synced container under afts.";
+    reference "2.2.0";
+  }
+
+  revision "2022-06-15" {
+    description
+      "Add decapsulate-header in NH AFT entry state";
+    reference "2.1.0";
+  }
+
+  revision "2022-05-17" {
+    description
+      "Relocate next-hop-group/next-hop-group-network-instance
+      from openconfig-aft-common to resolve absolute path
+      leafref specific to network-instances";
+    reference "2.0.0";
+  }
+
+  revision "2022-01-27" {
+    description
+      "Add next hop counters and prefix counters.";
+    reference "1.0.0";
+  }
+
+  revision "2022-01-26" {
+    description
+      "Add vni-label and tunnel-src-ip-address properties under next-hops";
+    reference "0.10.0";
+  }
+
+  revision "2021-12-09" {
+    description
+      "Add pop-top-label in NH AFT entry state";
+    reference "0.9.0";
+  }
+
+  revision "2021-08-06" {
+    description
+      "Add references to the network instance within which to resolve
+      a next-hop-group; fix defect where NHG could not be an ID defined
+      outside the current NI; add metadata; add IP-in-IP encap.";
+    reference "0.8.0";
+  }
+
+  revision "2021-07-15" {
+    description
+      "NHG-ID and NH-ID space management.";
+    reference "0.7.0";
+  }
+
+  revision "2020-11-06" {
+    description
+      "Make AFT model read-only.";
+    reference "0.6.0";
+  }
+
+  revision "2020-09-09" {
+    description
+      "Remove leafs that are not used as keys from config containers as
+      AFT model is ready-only.
+      * next-hop/interface-ref/config.
+      * all leafs under policy-forwarding-entry/config except index.";
+    reference "0.5.0";
+  }
+
+  revision "2019-11-07" {
+    description
+      "Move lsp-name leaf out of aft-common-entry-nexthop-state group.";
+    reference "0.4.1";
+  }
+
+  revision "2019-08-02" {
+    description
+      "Add installing protocol for IPv[46] unicast entries.
+      Add the ability to describe conditional next-hop groups
+      outside of the policy forwarding module to allow for efficient
+      handling of CBTS, where many prefixes may share the same next-hop
+      criteria.";
+    reference "0.4.0";
+  }
+
+  revision "2019-08-01" {
+    description
+      "Add lsp-name leaf to AFT next-hop.";
+    reference "0.3.3";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "0.3.2";
+  }
+
+  revision 2017-08-24 {
+    description
+      "Formatting fixes";
+    reference "0.3.1";
+  }
+
+  revision 2017-05-10 {
+    description
+      "Refactor to provide concretised per-AF schemas per AFT.";
+    reference "0.3.0";
+  }
+
+  // OpenConfig specific extensions for module metadata.
+  oc-ext:regexp-posix;
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  // config + state groupings
+
+  // structural groupings
+
+  grouping aft-top {
+    description
+      "Top-level grouping allowing per-protocol instantiation of the
+      AFT.";
+
+    container afts {
+      config false;
+      description
+        "The abstract forwarding tables (AFTs) that are associated
+        with the network instance. An AFT is instantiated per-protocol
+        running within the network-instance - such that one exists for
+        IPv4 Unicast, IPv6 Unicast, MPLS, L2 forwarding entries, etc.
+        A forwarding entry within the FIB has a set of next-hops,
+        which may be a reference to an entry within another table -
+        e.g., where a Layer 3 next-hop has an associated Layer 2
+        forwarding entry.";
+
+      container ipv4-unicast {
+        description
+          "The abstract forwarding table for IPv4 unicast. Entries
+          within this table are uniquely keyed on the IPv4 unicast
+          destination prefix which is matched by ingress packets.
+
+          The data set represented by the IPv4 Unicast AFT is the set
+          of entries from the IPv4 unicast RIB that have been selected
+          for installation into the FIB of the device exporting the
+          data structure.";
+
+        uses aft-ipv4-unicast-structural;
+      }
+
+      container ipv6-unicast {
+        description
+          "The abstract forwarding table for IPv6 unicast. Entries
+          within this table are uniquely keyed on the IPv6 unicast
+          destination prefix which is matched by ingress packets.
+
+          The data set represented by the IPv6 Unicast AFTis the set
+          of entries within the IPv6 unicast RIB that have been
+          selected for installation into the FIB of the device
+          exporting the data structure.";
+
+        uses aft-ipv6-unicast-structural;
+      }
+
+      container policy-forwarding {
+        description
+          "The abstract forwarding table for policy-based forwarding
+          entries. Since multiple match criteria can be utilised
+          within a policy-based forwarding rule, this AFT provides a
+          flexible match criteria, and is indexed based on an
+          arbitrary 64-bit index. Entries within the AFT may match on
+          multiple field types (e.g., L4 header fields, as well as L2
+          fields).
+
+          Examples of entries within this table are:
+            - IPv4 policy-based routing based on DSCP.
+            - MPLS policy-based forwarding entries.";
+
+        uses aft-pf-structural;
+      }
+
+      container mpls {
+        description
+          "The abstract forwarding table for MPLS label based
+          forwarding entries. Entries within the table are keyed based
+          on the top-most MPLS label in the stack on the ingress
+          packet.";
+
+        uses aft-mpls-structural;
+      }
+
+      container ethernet {
+        description
+          "The abstract forwarding table for Ethernet based forwarding
+          entries. Entries within the table are keyed based on the
+          destination MAC address on the ingress packet.";
+
+        uses aft-ethernet-structural;
+      }
+
+      container state-synced {
+        description
+          "In some cases AFT streaming (e.g., over gNMI) is an eventually consistent system.
+          When the device updates an entry it is usually expected to
+          stream an update to the client within a vert short amount
+          of time (few milliseconds). Given this is the casee, a telemetry collector or a
+          controller that parse the AFT doesn't have a consistent
+          snapshot, or overall versioned copy of AFT with the device
+          at any specific point of time.
+
+          In certain failure modes like device boot up, gNMI daemon
+          failure and device/routing engine stateful switchover
+          a telemetry collector or a controller need a flag to
+          determine whether it is in consistent with the device or
+          not such that it can a corrective action when needed.
+          A device sets this leaf or flag to indicate to the
+          client that AFT data/view is consistent.";
+
+        uses aft-state-synced-structural;
+      }
+
+      uses aft-next-hop-groups-structural;
+      uses aft-nhop-structural;
+    }
+  }
+}

--- a/models/yang/common/openconfig-alarms.yang
+++ b/models/yang/common/openconfig-alarms.yang
@@ -42,7 +42,13 @@ module openconfig-alarms {
     Section 4.c of the IETF Trust's Legal Provisions Relating
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
-  oc-ext:openconfig-version "0.3.1";
+  oc-ext:openconfig-version "0.3.2";
+
+  revision "2019-07-09" {
+    description
+      "Clarify relative base for leaves using timeticks64.";
+    reference "0.3.2";
+  }
 
   revision "2018-11-21" {
     description
@@ -119,7 +125,7 @@ module openconfig-alarms {
       type oc-types:timeticks64;
       description
         "The time at which the alarm was raised by the system.
-        This value is expressed as nanoseconds since the Unix Epoch";
+        This value is expressed relative to the Unix Epoch.";
     }
 
     leaf severity {

--- a/models/yang/common/openconfig-bfd.yang
+++ b/models/yang/common/openconfig-bfd.yang
@@ -1,0 +1,775 @@
+module openconfig-bfd {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/bfd";
+
+  prefix "oc-bfd";
+
+  // import some basic types
+  import openconfig-extensions { prefix "oc-ext"; }
+  import openconfig-types { prefix "oc-types"; }
+  import openconfig-interfaces { prefix "oc-if"; }
+  import openconfig-inet-types { prefix "oc-inet"; }
+  import openconfig-policy-types { prefix "oc-pol-types"; }
+  import ietf-inet-types { prefix "ietf-if"; }
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "An OpenConfig model of Bi-Directional Forwarding Detection (BFD)
+    configuration and operational state.";
+
+  oc-ext:openconfig-version "0.3.0";
+
+  revision "2024-03-05" {
+    description
+      "Add configuration of min interval, multiplier when
+      BFD is enabled at protocol level";
+    reference "0.3.0";
+ }
+
+  revision "2023-08-09" {
+    description
+      "Update interface key to use interface-id type";
+    reference "0.2.6";
+  }
+
+  revision "2023-02-06" {
+    description
+      "Clarify interface references.";
+    reference "0.2.5";
+  }
+
+  revision "2022-06-28" {
+    description
+      "Remove reference to invalid oc-ift type check";
+    reference "0.2.4";
+  }
+
+  revision "2021-06-16" {
+    description
+      "Remove trailing whitespace";
+    reference "0.2.3";
+  }
+
+  revision "2021-03-17" {
+    description
+      "Remove augments from bfd module.
+       Add bfd support directly on the protocols";
+    reference "0.2.2";
+  }
+
+  revision "2020-05-08" {
+    description
+      "Ensure that when statements reference only read-write leaves
+      from read-write contexts.
+      Add ietf-inet-types LAG type to conditions for micro-bfd.";
+    reference "0.2.1";
+  }
+
+  revision "2019-10-25" {
+    description
+      "Correct when statements.";
+    reference "0.2.0";
+  }
+
+  revision "2019-06-02" {
+    description
+      "Fix detection multiplier to be 8-bit value";
+    reference "0.1.1";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "0.1.0";
+  }
+
+  revision "2017-10-19" {
+    description
+      "Adopt OpenConfig types models, type corrections";
+    reference "0.0.2";
+  }
+
+  revision "2016-06-24" {
+    description
+      "Initial revision";
+    reference "0.0.1";
+  }
+
+  // OpenConfig specific extensions for module metadata.
+  oc-ext:regexp-posix;
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  typedef bfd-session-state {
+    type enumeration {
+      enum UP {
+        description
+          "The BFD session is perceived to be up by the system.";
+      }
+      enum DOWN {
+        description
+          "The BFD session is perceived to be down by the system.";
+      }
+      enum ADMIN_DOWN {
+        description
+          "The BFD session is administratively disabled.";
+      }
+      enum INIT {
+        description
+          "The BFD session is perceived to be initialising by the
+          system.";
+      }
+    }
+    description
+      "The state of the BFD session according to the system referred
+      to by the context of the leaf.";
+    reference
+      "RFC5880 - Bidirectional Forwarding Detection, Section
+      4.1";
+  }
+
+  typedef bfd-diagnostic-code {
+    type enumeration {
+      enum NO_DIAGNOSTIC {
+        value 0;
+        description
+          "No diagnostic code was specified, or the session has not
+          changed state.";
+      }
+      enum DETECTION_TIMEOUT {
+        value 1;
+        description
+          "The control detection time expired: no BFD packet was
+          received within the required period.";
+      }
+      enum ECHO_FAILED {
+        value 2;
+        description
+          "The BFD echo function failed - echo packets have not been
+          received for the required period of time.";
+      }
+      enum FORWARDING_RESET {
+        value 3;
+        description
+          "The forwarding plane in the local system was reset - such
+          that the remote system cannot rely on the forwarding state of
+          the device specifying this error code.";
+      }
+      enum PATH_DOWN {
+        value 4;
+        description
+          "Signalling outside of BFD specified that the path underlying
+          this session has failed.";
+      }
+      enum CONCATENATED_PATH_DOWN {
+        value 5;
+        description
+          "When a BFD session runs over a series of path segments, this
+          error code indicates that a subsequent path segment (i.e.,
+          one in the transmit path between the source and destination
+          of the session) has failed.";
+      }
+      enum ADMIN_DOWN {
+        value 6;
+        description
+          "The BFD session has been administratively disabled by the
+          peer.";
+      }
+      enum REVERSE_CONCATENATED_PATH_DOWN {
+        value 7;
+        description
+          "In the case that a BFD session is running over a series of
+          path segments, this error code indicates that a path segment
+          on the reverse path (i.e., in the transmit direction from the
+          destination to the source of the session) has failed.";
+      }
+    }
+    description
+      "Diagnostic codes defined by BFD. These typically indicate the
+      reason for a change of session state.";
+    reference
+      "RFC5880 - Bidirectional Forwarding Detection, Section
+      4.1";
+  }
+
+
+  grouping bfd-interface-config {
+    description
+      "Top-level per-interface configuration parameters for BFD.";
+
+    leaf id {
+      type oc-if:interface-id;
+      description
+        "A unique identifier for the interface.";
+    }
+
+    leaf enabled {
+      type boolean;
+      description
+        "When this leaf is set to true then the BFD session is enabled
+        on the specified interface - if it is set to false, it is
+        administratively disabled.";
+    }
+
+    leaf local-address {
+      type oc-inet:ip-address;
+      description
+        "The source IP address to be used for BFD sessions over this
+        interface.";
+    }
+
+    uses bfd-configuration;
+
+    leaf enable-per-member-link {
+      type boolean;
+      default false;
+      description
+        "When this leaf is set to true - BFD will be enabled on
+        each member interface of the aggregated Ethernet bundle.";
+    }
+  }
+
+  grouping bfd-interface-state {
+    // placeholder
+    description
+      "Operational state parameters relating to BFD running on an
+      interface.";
+  }
+
+  grouping bfd-session-state-mode-timers-common {
+    description
+      "Common operational state parameters that are re-used across
+      both asynchronous and echo modes of BFD.";
+
+    leaf last-packet-transmitted {
+      type uint64;
+      description
+        "The date and time at which the last BFD packet
+        was transmitted for this session, expressed as the number
+        of nanoseconds since the Unix Epoch (January 1, 1970,
+        00:00 UTC).";
+    }
+
+    leaf last-packet-received {
+      type uint64;
+      description
+        "The date and time at which the last BFD packet
+        was received for this session, expressed as the number
+        of nanoseconds since the Unix Epoch (January 1, 1970,
+        00:00 UTC).";
+    }
+
+    leaf transmitted-packets {
+      // TODO: looks to be unsupported on JUNOS
+      type uint64;
+      description
+        "The number of packets that have been transmitted
+        by the local system.";
+    }
+
+    leaf received-packets {
+      // TODO: looks to be unsupported on JUNOS
+      type uint64;
+      description
+        "The number of packets that have been received by the
+        local system from the remote neighbour.";
+    }
+
+    leaf up-transitions {
+      // TODO: looks to only be supported in SROS
+      type uint64;
+      description
+        "The number of times that the adjacency with the neighbor
+        has transitioned into the up state.";
+    }
+  }
+
+  grouping bfd-session-state-sessiondetails-common {
+    description
+      "Common session details for a BFD session.";
+
+    leaf session-state {
+      type bfd-session-state;
+      description
+        "The state of the BFD session perceived by the local system.";
+
+    }
+
+    leaf remote-session-state {
+      type bfd-session-state;
+      description
+        "The reported state of the BFD session according to the remote
+        system. This state reflects the last state reported in a BFD
+        control packet.";
+    }
+
+    leaf last-failure-time {
+      type oc-types:timeticks64;
+      description
+        "The time of the last transition of the BFD session out of
+        the UP state, expressed as the number of nanoseconds since
+        the Unix epoch.";
+    }
+
+    leaf failure-transitions {
+      type uint64;
+      description
+        "The number of times that the BFD session has transitioned
+        out of the UP state.";
+    }
+
+    leaf local-discriminator {
+      type string;
+      description
+        "A unique identifier used by the local system to identify this
+        BFD session.";
+    }
+
+    leaf remote-discriminator {
+      type string;
+      description
+        "A unique identified used by the remote system to identify this
+        BFD session.";
+    }
+
+    leaf local-diagnostic-code {
+      type bfd-diagnostic-code;
+      description
+        "The local BFD diagnostic code indicating the most recent
+        reason for failure of this BFD session.";
+    }
+
+    leaf remote-diagnostic-code {
+      type bfd-diagnostic-code;
+      description
+        "The remote BFD diagnostic code indicating the remote system's
+        reason for failure of the BFD session";
+    }
+
+    leaf remote-minimum-receive-interval {
+      type uint32;
+      description
+        "The value of the minimum receive interval that was specified
+        in the most recent BFD control packet received from the peer.";
+    }
+
+    leaf demand-mode-requested {
+      type boolean;
+      description
+        "This leaf is set to true when the remote system has requested
+        demand mode be run for this session.";
+    }
+
+    leaf remote-authentication-enabled {
+      type boolean;
+      description
+        "This leaf is set to true when the remote system has specified
+        that authentication is present for the BFD session.";
+    }
+
+    leaf remote-control-plane-independent {
+      type boolean;
+      description
+        "This leaf is set to true when the remote system has specified
+        that the hardware implementing this BFD session is independent
+        of the control plane's liveliness.";
+    }
+  }
+
+
+  grouping bfd-session-state-async-common {
+    description
+      "Common parameters for asynchronous BFD sessions";
+
+    container async {
+      description
+        "Operational state parameters specifically relating to
+        asynchronous mode of BFD.";
+
+      uses bfd-session-state-mode-timers-common;
+    }
+  }
+
+  grouping bfd-session-state-echo-common {
+    description
+      "Common parameters for echo-mode BFD sessions.";
+
+    container echo {
+      description
+        "Operational state parameters specifically relating to the
+        echo mode of BFD.";
+
+      leaf active {
+        type boolean;
+        description
+          "This leaf is set to true when echo mode is running between
+          the local and remote system. When it is set to false, solely
+          asynchronous mode is active.";
+      }
+
+      uses bfd-session-state-mode-timers-common;
+    }
+  }
+
+
+  grouping bfd-session-state-common {
+    description
+      "Common operational state parameters that may be re-used across
+      multiple BFD session contexts.";
+
+    leaf local-address {
+      type oc-inet:ip-address;
+      description
+        "The IP address used by the local system for this BFD session.";
+    }
+
+    leaf remote-address {
+      type oc-inet:ip-address;
+      description
+        "The IP address used by the remote system for this BFD session.";
+    }
+
+    leaf-list subscribed-protocols {
+      type identityref {
+        base "oc-pol-types:INSTALL_PROTOCOL_TYPE";
+      }
+      description
+        "Indicates the set of protocols that currently use
+        this BFD session for liveliness detection.";
+    }
+
+    uses bfd-session-state-sessiondetails-common;
+    uses bfd-session-state-echo-common;
+    uses bfd-session-state-async-common;
+  }
+
+  grouping bfd-session-microbfd-common {
+    description
+      "BFD session parameters utilised only for micro-BFD sessions.";
+
+    uses bfd-session-state-sessiondetails-common;
+    uses bfd-session-state-async-common;
+  }
+
+  grouping bfd-interface-peer-state {
+    description
+      "Per-peer, per-interface operational state parameters for BFD.";
+
+    uses bfd-session-state-common;
+  }
+
+  grouping bfd-interface-microbfd-config {
+    description
+      "Configuration parameters for a microBFD session on an
+      interface.";
+
+    leaf local-address {
+      type oc-inet:ip-address;
+      description
+        "The local IP address used by the system for the micro-BFD session
+        specified.";
+    }
+
+    leaf remote-address {
+      type oc-inet:ip-address;
+      description
+        "The remote IP destination that should be used by the system for
+        the micro-BFD session specified.";
+    }
+
+    leaf member-interface {
+      type leafref {
+        path "/oc-if:interfaces/" +
+          "oc-if:interface/oc-if:config/oc-if:name";
+      }
+      // rjs: Note that this does not restrict to only interfaces that
+      // are part of the current LAG. An implementation should return
+      // NOK if such an interface is specified.
+      description
+        "Reference to a member link of the aggregate interface being
+        described.";
+    }
+  }
+
+  grouping bfd-interface-microbfd-state {
+    description
+      "Operational state parameters relating to a micro-BFD session on
+      an interface.";
+
+    uses bfd-session-microbfd-common;
+  }
+
+  grouping bfd-interface-microbfd-structural {
+    description
+      "Structural grouping for micro-bfd configuration and state
+      parameters.";
+
+    container micro-bfd-sessions {
+      when "/oc-if:interfaces/oc-if:interface" +
+          "[oc-if:name=current()/../interface-ref/config/interface]/" +
+          "oc-if:config/oc-if:type = 'ietf-if:ieee8023adLag'" {
+        description
+          "Include per-member link BFD only when the type of
+          interface is a link aggregate.";
+      }
+
+      description
+        "Parameters relating to micro-BFD sessions associated
+        with the interface.";
+
+      list micro-bfd-session {
+        key "member-interface";
+
+        description
+          "This list contains configuration and state parameters
+          relating to micro-BFD session.";
+        reference
+          "RFC7130 - Bidirectional Forwarding Detection (BFD)
+          on Link Aggregation Group (LAG) Interfaces.";
+
+
+        leaf member-interface {
+          type leafref {
+            path "../config/member-interface";
+          }
+          description
+            "A reference to the member interface of the link
+            aggregate.";
+        }
+
+        container config {
+          description
+            "Configuration parameters for the micro-BFD session.";
+          uses bfd-interface-microbfd-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state parameters for the micro-BFD session.";
+          uses bfd-interface-microbfd-config;
+          uses bfd-interface-microbfd-state;
+        }
+      }
+    }
+  }
+
+  grouping bfd-interface-peer-structural {
+    description
+      "Structural grouping for BFD peers (in the context of an interface).";
+
+    container peers {
+      description
+        "Parameters relating to the BFD peers which are seen
+        over this interface.";
+
+      list peer {
+        key "local-discriminator";
+        config false;
+
+        description
+          "Parameters relating to the BFD peer specified by the
+          remote address.";
+
+        leaf local-discriminator {
+          type leafref {
+            path "../state/local-discriminator";
+          }
+          description
+            "The local discriminator, which is unique for the
+            session on the system.";
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state parameters for the BFD session.";
+
+          uses bfd-interface-peer-state;
+        }
+      }
+    }
+  }
+
+  grouping bfd-top {
+    description
+      "Structural grouping for Bidirectional Forwarding Detection (BFD).";
+
+    container bfd {
+      description
+        "Configuration and operational state parameters for BFD.";
+      reference "RFC5880, RFC5881";
+
+      container interfaces {
+        description
+          "Interfaces on which BFD sessions are to be enabled.";
+
+        list interface {
+          key "id";
+
+          description
+            "Per-interface configuration and state parameters for BFD.
+             The interface referenced is based on the interface and
+             subinterface leaves within the interface-ref container -
+             which reference an entry in the /interfaces/interface list -
+             and should not rely on the value of the list key.";
+
+          leaf id {
+            type leafref {
+              path "../config/id";
+            }
+            description
+              "A reference to an identifier for the interface on which
+              BFD is enabled.";
+          }
+
+          container config {
+            description
+              "Configuration parameters for BFD on the specified
+              interface.";
+            uses bfd-interface-config;
+          }
+
+          container state {
+            config false;
+            description
+              "Operational state parameters for BFD on the specified
+              interface.";
+            uses bfd-interface-config;
+            uses bfd-interface-state;
+          }
+
+          uses oc-if:interface-ref;
+
+          uses bfd-interface-microbfd-structural;
+          uses bfd-interface-peer-structural;
+        }
+      }
+    }
+  }
+
+  grouping enable-bfd-config {
+    description
+      "Configuration parameters relating to enabling BFD.";
+
+    leaf enabled {
+      type boolean;
+      description
+        "When this leaf is set to true, BFD is used to detect the
+        liveliness of the remote peer or next-hop.";
+    }
+  }
+
+  grouping bfd-configuration {
+    description
+       "Configuration parameters of BFD when it is enabled in protocols.";
+    leaf desired-minimum-tx-interval {
+      type uint32;
+      units microseconds;
+      description
+        "The minimum interval between transmission of BFD control
+        packets that the operator desires. This value is advertised to
+        the peer, however the actual interval used is specified by
+        taking the maximum of desired-minimum-tx-interval and the
+        value of the remote required-minimum-receive interval value.
+        This value is specified as an integer number of microseconds.
+        The value 0 is reserved and cannot be used.";
+      reference "section 4.1 of RFC 5880";
+    }
+
+    leaf required-minimum-receive {
+      type uint32;
+      units microseconds;
+      description
+        "The minimum interval between received BFD control packets that
+        this system should support. This value is advertised to the
+        remote peer to indicate the maximum frequency (i.e., minimum
+        inter-packet interval) between BFD control packets that is
+        acceptable to the local system.";
+      reference "section 4.1 of RFC 5880";
+    }
+
+    leaf detection-multiplier {
+      type uint8 {
+        range "1..max";
+      }
+      description
+        "The number of packets that must be missed to declare this
+        session as down. The detection interval for the BFD session
+        is calculated by multiplying the value of the negotiated
+        transmission interval by this value.";
+      reference "section 4.1 of RFC 5880";
+    }
+
+  }
+
+  grouping enable-bfd-state {
+    description
+      "Operational state parameters relating to enabling BFD.";
+
+    leaf associated-session {
+      // TODO: this is a leafref to something unique, but seems
+      // like it might be expensive for the NMS to find out since
+      // it will need to cycle through all interfaces looking for
+      // the associated local-discriminator.
+      type leafref {
+        path "/bfd/interfaces/interface/peers/peer/local-discriminator";
+      }
+      description
+        "A reference to the BFD session that is tracking the liveliness
+        of the remote entity.";
+    }
+
+    //
+    // A fix to the above is to have the following leaf to show which
+    // interface is associated.
+    //
+    // leaf associated-interface {
+    //   type leafref {
+    //     path "/bfd/interfaces/interface/config/id";
+    //   }
+    // }
+  }
+
+  grouping bfd-enable {
+    description
+      "Grouping which can be included in a protocol wishing to enable
+      BFD.";
+
+    container enable-bfd {
+      description
+        "Enable BFD for liveliness detection to the next-hop or
+        neighbour.";
+
+      container config {
+        description
+          "Configuration parameters relating to enabling BFD.";
+
+        uses enable-bfd-config;
+        uses bfd-configuration;
+
+      }
+
+      container state {
+        config false;
+        description
+          "Operational state parameters relating to enabing BFD.";
+
+        uses enable-bfd-config;
+        uses bfd-configuration;
+        //uses enable-bfd-state;
+      }
+    }
+  }
+
+  uses bfd-top;
+}

--- a/models/yang/common/openconfig-bgp-common-multiprotocol.yang
+++ b/models/yang/common/openconfig-bgp-common-multiprotocol.yang
@@ -1,0 +1,739 @@
+submodule openconfig-bgp-common-multiprotocol {
+
+  belongs-to openconfig-bgp {
+    prefix "oc-bgp";
+  }
+
+  import openconfig-extensions { prefix oc-ext; }
+  import openconfig-bgp-types { prefix oc-bgp-types; }
+  import openconfig-routing-policy { prefix oc-rpol; }
+  import openconfig-types { prefix oc-types; }
+
+  include openconfig-bgp-common;
+
+  // meta
+  organization
+    "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    netopenconfig@googlegroups.com";
+
+  description
+    "This sub-module contains groupings that are related to support
+    for multiple protocols in BGP. The groupings are common across
+    multiple contexts.";
+
+  oc-ext:openconfig-version "9.7.1";
+
+  revision "2023-12-28" {
+    description
+      "Clarification to last-prefix-limit-exceeded in description";
+          reference "9.7.1";
+  }
+
+  revision "2023-12-28" {
+    description
+      "Add support for controling use of link-bandwidth extended
+      community for BGP multipath.";
+    reference "9.7.0";
+  }
+  revision "2023-11-02" {
+    description
+      "Fix revision '2023-03-31': send-community-type was added to the
+       wrong grouping.
+      Allow configuring send-community per AFI-SAFI at
+       neighbor/peer-group.";
+    reference "9.6.0";
+  }
+
+  revision "2023-11-01" {
+    description
+      "Add default apply policy to global and per afi-safi config.";
+    reference "9.5.0";
+  }
+
+  revision "2023-06-27" {
+    description
+      "Clarify bgp remote-port description";
+    reference "9.4.1";
+  }
+
+  revision "2023-04-01" {
+    description
+      "Add support for BGP large communities [rfc8092] in
+      send-community.
+      Leaf send-community was replaced by the leaf-list
+      send-community-type to allow the combination of different
+      community types";
+    reference "9.4.0";
+  }
+
+  revision "2023-03-31" {
+    description
+      "Allow configuring send-community per AFI-SAFI at
+       neighbor/peer-group.";
+    reference "9.3.0";
+  }
+
+  revision "2022-12-12" {
+    description
+      "Removed the default of enabled leaf of AFI-SAFI
+      at neighbor/peer-group to support BGP inheritance model.";
+    reference "9.2.0";
+  }
+
+  revision "2022-05-21" {
+    description
+      "Added extended-next-hop-encoding leaf.";
+    reference "9.1.0";
+  }
+
+  revision "2022-04-26" {
+    description
+      "Transition decimal64 types to uint16 for various BGP timers";
+    reference "9.0.0";
+  }
+
+  revision "2022-03-21" {
+    description
+      "Add BGP port";
+    reference "8.1.0";
+  }
+
+  revision "2021-12-01" {
+    description
+      "Add prefix-limit-received, add prefix-limit
+      state nodes, change/relocate restart-timer";
+    reference "8.0.0";
+  }
+
+  revision "2021-10-21" {
+    description
+      "Removal of top-level /bgp container";
+    reference "7.0.0";
+  }
+
+  revision "2021-06-16" {
+    description
+      "Remove trailing whitespace";
+    reference "6.1.1";
+  }
+
+  revision "2021-03-17" {
+    description
+      "Add bfd support without augmentation.";
+    reference "6.1.0";
+  }
+
+  revision "2019-07-10" {
+    description
+      "Normalise timestamp units to nanoseconds.";
+    reference "6.0.0";
+  }
+
+  revision "2019-05-28" {
+    description
+      "Clarify prefix counter descriptions, add received-pre-policy
+      counter.";
+    reference "5.2.0";
+  }
+
+  revision "2019-04-16" {
+    description
+      "Add BGP RIB to the top-level BGP container";
+    reference "5.1.0";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "5.0.2";
+  }
+
+  revision "2018-08-20" {
+    description
+      "Correct description of AFI-SAFI enabled leaf.";
+    reference "5.0.1";
+  }
+
+  revision "2018-04-11" {
+    description
+      "Correct naming of BGP maximum prefix warning percentage leaf.";
+    reference "5.0.0";
+  }
+
+  revision "2018-03-20" {
+    description
+      "Added SR-TE policy SAFI";
+    reference "4.1.0";
+  }
+
+  revision "2017-07-30" {
+    description
+      "Clarification of add-paths send-max leaf";
+    reference "4.0.1";
+  }
+
+  revision "2017-07-10" {
+    description
+      "Add error notifications; moved add-paths config; add AS
+      prepend policy features; removed unneeded config leaves";
+    reference "4.0.0";
+  }
+
+  revision "2017-02-02" {
+    description
+      "Bugfix to remove remaining global-level policy data";
+    reference "3.0.1";
+  }
+
+  revision "2017-01-26" {
+    description
+      "Add dynamic neighbor support, migrate to OpenConfig types";
+    reference "3.0.0";
+  }
+
+  revision "2016-06-21" {
+    description
+      "OpenConfig BGP refactor";
+    reference "2.1.1";
+  }
+
+  grouping bgp-common-mp-afi-safi-graceful-restart-config {
+    description
+      "BGP graceful restart parameters that apply on a per-AFI-SAFI
+      basis";
+
+    leaf enabled {
+      type boolean;
+      default false;
+      description
+        "This leaf indicates whether graceful-restart is enabled for
+        this AFI-SAFI";
+    }
+  }
+
+  grouping bgp-common-mp-afi-safi-extended-next-hop-encoding-config {
+    description
+      "BGP extended next-hop encoding parameters that apply on a per-AFI-SAFI
+      basis";
+
+    leaf extended-next-hop-encoding {
+      type boolean;
+      default false;
+      description
+        "This leaf indicates whether extended next-hop encoding is enabled for
+        this AFI-SAFI";
+    }
+  }
+
+  grouping bgp-common-mp-global-afi-safi-config {
+    description
+      "Configuration parameters used for all BGP global AFI-SAFIs";
+
+    leaf afi-safi-name {
+      type identityref {
+        base oc-bgp-types:AFI_SAFI_TYPE;
+      }
+      description "AFI,SAFI";
+    }
+
+    leaf enabled {
+      type boolean;
+      default false;
+      description
+        "This leaf indicates whether the AFI-SAFI is enabled for all
+        neighbors or groups.";
+    }
+
+    leaf-list send-community-type {
+      type oc-bgp-types:community-type;
+      description
+        "Specify which types of community should be sent to the
+        neighbor or group. The default is to not send the
+        community attribute. This takes precedence over the neighbor
+        or group configuration";
+    }
+  }
+
+  grouping bgp-common-mp-afi-safi-config {
+    description
+      "Configuration parameters used for all BGP neighbors
+      or groups AFI-SAFIs";
+
+    leaf afi-safi-name {
+      type identityref {
+        base oc-bgp-types:AFI_SAFI_TYPE;
+      }
+      description "AFI,SAFI";
+    }
+
+    leaf enabled {
+      type boolean;
+      description
+        "This leaf indicates whether the AFI-SAFI is
+        enabled for the neighbor or group";
+    }
+
+    leaf-list send-community-type {
+      type oc-bgp-types:community-type;
+      description
+        "Specify which types of community should be sent to the
+        neighbor or group. The default is to not send the
+        community attribute. This takes precedence over the neighbor
+        or group configuration";
+    }
+  }
+
+  grouping bgp-common-mp-all-afi-safi-list-contents {
+    description
+      "A common grouping used for contents of the list that is used
+      for AFI-SAFI entries";
+
+    // import and export policy included for the afi/safi
+    uses oc-rpol:apply-policy-group;
+
+    uses bgp-common-mp-ipv4-unicast-group;
+    uses bgp-common-mp-ipv6-unicast-group;
+    uses bgp-common-mp-ipv4-labeled-unicast-group;
+    uses bgp-common-mp-ipv6-labeled-unicast-group;
+    uses bgp-common-mp-l3vpn-ipv4-unicast-group;
+    uses bgp-common-mp-l3vpn-ipv6-unicast-group;
+    uses bgp-common-mp-l3vpn-ipv4-multicast-group;
+    uses bgp-common-mp-l3vpn-ipv6-multicast-group;
+    uses bgp-common-mp-l2vpn-vpls-group;
+    uses bgp-common-mp-l2vpn-evpn-group;
+    uses bgp-common-mp-srte-policy-ipv4-group;
+    uses bgp-common-mp-srte-policy-ipv6-group;
+  }
+
+  // Groupings relating to each address family
+  grouping bgp-common-mp-ipv4-unicast-group {
+    description
+      "Group for IPv4 Unicast configuration options";
+
+    container ipv4-unicast {
+      when "../afi-safi-name = 'oc-bgp-types:IPV4_UNICAST'" {
+        description
+          "Include this container for IPv4 Unicast specific
+          configuration";
+      }
+
+      description "IPv4 unicast configuration options";
+      uses bgp-common-mp-ipv4-unicast-common;
+    }
+  }
+
+  grouping bgp-common-mp-ipv6-unicast-group {
+    description
+      "Group for IPv6 Unicast configuration options";
+
+    container ipv6-unicast {
+      when "../afi-safi-name = 'oc-bgp-types:IPV6_UNICAST'" {
+        description
+          "Include this container for IPv6 Unicast specific
+          configuration";
+      }
+
+      description "IPv6 unicast configuration options";
+      uses bgp-common-mp-ipv6-unicast-common;
+    }
+  }
+
+  grouping bgp-common-mp-ipv4-labeled-unicast-group {
+    description
+      "Group for IPv4 Labeled Unicast configuration options";
+
+    container ipv4-labeled-unicast {
+      when "../afi-safi-name = 'oc-bgp-types:IPV4_LABELED_UNICAST'" {
+        description
+          "Include this container for IPv4 Labeled Unicast specific
+          configuration";
+      }
+
+      description "IPv4 Labeled Unicast configuration options";
+
+      uses bgp-common-mp-all-afi-safi-common;
+
+      // placeholder for IPv4 Labeled Unicast specific config
+      // options
+    }
+  }
+
+  grouping bgp-common-mp-ipv6-labeled-unicast-group {
+    description
+      "Group for IPv6 Labeled Unicast configuration options";
+
+    container ipv6-labeled-unicast {
+      when "../afi-safi-name = 'oc-bgp-types:IPV6_LABELED_UNICAST'" {
+        description
+          "Include this container for IPv6 Labeled Unicast specific
+          configuration";
+      }
+
+      description "IPv6 Labeled Unicast configuration options";
+
+      uses bgp-common-mp-all-afi-safi-common;
+
+      // placeholder for IPv6 Labeled Unicast specific config
+      // options.
+    }
+  }
+
+  grouping bgp-common-mp-l3vpn-ipv4-unicast-group {
+    description
+      "Group for IPv4 Unicast L3VPN configuration options";
+
+    container l3vpn-ipv4-unicast {
+      when "../afi-safi-name = 'oc-bgp-types:L3VPN_IPV4_UNICAST'" {
+        description
+          "Include this container for IPv4 Unicast L3VPN specific
+          configuration";
+      }
+
+      description "Unicast IPv4 L3VPN configuration options";
+
+      // include common L3VPN configuration options
+      uses bgp-common-mp-l3vpn-ipv4-ipv6-unicast-common;
+
+      // placeholder for IPv4 Unicast L3VPN specific config options.
+    }
+  }
+
+  grouping bgp-common-mp-l3vpn-ipv6-unicast-group {
+    description
+      "Group for IPv6 Unicast L3VPN configuration options";
+
+    container l3vpn-ipv6-unicast {
+      when "../afi-safi-name = 'oc-bgp-types:L3VPN_IPV6_UNICAST'" {
+        description
+          "Include this container for unicast IPv6 L3VPN specific
+          configuration";
+      }
+
+      description "Unicast IPv6 L3VPN configuration options";
+
+      // include common L3VPN configuration options
+      uses bgp-common-mp-l3vpn-ipv4-ipv6-unicast-common;
+
+      // placeholder for IPv6 Unicast L3VPN specific configuration
+      // options
+    }
+  }
+
+  grouping bgp-common-mp-l3vpn-ipv4-multicast-group {
+    description
+      "Group for IPv4 L3VPN multicast configuration options";
+
+    container l3vpn-ipv4-multicast {
+      when "../afi-safi-name = 'oc-bgp-types:L3VPN_IPV4_MULTICAST'" {
+        description
+          "Include this container for multicast IPv6 L3VPN specific
+          configuration";
+      }
+
+      description "Multicast IPv4 L3VPN configuration options";
+
+      // include common L3VPN multicast options
+      uses bgp-common-mp-l3vpn-ipv4-ipv6-multicast-common;
+
+      // placeholder for IPv4 Multicast L3VPN specific configuration
+      // options
+    }
+  }
+
+  grouping bgp-common-mp-l3vpn-ipv6-multicast-group {
+    description
+      "Group for IPv6 L3VPN multicast configuration options";
+
+    container l3vpn-ipv6-multicast {
+      when "../afi-safi-name = 'oc-bgp-types:L3VPN_IPV6_MULTICAST'" {
+        description
+          "Include this container for multicast IPv6 L3VPN specific
+          configuration";
+      }
+
+      description "Multicast IPv6 L3VPN configuration options";
+
+      // include common L3VPN multicast options
+      uses bgp-common-mp-l3vpn-ipv4-ipv6-multicast-common;
+
+      // placeholder for IPv6 Multicast L3VPN specific configuration
+      // options
+    }
+  }
+
+  grouping bgp-common-mp-l2vpn-vpls-group {
+    description
+      "Group for BGP-signalled VPLS configuration options";
+
+    container l2vpn-vpls {
+      when "../afi-safi-name = 'oc-bgp-types:L2VPN_VPLS'" {
+        description
+          "Include this container for BGP-signalled VPLS specific
+          configuration";
+      }
+
+      description "BGP-signalled VPLS configuration options";
+
+      // include common L2VPN options
+      uses bgp-common-mp-l2vpn-common;
+
+      // placeholder for BGP-signalled VPLS specific configuration
+      // options
+    }
+  }
+
+  grouping bgp-common-mp-l2vpn-evpn-group {
+    description
+      "Group for BGP EVPN configuration options";
+
+    container l2vpn-evpn {
+      when "../afi-safi-name = 'oc-bgp-types:L2VPN_EVPN'" {
+        description
+          "Include this container for BGP EVPN specific
+          configuration";
+      }
+
+      description "BGP EVPN configuration options";
+
+      // include common L2VPN options
+      uses bgp-common-mp-l2vpn-common;
+
+      // placeholder for BGP EVPN specific configuration options
+    }
+  }
+
+  // Common groupings across multiple AFI,SAFIs
+  grouping bgp-common-mp-all-afi-safi-common {
+    description
+      "Grouping for configuration common to all AFI,SAFI";
+
+    container prefix-limit {
+      description
+        "Configure the maximum number of prefixes that will be
+        accepted from a peer";
+
+      container config {
+        description
+          "Configuration parameters relating to the prefix
+          limit for the AFI-SAFI";
+        uses bgp-common-mp-all-afi-safi-common-prefix-limit-config;
+      }
+
+      container state {
+        config false;
+        description
+          "State information relating to the prefix-limit for the
+          AFI-SAFI";
+        uses bgp-common-mp-all-afi-safi-common-prefix-limit-config;
+        uses bgp-common-mp-all-afi-safi-common-prefix-limit-state;
+      }
+    }
+
+    container prefix-limit-received {
+      description
+        "Configure the maximum number of prefixes that will be
+        received from a peer";
+
+      container config {
+        description
+          "Configuration parameters relating to the prefix
+          limit for the AFI-SAFI";
+        uses bgp-common-mp-all-afi-safi-common-prefix-limit-config;
+      }
+
+      container state {
+        config false;
+        description
+          "State information relating to the prefix-limit for the
+          AFI-SAFI";
+        uses bgp-common-mp-all-afi-safi-common-prefix-limit-config;
+        uses bgp-common-mp-all-afi-safi-common-prefix-limit-state;
+      }
+    }
+  }
+
+  grouping bgp-common-mp-ipv4-unicast-common {
+    description
+      "Configuration that is applicable for IPv4 unicast";
+
+    // include common afi-safi options.
+    uses bgp-common-mp-all-afi-safi-common;
+
+    container config {
+      description
+        "Configuration parameters for IPv4 unicast AFI-SAFI options";
+      // configuration options that are common to IPv[46] unicast
+      uses bgp-common-mp-ipv4-ipv6-unicast-common-config;
+
+      // configuration options that are specific to IPv4 unicast
+      uses bgp-common-mp-afi-safi-extended-next-hop-encoding-config;
+    }
+
+    container state {
+      config false;
+      description
+        "State information for IPv4 parameters";
+      uses bgp-common-mp-ipv4-ipv6-unicast-common-config;
+      uses bgp-common-mp-afi-safi-extended-next-hop-encoding-config;
+    }
+  }
+
+  grouping bgp-common-mp-ipv6-unicast-common {
+    description
+      "Configuration that is applicable for IPv6 unicast";
+
+    // include common afi-safi options.
+    uses bgp-common-mp-all-afi-safi-common;
+
+    // configuration options that are specific to IPv[46] unicast
+    container config {
+      description
+        "Configuration parameters for IPv6 unicast AFI-SAFI options";
+      // configuration options that are common to IPv[46] unicast
+      uses bgp-common-mp-ipv4-ipv6-unicast-common-config;
+
+      // placholder for IPv6 unicast specific options
+    }
+    container state {
+      config false;
+      description
+        "State information for IPv6 unicast parameters";
+      uses bgp-common-mp-ipv4-ipv6-unicast-common-config;
+    }
+  }
+
+  grouping bgp-common-mp-l3vpn-ipv4-ipv6-unicast-common {
+    description
+      "Common configuration applied across L3VPN for IPv4
+       and IPv6";
+
+    // placeholder -- specific configuration options that are generic
+    // across IPv[46] unicast address families.
+    uses bgp-common-mp-all-afi-safi-common;
+  }
+
+  grouping bgp-common-mp-l3vpn-ipv4-ipv6-multicast-common {
+    description
+      "Common configuration applied across L3VPN for IPv4
+      and IPv6";
+
+    // placeholder -- specific configuration options that are
+    // generic across IPv[46] multicast address families.
+    uses bgp-common-mp-all-afi-safi-common;
+  }
+
+  grouping bgp-common-mp-l2vpn-common {
+    description
+      "Common configuration applied across L2VPN address
+      families";
+
+    // placeholder -- specific configuration options that are
+    // generic across L2VPN address families
+    uses bgp-common-mp-all-afi-safi-common;
+  }
+
+  grouping bgp-common-mp-srte-policy-ipv4-group {
+    description
+      "Grouping for SR-TE for AFI 1";
+
+    container srte-policy-ipv4 {
+      when "../afi-safi-name = 'oc-bgp-types:SRTE_POLICY_IPV4'" {
+        description
+          "Only include this container when the address family is
+          specified to be SR-TE Policy SAFI for the IPv4 unicast
+          address family.";
+      }
+
+      description
+        "Configuration and operational state parameters relating to
+        the SR-TE Policy SAFI for IPv4 Unicast.";
+
+      uses bgp-common-mp-all-afi-safi-common;
+    }
+  }
+
+  grouping bgp-common-mp-srte-policy-ipv6-group {
+    description
+      "Grouping for SR-TE for AFI 2";
+
+    container srte-policy-ipv6 {
+      when "../afi-safi-name = 'oc-bgp-types:SRTE_POLICY_IPV6'" {
+        description
+          "Only include this container when the address family is
+          specified to be SR-TE Policy SAFI for the IPv6 unicast
+          address family.";
+      }
+
+      description
+        "Configuration and operational state parameters relating to
+        the SR-TE Policy SAFI for IPv6 Unicast.";
+
+      uses bgp-common-mp-all-afi-safi-common;
+    }
+  }
+
+  // Config groupings for common groups
+  grouping bgp-common-mp-all-afi-safi-common-prefix-limit-config {
+    description
+      "Configuration parameters relating to prefix-limits for an
+      AFI-SAFI";
+
+    leaf max-prefixes {
+      type uint32;
+      description
+        "Maximum number of prefixes that will be accepted
+        from the neighbor";
+    }
+
+    leaf prevent-teardown {
+      type boolean;
+      default false;
+      description
+        "Do not tear down the BGP session when the maximum
+        prefix limit is exceeded, but rather only log a
+        warning. The default of this leaf is false, such
+        that when it is not specified, the session is torn
+        down.";
+    }
+
+    leaf warning-threshold-pct {
+      type oc-types:percentage;
+      description
+        "Threshold on number of prefixes that can be received
+        from a neighbor before generation of warning messages
+        or log entries. Expressed as a percentage of
+        max-prefixes";
+    }
+  }
+
+  grouping bgp-common-mp-all-afi-safi-common-prefix-limit-state {
+    description
+      "State parameters relating to prefix-limits for an AFI-SAFI";
+
+    leaf prefix-limit-exceeded {
+      type boolean;
+      description
+        "If set to true, the prefix-limit has been exceeded.  When the
+        prefix-limit has been exceeded, the value of true must be retained
+        until the restart-time has expired.  Prior to session re-establishment,
+        the value must be reset to false";
+    }
+  }
+
+
+  grouping bgp-common-mp-ipv4-ipv6-unicast-common-config {
+    description
+      "Common configuration parameters for IPv4 and IPv6 Unicast
+      address families";
+
+    leaf send-default-route {
+      type boolean;
+      default "false";
+      description
+        "If set to true, send the default-route to the neighbor(s)";
+    }
+  }
+}

--- a/models/yang/common/openconfig-bgp-common-structure.yang
+++ b/models/yang/common/openconfig-bgp-common-structure.yang
@@ -1,0 +1,322 @@
+submodule openconfig-bgp-common-structure {
+
+  belongs-to openconfig-bgp {
+    prefix "oc-bgp";
+  }
+
+  import openconfig-extensions { prefix oc-ext; }
+
+  include openconfig-bgp-common-multiprotocol;
+  include openconfig-bgp-common;
+
+  // meta
+  organization
+    "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    netopenconfig@googlegroups.com";
+
+  description
+    "This sub-module contains groupings that are common across multiple BGP
+    contexts and provide structure around other primitive groupings.";
+
+  oc-ext:openconfig-version "9.7.1";
+
+  revision "2023-12-28" {
+    description
+      "Clarification to last-prefix-limit-exceeded in description";
+          reference "9.7.1";
+  }
+
+  revision "2023-12-28" {
+    description
+      "Add support for controling use of link-bandwidth extended
+      community for BGP multipath.";
+    reference "9.7.0";
+  }
+
+  revision "2023-11-02" {
+    description
+      "Fix revision '2023-03-31': send-community-type was added to the
+       wrong grouping.
+      Allow configuring send-community per AFI-SAFI at
+       neighbor/peer-group.";
+    reference "9.6.0";
+  }
+
+  revision "2023-11-01" {
+    description
+      "Add default apply policy to global and per afi-safi config.";
+    reference "9.5.0";
+  }
+
+  revision "2023-06-27" {
+    description
+      "Clarify bgp remote-port description";
+    reference "9.4.1";
+  }
+
+  revision "2023-04-01" {
+    description
+      "Add support for BGP large communities [rfc8092] in
+      send-community.
+      Leaf send-community was replaced by the leaf-list
+      send-community-type to allow the combination of different
+      community types";
+    reference "9.4.0";
+  }
+
+  revision "2023-03-31" {
+    description
+      "Allow configuring send-community per AFI-SAFI at
+       neighbor/peer-group.";
+    reference "9.3.0";
+  }
+
+  revision "2022-12-12" {
+    description
+      "Removed the default of enabled leaf of AFI-SAFI
+      at neighbor/peer-group to support BGP inheritance model.";
+    reference "9.2.0";
+  }
+
+  revision "2022-05-21" {
+    description
+      "Added extended-next-hop-encoding leaf.";
+    reference "9.1.0";
+  }
+
+  revision "2022-04-26" {
+    description
+      "Transition decimal64 types to uint16 for various BGP timers";
+    reference "9.0.0";
+  }
+
+  revision "2022-03-21" {
+    description
+      "Add BGP port";
+    reference "8.1.0";
+  }
+
+  revision "2021-12-01" {
+    description
+      "Add prefix-limit-received, add prefix-limit
+      state nodes, change/relocate restart-timer";
+    reference "8.0.0";
+  }
+
+  revision "2021-10-21" {
+    description
+      "Removal of top-level /bgp container";
+    reference "7.0.0";
+  }
+
+  revision "2021-06-16" {
+    description
+      "Remove trailing whitespace";
+    reference "6.1.1";
+  }
+
+  revision "2021-03-17" {
+    description
+      "Add bfd support without augmentation.";
+    reference "6.1.0";
+  }
+
+  revision "2019-07-10" {
+    description
+      "Normalise timestamp units to nanoseconds.";
+    reference "6.0.0";
+  }
+
+  revision "2019-05-28" {
+    description
+      "Clarify prefix counter descriptions, add received-pre-policy
+      counter.";
+    reference "5.2.0";
+  }
+
+  revision "2019-04-16" {
+    description
+      "Add BGP RIB to the top-level BGP container";
+    reference "5.1.0";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "5.0.2";
+  }
+
+  revision "2018-08-20" {
+    description
+      "Correct description of AFI-SAFI enabled leaf.";
+    reference "5.0.1";
+  }
+
+  revision "2018-04-11" {
+    description
+      "Correct naming of BGP maximum prefix warning percentage leaf.";
+    reference "5.0.0";
+  }
+
+  revision "2018-03-20" {
+    description
+      "Added SR-TE policy SAFI";
+    reference "4.1.0";
+  }
+
+  revision "2017-07-30" {
+    description
+      "Clarification of add-paths send-max leaf";
+    reference "4.0.1";
+  }
+
+  revision "2017-07-10" {
+    description
+      "Add error notifications; moved add-paths config; add AS
+      prepend policy features; removed unneeded config leaves";
+    reference "4.0.0";
+  }
+
+  revision "2017-02-02" {
+    description
+      "Bugfix to remove remaining global-level policy data";
+    reference "3.0.1";
+  }
+
+  revision "2017-01-26" {
+    description
+      "Add dynamic neighbor support, migrate to OpenConfig types";
+    reference "3.0.0";
+  }
+
+  revision "2016-06-21" {
+    description
+      "OpenConfig BGP refactor";
+    reference "2.1.1";
+  }
+
+  grouping bgp-common-structure-neighbor-group-logging-options {
+    description
+      "Structural grouping used to include error handling configuration and
+      state for both BGP neighbors and groups";
+
+    container logging-options {
+      description
+        "Logging options for events related to the BGP neighbor or
+        group";
+      container config {
+        description
+          "Configuration parameters enabling or modifying logging
+          for events relating to the BGPgroup";
+        uses bgp-common-neighbor-group-logging-options-config;
+      }
+      container state {
+        config false;
+        description
+          "State information relating to logging for the BGP neighbor
+          or group";
+        uses bgp-common-neighbor-group-logging-options-config;
+      }
+    }
+  }
+
+  grouping bgp-common-structure-neighbor-group-ebgp-multihop {
+    description
+      "Structural grouping used to include eBGP multihop configuration and
+      state for both BGP neighbors and peer groups";
+
+    container ebgp-multihop {
+      description
+        "eBGP multi-hop parameters for the BGPgroup";
+      container config {
+        description
+          "Configuration parameters relating to eBGP multihop for the
+          BGP group";
+        uses bgp-common-neighbor-group-multihop-config;
+      }
+      container state {
+        config false;
+        description
+          "State information for eBGP multihop, for the BGP neighbor
+          or group";
+        uses bgp-common-neighbor-group-multihop-config;
+      }
+    }
+  }
+
+  grouping bgp-common-structure-neighbor-group-route-reflector {
+    description
+      "Structural grouping used to include route reflector configuration and
+      state for both BGP neighbors and peer groups";
+
+    container route-reflector {
+      description
+        "Route reflector parameters for the BGPgroup";
+      container config {
+        description
+          "Configuraton parameters relating to route reflection
+          for the BGPgroup";
+        uses bgp-common-neighbor-group-route-reflector-config;
+      }
+      container state {
+        config false;
+        description
+          "State information relating to route reflection for the
+          BGPgroup";
+        uses bgp-common-neighbor-group-route-reflector-config;
+      }
+    }
+  }
+
+  grouping bgp-common-structure-neighbor-group-as-path-options {
+    description
+      "Structural grouping used to include AS_PATH manipulation configuration
+      and state for both BGP neighbors and peer groups";
+
+    container as-path-options {
+      description
+        "AS_PATH manipulation parameters for the BGP neighbor or
+        group";
+      container config {
+        description
+          "Configuration parameters relating to AS_PATH manipulation
+          for the BGP peer or group";
+        uses bgp-common-neighbor-group-as-path-options-config;
+      }
+      container state {
+        config false;
+        description
+          "State information relating to the AS_PATH manipulation
+          mechanisms for the BGP peer or group";
+        uses bgp-common-neighbor-group-as-path-options-config;
+      }
+    }
+  }
+
+  grouping bgp-common-structure-neighbor-group-add-paths {
+    description
+      "Structural grouping used to include ADD-PATHs configuration and state
+      for both BGP neighbors and peer groups";
+
+    container add-paths {
+      description
+        "Parameters relating to the advertisement and receipt of
+        multiple paths for a single NLRI (add-paths)";
+      container config {
+        description
+          "Configuration parameters relating to ADD_PATHS";
+        uses bgp-common-neighbor-group-add-paths-config;
+      }
+      container state {
+        config false;
+        description
+          "State information associated with ADD_PATHS";
+        uses bgp-common-neighbor-group-add-paths-config;
+      }
+    }
+  }
+
+}

--- a/models/yang/common/openconfig-bgp-common.yang
+++ b/models/yang/common/openconfig-bgp-common.yang
@@ -1,0 +1,849 @@
+submodule openconfig-bgp-common {
+
+  belongs-to openconfig-bgp {
+    prefix "oc-bgp";
+  }
+
+  import openconfig-extensions { prefix oc-ext; }
+  import openconfig-bgp-types { prefix oc-bgp-types; }
+  import openconfig-routing-policy { prefix oc-rpol; }
+  import openconfig-types { prefix oc-types; }
+  import openconfig-inet-types { prefix oc-inet; }
+
+  // meta
+  organization
+    "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    netopenconfig@googlegroups.com";
+
+  description
+    "This sub-module contains common groupings that are common across
+    multiple contexts within the BGP module. That is to say that they
+    may be application to a subset of global, peer-group or neighbor
+    contexts.";
+
+  oc-ext:openconfig-version "9.7.1";
+
+  revision "2023-12-28" {
+    description
+      "Clarification to last-prefix-limit-exceeded in description";
+          reference "9.7.1";
+  }
+
+  revision "2023-12-28" {
+    description
+      "Add support for controling use of link-bandwidth extended
+      community for BGP multipath.";
+          reference "9.7.0";
+  }
+
+  revision "2023-11-02" {
+    description
+      "Fix revision '2023-03-31': send-community-type was added to the
+       wrong grouping.
+      Allow configuring send-community per AFI-SAFI at
+       neighbor/peer-group.";
+    reference "9.6.0";
+  }
+
+  revision "2023-11-01" {
+    description
+      "Add default apply policy to global and per afi-safi config.";
+    reference "9.5.0";
+  }
+
+  revision "2023-06-27" {
+    description
+      "Clarify bgp remote-port description";
+    reference "9.4.1";
+  }
+
+  revision "2023-04-01" {
+    description
+      "Add support for BGP large communities [rfc8092] in
+      send-community.
+      Leaf send-community was replaced by the leaf-list
+      send-community-type to allow the combination of different
+      community types";
+    reference "9.4.0";
+  }
+
+  revision "2023-03-31" {
+    description
+      "Allow configuring send-community per AFI-SAFI at
+       neighbor/peer-group.";
+    reference "9.3.0";
+  }
+
+  revision "2022-12-12" {
+    description
+      "Removed the default of enabled leaf of AFI-SAFI
+      at neighbor/peer-group to support BGP inheritance model.";
+    reference "9.2.0";
+  }
+
+  revision "2022-05-21" {
+    description
+      "Added extended-next-hop-encoding leaf.";
+    reference "9.1.0";
+  }
+
+  revision "2022-04-26" {
+    description
+      "Transition decimal64 types to uint16 for various BGP timers";
+    reference "9.0.0";
+  }
+
+  revision "2022-03-21" {
+    description
+      "Add BGP port";
+    reference "8.1.0";
+  }
+
+  revision "2021-12-01" {
+    description
+      "Add prefix-limit-received, add prefix-limit
+      state nodes, change/relocate restart-timer";
+    reference "8.0.0";
+  }
+
+  revision "2021-10-21" {
+    description
+      "Removal of top-level /bgp container";
+    reference "7.0.0";
+  }
+
+  revision "2021-06-16" {
+    description
+      "Remove trailing whitespace";
+    reference "6.1.1";
+  }
+
+  revision "2021-03-17" {
+    description
+      "Add bfd support without augmentation.";
+    reference "6.1.0";
+  }
+
+  revision "2019-07-10" {
+    description
+      "Normalise timestamp units to nanoseconds.";
+    reference "6.0.0";
+  }
+
+  revision "2019-05-28" {
+    description
+      "Clarify prefix counter descriptions, add received-pre-policy
+      counter.";
+    reference "5.2.0";
+  }
+
+  revision "2019-04-16" {
+    description
+      "Add BGP RIB to the top-level BGP container";
+    reference "5.1.0";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "5.0.2";
+  }
+
+  revision "2018-08-20" {
+    description
+      "Correct description of AFI-SAFI enabled leaf.";
+    reference "5.0.1";
+  }
+
+  revision "2018-04-11" {
+    description
+      "Correct naming of BGP maximum prefix warning percentage leaf.";
+    reference "5.0.0";
+  }
+
+  revision "2018-03-20" {
+    description
+      "Added SR-TE policy SAFI";
+    reference "4.1.0";
+  }
+
+  revision "2017-07-30" {
+    description
+      "Clarification of add-paths send-max leaf";
+    reference "4.0.1";
+  }
+
+  revision "2017-07-10" {
+    description
+      "Add error notifications; moved add-paths config; add AS
+      prepend policy features; removed unneeded config leaves";
+    reference "4.0.0";
+  }
+
+  revision "2017-02-02" {
+    description
+      "Bugfix to remove remaining global-level policy data";
+    reference "3.0.1";
+  }
+
+  revision "2017-01-26" {
+    description
+      "Add dynamic neighbor support, migrate to OpenConfig types";
+    reference "3.0.0";
+  }
+
+  revision "2016-06-21" {
+    description
+      "OpenConfig BGP refactor";
+    reference "2.1.1";
+  }
+
+  grouping bgp-common-neighbor-group-timers-config {
+    description
+      "Config parameters related to timers associated with the BGP
+      peer";
+
+    leaf connect-retry {
+      type uint16;
+      default 30;
+      description
+        "Time interval in seconds between attempts to establish a
+        session with the peer.";
+    }
+
+    leaf hold-time {
+      type uint16;
+      default 90;
+      description
+        "Time interval in seconds that a BGP session will be
+        considered active in the absence of keepalive or other
+        messages from the peer.  The hold-time is typically
+        set to 3x the keepalive-interval.";
+      reference
+        "RFC 4271 - A Border Gateway Protocol 4, Sec. 10";
+    }
+
+    leaf keepalive-interval {
+      type uint16;
+      default 30;
+      description
+        "Time interval in seconds between transmission of keepalive
+        messages to the neighbor.  Typically set to 1/3 the
+        hold-time.";
+    }
+
+    leaf minimum-advertisement-interval {
+      type uint16;
+      default 30;
+      description
+        "Minimum time which must elapse between subsequent UPDATE
+        messages relating to a common set of NLRI being transmitted
+        to a peer. This timer is referred to as
+        MinRouteAdvertisementIntervalTimer by RFC 4721 and serves to
+        reduce the number of UPDATE messages transmitted when a
+        particular set of NLRI exhibit instability.";
+      reference
+        "RFC 4271 - A Border Gateway Protocol 4, Sec 9.2.1.1";
+    }
+
+    leaf restart-time {
+      type uint16;
+      units "seconds";
+      description
+        "Time interval in seconds after which the BGP session is
+        re-established after being torn down due to exceeding any
+        configured max prefix-limit.";
+    }
+  }
+
+  grouping bgp-common-neighbor-group-config {
+    description
+      "Neighbor level configuration items.";
+
+    leaf peer-as {
+      type oc-inet:as-number;
+      description
+        "AS number of the peer.";
+    }
+
+    leaf local-as {
+      type oc-inet:as-number;
+      description
+        "The local autonomous system number that is to be used
+        when establishing sessions with the remote peer or peer
+        group, if this differs from the global BGP router
+        autonomous system number.";
+    }
+
+    leaf peer-type {
+        type oc-bgp-types:peer-type;
+        description
+          "Explicitly designate the peer or peer group as internal
+          (iBGP) or external (eBGP).";
+    }
+
+    leaf auth-password {
+      type oc-types:routing-password;
+      description
+        "Configures an MD5 authentication password for use with
+        neighboring devices.";
+    }
+
+    leaf remove-private-as {
+      // could also make this a container with a flag to enable
+      // remove-private and separate option.  here, option implies
+      // remove-private is enabled.
+      type oc-bgp-types:remove-private-as-option;
+      description
+        "Remove private AS numbers from updates sent to peers - when
+        this leaf is not specified, the AS_PATH attribute should be
+        sent to the peer unchanged";
+    }
+
+    leaf route-flap-damping {
+      type boolean;
+      default false;
+      description
+        "Enable route flap damping.";
+    }
+
+    leaf send-community {
+      status deprecated;
+      type oc-bgp-types:community-type;
+      default "NONE";
+      description
+        "This leaf has been deprecated and replaced by send-community-type to
+        support large communities.
+
+        Specify which types of community should be sent to the
+        neighbor or group. The default is to not send the
+        community attribute";
+    }
+
+    leaf-list send-community-type {
+      type oc-bgp-types:community-type;
+      description
+        "Specify which types of community should be sent to the
+        neighbor or group. The default is to not send the
+        community attribute";
+    }
+
+    leaf description {
+      type string;
+      description
+        "An optional textual description (intended primarily for use
+        with a peer or group";
+    }
+  }
+
+  grouping bgp-common-neighbor-group-transport-config {
+    description
+      "Configuration parameters relating to the transport protocol
+      used by the BGP session to the peer";
+
+    leaf tcp-mss {
+      type uint16;
+      description
+        "Sets the max segment size for BGP TCP sessions.";
+    }
+
+    leaf mtu-discovery {
+      type boolean;
+      default false;
+      description
+        "Turns path mtu discovery for BGP TCP sessions on (true)
+        or off (false)";
+    }
+
+    leaf passive-mode {
+      type boolean;
+      default false;
+      description
+        "Wait for peers to issue requests to open a BGP session,
+        rather than initiating sessions from the local router.";
+    }
+
+    leaf local-address {
+      type union {
+        type oc-inet:ip-address;
+        type string;
+      }
+      //TODO:  the string should be converted to a leafref type
+      //to point to an interface when YANG 1.1 is available with
+      //leafrefs in union types.
+      description
+        "Set the local IP (either IPv4 or IPv6) address to use
+        for the session when sending BGP update messages.  This
+        may be expressed as either an IP address or reference
+        to the name of an interface.";
+    }
+  }
+
+  grouping bgp-common-neighbor-group-error-handling-config {
+    description
+      "Configuration parameters relating to enhanced error handling
+      behaviours for BGP";
+
+    leaf treat-as-withdraw {
+      type boolean;
+      default "false";
+      description
+        "Specify whether erroneous UPDATE messages for which the
+        NLRI can be extracted are reated as though the NLRI is
+        withdrawn - avoiding session reset";
+      reference "draft-ietf-idr-error-handling-16";
+    }
+  }
+
+  grouping bgp-common-neighbor-group-logging-options-config {
+    description
+      "Configuration parameters specifying the logging behaviour for
+      BGP sessions to the peer";
+
+    leaf log-neighbor-state-changes {
+      type boolean;
+      default "true";
+      description
+        "Configure logging of peer state changes.  Default is
+        to enable logging of peer state changes.";
+    }
+  }
+
+  grouping bgp-common-neighbor-group-multihop-config {
+    description
+      "Configuration parameters specifying the multihop behaviour for
+      BGP sessions to the peer";
+
+    leaf enabled {
+      type boolean;
+      default "false";
+      description
+        "When enabled the referenced group or neighbors are permitted
+        to be indirectly connected - including cases where the TTL
+        can be decremented between the BGP peers";
+    }
+
+    leaf multihop-ttl {
+      type uint8;
+      description
+        "Time-to-live value to use when packets are sent to the
+        referenced group or neighbors and ebgp-multihop is enabled";
+    }
+  }
+
+  grouping bgp-common-neighbor-group-route-reflector-config {
+    description
+      "Configuration parameters determining whether the behaviour of
+      the local system when acting as a route-reflector";
+
+    leaf route-reflector-cluster-id {
+      type oc-bgp-types:rr-cluster-id-type;
+      description
+        "route-reflector cluster id to use when local router is
+        configured as a route reflector.  Commonly set at the group
+        level, but allows a different cluster
+        id to be set for each neighbor.";
+    }
+
+    leaf route-reflector-client {
+      type boolean;
+      default "false";
+      description
+        "Configure the neighbor as a route reflector client.";
+    }
+  }
+
+  grouping bgp-common-neighbor-group-as-path-options-config {
+    description
+      "Configuration parameters allowing manipulation of the AS_PATH
+      attribute";
+
+    leaf allow-own-as {
+      type uint8;
+      default 0;
+      description
+        "Specify the number of occurrences of the local BGP speaker's
+        AS that can occur within the AS_PATH before it is rejected.";
+    }
+
+    leaf replace-peer-as {
+      type boolean;
+      default "false";
+      description
+        "Replace occurrences of the peer's AS in the AS_PATH
+        with the local autonomous system number";
+    }
+
+    leaf disable-peer-as-filter {
+      type boolean;
+      default "false";
+      description
+        "When set to true, the system advertises routes to a peer
+        even if the peer's AS was in the AS path.  The default
+        behavior (false) suppresses advertisements to peers if
+        their AS number is in the AS path of the route.";
+    }
+  }
+
+  grouping bgp-common-neighbor-group-add-paths-config {
+    description
+      "Configuration parameters specfying whether the local system
+      will send or receive multiple paths using ADD_PATHS";
+
+    leaf receive {
+      type boolean;
+      default false;
+      description
+        "Enable capability negotiation to receive multiple path
+        advertisements for an NLRI from the neighbor or group";
+      reference
+        "RFC 7911 - Advertisement of Multiple Paths in BGP";
+    }
+
+    leaf send {
+      type boolean;
+      default false;
+      description
+        "Enable capability negotiation to send multiple path
+        advertisements for an NLRI from the neighbor or group";
+      reference
+        "RFC 7911 - Advertisement of Multiple Paths in BGP";
+    }
+
+    leaf send-max {
+      type uint8;
+      description
+        "The maximum total number of paths to advertise to neighbors
+        for a single NLRI.  This includes the single best path as
+        well as additional paths advertised when add-paths is
+        enabled.";
+    }
+
+    leaf eligible-prefix-policy {
+      type leafref {
+        path "/oc-rpol:routing-policy/oc-rpol:policy-definitions/" +
+          "oc-rpol:policy-definition/oc-rpol:name";
+      }
+      description
+        "A reference to a routing policy which can be used to
+        restrict the prefixes for which add-paths is enabled";
+    }
+  }
+
+  grouping bgp-common-graceful-restart-config {
+    description
+      "Configuration parameters relating to BGP graceful restart.";
+
+    leaf enabled {
+      type boolean;
+      description
+        "Enable or disable the graceful-restart capability.";
+    }
+
+    leaf restart-time {
+      type uint16 {
+        range 0..4096;
+      }
+      description
+        "Estimated time (in seconds) for the local BGP speaker to
+        restart a session. This value is advertise in the graceful
+        restart BGP capability.  This is a 12-bit value, referred to
+        as Restart Time in RFC4724.  Per RFC4724, the suggested
+        default value is <= the hold-time value.";
+    }
+
+    leaf stale-routes-time {
+      type uint16;
+      description
+        "An upper-bound on the time thate stale routes will be
+        retained by a router after a session is restarted. If an
+        End-of-RIB (EOR) marker is received prior to this timer
+        expiring stale-routes will be flushed upon its receipt - if
+        no EOR is received, then when this timer expires stale paths
+        will be purged. This timer is referred to as the
+        Selection_Deferral_Timer in RFC4724";
+    }
+
+    leaf helper-only {
+      type boolean;
+      description
+        "Enable graceful-restart in helper mode only. When this
+        leaf is set, the local system does not retain forwarding
+        its own state during a restart, but supports procedures
+        for the receiving speaker, as defined in RFC4724.";
+    }
+  }
+
+  grouping bgp-common-use-multiple-paths-config {
+    description
+      "Generic configuration options relating to use of multiple
+      paths for a referenced AFI-SAFI, group or neighbor";
+
+    leaf enabled {
+      type boolean;
+      default false;
+      description
+        "Whether the use of multiple paths for the same NLRI is
+        enabled for the neighbor. This value is overridden by
+        any more specific configuration value.";
+    }
+  }
+
+  grouping bgp-common-use-multiple-paths-ebgp-as-options-config {
+    description
+      "Configuration parameters specific to eBGP multipath applicable
+      to all contexts";
+
+    leaf allow-multiple-as {
+     type boolean;
+     default "false";
+     description
+      "Allow multipath to use paths from different neighbouring
+      ASes.  The default is to only consider multiple paths from
+      the same neighbouring AS.";
+    }
+  }
+
+  grouping bgp-common-global-group-use-multiple-paths {
+    description
+      "Common grouping used for both global and groups which provides
+      configuration and state parameters relating to use of multiple
+      paths";
+
+    container use-multiple-paths {
+      description
+        "Parameters related to the use of multiple paths for the
+        same NLRI";
+
+      container config {
+        description
+          "Configuration parameters relating to multipath";
+        uses bgp-common-use-multiple-paths-config;
+      }
+      container state {
+        config false;
+        description
+          "State parameters relating to multipath";
+        uses bgp-common-use-multiple-paths-config;
+      }
+
+      container ebgp {
+        description
+          "Multipath parameters for eBGP";
+        container link-bandwidth-ext-community {
+          description
+            "Usage of DMZ Link-Bandwidth extended community";
+          container config {
+            description
+            "Configuration parameters relating to usage of link-bandwidth";
+            uses bgp-common-use-multiple-paths-link-bandwidth-config;
+          }
+          container state {
+            config false;
+            description
+            "State information relating to usage of link-bandwidth";
+            uses bgp-common-use-multiple-paths-link-bandwidth-config;
+          }
+        }
+        container config {
+          description
+            "Configuration parameters relating to eBGP multipath";
+          uses bgp-common-use-multiple-paths-ebgp-config;
+        }
+        container state {
+          config false;
+          description
+            "State information relating to eBGP multipath";
+          uses bgp-common-use-multiple-paths-ebgp-config;
+        }
+      }
+
+      container ibgp {
+        description
+          "Multipath parameters for iBGP";
+        container link-bandwidth-ext-community {
+          description
+            "Usage of DMZ Link-Bandwidth extended community";
+          container config {
+            description
+            "Configuration parameters relating to usage of link-bandwidth";
+            uses bgp-common-use-multiple-paths-link-bandwidth-config;
+          }
+          container state {
+            config false;
+            description
+            "State information relating to usage of link-bandwidth";
+            uses bgp-common-use-multiple-paths-link-bandwidth-config;
+          }
+        }
+        container config {
+          description
+            "Configuration parameters relating to iBGP multipath";
+          uses bgp-common-use-multiple-paths-ibgp-config;
+        }
+        container state {
+          config false;
+          description
+            "State information relating to iBGP multipath";
+          uses bgp-common-use-multiple-paths-ibgp-config;
+        }
+      }
+    }
+  }
+
+  grouping bgp-common-use-multiple-paths-link-bandwidth-config {
+    description
+      "Parameters controlling usage of  of DMZ Link-Bandwidth
+      extended community in pultipath RIB/FIB formation";
+    leaf enabled {
+      type boolean;
+      description
+      "When set to TRUE, BGP multiplepath shall distributed traffic
+      load among contributing routes proportionally to value of
+      Local Administrator subfield of link-bandwidth extended
+      community [draft-ietf-idr-link-bandwidth-07].
+      This leaf has no effect if BGP multi-path is disabled or
+      if maximum-path attribute of BGP multi-path value is set
+      to 1";
+    }
+  }
+
+  grouping bgp-common-use-multiple-paths-ebgp-config {
+    description
+      "Configuration parameters relating to multipath for eBGP";
+
+    leaf allow-multiple-as {
+     type boolean;
+     default "false";
+     description
+      "Allow multipath to use paths from different neighbouring
+      ASes.  The default is to only consider multiple paths from
+      the same neighbouring AS.";
+    }
+
+    leaf maximum-paths {
+     type uint32;
+     default 1;
+     description
+      "Maximum number of parallel paths to consider when using
+      BGP multipath. The default is use a single path.";
+    }
+  }
+
+  grouping bgp-common-use-multiple-paths-ibgp-config {
+    description
+      "Configuration parmaeters relating to multipath for iBGP";
+
+    leaf maximum-paths {
+      type uint32;
+      default 1;
+      description
+        "Maximum number of parallel paths to consider when using
+        iBGP multipath. The default is to use a single path";
+    }
+  }
+
+  grouping bgp-common-route-selection-options-config {
+    description
+      "Set of configuration options that govern best
+       path selection.";
+
+    leaf always-compare-med {
+      type boolean;
+      default "false";
+      description
+        "Compare multi-exit discriminator (MED) value from
+        different ASes when selecting the best route.  The
+        default behavior is to only compare MEDs for paths
+        received from the same AS.";
+    }
+
+    leaf ignore-as-path-length {
+      type boolean;
+      default "false";
+      description
+        "Ignore the AS path length when selecting the best path.
+        The default is to use the AS path length and prefer paths
+        with shorter length.";
+    }
+
+    leaf external-compare-router-id {
+      type boolean;
+      default "true";
+      description
+        "When comparing similar routes received from external
+        BGP peers, use the router-id as a criterion to select
+        the active path.";
+    }
+
+    leaf advertise-inactive-routes {
+      type boolean;
+      default "false";
+      description
+        "Advertise inactive routes to external peers.  The
+        default is to only advertise active routes.";
+    }
+
+    leaf enable-aigp {
+      type boolean;
+      default false;
+      description
+        "Flag to enable sending / receiving accumulated IGP
+        attribute in routing updates";
+    }
+
+    leaf ignore-next-hop-igp-metric {
+      type boolean;
+      default "false";
+      description
+        "Ignore the IGP metric to the next-hop when calculating
+        BGP best-path. The default is to select the route for
+        which the metric to the next-hop is lowest";
+    }
+  }
+
+  grouping bgp-common-route-selection-options {
+    description
+      "Configuration and state relating to route selection options";
+
+    container route-selection-options {
+      description
+        "Parameters relating to options for route selection";
+      container config {
+        description
+          "Configuration parameters relating to route selection
+          options";
+        uses bgp-common-route-selection-options-config;
+      }
+      container state {
+        config false;
+        description
+          "State information for the route selection options";
+        uses bgp-common-route-selection-options-config;
+      }
+    }
+  }
+
+  grouping bgp-common-state {
+    description
+      "Grouping containing common counters relating to prefixes and
+      paths";
+
+    leaf total-paths {
+      type uint32;
+      description
+        "Total number of BGP paths within the context";
+    }
+
+    leaf total-prefixes {
+      type uint32;
+      description
+        "Total number of BGP prefixes received within the context";
+    }
+  }
+
+
+}

--- a/models/yang/common/openconfig-bgp-errors.yang
+++ b/models/yang/common/openconfig-bgp-errors.yang
@@ -1,0 +1,495 @@
+submodule openconfig-bgp-errors {
+
+  belongs-to openconfig-bgp-types {
+    prefix "oc-bgp-types";
+  }
+
+  import openconfig-extensions { prefix "oc-ext"; }
+
+  // meta
+  organization
+    "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    netopenconfig@googlegroups.com";
+
+  description
+    "This module defines BGP NOTIFICATION message error codes
+    and subcodes";
+
+  oc-ext:openconfig-version "6.0.0";
+
+  revision "2024-01-31" {
+    description
+      "Update community-sets/members/member union type by replacing
+      the bgp-regex type with posix-eregexp.";
+    reference "6.0.0";
+  }
+
+  revision "2023-12-26" {
+    description
+      "Add regex for bgp link bandwidth";
+    reference "5.6.0";
+  }
+
+  revision "2023-09-06" {
+    description
+      "Add GRACEFUL_SHUTDOWN as a BGP_WELL_KNOWN_STD_COMMUNITY";
+    reference "5.5.0";
+  }
+
+  revision "2023-03-31" {
+    description
+      "Add support for BGP large communities [rfc8092] in
+       send-community-type
+
+      Types impacted:
+      - community-type";
+    reference "5.4.0";
+  }
+
+  revision "2021-08-06" {
+    description
+      "Fix pattern regexes to allow full 4-byte private ASN range including
+       42xxxxxxxx in extended communities
+
+      Types impacted:
+      - bgp-ext-community-type";
+    reference "5.3.1";
+  }
+
+  revision "2021-01-07" {
+    description
+      "Remove module extension oc-ext:regexp-posix by making pattern regexes
+      conform to RFC7950.
+
+      Types impacted:
+      - bgp-std-community-type
+      - bgp-ext-community-type";
+    reference "5.3.0";
+  }
+
+  revision "2020-06-30" {
+    description
+      "Add OpenConfig POSIX pattern extensions.";
+    reference "5.2.1";
+  }
+
+  revision "2020-06-17" {
+    description
+      "Add RFC5549 capability identity.";
+    reference "5.2.0";
+  }
+
+  revision "2020-03-24" {
+    description
+      "Add FlowSpec, BGP-LS and LSVR AFI-SAFI identities.";
+    reference "5.1.0";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "5.0.2";
+  }
+
+  revision "2018-08-20" {
+    description
+      "Correct description of AFI-SAFI enabled leaf.";
+    reference "5.0.1";
+  }
+
+  revision "2018-04-11" {
+    description
+      "Correct naming of BGP maximum prefix warning percentage leaf.";
+    reference "5.0.0";
+  }
+
+  revision "2018-03-20" {
+    description
+      "Added SR-TE policy SAFI";
+    reference "4.1.0";
+  }
+
+  revision "2017-07-30" {
+    description
+      "Clarification of add-paths send-max leaf";
+    reference "4.0.1";
+  }
+
+  revision "2017-07-10" {
+    description
+      "Add error notifications; moved add-paths config; add AS
+      prepend policy features; removed unneeded config leaves";
+    reference "4.0.0";
+  }
+
+  identity BGP_ERROR_CODE {
+    description
+      "Indicates the error type in a BGP NOTIFICATION message";
+    reference
+      "RFC 4271 - A Border Gateway Protocol 4 (BGP-4)";
+  }
+
+  identity BGP_ERROR_SUBCODE {
+    description
+      "Provides more specific information about the nature of the
+      error reported in a NOTIFICATION message. Each Error
+      Code may have one or more Error Subcodes associated with it.";
+    reference
+      "RFC 4271 - A Border Gateway Protocol 4 (BGP-4)";
+  }
+
+
+  identity UNSPECIFIC {
+    base  BGP_ERROR_SUBCODE;
+    description
+      "The error subcode field is unspecific when the NOTIFICATION
+      message does not include any specific error subcode (i.e..,
+      value 0).";
+  }
+
+  identity MESSAGE_HEADER_ERROR {
+    base BGP_ERROR_CODE;
+    description
+      "Errors detected while processing the Message Header";
+  }
+
+  identity OPEN_MESSAGE_ERROR {
+    base BGP_ERROR_CODE;
+    description
+      "Errors detected while processing the OPEN message";
+  }
+
+  identity UPDATE_MESSAGE_ERROR {
+    base BGP_ERROR_CODE;
+    description
+      "Errors detected while processing the UPDATE message";
+  }
+
+  identity HOLD_TIMER_EXPIRED {
+    base BGP_ERROR_CODE;
+    description
+      "Indicates that the system did not receive successive
+      KEEPALIVE, UPDATE, and/or NOTIFICATION messages within the
+      period specified in the Hold Time field of the OPEN message";
+  }
+
+  identity FINITE_STATE_MACHINE_ERROR {
+    base BGP_ERROR_CODE;
+    description
+      "Error detected by the BGP Finite State Machine
+      (e.g., receipt of an unexpected event)";
+  }
+
+  identity CEASE {
+    base BGP_ERROR_CODE;
+    description
+      "Sent by a BGP peer to close its BGP connection in absence of
+      any fatal errors.  If the BGP speaker terminates its
+      connection with a neihbor because the number of prefixes
+      received exceeds the configured upper bound, the speaker must
+      send the neighbor a NOTIFICATION message with the Cease
+      error code.";
+  }
+
+  identity ROUTE_REFRESH_MESSAGE_ERROR {
+    base BGP_ERROR_CODE;
+    description
+      "The length, excluding the fixed-size message header, of the
+      received ROUTE-REFRESH message with Message Subtype 1 and 2 is
+      not 4.  Applicable only when a BGP speaker has received the
+      'Enhanced Route Refresh Capability' from a peer";
+    reference
+      "RFC 7313 - Enhanced Route Refresh Capability for BGP-4";
+  }
+
+  identity MESSAGE_HEADER_SUBCODE {
+    base BGP_ERROR_SUBCODE;
+    description
+      "Error subcode definitions for Message Header error
+      notifications";
+  }
+
+  identity CONNECTION_NOT_SYNCHRONIZED {
+    base MESSAGE_HEADER_SUBCODE;
+    description
+      "Marker field of the message header is not all ones as
+      expected";
+  }
+
+  identity BAD_MESSAGE_LENGTH {
+    base MESSAGE_HEADER_SUBCODE;
+    description
+      "Indicates the message has an erroneous length with one
+      or more of the following:
+
+      - the Length field of the message header is less than 19 or
+        greater than 4096
+
+      - the Length field of an OPEN message is less than the minimum
+        length of the OPEN message
+
+      - the Length field of an UPDATE message is less than the
+        minimum length of the UPDATE message
+
+      - the Length field of a KEEPALIVE message is not equal to 19
+
+      - the Length field of a NOTIFICATION message is less than the
+        minimum length of the NOTIFICATION message
+
+      The erroneous Length field must be reported in the
+      NOTIFICATION data.";
+  }
+
+  identity BAD_MESSAGE_TYPE {
+    base MESSAGE_HEADER_SUBCODE;
+    description
+      "Type field of the message header is not recognized.  The
+      erroneous type field must be reported in the NOTIFICATION
+      data";
+  }
+
+  identity OPEN_MESSAGE_SUBCODE {
+    base BGP_ERROR_SUBCODE;
+    description
+      "Error subcode definitions for OPEN message error
+      notifications";
+  }
+
+  identity UNSUPPORTED_VERSION_NUMBER {
+    base OPEN_MESSAGE_SUBCODE;
+    description
+      "Version number in the Version field of the received OPEN
+      message is not supported";
+  }
+
+  identity BAD_PEER_AS {
+    base  OPEN_MESSAGE_SUBCODE;
+    description
+      "Autonomous System field of the OPEN message is unacceptable";
+  }
+
+  identity BAD_BGP_IDENTIFIER {
+    base OPEN_MESSAGE_SUBCODE;
+    description
+      "BGP Identifier field of the OPEN message is syntactically
+      incorrect";
+  }
+
+  identity UNSUPPORTED_OPTIONAL_PARAMETER {
+    base OPEN_MESSAGE_SUBCODE;
+    description
+      "One of the Optional Parameters in the OPEN message is not
+      recognized";
+  }
+
+  identity UNACCEPTABLE_HOLD_TIME {
+    base OPEN_MESSAGE_SUBCODE;
+    description
+      "Hold Time field of the OPEN message is unacceptable";
+  }
+
+  identity UNSUPPORTED_CAPABILITY {
+    base OPEN_MESSAGE_SUBCODE;
+    description
+      "Inidicates that the peer does not support capabilities
+      advertisement -- the peer may send this subcode in response to
+      an OPEN message that carries the Capabilities Optional
+      Parameter";
+    reference
+      "RFC 5492 - Capabilities Advertisement with BGP-4";
+  }
+
+  identity UPDATE_MESSAGE_SUBCODE {
+    base BGP_ERROR_SUBCODE;
+    description
+      "Error subcode definitions for UPDATE message error
+      notifications";
+  }
+
+  identity MALFORMED_ATTRIBUTE_LIST {
+    base UPDATE_MESSAGE_SUBCODE;
+    description
+      "Inidicates Withdrawn Routes Length or Total Attribute Length
+      is too large, or
+
+      An attribute appears more than once in the UPDATE message";
+  }
+
+  identity UNRECOGNIZED_WELL_KNOWN_ATTRIBUTE {
+    base UPDATE_MESSAGE_SUBCODE;
+    description
+      "One or more of the well-known mandatory attributes are not
+      recognized";
+  }
+
+  identity MISSING_WELL_KNOWN_ATTRIBUTE {
+    base UPDATE_MESSAGE_SUBCODE;
+    description
+      "One or more of the well-known mandatory attributes are not
+      present";
+  }
+
+  identity ATTRIBUTE_FLAGS_ERROR {
+    base UPDATE_MESSAGE_SUBCODE;
+    description
+      "Attribute has Attribute Flags that conflict with the
+      Attribute Type Code";
+  }
+
+  identity ATTRIBUTE_LENGTH_ERROR {
+    base UPDATE_MESSAGE_SUBCODE;
+    description
+      "Attribute has an Attribute Length that conflicts with the
+      expected length (based on the attribute type code)";
+  }
+
+  identity INVALID_ORIGIN_ATTRIBUTE {
+    base UPDATE_MESSAGE_SUBCODE;
+    description
+      "ORIGIN attribute has an undefined value";
+  }
+
+  identity INVALID_NEXT_HOP_ATTRIBUTE {
+    base UPDATE_MESSAGE_SUBCODE;
+    description
+      "The NEXT_HOP attribute field is syntactically incorrect";
+  }
+
+  identity OPTIONAL_ATTRIBUTE_ERROR {
+    base UPDATE_MESSAGE_SUBCODE;
+    description
+      "An error is detected in the value of a recognized optional
+      attribute (such an attribute must be discarded)";
+  }
+
+  identity INVALID_NETWORK_FIELD {
+    base UPDATE_MESSAGE_SUBCODE;
+    description
+      "The NLRI field in the UPDATE message is syntactically
+      incorrect";
+  }
+
+  identity MALFORMED_AS_PATH {
+    base UPDATE_MESSAGE_SUBCODE;
+    description
+      "The AS_PATH attribute is syntactically incorrect";
+  }
+
+  identity FINITE_STATE_MACHINE_SUBCODE {
+    base BGP_ERROR_SUBCODE;
+    description
+      "Error subcode definitions for BGP finite state machine
+      errors.";
+    reference
+      "RFC 6608 - Subcodes for BGP Finite State Machine Error";
+  }
+
+  identity RECEIVE_UNEXPECTED_MESSAGE_OPENSENT {
+    base FINITE_STATE_MACHINE_SUBCODE;
+    description
+      "The peer BGP speaker received an unexpected message from
+      the local system while the peer speaker session was in the
+      OpenSent state";
+  }
+
+  identity RECEIVE_UNEXPECTED_MESSAGE_OPENCONFIRM {
+    base FINITE_STATE_MACHINE_SUBCODE;
+    description
+      "The peer BGP speaker received an unexpected message from
+      the local system while the peer speaker session was in the
+      OpenConfirm state";
+  }
+
+  identity RECEIVE_UNEXPECTED_MESSAGE_ESTABLISHED {
+    base FINITE_STATE_MACHINE_SUBCODE;
+    description
+      "The peer BGP speaker received an unexpected message from
+      the local system while the peer speaker session was in the
+      Established state";
+  }
+
+  identity CEASE_SUBCODE {
+    base BGP_ERROR_SUBCODE;
+    description
+      "Error subcode definitions for Cease notification messages";
+    reference
+      "RFC 4486 - Subcodes for BGP Cease Notification Message";
+  }
+
+  identity MAX_NUM_PREFIXES_REACHED {
+    base CEASE_SUBCODE;
+    description
+      "The peer BGP speaker terminated its peering with the local
+      system because the number of address prefixes received
+      exceeds a locally configured upper bound";
+  }
+
+  identity ADMINISTRATIVE_SHUTDOWN {
+    base CEASE_SUBCODE;
+    description
+      "The peer BGP speaker administratively shut down its peering
+      with the local system";
+  }
+
+  identity PEER_DE_CONFIGURED {
+    base CEASE_SUBCODE;
+    description
+      "The peer BGP speaker de-configure the peering with the local
+      system";
+  }
+
+  identity ADMINISTRATIVE_RESET {
+    base CEASE_SUBCODE;
+    description
+      "The peer BGP speaker administratively reset the peering with
+      the local system";
+  }
+
+  identity CONNECTION_REJECTED {
+    base CEASE_SUBCODE;
+    description
+      "The peer BGP speaker disallowed the BGP connection to the
+      local system after the peer speaker accepted a transport
+      protocol connection";
+  }
+
+  identity OTHER_CONFIG_CHANGE {
+    base CEASE_SUBCODE;
+    description
+      "The peer BGP speaker administratively reset the peering with
+      the local sytem due to a configuration change that is not
+      covered by another subcode.";
+  }
+
+  identity CONN_COLLISION_RESOLUTION {
+    base CEASE_SUBCODE;
+    description
+      "The peer BGP speaker sent a CEASE NOTIFICATION as a result of
+      the collision resolution procedure described in RFC 4271";
+  }
+
+  identity OUT_OF_RESOURCES {
+    base CEASE_SUBCODE;
+    description
+      "The peer BGP speaker ran out of resources (e.g., memory) and
+      reset the session with the local system";
+  }
+
+  identity ROUTE_REFRESH_SUBCODE {
+    base BGP_ERROR_SUBCODE;
+    description
+      "Error subcode definitions for the ROUTE-REFRESH message
+      error";
+  }
+
+  identity INVALID_MESSAGE_LENGTH {
+    base ROUTE_REFRESH_SUBCODE;
+    description
+      "The length, excluding the fixed-size message header, of the
+      received ROUTE-REFRESH message with Message Subtype 1 and 2
+      is not 4";
+  }
+}

--- a/models/yang/common/openconfig-bgp-global.yang
+++ b/models/yang/common/openconfig-bgp-global.yang
@@ -1,0 +1,518 @@
+submodule openconfig-bgp-global {
+
+  belongs-to openconfig-bgp {
+    prefix "oc-bgp";
+  }
+
+  import openconfig-extensions { prefix oc-ext; }
+  import openconfig-yang-types { prefix oc-yang; }
+  import openconfig-inet-types { prefix oc-inet; }
+  import openconfig-routing-policy { prefix oc-rpol; }
+
+  // Include common submodules
+  include openconfig-bgp-common;
+  include openconfig-bgp-common-multiprotocol;
+  include openconfig-bgp-peer-group;
+  include openconfig-bgp-common-structure;
+
+  // meta
+  organization
+    "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    netopenconfig@googlegroups.com";
+
+  description
+    "This sub-module contains groupings that are specific to the
+    global context of the OpenConfig BGP module";
+
+  oc-ext:openconfig-version "9.7.1";
+
+  revision "2023-12-28" {
+    description
+      "Clarification to last-prefix-limit-exceeded in description";
+          reference "9.7.1";
+  }
+
+  revision "2023-12-28" {
+    description
+      "Add support for controling use of link-bandwidth extended
+      community for BGP multipath.";
+    reference "9.7.0";
+  }
+
+  revision "2023-11-02" {
+    description
+      "Fix revision '2023-03-31': send-community-type was added to the
+       wrong grouping.
+      Allow configuring send-community per AFI-SAFI at
+       neighbor/peer-group.";
+    reference "9.6.0";
+  }
+
+  revision "2023-11-01" {
+    description
+      "Add default apply policy to global and per afi-safi config.";
+    reference "9.5.0";
+  }
+
+  revision "2023-06-27" {
+    description
+      "Clarify bgp remote-port description";
+    reference "9.4.1";
+  }
+
+  revision "2023-04-01" {
+    description
+      "Add support for BGP large communities [rfc8092] in
+      send-community.
+      Leaf send-community was replaced by the leaf-list
+      send-community-type to allow the combination of different
+      community types";
+    reference "9.4.0";
+  }
+
+  revision "2023-03-31" {
+    description
+      "Allow configuring send-community per AFI-SAFI at
+       neighbor/peer-group.";
+    reference "9.3.0";
+  }
+
+  revision "2022-12-12" {
+    description
+      "Removed the default of enabled leaf of AFI-SAFI
+      at neighbor/peer-group to support BGP inheritance model.";
+    reference "9.2.0";
+  }
+
+  revision "2022-05-21" {
+    description
+      "Added extended-next-hop-encoding leaf.";
+    reference "9.1.0";
+  }
+
+  revision "2022-04-26" {
+    description
+      "Transition decimal64 types to uint16 for various BGP timers";
+    reference "9.0.0";
+  }
+
+  revision "2022-03-21" {
+    description
+      "Add BGP port";
+    reference "8.1.0";
+  }
+
+  revision "2021-12-01" {
+    description
+      "Add prefix-limit-received, add prefix-limit
+      state nodes, change/relocate restart-timer";
+    reference "8.0.0";
+  }
+
+  revision "2021-10-21" {
+    description
+      "Removal of top-level /bgp container";
+    reference "7.0.0";
+  }
+
+  revision "2021-06-16" {
+    description
+      "Remove trailing whitespace";
+    reference "6.1.1";
+  }
+
+  revision "2021-03-17" {
+    description
+      "Add bfd support without augmentation.";
+    reference "6.1.0";
+  }
+
+  revision "2019-07-10" {
+    description
+      "Normalise timestamp units to nanoseconds.";
+    reference "6.0.0";
+  }
+
+  revision "2019-05-28" {
+    description
+      "Clarify prefix counter descriptions, add received-pre-policy
+      counter.";
+    reference "5.2.0";
+  }
+
+  revision "2019-04-16" {
+    description
+      "Add BGP RIB to the top-level BGP container";
+    reference "5.1.0";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "5.0.2";
+  }
+
+  revision "2018-08-20" {
+    description
+      "Correct description of AFI-SAFI enabled leaf.";
+    reference "5.0.1";
+  }
+
+  revision "2018-04-11" {
+    description
+      "Correct naming of BGP maximum prefix warning percentage leaf.";
+    reference "5.0.0";
+  }
+
+  revision "2018-03-20" {
+    description
+      "Added SR-TE policy SAFI";
+    reference "4.1.0";
+  }
+
+  revision "2017-07-10" {
+    description
+      "Add error notifications; moved add-paths config; add AS
+      prepend policy features; removed unneeded config leaves";
+    reference "4.0.0";
+  }
+
+  revision "2017-02-02" {
+    description
+      "Bugfix to remove remaining global-level policy data";
+    reference "3.0.1";
+  }
+
+  revision "2017-01-26" {
+    description
+      "Add dynamic neighbor support, migrate to OpenConfig types";
+    reference "3.0.0";
+  }
+
+  revision "2016-06-21" {
+    description
+      "OpenConfig BGP refactor";
+    reference "2.1.1";
+  }
+
+  grouping bgp-global-config {
+    description
+      "Global configuration options for the BGP router.";
+
+    leaf as {
+      type oc-inet:as-number;
+      mandatory true;
+      description
+        "Local autonomous system number of the router.  Uses
+        the 32-bit as-number type from the model in RFC 6991.";
+    }
+
+    leaf router-id {
+      type oc-yang:dotted-quad;
+      description
+        "Router id of the router - an unsigned 32-bit integer
+        expressed in dotted quad notation.";
+      reference
+        "RFC4271 - A Border Gateway Protocol 4 (BGP-4),
+        Section 4.2";
+    }
+  }
+
+  grouping bgp-global-state {
+    description
+      "Operational state parameters for the BGP neighbor";
+
+    uses bgp-common-state;
+  }
+
+  grouping bgp-global-default-route-distance-config {
+    description
+      "Configuration options relating to the administrative distance
+      (or preference) assigned to routes received from different
+      sources (external, internal, and local).";
+
+    leaf external-route-distance {
+      type uint8 {
+        range "1..255";
+      }
+      description
+        "Administrative distance for routes learned from external
+        BGP (eBGP).";
+    }
+    leaf internal-route-distance {
+      type uint8 {
+        range "1..255";
+      }
+      description
+        "Administrative distance for routes learned from internal
+        BGP (iBGP).";
+    }
+  }
+
+  grouping bgp-global-confederation-config {
+    description
+      "Configuration options specifying parameters when the local
+      router is within an autonomous system which is part of a BGP
+      confederation.";
+
+    leaf identifier {
+      type oc-inet:as-number;
+      description
+        "Confederation identifier for the autonomous system.
+        Setting the identifier indicates that the local-AS is part
+        of a BGP confederation.";
+    }
+
+    leaf-list member-as {
+      type oc-inet:as-number;
+      description
+        "Remote autonomous systems that are to be treated
+        as part of the local confederation.";
+    }
+  }
+
+  grouping bgp-global-dynamic-neighbors {
+    description
+      "Grouping containing configuration relating to dynamic peers.";
+
+    container dynamic-neighbor-prefixes {
+      description
+        "A list of IP prefixes from which the system should:
+          - Accept connections to the BGP daemon
+          - Dynamically configure a BGP neighbor corresponding to the
+            source address of the remote system, using the parameters
+            of the specified peer-group.
+         For such neighbors, an entry within the neighbor list should
+         be created, indicating that the peer was dynamically
+         configured, and referencing the peer-group from which the
+         configuration was derived.";
+
+      list dynamic-neighbor-prefix {
+        key "prefix";
+        description
+          "An individual prefix from which dynamic neighbor
+          connections are allowed.";
+
+        leaf prefix {
+          type leafref {
+            path "../config/prefix";
+          }
+          description
+            "Reference to the IP prefix from which source connections
+            are allowed for the dynamic neighbor group.";
+        }
+
+        container config {
+          description
+            "Configuration parameters relating to the source prefix
+            for the dynamic BGP neighbor connections.";
+
+          uses bgp-global-dynamic-neighbor-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state parameters relating to the source
+            prefix for the dynamic BGP neighbor connections.";
+
+          uses bgp-global-dynamic-neighbor-config;
+        }
+      }
+    }
+  }
+
+  grouping bgp-global-dynamic-neighbor-config {
+    description
+      "Configuration parameters relating to an individual prefix from
+      which dynamic neighbors are accepted.";
+
+    leaf prefix {
+      type oc-inet:ip-prefix;
+      description
+        "The IP prefix within which the source address of the remote
+        BGP speaker must fall to be considered eligible to the
+        dynamically configured."; }
+
+    leaf peer-group {
+      type leafref {
+        // At bgp/global/dynamic-neighbor-prefixes/dynamic-neighbor
+        // prefix/config/peer-group
+        path "../../../../../peer-groups/peer-group/config/" +
+             "peer-group-name";
+      }
+      description
+        "The peer-group within which the dynamic neighbor will be
+        configured.  The configuration parameters used for the dynamic
+        neighbor are those specified within the referenced peer
+        group.";
+    }
+  }
+
+  grouping bgp-global-mp-all-afi-safi-list-contents {
+    description
+      "A grouping used for contents of the list of AFI-SAFI
+      entries at the global BGP level.";
+
+    // import and export policy included for the afi/safi
+
+    uses bgp-common-mp-ipv4-unicast-group;
+    uses bgp-common-mp-ipv6-unicast-group;
+    uses bgp-common-mp-ipv4-labeled-unicast-group;
+    uses bgp-common-mp-ipv6-labeled-unicast-group;
+    uses bgp-common-mp-l3vpn-ipv4-unicast-group;
+    uses bgp-common-mp-l3vpn-ipv6-unicast-group;
+    uses bgp-common-mp-l3vpn-ipv4-multicast-group;
+    uses bgp-common-mp-l3vpn-ipv6-multicast-group;
+    uses bgp-common-mp-l2vpn-vpls-group;
+    uses bgp-common-mp-l2vpn-evpn-group;
+    uses bgp-common-mp-srte-policy-ipv4-group;
+    uses bgp-common-mp-srte-policy-ipv6-group;
+  }
+
+  grouping bgp-global-afi-safi-list {
+    description
+      "List of address-families associated with the BGP instance";
+
+    list afi-safi {
+      key "afi-safi-name";
+
+      description
+        "AFI,SAFI configuration available for the
+        neighbour or group";
+
+      leaf afi-safi-name {
+        type leafref {
+          path "../config/afi-safi-name";
+        }
+        description
+          "Reference to the AFI-SAFI name used as a key
+          for the AFI-SAFI list";
+      }
+
+      container config {
+        description
+          "Configuration parameters for the AFI-SAFI";
+        uses bgp-common-mp-global-afi-safi-config;
+      }
+      container state {
+        config false;
+        description
+          "State information relating to the AFI-SAFI";
+        uses bgp-common-mp-global-afi-safi-config;
+        uses bgp-common-state;
+      }
+
+      container graceful-restart {
+        description
+          "Parameters relating to BGP graceful-restart";
+        container config {
+          description
+            "Configuration options for BGP graceful-restart";
+          uses bgp-common-mp-afi-safi-graceful-restart-config;
+        }
+        container state {
+          config false;
+          description
+            "State information for BGP graceful-restart";
+          uses bgp-common-mp-afi-safi-graceful-restart-config;
+        }
+      }
+
+      uses bgp-common-route-selection-options;
+      uses bgp-common-global-group-use-multiple-paths;
+      uses bgp-common-structure-neighbor-group-add-paths;
+      uses bgp-global-mp-all-afi-safi-list-contents;
+      uses oc-rpol:default-policy-group;
+    }
+  }
+
+  // Structural groupings
+  grouping bgp-global-base {
+    description
+      "Global configuration parameters for the BGP router";
+
+    container config {
+      description
+        "Configuration parameters relating to the global BGP router";
+      uses bgp-global-config;
+    }
+    container state {
+      config false;
+      description
+        "State information relating to the global BGP router";
+      uses bgp-global-config;
+      uses bgp-global-state;
+    }
+
+    container default-route-distance {
+      description
+        "Administrative distance (or preference) assigned to
+        routes received from different sources
+        (external, internal, and local).";
+
+      container config {
+        description
+          "Configuration parameters relating to the default route
+          distance";
+        uses bgp-global-default-route-distance-config;
+      }
+      container state {
+        config false;
+        description
+          "State information relating to the default route distance";
+        uses bgp-global-default-route-distance-config;
+      }
+    }
+
+    container confederation {
+      description
+        "Parameters indicating whether the local system acts as part
+        of a BGP confederation";
+
+      container config {
+        description
+          "Configuration parameters relating to BGP confederations";
+        uses bgp-global-confederation-config;
+      }
+      container state {
+        config false;
+        description
+          "State information relating to the BGP confederations";
+        uses bgp-global-confederation-config;
+      }
+    }
+
+    container graceful-restart {
+      description
+        "Parameters relating the graceful restart mechanism for BGP";
+      container config {
+        description
+          "Configuration parameters relating to graceful-restart";
+        uses bgp-common-graceful-restart-config;
+      }
+      container state {
+        config false;
+        description
+          "State information associated with graceful-restart";
+        uses bgp-common-graceful-restart-config;
+      }
+    }
+
+    uses bgp-common-global-group-use-multiple-paths;
+    uses bgp-common-route-selection-options;
+
+    container afi-safis {
+      description
+        "Address family specific configuration";
+      uses bgp-global-afi-safi-list;
+    }
+
+    uses bgp-global-dynamic-neighbors;
+    uses oc-rpol:default-policy-group;
+  }
+
+}

--- a/models/yang/common/openconfig-bgp-neighbor.yang
+++ b/models/yang/common/openconfig-bgp-neighbor.yang
@@ -1,0 +1,885 @@
+submodule openconfig-bgp-neighbor {
+
+  belongs-to openconfig-bgp {
+    prefix "oc-bgp";
+  }
+
+  import openconfig-extensions { prefix oc-ext; }
+  import openconfig-routing-policy { prefix oc-rpol; }
+  import openconfig-types { prefix oc-types; }
+  import openconfig-bgp-types { prefix oc-bgp-types; }
+  import openconfig-inet-types { prefix oc-inet; }
+  import openconfig-yang-types { prefix oc-yang; }
+  import openconfig-bfd { prefix oc-bfd; }
+
+  // Include the common submodule
+  include openconfig-bgp-common;
+  include openconfig-bgp-common-multiprotocol;
+  include openconfig-bgp-peer-group;
+  include openconfig-bgp-common-structure;
+
+  // meta
+  organization
+    "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    netopenconfig@googlegroups.com";
+
+  description
+    "This sub-module contains groupings that are specific to the
+    neighbor context of the OpenConfig BGP module.";
+
+  oc-ext:openconfig-version "9.7.1";
+
+  revision "2023-12-28" {
+    description
+      "Clarification to last-prefix-limit-exceeded in description";
+          reference "9.7.1";
+  }
+
+  revision "2023-12-28" {
+    description
+      "Add support for controling use of link-bandwidth extended
+      community for BGP multipath.";
+          reference "9.7.0";
+  }
+
+  revision "2023-11-02" {
+    description
+      "Fix revision '2023-03-31': send-community-type was added to the
+       wrong grouping.
+      Allow configuring send-community per AFI-SAFI at
+       neighbor/peer-group.";
+    reference "9.6.0";
+  }
+
+  revision "2023-11-01" {
+    description
+      "Add default apply policy to global and per afi-safi config.";
+    reference "9.5.0";
+  }
+
+  revision "2023-06-27" {
+    description
+      "Clarify bgp neighbor-port, remote-port and local-port descriptions";
+    reference "9.4.1";
+  }
+
+  revision "2023-04-01" {
+    description
+      "Add support for BGP large communities [rfc8092] in
+      send-community.
+      Leaf send-community was replaced by the leaf-list
+      send-community-type to allow the combination of different
+      community types";
+    reference "9.4.0";
+  }
+
+  revision "2023-03-31" {
+    description
+      "Allow configuring send-community per AFI-SAFI at
+       neighbor/peer-group.";
+    reference "9.3.0";
+  }
+
+  revision "2022-12-12" {
+    description
+      "Removed the default of enabled leaf of AFI-SAFI
+      at neighbor/peer-group to support BGP inheritance model.";
+    reference "9.2.0";
+  }
+
+  revision "2022-05-21" {
+    description
+      "Added extended-next-hop-encoding leaf.";
+    reference "9.1.0";
+  }
+
+  revision "2022-04-26" {
+    description
+      "Transition decimal64 types to uint16 for various BGP timers";
+    reference "9.0.0";
+  }
+
+  revision "2022-03-21" {
+    description
+      "Add BGP port";
+    reference "8.1.0";
+  }
+
+  revision "2021-12-01" {
+    description
+      "Add prefix-limit-received, add prefix-limit
+      state nodes, change/relocate restart-timer";
+    reference "8.0.0";
+  }
+
+  revision "2021-10-21" {
+    description
+      "Removal of top-level /bgp container";
+    reference "7.0.0";
+  }
+
+  revision "2021-06-16" {
+    description
+      "Remove trailing whitespace";
+    reference "6.1.1";
+  }
+
+  revision "2021-03-17" {
+    description
+      "Add bfd support without augmentation.";
+    reference "6.1.0";
+  }
+
+  revision "2019-07-10" {
+    description
+      "Normalise timestamp units to nanoseconds.";
+    reference "6.0.0";
+  }
+
+  revision "2019-05-28" {
+    description
+      "Clarify prefix counter descriptions, add received-pre-policy
+      counter.";
+    reference "5.2.0";
+  }
+
+  revision "2019-04-16" {
+    description
+      "Add BGP RIB to the top-level BGP container";
+    reference "5.1.0";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "5.0.2";
+  }
+
+  revision "2018-08-20" {
+    description
+      "Correct description of AFI-SAFI enabled leaf.";
+    reference "5.0.1";
+  }
+
+  revision "2018-04-11" {
+    description
+      "Correct naming of BGP maximum prefix warning percentage leaf.";
+    reference "5.0.0";
+  }
+
+  revision "2018-03-20" {
+    description
+      "Added SR-TE policy SAFI";
+    reference "4.1.0";
+  }
+
+  revision "2017-07-30" {
+    description
+      "Clarification of add-paths send-max leaf";
+    reference "4.0.1";
+  }
+
+  revision "2017-07-10" {
+    description
+      "Add error notifications; moved add-paths config; add AS
+      prepend policy features; removed unneeded config leaves";
+    reference "4.0.0";
+  }
+
+  revision "2017-02-02" {
+    description
+      "Bugfix to remove remaining global-level policy data";
+    reference "3.0.1";
+  }
+
+  revision "2017-01-26" {
+    description
+      "Add dynamic neighbor support, migrate to OpenConfig types";
+    reference "3.0.0";
+  }
+
+  revision "2016-06-21" {
+    description
+      "OpenConfig BGP refactor";
+    reference "2.1.1";
+  }
+
+  grouping bgp-neighbor-config {
+    description
+      "Configuration parameters relating to a base BGP neighbor that
+      are not also applicable to any other context
+      (e.g., peer group)";
+
+    leaf peer-group {
+      type leafref {
+        path "../../../../peer-groups/peer-group/peer-group-name";
+      }
+      description
+        "The peer-group with which this neighbor is associated";
+    }
+
+    leaf neighbor-address {
+        type oc-inet:ip-address;
+        description
+          "Address of the BGP peer, either in IPv4 or IPv6";
+    }
+
+    leaf neighbor-port {
+        type oc-inet:port-number;
+        default 179;
+        description
+          "Destination TCP port number of the BGP peer when initiating a
+          session from the local router";
+    }
+
+    leaf enabled {
+        type boolean;
+        default true;
+        description
+          "Whether the BGP peer is enabled. In cases where the
+          enabled leaf is set to false, the local system should not
+          initiate connections to the neighbor, and should not
+          respond to TCP connections attempts from the neighbor. If
+          the state of the BGP session is ESTABLISHED at the time
+          that this leaf is set to false, the BGP session should be
+          ceased.";
+    }
+  }
+
+  grouping bgp-neighbor-use-multiple-paths {
+    description
+      "Multipath configuration and state applicable to a BGP
+      neighbor";
+
+    container use-multiple-paths {
+      description
+        "Parameters related to the use of multiple-paths for the same
+        NLRI when they are received only from this neighbor";
+
+      container config {
+        description
+          "Configuration parameters relating to multipath";
+        uses bgp-common-use-multiple-paths-config;
+      }
+      container state {
+        config false;
+        description
+          "State parameters relating to multipath";
+        uses bgp-common-use-multiple-paths-config;
+      }
+
+      container ebgp {
+        description
+          "Multipath configuration for eBGP";
+        container config {
+          description
+            "Configuration parameters relating to eBGP multipath";
+          uses bgp-common-use-multiple-paths-ebgp-as-options-config;
+        }
+        container state {
+          config false;
+          description
+            "State information relating to eBGP multipath";
+          uses bgp-common-use-multiple-paths-ebgp-as-options-config;
+        }
+      }
+    }
+  }
+
+  grouping bgp-neighbor-state {
+    description
+      "Operational state parameters relating only to a BGP neighbor";
+
+    leaf session-state {
+      type enumeration {
+          enum IDLE {
+            description
+              "neighbor is down, and in the Idle state of the
+              FSM";
+          }
+          enum CONNECT {
+            description
+              "neighbor is down, and the session is waiting for
+              the underlying transport session to be established";
+          }
+          enum ACTIVE {
+            description
+              "neighbor is down, and the local system is awaiting
+              a conncetion from the remote peer";
+          }
+          enum OPENSENT {
+            description
+              "neighbor is in the process of being established.
+              The local system has sent an OPEN message";
+          }
+          enum OPENCONFIRM {
+            description
+              "neighbor is in the process of being established.
+              The local system is awaiting a NOTIFICATION or
+              KEEPALIVE message";
+          }
+          enum ESTABLISHED {
+            description
+              "neighbor is up - the BGP session with the peer is
+              established";
+          }
+        }
+      description
+        "Operational state of the BGP peer";
+    }
+
+    leaf last-established {
+      type oc-types:timeticks64;
+      description
+        "This timestamp indicates the time that the
+        BGP session last transitioned in or out of the Established
+        state.  The value is the timestamp in nanoseconds relative to
+        the Unix Epoch (Jan 1, 1970 00:00:00 UTC).
+
+        The BGP session uptime can be computed by clients as the
+        difference between this value and the current time in UTC
+        (assuming the session is in the ESTABLISHED state, per the
+        session-state leaf).";
+    }
+
+    leaf established-transitions {
+      type oc-yang:counter64;
+      description
+        "Number of transitions to the Established state for
+        the neighbor session.  This value is analogous to the
+        bgpPeerFsmEstablishedTransitions object from the standard
+        BGP-4 MIB";
+      reference
+        "RFC 4273 - Definitions of Managed Objects for BGP-4";
+    }
+
+    leaf-list supported-capabilities {
+      type identityref {
+        base oc-bgp-types:BGP_CAPABILITY;
+      }
+      description
+        "BGP capabilities negotiated as supported with the peer";
+    }
+
+    container messages {
+      description
+        "Counters for BGP messages sent and received from the
+        neighbor";
+      container sent {
+        description
+          "Counters relating to BGP messages sent to the neighbor";
+        uses bgp-neighbor-counters-message-types-state;
+        }
+
+      container received {
+        description
+          "Counters for BGP messages received from the neighbor";
+        uses bgp-neighbor-counters-message-types-state;
+      }
+    }
+
+    container queues {
+      description
+        "Counters related to queued messages associated with the
+        BGP neighbor";
+      uses bgp-neighbor-queue-counters-state;
+    }
+
+    leaf dynamically-configured {
+      type boolean;
+      default false;
+      description
+        "When this leaf is set to true, the peer was configured dynamically
+        due to an inbound connection request from a specified source prefix
+        within a dynamic-neighbor-prefix.";
+    }
+
+    leaf last-prefix-limit-exceeded {
+      type oc-types:timeticks64;
+      description
+        "This timestamp indicates the time that the BGP session last
+        violated a configured recived (pre-policy) or accepted (post-policy)
+        max prefix-limit for any AFI/SAFI combination
+        on the session.  The value is the timestamp in nanoseconds relative
+        to the Unix Epoch (Jan 1, 1970 00:00:00 UTC).
+
+        If the 'prefix-limit-exceeded' node is set to true for any AFI/SAFI
+        on the session, then the next restart time for the session can be
+        calculated as this value plus the configured 'restart-time' under
+        the neighbor timers.
+
+        This value should be retained across established sessions and is only
+        set/updated when prefix-limit-exceeded transitions from false/unset to
+        true.";
+    }
+  }
+
+  grouping bgp-neighbor-counters-message-types-state {
+    description
+      "Grouping of BGP message types, included for re-use
+      across counters";
+
+    leaf UPDATE {
+      type uint64;
+      description
+        "Number of BGP UPDATE messages announcing, withdrawing
+        or modifying paths exchanged.";
+    }
+
+    leaf NOTIFICATION {
+      type uint64;
+      description
+        "Number of BGP NOTIFICATION messages indicating an
+        error condition has occurred exchanged.";
+    }
+
+    leaf last-notification-time {
+      type oc-types:timeticks64;
+      description
+        "This timestamp indicates the time that a NOTIFICATION
+        message was sent or received on the peering session
+        (based on whether this leaf is associated with
+        sent or received messages).
+
+        The value is the timestamp in nanoseconds relative to
+        the Unix Epoch (Jan 1, 1970 00:00:00 UTC).";
+    }
+
+    leaf last-notification-error-code {
+      type identityref {
+        base oc-bgp-types:BGP_ERROR_CODE;
+      }
+      description
+        "Indicates the last BGP error sent or received on the peering
+        session (based on whether this leaf is associated with
+        sent or received messages).";
+    }
+
+    leaf last-notification-error-subcode {
+      type identityref {
+        base oc-bgp-types:BGP_ERROR_SUBCODE;
+      }
+      description
+        "Indicates the last BGP error subcode sent or received on
+        the peering session (based on whether this leaf is associated
+        with sent or received messages)";
+    }
+  }
+
+  grouping bgp-neighbor-queue-counters-state {
+    description
+      "Counters relating to the message queues associated with the
+      BGP peer";
+
+    leaf input {
+      type uint32;
+      description
+        "The number of messages received from the peer currently
+        queued";
+    }
+
+    leaf output {
+      type uint32;
+      description
+        "The number of messages queued to be sent to the peer";
+    }
+  }
+
+  grouping bgp-neighbor-transport-state {
+    description
+      "Operational state parameters relating to the transport session
+      used for the BGP session";
+
+    leaf local-port {
+      type oc-inet:port-number;
+      description
+        "Local, source TCP port being used for the TCP session supporting
+        the BGP session";
+    }
+
+    leaf remote-address {
+      type oc-inet:ip-address;
+      description
+        "Remote address to which the BGP session has been
+        established";
+    }
+
+    leaf remote-port {
+      type oc-inet:port-number;
+      description
+        "The source TCP port being used by the peer for the TCP session
+        supporting the BGP session.  This is expected to be the same value
+        as the configured neighbor-port if the local device initiated the
+        connection or a different TCP port if the peer initiated the TCP
+        session.";
+    }
+  }
+
+  grouping bgp-neighbor-error-handling-state {
+    description
+      "Operational state parameters relating to enhanced error
+      error handling for BGP";
+
+    leaf erroneous-update-messages {
+      type uint32;
+      description
+        "The number of BGP UPDATE messages for which the
+        treat-as-withdraw mechanism has been applied based
+        on erroneous message contents";
+    }
+  }
+
+  grouping bgp-neighbor-timers-state {
+    description
+      "Operational state parameters relating to BGP timers associated
+      with the BGP session";
+
+    leaf negotiated-hold-time {
+      type uint16;
+      description
+        "The negotiated hold-time for the BGP session";
+    }
+  }
+
+  grouping bgp-neighbor-afi-safi-graceful-restart-state {
+    description
+      "Operational state variables relating to the graceful-restart
+      mechanism on a per-AFI-SAFI basis";
+
+    leaf received {
+      type boolean;
+      description
+        "This leaf indicates whether the neighbor advertised the
+        ability to support graceful-restart for this AFI-SAFI";
+    }
+
+    leaf advertised {
+      type boolean;
+      description
+        "This leaf indicates whether the ability to support
+        graceful-restart has been advertised to the peer";
+    }
+  }
+
+  grouping bgp-neighbor-graceful-restart-state {
+    description
+      "Operational state information relevant to graceful restart
+      for BGP";
+
+    leaf peer-restart-time {
+      type uint16 {
+        range 0..4096;
+      }
+      description
+        "The period of time (advertised by the peer) that
+        the peer expects a restart of a BGP session to
+        take";
+    }
+
+    leaf peer-restarting {
+      type boolean;
+      description
+        "This flag indicates whether the remote neighbor is currently
+        in the process of restarting, and hence received routes are
+        currently stale";
+    }
+
+    leaf local-restarting {
+      type boolean;
+      description
+        "This flag indicates whether the local neighbor is currently
+        restarting. The flag is unset after all NLRI have been
+        advertised to the peer, and the End-of-RIB (EOR) marker has
+        been unset";
+    }
+
+    leaf mode {
+      type enumeration {
+        enum HELPER_ONLY {
+          description
+            "The local router is operating in helper-only mode, and
+            hence will not retain forwarding state during a local
+            session restart, but will do so during a restart of the
+            remote peer";
+        }
+        enum BILATERAL {
+          description
+            "The local router is operating in both helper mode, and
+            hence retains forwarding state during a remote restart,
+            and also maintains forwarding state during local session
+            restart";
+        }
+        enum REMOTE_HELPER {
+          description
+            "The local system is able to retain routes during restart
+            but the remote system is only able to act as a helper";
+        }
+      }
+      description
+        "Ths leaf indicates the mode of operation of BGP graceful
+        restart with the peer";
+    }
+  }
+
+  grouping bgp-neighbor-afi-safi-state {
+    description
+      "Operational state parameters relating to an individual AFI,
+      SAFI for a neighbor";
+
+    leaf active {
+      type boolean;
+      description
+        "This value indicates whether a particular AFI-SAFI has
+        been succesfully negotiated with the peer. An AFI-SAFI
+        may be enabled in the current running configuration, but a
+        session restart may be required in order to negotiate the new
+        capability.";
+    }
+
+    container prefixes {
+      description "Prefix counters for the BGP session";
+      leaf received {
+        type uint32;
+        description
+          "The number of prefixes that are received from the
+          neighbor after applying any policies. This count is the
+          number of prefixes present in the post-policy Adj-RIB-In
+          for the neighbor";
+      }
+
+      leaf received-pre-policy {
+        type uint32;
+        description
+          "The number of prefixes that are received from the
+          neighbor before applying any policies. This count is
+          the number of prefixes present in the pre-policy
+          Adj-RIB-In for the neighbor";
+      }
+
+      leaf sent {
+        type uint32;
+        description
+          "The number of prefixes that are advertised to the
+          neighbor after applying any policies. This count is
+          the number of prefixes present in the post-policy
+          Adj-RIB-Out for the neighbor";
+      }
+
+      leaf installed {
+        type uint32;
+        description
+          "The number of prefices received from the neighbor that
+          are installed in the network instance RIB and actively used
+          for forwarding.
+
+          Routes that are actively used for forwarding are
+           defined to be those that:
+           - are selected, after the application of policies, to be
+             included in the Adj-RIB-In-Post, AND
+           - are selected by best path selection and hence installed
+             in the Loc-RIB (either as the only route, or as part of
+             a multipath set, AND
+           - are selected, after the application of protocol
+             preferences (e.g., administrative distance) as the
+             route to be used by the system's RIB";
+      }
+    }
+  }
+
+  grouping bgp-neighbor-afi-safi-list {
+    description
+      "List of address-families associated with the BGP neighbor";
+
+    list afi-safi {
+      key "afi-safi-name";
+
+      description
+        "AFI,SAFI configuration available for the
+        neighbour or group";
+
+
+      leaf afi-safi-name {
+        type leafref {
+          path "../config/afi-safi-name";
+        }
+        description
+          "Reference to the AFI-SAFI name used as a key
+          for the AFI-SAFI list";
+      }
+
+      container config {
+        description
+          "Configuration parameters for the AFI-SAFI";
+        uses bgp-common-mp-afi-safi-config;
+      }
+      container state {
+        config false;
+        description
+          "State information relating to the AFI-SAFI";
+        uses bgp-common-mp-afi-safi-config;
+        uses bgp-neighbor-afi-safi-state;
+      }
+
+
+      container graceful-restart {
+        description
+          "Parameters relating to BGP graceful-restart";
+        container config {
+          description
+            "Configuration options for BGP graceful-restart";
+          uses bgp-common-mp-afi-safi-graceful-restart-config;
+        }
+        container state {
+          config false;
+          description
+            "State information for BGP graceful-restart";
+          uses bgp-common-mp-afi-safi-graceful-restart-config;
+          uses bgp-neighbor-afi-safi-graceful-restart-state;
+        }
+      }
+
+      uses bgp-common-structure-neighbor-group-add-paths;
+      uses bgp-common-mp-all-afi-safi-list-contents;
+      uses bgp-neighbor-use-multiple-paths;
+    }
+  }
+
+  grouping bgp-neighbor-base {
+    description
+      "Parameters related to a BGP neighbor";
+
+    container config {
+      description
+        "Configuration parameters relating to the BGP neighbor or
+        group";
+      uses bgp-neighbor-config;
+      uses bgp-common-neighbor-group-config;
+    }
+    container state {
+      config false;
+      description
+        "State information relating to the BGP neighbor";
+      uses bgp-neighbor-config;
+      uses bgp-common-neighbor-group-config;
+      uses bgp-neighbor-state;
+    }
+
+    container timers {
+      description
+        "Timers related to a BGP neighbor";
+      container config {
+        description
+          "Configuration parameters relating to timers used for the
+          BGP neighbor";
+        uses bgp-common-neighbor-group-timers-config;
+      }
+      container state {
+        config false;
+        description
+          "State information relating to the timers used for the BGP
+          neighbor";
+        uses bgp-common-neighbor-group-timers-config;
+        uses bgp-neighbor-timers-state;
+      }
+    }
+
+    container transport {
+      description
+        "Transport session parameters for the BGP neighbor";
+      container config {
+        description
+          "Configuration parameters relating to the transport
+          session(s) used for the BGP neighbor";
+        uses bgp-common-neighbor-group-transport-config;
+      }
+      container state {
+        config false;
+        description
+          "State information relating to the transport session(s)
+          used for the BGP neighbor";
+        uses bgp-common-neighbor-group-transport-config;
+        uses bgp-neighbor-transport-state;
+      }
+    }
+
+    container error-handling {
+      description
+        "Error handling parameters used for the BGP neighbor or
+        group";
+      container config {
+        description
+          "Configuration parameters enabling or modifying the
+          behavior or enhanced error handling mechanisms for the BGP
+          neighbor";
+        uses bgp-common-neighbor-group-error-handling-config;
+      }
+      container state {
+        config false;
+        description
+          "State information relating to enhanced error handling
+          mechanisms for the BGP neighbor";
+        uses bgp-common-neighbor-group-error-handling-config;
+        uses bgp-neighbor-error-handling-state;
+      }
+    }
+
+    container graceful-restart {
+      description
+        "Parameters relating the graceful restart mechanism for BGP";
+      container config {
+        description
+          "Configuration parameters relating to graceful-restart";
+        uses bgp-common-graceful-restart-config;
+      }
+      container state {
+        config false;
+        description
+          "State information associated with graceful-restart";
+        uses bgp-common-graceful-restart-config;
+        uses bgp-neighbor-graceful-restart-state;
+      }
+    }
+
+    uses bgp-common-structure-neighbor-group-logging-options;
+    uses bgp-common-structure-neighbor-group-ebgp-multihop;
+    uses bgp-common-structure-neighbor-group-route-reflector;
+    uses bgp-common-structure-neighbor-group-as-path-options;
+    uses bgp-neighbor-use-multiple-paths;
+    uses oc-rpol:apply-policy-group;
+
+    container afi-safis {
+      description
+        "Per-address-family configuration parameters associated with
+        the neighbor";
+      uses bgp-neighbor-afi-safi-list;
+    }
+  }
+
+  grouping bgp-neighbor-list {
+    description
+      "The list of BGP neighbors";
+
+    list neighbor {
+      key "neighbor-address";
+      description
+        "List of BGP neighbors configured on the local system,
+        uniquely identified by peer IPv[46] address";
+
+      leaf neighbor-address {
+        type leafref {
+          path "../config/neighbor-address";
+        }
+        description
+          "Reference to the address of the BGP neighbor used as
+          a key in the neighbor list";
+      }
+
+      uses bgp-neighbor-base;
+      uses oc-bfd:bfd-enable;
+    }
+
+  }
+}

--- a/models/yang/common/openconfig-bgp-peer-group.yang
+++ b/models/yang/common/openconfig-bgp-peer-group.yang
@@ -1,0 +1,393 @@
+submodule openconfig-bgp-peer-group {
+
+  belongs-to openconfig-bgp {
+    prefix "oc-bgp";
+  }
+
+  import openconfig-extensions { prefix oc-ext; }
+  import openconfig-routing-policy { prefix oc-rpol; }
+  import openconfig-bfd { prefix oc-bfd; }
+
+  // Include the common submodule
+  include openconfig-bgp-common;
+  include openconfig-bgp-common-multiprotocol;
+  include openconfig-bgp-common-structure;
+
+  // meta
+  organization
+    "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    netopenconfig@googlegroups.com";
+
+  description
+    "This sub-module contains groupings that are specific to the
+    peer-group context of the OpenConfig BGP module.";
+
+  oc-ext:openconfig-version "9.7.1";
+
+  revision "2023-12-28" {
+    description
+      "Clarification to last-prefix-limit-exceeded in description";
+          reference "9.7.1";
+  }
+
+  revision "2023-12-28" {
+    description
+      "Add support for controling use of link-bandwidth extended
+      community for BGP multipath.";
+    reference "9.7.0";
+  }
+
+  revision "2023-11-02" {
+    description
+      "Fix revision '2023-03-31': send-community-type was added to the
+       wrong grouping.
+      Allow configuring send-community per AFI-SAFI at
+       neighbor/peer-group.";
+    reference "9.6.0";
+  }
+
+  revision "2023-11-01" {
+    description
+      "Add default apply policy to global and per afi-safi config.";
+    reference "9.5.0";
+  }
+
+  revision "2023-06-27" {
+    description
+      "Clarify bgp remote-port description";
+    reference "9.4.1";
+  }
+
+  revision "2023-04-01" {
+    description
+      "Add support for BGP large communities [rfc8092] in
+      send-community.
+      Leaf send-community was replaced by the leaf-list
+      send-community-type to allow the combination of different
+      community types";
+    reference "9.4.0";
+  }
+
+  revision "2023-03-31" {
+    description
+      "Allow configuring send-community per AFI-SAFI at
+       neighbor/peer-group.";
+    reference "9.3.0";
+  }
+
+  revision "2022-12-12" {
+    description
+      "Removed the default of enabled leaf of AFI-SAFI
+      at neighbor/peer-group to support BGP inheritance model.";
+    reference "9.2.0";
+  }
+
+  revision "2022-05-21" {
+    description
+      "Added extended-next-hop-encoding leaf.";
+    reference "9.1.0";
+  }
+
+  revision "2022-04-26" {
+    description
+      "Transition decimal64 types to uint16 for various BGP timers";
+    reference "9.0.0";
+  }
+
+  revision "2022-03-21" {
+    description
+      "Add BGP port";
+    reference "8.1.0";
+  }
+
+  revision "2021-12-01" {
+    description
+      "Add prefix-limit-received, add prefix-limit
+      state nodes, change/relocate restart-timer";
+    reference "8.0.0";
+  }
+
+  revision "2021-10-21" {
+    description
+      "Removal of top-level /bgp container";
+    reference "7.0.0";
+  }
+
+  revision "2021-06-16" {
+    description
+      "Remove trailing whitespace";
+    reference "6.1.1";
+  }
+
+  revision "2021-03-17" {
+    description
+      "Add bfd support without augmentation.";
+    reference "6.1.0";
+  }
+
+  revision "2019-07-10" {
+    description
+      "Normalise timestamp units to nanoseconds.";
+    reference "6.0.0";
+  }
+
+  revision "2019-05-28" {
+    description
+      "Clarify prefix counter descriptions, add received-pre-policy
+      counter.";
+    reference "5.2.0";
+  }
+
+  revision "2019-04-16" {
+    description
+      "Add BGP RIB to the top-level BGP container";
+    reference "5.1.0";
+  }
+
+  revision "2018-08-20" {
+    description
+      "Correct description of AFI-SAFI enabled leaf.";
+    reference "5.0.1";
+  }
+
+  revision "2018-04-11" {
+    description
+      "Correct naming of BGP maximum prefix warning percentage leaf.";
+    reference "5.0.0";
+  }
+
+  revision "2018-03-20" {
+    description
+      "Added SR-TE policy SAFI";
+    reference "4.1.0";
+  }
+
+  revision "2017-07-10" {
+    description
+      "Add error notifications; moved add-paths config; add AS
+      prepend policy features; removed unneeded config leaves";
+    reference "4.0.0";
+  }
+
+  revision "2017-02-02" {
+    description
+      "Bugfix to remove remaining global-level policy data";
+    reference "3.0.1";
+  }
+
+  revision "2017-01-26" {
+    description
+      "Add dynamic neighbor support, migrate to OpenConfig types";
+    reference "3.0.0";
+  }
+
+  revision "2016-06-21" {
+    description
+      "OpenConfig BGP refactor";
+    reference "2.1.1";
+  }
+
+  grouping bgp-peer-group-config {
+    description
+      "Configuration parameters relating to a base BGP peer group that
+      are not also applicable to any other context (e.g., neighbor)";
+
+    leaf peer-group-name {
+      type string;
+      description
+        "Name of the BGP peer-group";
+    }
+
+  }
+
+  grouping bgp-peer-group-afi-safi-list {
+    description
+      "List of address-families associated with the BGP peer-group";
+
+    list afi-safi {
+      key "afi-safi-name";
+
+      description
+        "AFI,SAFI configuration available for the
+        neighbour or group";
+
+      leaf afi-safi-name {
+        type leafref {
+          path "../config/afi-safi-name";
+        }
+        description
+          "Reference to the AFI-SAFI name used as a key
+          for the AFI-SAFI list";
+      }
+
+      container config {
+        description
+          "Configuration parameters for the AFI-SAFI";
+        uses bgp-common-mp-afi-safi-config;
+      }
+      container state {
+        config false;
+        description
+          "State information relating to the AFI-SAFI";
+        uses bgp-common-mp-afi-safi-config;
+      }
+
+      container graceful-restart {
+        description
+          "Parameters relating to BGP graceful-restart";
+        container config {
+          description
+            "Configuration options for BGP graceful-restart";
+          uses bgp-common-mp-afi-safi-graceful-restart-config;
+        }
+        container state {
+          config false;
+          description
+            "State information for BGP graceful-restart";
+          uses bgp-common-mp-afi-safi-graceful-restart-config;
+        }
+      }
+
+      uses bgp-common-structure-neighbor-group-add-paths;
+      uses bgp-common-global-group-use-multiple-paths;
+      uses bgp-common-mp-all-afi-safi-list-contents;
+    }
+  }
+
+  grouping bgp-peer-group-base {
+    description
+      "Parameters related to a BGP group";
+
+    container config {
+      description
+        "Configuration parameters relating to the BGP neighbor or
+        group";
+      uses bgp-peer-group-config;
+      uses bgp-common-neighbor-group-config;
+    }
+    container state {
+      config false;
+      description
+        "State information relating to the BGP peer-group";
+      uses bgp-peer-group-config;
+      uses bgp-common-neighbor-group-config;
+      uses bgp-common-state;
+    }
+
+    container timers {
+      description
+        "Timers related to a BGP peer-group";
+
+      container config {
+        description
+          "Configuration parameters relating to timers used for the
+          BGP neighbor or peer group";
+        uses bgp-common-neighbor-group-timers-config;
+      }
+      container state {
+        config false;
+        description
+          "State information relating to the timers used for the BGP
+         group";
+        uses bgp-common-neighbor-group-timers-config;
+      }
+    }
+
+    container transport {
+      description
+        "Transport session parameters for the BGP peer-group";
+
+      container config {
+        description
+          "Configuration parameters relating to the transport
+          session(s) used for the BGP neighbor or group";
+        uses bgp-common-neighbor-group-transport-config;
+      }
+      container state {
+        config false;
+        description
+          "State information relating to the transport session(s)
+          used for the BGP neighbor or group";
+        uses bgp-common-neighbor-group-transport-config;
+      }
+    }
+
+    container error-handling {
+      description
+        "Error handling parameters used for the BGP peer-group";
+
+      container config {
+        description
+          "Configuration parameters enabling or modifying the
+          behavior or enhanced error handling mechanisms for the BGP
+          group";
+        uses bgp-common-neighbor-group-error-handling-config;
+      }
+      container state {
+        config false;
+        description
+          "State information relating to enhanced error handling
+          mechanisms for the BGP group";
+        uses bgp-common-neighbor-group-error-handling-config;
+      }
+    }
+
+    container graceful-restart {
+      description
+        "Parameters relating the graceful restart mechanism for BGP";
+      container config {
+        description
+          "Configuration parameters relating to graceful-restart";
+        uses bgp-common-graceful-restart-config;
+      }
+      container state {
+        config false;
+        description
+          "State information associated with graceful-restart";
+        uses bgp-common-graceful-restart-config;
+      }
+    }
+
+    uses bgp-common-structure-neighbor-group-logging-options;
+    uses bgp-common-structure-neighbor-group-ebgp-multihop;
+    uses bgp-common-structure-neighbor-group-route-reflector;
+    uses bgp-common-structure-neighbor-group-as-path-options;
+    uses bgp-common-global-group-use-multiple-paths;
+    uses oc-rpol:apply-policy-group;
+
+    container afi-safis {
+      description
+        "Per-address-family configuration parameters associated with
+        thegroup";
+      uses bgp-peer-group-afi-safi-list;
+    }
+  }
+
+  grouping bgp-peer-group-list {
+    description
+      "The list of BGP peer groups";
+
+    list peer-group {
+      key "peer-group-name";
+      description
+        "List of BGP peer-groups configured on the local system -
+        uniquely identified by peer-group name";
+
+    leaf peer-group-name {
+      type leafref {
+        path "../config/peer-group-name";
+      }
+      description
+        "Reference to the name of the BGP peer-group used as a
+        key in the peer-group list";
+      }
+
+      uses bgp-peer-group-base;
+      uses oc-bfd:bfd-enable;
+    }
+  }
+
+}

--- a/models/yang/common/openconfig-bgp-policy.yang
+++ b/models/yang/common/openconfig-bgp-policy.yang
@@ -1,0 +1,1410 @@
+module openconfig-bgp-policy {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/bgp-policy";
+
+  prefix "oc-bgp-pol";
+
+  // import some basic types
+  import openconfig-inet-types { prefix oc-inet; }
+  import openconfig-routing-policy {prefix oc-rpol; }
+  import openconfig-policy-types { prefix oc-pol-types; }
+  import openconfig-bgp-types { prefix oc-bgp-types; }
+  import openconfig-extensions { prefix oc-ext; }
+  import openconfig-types { prefix oc-types; }
+
+  // meta
+  organization
+    "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    netopenconfig@googlegroups.com";
+
+  description
+    "This module contains data definitions for BGP routing policy.
+    It augments the base routing-policy module with BGP-specific
+    options for conditions and actions.";
+
+  oc-ext:openconfig-version "7.1.0";
+
+  revision "2024-07-02" {
+    description
+      "Add ext-community-count container, which also clarifies that
+      community-count does not include other types of communities (e.g.
+      extended).";
+    reference "7.1.0";
+  }
+
+  revision "2024-01-31" {
+    description
+      "Update community-sets/members/member union type by replacing
+      the bgp-regex type with posix-eregexp.";
+    reference "7.0.0";
+  }
+
+  revision "2023-12-19" {
+    description
+    "Add PEER_ADDRESS to bgp-next-hop-type.";
+    reference "6.4.0";
+  }
+
+  revision "2023-10-23" {
+    description
+      "Revert revision 2019-02-01.
+      Move match-set-options of BGP community and BGP extended community from
+      defined-sets/bgp-defined-sets/community-set and
+      defined-sets/bgp-defined-sets/ext-community-set back to
+      policy-definitions/statements/.../bgp-conditions
+      for consistency across sets.";
+    reference "6.3.0";
+  }
+
+  revision "2023-10-03" {
+    description
+      "Deprecate community-set-ref and ext-community-set-ref,
+      add the following leaf-list nodes:
+      * community-set-refs
+      * ext-community-set-refs";
+    reference "6.2.0";
+  }
+
+  revision "2023-03-27" {
+    description
+      "Clarify bgp-set-med-type description";
+    reference "6.1.1";
+  }
+
+  revision "2022-05-24" {
+    description
+      "Remove module extension oc-ext:regexp-posix by making pattern regexes
+      conform to RFC6020/RFC7950.
+
+      Types impacted:
+      - bgp-set-med-type";
+    reference "6.1.0";
+  }
+
+  revision "2020-06-30" {
+    description
+      "Add OpenConfig POSIX pattern extensions.";
+    reference "6.0.2";
+  }
+
+  revision "2019-11-28" {
+    description
+      "Fix quotes on literals in when statements";
+    reference "6.0.1";
+  }
+
+  revision "2019-02-01" {
+    description
+      "Move BGP community match-set-options from
+      policy-definitions/statements/.../bgp-conditions to
+      defined-sets/bgp-defined-sets/community-set for wider platform
+      support.";
+    reference "6.0.0";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "5.0.2";
+  }
+
+  revision "2018-08-20" {
+    description
+      "Correct description of AFI-SAFI enabled leaf.";
+    reference "5.0.1";
+  }
+
+  revision "2018-04-11" {
+    description
+      "Correct naming of BGP maximum prefix warning percentage leaf.";
+    reference "5.0.0";
+  }
+
+  revision "2018-03-20" {
+    description
+      "Added SR-TE policy SAFI";
+    reference "4.1.0";
+  }
+
+  revision "2017-07-10" {
+    description
+      "Add error notifications; moved add-paths config; add AS
+      prepend policy features; removed unneeded config leaves";
+    reference "4.0.0";
+  }
+
+  revision "2017-02-02" {
+    description
+      "Bugfix to remove remaining global-level policy data";
+    reference "3.0.1";
+  }
+
+  revision "2017-01-26" {
+    description
+      "Add dynamic neighbor support, migrate to OpenConfig types";
+    reference "3.0.0";
+  }
+
+  revision "2016-06-21" {
+    description
+      "OpenConfig BGP refactor";
+    reference "2.1.1";
+  }
+
+  // OpenConfig specific extensions for module metadata.
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  // typedef statements
+
+  typedef bgp-set-community-option-type {
+    type enumeration {
+      enum ADD {
+        description
+          "add the specified communities to the existing
+          community attribute";
+      }
+      enum REMOVE {
+        description
+          "remove the specified communities from the
+          existing community attribute";
+      }
+      enum REPLACE {
+        description
+          "replace the existing community attribute with
+          the specified communities. If an empty set is
+          specified, this removes the community attribute
+          from the route.";
+      }
+    }
+    description
+      "Type definition for options when setting the community
+      attribute in a policy action";
+  }
+
+  typedef bgp-next-hop-type {
+    type union {
+      type oc-inet:ip-address;
+      type enumeration {
+        enum SELF {
+          description "special designation for local router's own
+          address, i.e., next-hop-self";
+        }
+        enum PEER_ADDRESS {
+          description "The ip address of the peer should be used.
+          This enum is efficient to use when setting the next hop
+          in a policy applied to a peer group.";
+        }
+      }
+    }
+    description
+      "type definition for specifying next-hop in policy actions";
+  }
+
+  typedef bgp-set-med-type {
+    type union {
+      type uint32;
+      type string {
+        pattern '[+-][0-9]+';
+        oc-ext:posix-pattern '^[+-][0-9]+$';
+      }
+      type enumeration {
+        enum IGP {
+          description "set the MED value to the IGP cost toward the
+          next hop for the route";
+        }
+      }
+    }
+    description
+      "Type definition for specifying how the BGP MED can
+      be set in BGP policy actions. The three choices are to set
+      the MED directly using the uint32 type or increment/decrement
+      using +/- notation in the string type or setting it to
+      the IGP cost using the enum (predefined value).";
+  }
+
+  // grouping statements
+
+  grouping match-as-path-config {
+    description
+      "Configuration data for match conditions on AS path set";
+
+    leaf as-path-set {
+      type leafref {
+        path "/oc-rpol:routing-policy/oc-rpol:defined-sets/" +
+          "oc-bgp-pol:bgp-defined-sets/oc-bgp-pol:as-path-sets/" +
+          "oc-bgp-pol:as-path-set/oc-bgp-pol:as-path-set-name";
+      }
+      description "References a defined AS path set";
+    }
+    uses oc-rpol:match-set-options-group;
+  }
+
+  grouping match-as-path-state {
+    description
+      "Operational state data for match conditions on AS path set";
+  }
+
+  grouping match-as-path-top {
+    description
+      "Top-level grouping for match conditions on AS path set";
+
+    container match-as-path-set {
+      description
+        "Match a referenced as-path set according to the logic
+        defined in the match-set-options leaf";
+
+      container config {
+        description
+          "Configuration data for match conditions on AS path set";
+
+        uses match-as-path-config;
+      }
+
+      container state {
+
+        config false;
+
+        description
+          "Operational state data for match conditions on AS
+          path set";
+
+        uses match-as-path-config;
+        uses match-as-path-state;
+      }
+    }
+  }
+
+  grouping match-community-config {
+    description
+      "Configuration data for match conditions on community set";
+
+    leaf community-set {
+      type leafref {
+        path "/oc-rpol:routing-policy/oc-rpol:defined-sets/" +
+          "oc-bgp-pol:bgp-defined-sets/oc-bgp-pol:community-sets/" +
+          "oc-bgp-pol:community-set/oc-bgp-pol:community-set-name";
+      }
+      description "References a defined community set";
+    }
+    uses oc-rpol:match-set-options-group;
+  }
+
+  grouping match-community-state {
+    description
+      "Operational state data for match conditions on community set";
+  }
+
+  grouping match-community-top {
+    description
+      "Top-level grouping for match conditions on community set";
+
+    container match-community-set {
+      description
+        "Match a referenced community set according to the logic
+        defined in the match-set-options leaf";
+
+      container config {
+        description
+          "Configuration data for match conditions on community set";
+
+        uses match-community-config;
+      }
+
+      container state {
+
+        config false;
+
+        description
+          "Operational state data for match conditions on community set";
+
+        uses match-community-config;
+        uses match-community-state;
+      }
+    }
+  }
+
+  grouping match-ext-community-config {
+    description
+      "Configuration data for match conditions on extended community set";
+
+    leaf ext-community-set {
+      type leafref {
+        path "/oc-rpol:routing-policy/oc-rpol:defined-sets/" +
+          "oc-bgp-pol:bgp-defined-sets/oc-bgp-pol:ext-community-sets/" +
+          "oc-bgp-pol:ext-community-set/oc-bgp-pol:ext-community-set-name";
+      }
+      description "References a defined extended community set";
+    }
+    uses oc-rpol:match-set-options-group;
+  }
+
+  grouping match-ext-community-state {
+    description
+      "Operational state data for match conditions on extended community set";
+  }
+
+  grouping match-ext-community-top {
+    description
+      "Top-level grouping for match conditions on extended community set";
+
+    container match-ext-community-set {
+      description
+        "Match a referenced extended community set according to the logic
+        defined in the match-set-options leaf";
+
+      container config {
+        description
+          "Configuration data for match conditions on extended community set";
+
+        uses match-ext-community-config;
+      }
+
+      container state {
+
+        config false;
+
+        description
+          "Operational state data for match conditions on extended
+          community set";
+
+        uses match-ext-community-config;
+        uses match-ext-community-state;
+      }
+    }
+  }
+
+  grouping bgp-match-set-conditions {
+    description
+      "Condition statement definitions for checking membership in a
+      defined set";
+
+    uses match-as-path-top;
+    uses match-community-top;
+    uses match-ext-community-top;
+  }
+
+  grouping community-count-config {
+    description
+      "Configuration data for different community count conditions";
+
+    uses oc-pol-types:attribute-compare-operators;
+  }
+
+  grouping community-count-state {
+    description
+      "Operational state data for different community count conditions";
+  }
+
+  grouping community-count-top {
+    description
+      "Top-level grouping for different community count conditions";
+
+    container community-count {
+      description
+        "Value and comparison operations for conditions based on the
+        number of regular communities in the route update.";
+
+      container config {
+        description
+          "Configuration data for regular community count condition";
+
+        uses community-count-config;
+      }
+
+      container state {
+
+        config false;
+
+        description
+          "Operational state data for regular community count condition";
+
+        uses community-count-config;
+        uses community-count-state;
+      }
+    }
+
+    container ext-community-count {
+      description
+        "Value and comparison operations for conditions based on the
+        number of extended communities in the route update.";
+
+      container config {
+        description
+          "Configuration data for extended community count condition";
+
+        uses community-count-config;
+      }
+
+      container state {
+
+        config false;
+
+        description
+          "Operational state data for extended community count condition";
+
+        uses community-count-config;
+        uses community-count-state;
+      }
+    }
+  }
+
+  grouping as-path-length-config {
+    description
+      "Configuration data for AS path length condition";
+
+    uses oc-pol-types:attribute-compare-operators;
+  }
+
+  grouping as-path-length-state {
+    description
+      "Operational state data for AS path length condition";
+  }
+
+  grouping as-path-length-top {
+    description
+      "Top-level grouping for AS path length condition";
+
+    container as-path-length {
+      description
+        "Value and comparison operations for conditions based on the
+        length of the AS path in the route update";
+
+      container config {
+        description
+          "Configuration data for AS path length condition";
+
+        uses as-path-length-config;
+      }
+
+      container state {
+
+        config false;
+
+        description
+          "Operational state data for AS path length condition";
+
+        uses as-path-length-config;
+        uses as-path-length-state;
+      }
+    }
+  }
+
+  grouping bgp-conditions-config {
+    description
+      "Configuration data for BGP-specific policy conditions";
+
+    leaf med-eq {
+      type uint32;
+      description
+        "Condition to check if the received MED value is equal to
+        the specified value";
+    }
+
+    leaf origin-eq {
+      type oc-bgp-types:bgp-origin-attr-type;
+      description
+        "Condition to check if the route origin is equal to the
+        specified value";
+    }
+
+    leaf-list next-hop-in {
+      type oc-inet:ip-address;
+      description
+        "List of next hop addresses to check for in the route
+        update";
+    }
+
+    leaf-list afi-safi-in {
+      type identityref {
+        base oc-bgp-types:AFI_SAFI_TYPE;
+      }
+      description
+        "List of address families which the NLRI may be
+        within";
+    }
+
+    leaf local-pref-eq {
+      type uint32;
+      // TODO: add support for other comparisons if needed
+      description
+        "Condition to check if the local pref attribute is equal to
+        the specified value";
+    }
+
+    leaf route-type {
+      // TODO: verify extent of vendor support for this comparison
+      type enumeration {
+        enum INTERNAL {
+          description "route type is internal";
+        }
+        enum EXTERNAL {
+          description "route type is external";
+        }
+      }
+      description
+        "Condition to check the route type in the route update";
+    }
+
+    leaf community-set {
+      status deprecated;
+      type leafref {
+        path "/oc-rpol:routing-policy/oc-rpol:defined-sets/" +
+          "oc-bgp-pol:bgp-defined-sets/oc-bgp-pol:community-sets/" +
+          "oc-bgp-pol:community-set/oc-bgp-pol:community-set-name";
+      }
+      description
+        "References a defined community set";
+    }
+
+    leaf ext-community-set {
+      status deprecated;
+      type leafref {
+        path "/oc-rpol:routing-policy/oc-rpol:defined-sets/" +
+          "oc-bgp-pol:bgp-defined-sets/oc-bgp-pol:ext-community-sets/" +
+          "oc-bgp-pol:ext-community-set/" +
+          "oc-bgp-pol:ext-community-set-name";
+      }
+      description "References a defined extended community set";
+    }
+  }
+
+  grouping bgp-conditions-state {
+    description
+      "Operational state data for BGP-specific policy conditions";
+  }
+
+  grouping bgp-conditions-top {
+    description
+      "Top-level grouping for BGP-specific policy conditions";
+
+    container bgp-conditions {
+      description
+        "Top-level container ";
+
+      container config {
+        description
+          "Configuration data for BGP-specific policy conditions";
+
+        uses bgp-conditions-config;
+      }
+
+      container state {
+
+        config false;
+
+        description
+          "Operational state data for BGP-specific policy
+          conditions";
+
+        uses bgp-conditions-config;
+        uses bgp-conditions-state;
+      }
+
+      uses community-count-top;
+      uses as-path-length-top;
+      uses bgp-match-set-conditions;
+    }
+  }
+
+  grouping community-set-config {
+    description
+      "Configuration data for BGP community sets";
+
+    leaf community-set-name {
+      type string;
+      mandatory true;
+      description
+        "name / label of the community set -- this is used to
+        reference the set in match conditions";
+    }
+
+    leaf-list community-member {
+      type union {
+        type oc-bgp-types:bgp-std-community-type;
+        type oc-bgp-types:bgp-community-regexp-type;
+        type oc-bgp-types:bgp-well-known-community-type;
+      }
+      description
+        "Members of the community set.
+        For an ADD operation these are the communities that will be
+        added.  The regexp type is not valid in this operation.
+
+        For REMOVE or REPLACE operations then matching communities will
+        be removed unless match-set-options is INVERT which will
+        reverse this to mean that anything that does not match will be
+        removed.
+
+        For MATCH operations the posix-eregexp type should be evaluated
+        against each community associated with a prefix one community
+        at a time.  Communities must be represented as strings in formats
+        conforming to oc-bgp-types:bgp-std-community-type.  For example:
+        `1000:1000` for a standard community";
+    }
+
+    leaf match-set-options {
+      status deprecated;
+      type oc-pol-types:match-set-options-type;
+      description
+        "Optional parameter that governs the behaviour of the
+        match operation";
+    }
+  }
+
+  grouping community-set-state {
+    description
+      "Operational state data for BGP community sets";
+  }
+
+  grouping community-set-top {
+    description
+      "Top-level grouping for BGP community sets";
+
+    container community-sets {
+      description
+        "Enclosing container for list of defined BGP community sets";
+
+      list community-set {
+        key "community-set-name";
+        description
+          "List of defined BGP community sets";
+
+        leaf community-set-name {
+          type leafref {
+            path "../config/community-set-name";
+          }
+          description
+            "Reference to list key";
+        }
+
+        container config {
+          description
+            "Configuration data for BGP community sets";
+
+          uses community-set-config;
+        }
+
+        container state {
+
+          config false;
+
+          description
+            "Operational state data for BGP community sets";
+
+          uses community-set-config;
+          uses community-set-state;
+        }
+      }
+    }
+  }
+
+  grouping ext-community-set-config {
+    description
+      "Configuration data for extended BGP community sets";
+
+    leaf ext-community-set-name {
+      type string;
+      description
+        "name / label of the extended community set -- this is
+        used to reference the set in match conditions";
+    }
+
+    leaf-list ext-community-member {
+      type union {
+        type oc-bgp-types:bgp-ext-community-type;
+        type oc-types:posix-eregexp;
+      }
+      description
+        "Members of the extended community set.
+        For an ADD operation these are the communities that will be added;
+        the regexp type is not valid in this operation.
+
+        For REMOVE or REPLACE operations then matching communities will
+        be removed unless match-set-options is INVERT which will
+        reverse this to mean that anything that does not match will be
+        removed.
+
+        For MATCH operations the posix-eregexp type should be evaluated
+        against each community associated with a prefix one community
+        at a time.  Communities must be represented as strings in formats
+        conforming to oc-bgp-types:bgp-ext-community-type.  For example:
+        `route-origin:1000:1000` for the origin type extended community,
+        and so on.";
+    }
+
+    leaf match-set-options {
+      status deprecated;
+      type oc-pol-types:match-set-options-type;
+      description
+        "Optional parameter that governs the behaviour of the
+        match operation";
+    }
+  }
+
+  grouping ext-community-set-state {
+    description
+      "Operational state data for extended BGP community sets";
+  }
+
+  grouping ext-community-set-top {
+    description
+      "Top-level grouping for extended BGP community sets";
+
+    container ext-community-sets {
+      description
+        "Enclosing container for list of extended BGP community
+        sets";
+
+      list ext-community-set {
+        key "ext-community-set-name";
+        description
+          "List of defined extended BGP community sets";
+
+        leaf ext-community-set-name {
+          type leafref {
+            path "../config/ext-community-set-name";
+          }
+          description
+            "Reference to list key";
+        }
+
+        container config {
+          description
+            "Configuration data for extended BGP community sets";
+
+          uses ext-community-set-config;
+        }
+
+        container state {
+
+          config false;
+
+          description
+            "Operational state data for extended BGP community sets";
+
+          uses ext-community-set-config;
+          uses ext-community-set-state;
+        }
+      }
+    }
+  }
+
+  grouping as-path-set-config {
+    description
+      "Configuration data for AS path sets";
+
+    leaf as-path-set-name {
+      type string;
+      description
+        "name of the AS path set -- this is used to reference
+        the set in match conditions";
+    }
+
+    leaf-list as-path-set-member {
+      // TODO: need to refine typedef for AS path expressions
+      type string;
+      description
+          "AS path expression -- list of ASes in the set";
+    }
+  }
+
+  grouping as-path-set-state {
+    description
+      "Operational state data for AS path sets";
+  }
+
+  grouping as-path-set-top {
+    description
+      "Top-level grouping for AS path sets";
+
+    container as-path-sets {
+      description
+        "Enclosing container for list of define AS path sets";
+
+      list as-path-set {
+        key "as-path-set-name";
+        description
+          "List of defined AS path sets";
+
+        leaf as-path-set-name {
+          type leafref {
+            path "../config/as-path-set-name";
+          }
+          description
+            "Reference to list key";
+        }
+
+        container config {
+          description
+            "Configuration data for AS path sets";
+
+          uses as-path-set-config;
+        }
+
+        container state {
+
+          config false;
+
+          description
+            "Operational state data for AS path sets";
+
+          uses as-path-set-config;
+          uses as-path-set-state;
+        }
+      }
+    }
+  }
+
+  // augment statements
+
+  augment "/oc-rpol:routing-policy/oc-rpol:defined-sets" {
+    description "adds BGP defined sets container to routing policy
+    model";
+
+    container bgp-defined-sets {
+      description
+        "BGP-related set definitions for policy match conditions";
+
+      uses community-set-top;
+      uses ext-community-set-top;
+      uses as-path-set-top;
+    }
+  }
+
+  grouping as-path-prepend-config {
+    description
+      "Configuration data for the AS path prepend action";
+
+    leaf repeat-n {
+      type uint8 {
+        range 1..max;
+      }
+      description
+        "Number of times to prepend the value specified in the asn
+        leaf to the AS path. If no value is specified by the asn
+        leaf, the local AS number of the system is used. The value
+        should be between 1 and the maximum supported by the
+        implementation.";
+    }
+
+    leaf asn {
+      type oc-inet:as-number;
+      description
+        "The AS number to prepend to the AS path. If this leaf is
+        not specified and repeat-n is set, then the local AS
+        number will be used for prepending.";
+    }
+  }
+
+  grouping as-path-prepend-state {
+    description
+      "Operational state data for the AS path prepend action";
+  }
+
+  grouping as-path-prepend-top {
+    description
+      "Top-level grouping for the AS path prepend action";
+
+    container set-as-path-prepend {
+      description
+        "Action to prepend the specified AS number to the AS-path a
+        specified number of times";
+
+      container config {
+        description
+          "Configuration data for the AS path prepend action";
+
+        uses as-path-prepend-config;
+      }
+
+      container state {
+
+        config false;
+
+        description
+          "Operational state data for the AS path prepend action";
+
+        uses as-path-prepend-config;
+        uses as-path-prepend-state;
+      }
+    }
+  }
+
+  grouping set-community-action-common {
+    description
+      "Common leaves for set-community and set-ext-community
+      actions";
+
+    leaf method {
+      type enumeration {
+        enum INLINE {
+          description
+            "The extended communities are specified inline as a
+            list";
+        }
+        enum REFERENCE {
+          description
+            "The extended communities are specified by referencing a
+            defined ext-community set";
+        }
+      }
+      description
+        "Indicates the method used to specify the extended
+        communities for the set-ext-community action";
+    }
+
+    leaf options {
+      type bgp-set-community-option-type;
+      description
+        "Options for modifying the community attribute with
+        the specified values.  These options apply to both
+        methods of setting the community attribute.";
+    }
+  }
+
+  grouping set-community-inline-config {
+    description
+      "Configuration data for inline specification of set-community
+      action";
+
+    leaf-list communities {
+      type union {
+        type oc-bgp-types:bgp-std-community-type;
+        type oc-bgp-types:bgp-well-known-community-type;
+      }
+      description
+        "Set the community values for the update inline with
+        a list.";
+    }
+  }
+
+  grouping set-community-inline-state {
+    description
+      "Operational state data or inline specification of
+      set-community action";
+  }
+
+  grouping set-community-inline-top {
+    description
+      "Top-level grouping or inline specification of set-community
+      action";
+
+    container inline {
+      when "../config/method='INLINE'" {
+        description
+          "Active only when the set-community method is INLINE";
+      }
+      description
+        "Set the community values for the action inline with
+        a list.";
+
+      container config {
+        description
+          "Configuration data or inline specification of set-community
+      action";
+
+        uses set-community-inline-config;
+      }
+
+      container state {
+
+        config false;
+
+        description
+          "Operational state data or inline specification of
+          set-community action";
+
+        uses set-community-inline-config;
+        uses set-community-inline-state;
+      }
+    }
+  }
+
+  grouping set-community-reference-config {
+    description
+      "Configuration data for referening a community-set in the
+      set-community action";
+
+    leaf-list community-set-refs {
+      type leafref {
+        path "/oc-rpol:routing-policy/oc-rpol:defined-sets/" +
+          "oc-bgp-pol:bgp-defined-sets/" +
+          "oc-bgp-pol:community-sets/oc-bgp-pol:community-set/" +
+          "oc-bgp-pol:community-set-name";
+      }
+      description
+        "References a list of defined community sets by name";
+    }
+
+    leaf community-set-ref {
+      status deprecated;
+      type leafref {
+        path "/oc-rpol:routing-policy/oc-rpol:defined-sets/" +
+          "oc-bgp-pol:bgp-defined-sets/" +
+          "oc-bgp-pol:community-sets/oc-bgp-pol:community-set/" +
+          "oc-bgp-pol:community-set-name";
+      }
+      description
+        "References a defined community set by name";
+    }
+  }
+
+  grouping set-community-reference-state {
+    description
+      "Operational state data for referening a community-set in the
+      set-community action";
+  }
+
+  grouping set-community-reference-top {
+    description
+      "Top-level grouping for referening a community-set in the
+      set-community action";
+
+    container reference {
+      when "../config/method='REFERENCE'" {
+        description
+          "Active only when the set-community method is REFERENCE";
+      }
+      description
+        "Provide a reference to a defined community set for the
+        set-community action";
+
+      container config {
+        description
+          "Configuration data for referening a community-set in the
+      set-community action";
+
+        uses set-community-reference-config;
+      }
+
+      container state {
+
+        config false;
+
+        description
+          "Operational state data for referening a community-set
+          in the set-community action";
+
+        uses set-community-reference-config;
+        uses set-community-reference-state;
+      }
+    }
+  }
+
+  grouping set-community-action-config {
+    description
+      "Configuration data for the set-community action";
+
+    uses set-community-action-common;
+  }
+
+  grouping set-community-action-state {
+    description
+      "Operational state data for the set-community action";
+  }
+
+  grouping set-community-action-top {
+    description
+      "Top-level grouping for the set-community action";
+
+    container set-community {
+      description
+        "Action to set the community attributes of the route, along
+        with options to modify how the community is modified.
+        Communities may be set using an inline list OR
+        reference to an existing defined set (not both).";
+
+      container config {
+        description
+          "Configuration data for the set-community action";
+
+        uses set-community-action-config;
+      }
+
+      container state {
+
+        config false;
+
+        description
+          "Operational state data for the set-community action";
+
+        uses set-community-action-config;
+        uses set-community-action-state;
+      }
+
+      uses set-community-inline-top;
+      uses set-community-reference-top;
+    }
+  }
+
+  grouping set-ext-community-inline-config {
+    description
+      "Configuration data for inline specification of
+      set-ext-community action";
+
+    leaf-list communities {
+      type union {
+        type oc-bgp-types:bgp-ext-community-type;
+        type oc-bgp-types:bgp-well-known-community-type;
+      }
+      description
+        "Set the extended community values for the update inline
+        with a list.";
+    }
+  }
+
+  grouping set-ext-community-inline-state {
+    description
+      "Operational state data or inline specification of
+      set-ext-community action";
+  }
+
+  grouping set-ext-community-inline-top {
+    description
+      "Top-level grouping or inline specification of set-ext-community
+      action";
+
+    container inline {
+      when "../config/method='INLINE'" {
+        description
+          "Active only when the set-community method is INLINE";
+      }
+      description
+        "Set the extended community values for the action inline with
+        a list.";
+
+      container config {
+        description
+          "Configuration data or inline specification of
+          set-ext-community action";
+
+        uses set-ext-community-inline-config;
+      }
+
+      container state {
+
+        config false;
+
+        description
+          "Operational state data or inline specification of
+          set-ext-community action";
+
+        uses set-ext-community-inline-config;
+        uses set-ext-community-inline-state;
+      }
+    }
+  }
+
+  grouping set-ext-community-reference-config {
+    description
+      "Configuration data for referening a extended community-set
+      in the set-ext-community action";
+
+    leaf-list ext-community-set-refs {
+      type leafref {
+        path "/oc-rpol:routing-policy/oc-rpol:defined-sets/" +
+          "oc-bgp-pol:bgp-defined-sets/" +
+          "oc-bgp-pol:ext-community-sets/" +
+          "oc-bgp-pol:ext-community-set/" +
+          "oc-bgp-pol:ext-community-set-name";
+      }
+      description
+        "References a list of defined extended community sets by
+        name";
+    }
+
+    leaf ext-community-set-ref {
+      status deprecated;
+      type leafref {
+        path "/oc-rpol:routing-policy/oc-rpol:defined-sets/" +
+          "oc-bgp-pol:bgp-defined-sets/" +
+          "oc-bgp-pol:ext-community-sets/" +
+          "oc-bgp-pol:ext-community-set/" +
+          "oc-bgp-pol:ext-community-set-name";
+      }
+      description
+        "References a defined extended community set by
+        name";
+    }
+  }
+
+  grouping set-ext-community-reference-state {
+    description
+      "Operational state data for referening an extended
+      community-set in the set-ext-community action";
+  }
+
+  grouping set-ext-community-reference-top {
+    description
+      "Top-level grouping for referening an extended community-set
+      in the set-community action";
+
+    container reference {
+      when "../config/method='REFERENCE'" {
+        description
+          "Active only when the set-community method is REFERENCE";
+      }
+      description
+        "Provide a reference to an extended community set for the
+        set-ext-community action";
+
+      container config {
+        description
+          "Configuration data for referening an extended
+          community-set in the set-ext-community action";
+
+        uses set-ext-community-reference-config;
+      }
+
+      container state {
+
+        config false;
+
+        description
+          "Operational state data for referening an extended
+          community-set in the set-ext-community action";
+
+        uses set-ext-community-reference-config;
+        uses set-ext-community-reference-state;
+      }
+    }
+  }
+
+  grouping set-ext-community-action-config {
+    description
+      "Configuration data for the set-ext-community action";
+
+    uses set-community-action-common;
+  }
+
+  grouping set-ext-community-action-state {
+    description
+      "Operational state data for the set-ext-community action";
+  }
+
+  grouping set-ext-community-action-top {
+    description
+      "Top-level grouping for the set-ext-community action";
+
+    container set-ext-community {
+      description
+        "Action to set the extended community attributes of the
+        route, along with options to modify how the community is
+        modified. Extended communities may be set using an inline
+        list OR a reference to an existing defined set (but not
+        both).";
+
+      container config {
+        description
+          "Configuration data for the set-ext-community action";
+
+        uses set-ext-community-action-config;
+      }
+
+      container state {
+
+        config false;
+
+        description
+          "Operational state data for the set-ext-community action";
+
+        uses set-ext-community-action-config;
+        uses set-ext-community-action-state;
+      }
+      uses set-ext-community-inline-top;
+      uses set-ext-community-reference-top;
+    }
+  }
+
+  grouping bgp-actions-config {
+    description
+      "Configuration data for BGP-specific actions";
+
+    leaf set-route-origin {
+      type oc-bgp-types:bgp-origin-attr-type;
+      description "set the origin attribute to the specified
+      value";
+    }
+
+    leaf set-local-pref {
+      type uint32;
+      description "set the local pref attribute on the route
+      update";
+    }
+
+    leaf set-next-hop {
+      type bgp-next-hop-type;
+      description "set the next-hop attribute in the route update";
+    }
+
+    leaf set-med {
+      type bgp-set-med-type;
+      description "set the med metric attribute in the route
+      update";
+    }
+  }
+
+  grouping bgp-actions-state {
+    description
+      "Operational state data for BGP-specific actions";
+  }
+
+  grouping bgp-actions-top {
+    description
+      "Top-level grouping for BGP-specific actions";
+
+    container bgp-actions {
+      description
+        "Top-level container for BGP-specific actions";
+
+      container config {
+        description
+          "Configuration data for BGP-specific actions";
+
+        uses bgp-actions-config;
+      }
+
+      container state {
+
+        config false;
+
+        description
+          "Operational state data for BGP-specific actions";
+
+        uses bgp-actions-config;
+        uses bgp-actions-state;
+      }
+      uses as-path-prepend-top;
+      uses set-community-action-top;
+      uses set-ext-community-action-top;
+    }
+  }
+
+  augment "/oc-rpol:routing-policy/oc-rpol:policy-definitions/" +
+    "oc-rpol:policy-definition/oc-rpol:statements/oc-rpol:statement/" +
+    "oc-rpol:conditions" {
+    description
+      "BGP policy conditions added to routing policy module";
+
+    uses bgp-conditions-top;
+  }
+
+  augment "/oc-rpol:routing-policy/oc-rpol:policy-definitions/" +
+    "oc-rpol:policy-definition/oc-rpol:statements/oc-rpol:statement/" +
+    "oc-rpol:actions" {
+    description "BGP policy actions added to routing policy
+    module";
+
+    uses bgp-actions-top;
+  }
+
+  // rpc statements
+
+  // notification statements
+}

--- a/models/yang/common/openconfig-bgp-types.yang
+++ b/models/yang/common/openconfig-bgp-types.yang
@@ -1,0 +1,840 @@
+module openconfig-bgp-types {
+  yang-version "1";
+
+  namespace "http://openconfig.net/yang/bgp-types";
+
+  prefix "oc-bgp-types";
+  import openconfig-types { prefix "oc-types"; }
+  import openconfig-inet-types { prefix "oc-inet"; }
+  import openconfig-extensions { prefix "oc-ext"; }
+
+  // Include definitions of BGP error notifications
+  include openconfig-bgp-errors;
+
+  // meta
+  organization
+    "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    netopenconfig@googlegroups.com";
+
+  description
+    "This module contains general data definitions for use in BGP
+    policy. It can be imported by modules that make use of BGP
+    attributes";
+
+  oc-ext:openconfig-version "6.0.0";
+
+  revision "2024-02-01" {
+    description
+      "Modify bgp-community-regexp-type.";
+    reference "6.0.0";
+  }
+
+  revision "2023-12-26" {
+    description
+      "Add regex for bgp link bandwidth";
+    reference "5.6.0";
+  }
+
+  revision "2023-09-06" {
+    description
+      "Add GRACEFUL_SHUTDOWN as a BGP_WELL_KNOWN_STD_COMMUNITY";
+    reference "5.5.0";
+  }
+
+  revision "2023-03-31" {
+    description
+      "Add support for BGP large communities [rfc8092] in
+      send-community
+
+      Types impacted:
+      - community-type";
+    reference "5.4.0";
+  }
+
+  revision "2021-08-06" {
+    description
+      "Fix pattern regexes to allow full 4-byte private ASN range including
+       42xxxxxxxx in extended communities
+
+      Types impacted:
+      - bgp-ext-community-type";
+    reference "5.3.1";
+  }
+
+  revision "2021-01-07" {
+    description
+      "Remove module extension oc-ext:regexp-posix by making pattern regexes
+      conform to RFC7950.
+
+      Types impacted:
+      - bgp-std-community-type
+      - bgp-ext-community-type";
+    reference "5.3.0";
+  }
+
+  revision "2020-06-30" {
+    description
+      "Add OpenConfig POSIX pattern extensions.";
+    reference "5.2.1";
+  }
+
+  revision "2020-06-17" {
+    description
+      "Add RFC5549 capability identity.";
+    reference "5.2.0";
+  }
+
+  revision "2020-03-24" {
+    description
+      "Add FlowSpec, BGP-LS and LSVR AFI-SAFI identities.";
+    reference "5.1.0";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "5.0.2";
+  }
+
+  revision "2018-08-20" {
+    description
+      "Correct description of AFI-SAFI enabled leaf.";
+    reference "5.0.1";
+  }
+
+  revision "2018-04-11" {
+    description
+      "Correct naming of BGP maximum prefix warning percentage leaf.";
+    reference "5.0.0";
+  }
+
+  revision "2018-03-20" {
+    description
+      "Added SR-TE policy SAFI";
+    reference "4.1.0";
+  }
+
+  revision "2018-03-20" {
+    description
+      "Added color extended community";
+    reference "4.0.2";
+  }
+
+  revision "2017-07-30" {
+    description
+      "Clarification of add-paths send-max leaf";
+    reference "4.0.1";
+  }
+
+  revision "2017-07-10" {
+    description
+      "Add error notifications; moved add-paths config; add AS
+      prepend policy features; removed unneeded config leaves";
+    reference "4.0.0";
+  }
+
+  revision "2017-02-02" {
+    description
+      "Bugfix to remove remaining global-level policy data";
+    reference "3.0.1";
+  }
+
+  revision "2017-01-26" {
+    description
+      "Add dynamic neighbor support, migrate to OpenConfig types";
+    reference "3.0.0";
+  }
+
+  revision "2016-06-21" {
+    description
+      "OpenConfig BGP refactor";
+    reference "2.1.1";
+  }
+
+  // OpenConfig specific extensions for module metadata.
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  identity BGP_CAPABILITY {
+    description "Base identity for a BGP capability";
+  }
+
+  identity MPBGP {
+    base BGP_CAPABILITY;
+    description
+      "Multi-protocol extensions to BGP";
+    reference "RFC2858";
+  }
+
+  identity ROUTE_REFRESH {
+    base BGP_CAPABILITY;
+    description
+      "The BGP route-refresh functionality";
+    reference "RFC2918";
+  }
+
+  identity ASN32 {
+    base BGP_CAPABILITY;
+    description
+      "4-byte (32-bit) AS number functionality";
+    reference "RFC6793";
+  }
+
+  identity GRACEFUL_RESTART {
+    base BGP_CAPABILITY;
+    description
+      "Graceful restart functionality";
+    reference "RFC4724";
+  }
+
+  identity ADD_PATHS {
+    base BGP_CAPABILITY;
+    description
+      "BGP add-paths";
+    reference "draft-ietf-idr-add-paths";
+  }
+
+  identity EXTENDED_NEXTHOP_ENCODING {
+    base BGP_CAPABILITY;
+    description
+      "BGP Extended Next Hop Encoding functionality";
+    reference "RFC5549";
+  }
+
+  identity AFI_SAFI_TYPE {
+    description
+      "Base identity type for AFI,SAFI tuples for BGP-4";
+    reference "RFC4760 - multiprotocol extensions for BGP-4";
+  }
+
+  identity IPV4_UNICAST {
+    base AFI_SAFI_TYPE;
+    description
+      "IPv4 unicast (AFI,SAFI = 1,1)";
+    reference "RFC4760";
+  }
+
+  identity IPV6_UNICAST {
+    base AFI_SAFI_TYPE;
+    description
+      "IPv6 unicast (AFI,SAFI = 2,1)";
+    reference "RFC4760";
+  }
+
+  identity IPV4_LABELED_UNICAST {
+    base AFI_SAFI_TYPE;
+    description
+      "Labeled IPv4 unicast (AFI,SAFI = 1,4)";
+    reference "RFC3107";
+  }
+
+  identity IPV6_LABELED_UNICAST {
+    base AFI_SAFI_TYPE;
+    description
+      "Labeled IPv6 unicast (AFI,SAFI = 2,4)";
+    reference "RFC3107";
+  }
+
+  identity L3VPN_IPV4_UNICAST {
+    base AFI_SAFI_TYPE;
+    description
+      "Unicast IPv4 MPLS L3VPN (AFI,SAFI = 1,128)";
+    reference "RFC4364";
+  }
+
+  identity L3VPN_IPV6_UNICAST {
+    base AFI_SAFI_TYPE;
+    description
+      "Unicast IPv6 MPLS L3VPN (AFI,SAFI = 2,128)";
+    reference "RFC4659";
+  }
+
+  identity L3VPN_IPV4_MULTICAST {
+    base AFI_SAFI_TYPE;
+    description
+      "Multicast IPv4 MPLS L3VPN (AFI,SAFI = 1,129)";
+    reference "RFC6514";
+  }
+
+  identity L3VPN_IPV6_MULTICAST {
+    base AFI_SAFI_TYPE;
+    description
+      "Multicast IPv6 MPLS L3VPN (AFI,SAFI = 2,129)";
+    reference "RFC6514";
+  }
+
+  identity L2VPN_VPLS {
+    base AFI_SAFI_TYPE;
+    description
+      "BGP-signalled VPLS (AFI,SAFI = 25,65)";
+    reference "RFC4761";
+  }
+
+  identity L2VPN_EVPN {
+    base AFI_SAFI_TYPE;
+    description
+      "BGP MPLS Based Ethernet VPN (AFI,SAFI = 25,70)";
+  }
+
+  identity SRTE_POLICY_IPV4 {
+    base AFI_SAFI_TYPE;
+    description
+      "Segment Routing Traffic Engineering (SRTE) Policy
+      for IPv4 (AFI,SAFI = 1,73)";
+  }
+
+  identity SRTE_POLICY_IPV6 {
+    base AFI_SAFI_TYPE;
+    description
+      "Segment Routing Traffic Engineering (SRTE) Policy
+      for IPv6 (AFI,SAFI = 2,73)";
+  }
+
+  identity IPV4_FLOWSPEC {
+    base AFI_SAFI_TYPE;
+    description
+      "IPv4 dissemination of flow specification rules
+      (AFI,SAFI = 1,133)";
+    reference "RFC5575";
+  }
+
+  identity VPNV4_FLOWSPEC {
+    base AFI_SAFI_TYPE;
+    description
+      "IPv4 dissemination of flow specification rules
+      (AFI,SAFI = 1,134)";
+    reference "RFC5575";
+  }
+
+  identity LINKSTATE {
+    base AFI_SAFI_TYPE;
+    description
+      "BGP-LS (AFI,SAFI = 16388,71)";
+    reference "RFC7752";
+  }
+
+  identity LINKSTATE_VPN {
+    base AFI_SAFI_TYPE;
+    description
+      "BGP-LS-VPN (AFI,SAFI = 16388,72)";
+    reference "RFC7752";
+  }
+
+  identity LINKSTATE_SPF {
+    base AFI_SAFI_TYPE;
+    description
+      "BGP-LS SPF (AFI,SAFI = 16388,TBD)";
+    reference "draft-ietf-lsvr-bgp-spf";
+  }
+
+
+  identity BGP_WELL_KNOWN_STD_COMMUNITY {
+    description
+      "Reserved communities within the standard community space
+      defined by RFC1997. These communities must fall within the
+      range 0x00000000 to 0xFFFFFFFF";
+    reference "RFC1997";
+  }
+
+  identity NO_EXPORT {
+    base BGP_WELL_KNOWN_STD_COMMUNITY;
+    description
+      "Do not export NLRI received carrying this community outside
+      the bounds of this autonomous system, or this confederation if
+      the local autonomous system is a confederation member AS. This
+      community has a value of 0xFFFFFF01.";
+    reference "RFC1997";
+  }
+
+  identity NO_ADVERTISE {
+    base BGP_WELL_KNOWN_STD_COMMUNITY;
+    description
+      "All NLRI received carrying this community must not be
+      advertised to other BGP peers. This community has a value of
+      0xFFFFFF02.";
+    reference "RFC1997";
+  }
+
+  identity NO_EXPORT_SUBCONFED {
+    base BGP_WELL_KNOWN_STD_COMMUNITY;
+    description
+      "All NLRI received carrying this community must not be
+      advertised to external BGP peers - including over confederation
+      sub-AS boundaries. This community has a value of 0xFFFFFF03.";
+    reference "RFC1997";
+  }
+
+  identity NOPEER {
+    base BGP_WELL_KNOWN_STD_COMMUNITY;
+    description
+      "An autonomous system receiving NLRI tagged with this community
+      is advised not to readvertise the NLRI to external bi-lateral
+      peer autonomous systems. An AS may also filter received NLRI
+      from bilateral peer sessions when they are tagged with this
+      community value";
+    reference "RFC3765";
+  }
+
+  identity GRACEFUL_SHUTDOWN {
+    base BGP_WELL_KNOWN_STD_COMMUNITY;
+    description
+      "An autonomous system which supports the graceful shutdown
+      receiver procedure receiving NLRI tagged with this community
+      will set LOCAL_PREF to a low value for those NLRI.  This
+      community has a value of 0xFFFF0000.";
+    reference "RFC8326";
+  }
+
+  typedef bgp-session-direction {
+    type enumeration {
+      enum INBOUND {
+        description
+          "Refers to all NLRI received from the BGP peer";
+      }
+      enum OUTBOUND {
+        description
+          "Refers to all NLRI advertised to the BGP peer";
+      }
+    }
+    description
+      "Type to describe the direction of NLRI transmission";
+  }
+
+  typedef bgp-well-known-community-type {
+    type identityref {
+      base BGP_WELL_KNOWN_STD_COMMUNITY;
+    }
+    description
+      "Type definition for well-known IETF community attribute
+      values";
+    reference
+      "IANA Border Gateway Protocol (BGP) Well Known Communities";
+  }
+
+
+  typedef bgp-std-community-type {
+    // TODO: further refine restrictions and allowed patterns
+    // 4-octet value:
+    //  <as number> 2 octets
+    //  <community value> 2 octets
+    type union {
+      type uint32 {
+      // per RFC 1997, 0x00000000 - 0x0000FFFF and 0xFFFF0000 -
+      // 0xFFFFFFFF are reserved
+      }
+      type string {
+        pattern '(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}'      +
+                '|6[0-4][0-9]{3}|[1-5][0-9]{4}|[1-9][0-9]{1,3}|[0-9]):'      +
+                '(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}'       +
+                '|6[0-4][0-9]{3}|[1-5][0-9]{4}|[1-9][0-9]{1,3}|[0-9])';
+        oc-ext:posix-pattern '^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}'      +
+                '|6[0-4][0-9]{3}|[1-5][0-9]{4}|[1-9][0-9]{1,3}|[0-9]):'      +
+                '(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}'       +
+                '|6[0-4][0-9]{3}|[1-5][0-9]{4}|[1-9][0-9]{1,3}|[0-9])$';
+      }
+    }
+    description
+      "Type definition for standard commmunity attributes represented as
+      a integer value, or a string of the form N:M where N and M are
+      integers between 0 and 65535.";
+    reference "RFC 1997 - BGP Communities Attribute";
+  }
+
+  typedef bgp-ext-community-type {
+    type union {
+      type string {
+        // Type 1: 2-octet global and 4-octet local
+        //         (AS number)        (Integer)
+        pattern '(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}'      +
+                '|6[0-4][0-9]{3}|[1-5][0-9]{4}|[1-9][0-9]{1,3}|[0-9]):'      +
+                '(429496729[0-5]|42949672[0-8][0-9]|4294967[0-1][0-9]{2}'    +
+                '|429496[0-6][0-9]{3}|42949[0-5][0-9]{4}|4294[0-8][0-9]{5}|' +
+                '429[0-3][0-9]{6}|42[0-8][0-9]{7}|4[0-1][0-9]{8}|[1-3][0-9]{9}|'  +
+                '[1-9][0-9]{1,8}|[0-9])';
+        oc-ext:posix-pattern '^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}'     +
+                '|6[0-4][0-9]{3}|[1-5][0-9]{4}|[1-9][0-9]{1,3}|[0-9]):'      +
+                '(429496729[0-5]|42949672[0-8][0-9]|4294967[0-1][0-9]{2}'    +
+                '|429496[0-6][0-9]{3}|42949[0-5][0-9]{4}|4294[0-8][0-9]{5}|' +
+                '429[0-3][0-9]{6}|42[0-8][0-9]{7}|4[0-1][0-9]{8}|[1-3][0-9]{9}|'  +
+                '[1-9][0-9]{1,8}|[0-9])$';
+      }
+      type string {
+        // Type 2: 4-octet global and 2-octet local
+        //         (ipv4-address)     (integer)
+        pattern '(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|'         +
+                '25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|'         +
+                '2[0-4][0-9]|25[0-5]):'                                +
+                '(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}' +
+                '|6[0-4][0-9]{3}|[1-5][0-9]{4}|[1-9][0-9]{1,3}|[0-9])';
+        oc-ext:posix-pattern '^(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|'         +
+                '25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|'         +
+                '2[0-4][0-9]|25[0-5]):'                                +
+                '(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}' +
+                '|6[0-4][0-9]{3}|[1-5][0-9]{4}|[1-9][0-9]{1,3}|[0-9])$';
+      }
+      type string {
+        // RFC5668: 4-octet global and 2-octet local
+        //            (AS number)        (integer)
+        pattern '(429496729[0-5]|42949672[0-8][0-9]|4294967[0-1][0-9]{2}'    +
+                '|429496[0-6][0-9]{3}|42949[0-5][0-9]{4}|4294[0-8][0-9]{5}|' +
+                '429[0-3][0-9]{6}|42[0-8][0-9]{7}|4[0-1][0-9]{8}|[1-3][0-9]{9}|'  +
+                '[1-9][0-9]{1,8}|[0-9]):'                                    +
+                '(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}'       +
+                '|6[0-4][0-9]{3}|[1-5][0-9]{4}|[1-9][0-9]{1,3}|[0-9])';
+        oc-ext:posix-pattern '^(429496729[0-5]|42949672[0-8][0-9]|4294967[0-1][0-9]{2}'   +
+                '|429496[0-6][0-9]{3}|42949[0-5][0-9]{4}|4294[0-8][0-9]{5}|' +
+                '429[0-3][0-9]{6}|42[0-8][0-9]{7}|4[0-1][0-9]{8}|[1-3][0-9]{9}|'  +
+                '[1-9][0-9]{1,8}|[0-9]):'                                    +
+                '(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}'       +
+                '|6[0-4][0-9]{3}|[1-5][0-9]{4}|[1-9][0-9]{1,3}|[0-9])$';
+      }
+      type string {
+        // route-target with Type 1
+        // route-target:(ASN):(local-part)
+        pattern 'route\-target:'                                             +
+                '(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}'       +
+                '|6[0-4][0-9]{3}|[1-5][0-9]{4}|[1-9][0-9]{1,3}|[0-9]):'      +
+                '(429496729[0-5]|42949672[0-8][0-9]|4294967[0-1][0-9]{2}'    +
+                '|429496[0-6][0-9]{3}|42949[0-5][0-9]{4}|4294[0-8][0-9]{5}|' +
+                '429[0-3][0-9]{6}|42[0-8][0-9]{7}|4[0-1][0-9]{8}|[1-3][0-9]{9}|'  +
+                '[1-9][0-9]{1,8}|[0-9])';
+        oc-ext:posix-pattern '^route\-target:'                               +
+                '(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}'       +
+                '|6[0-4][0-9]{3}|[1-5][0-9]{4}|[1-9][0-9]{1,3}|[0-9]):'      +
+                '(429496729[0-5]|42949672[0-8][0-9]|4294967[0-1][0-9]{2}'    +
+                '|429496[0-6][0-9]{3}|42949[0-5][0-9]{4}|4294[0-8][0-9]{5}|' +
+                '429[0-3][0-9]{6}|42[0-8][0-9]{7}|4[0-1][0-9]{8}|[1-3][0-9]{9}|'  +
+                '[1-9][0-9]{1,8}|[0-9])$';
+      }
+      type string {
+        // route-target with Type 2
+        // route-target:(IPv4):(local-part)
+        pattern 'route\-target:'                                      +
+                '(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|'          +
+                '25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|'         +
+                '2[0-4][0-9]|25[0-5]):'                                +
+                '(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}' +
+                '|6[0-4][0-9]{3}|[1-5][0-9]{4}|[1-9][0-9]{1,3}|[0-9])';
+        oc-ext:posix-pattern '^route\-target:'                                      +
+                '(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|'          +
+                '25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|'         +
+                '2[0-4][0-9]|25[0-5]):'                                +
+                '(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}' +
+                '|6[0-4][0-9]{3}|[1-5][0-9]{4}|[1-9][0-9]{1,3}|[0-9])$';
+      }
+      type string {
+        // 4-byte AS Type 1 route-target
+        pattern 'route\-target:'                                            +
+                '(429496729[0-5]|42949672[0-8][0-9]|4294967[0-1][0-9]{2}'    +
+                '|429496[0-6][0-9]{3}|42949[0-5][0-9]{4}|4294[0-8][0-9]{5}|' +
+                '429[0-3][0-9]{6}|42[0-8][0-9]{7}|4[0-1][0-9]{8}|[1-3][0-9]{9}|'  +
+                '[1-9][0-9]{1,8}|[0-9]):'                                    +
+                '(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}'       +
+                '|6[0-4][0-9]{3}|[1-5][0-9]{4}|[1-9][0-9]{1,3}|[0-9])';
+        oc-ext:posix-pattern '^route\-target:'                                            +
+                '(429496729[0-5]|42949672[0-8][0-9]|4294967[0-1][0-9]{2}'    +
+                '|429496[0-6][0-9]{3}|42949[0-5][0-9]{4}|4294[0-8][0-9]{5}|' +
+                '429[0-3][0-9]{6}|42[0-8][0-9]{7}|4[0-1][0-9]{8}|[1-3][0-9]{9}|'  +
+                '[1-9][0-9]{1,8}|[0-9]):'                                    +
+                '(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}'       +
+                '|6[0-4][0-9]{3}|[1-5][0-9]{4}|[1-9][0-9]{1,3}|[0-9])$';
+      }
+      type string {
+        // route-origin with Type 1
+        pattern 'route\-origin:'                                            +
+                '(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}'       +
+                '|6[0-4][0-9]{3}|[1-5][0-9]{4}|[1-9][0-9]{1,3}|[0-9]):'      +
+                '(429496729[0-5]|42949672[0-8][0-9]|4294967[0-1][0-9]{2}'    +
+                '|429496[0-6][0-9]{3}|42949[0-5][0-9]{4}|4294[0-8][0-9]{5}|' +
+                '429[0-3][0-9]{6}|42[0-8][0-9]{7}|4[0-1][0-9]{8}|[1-3][0-9]{9}|'  +
+                '[1-9][0-9]{1,8}|[0-9])';
+        oc-ext:posix-pattern '^route\-origin:'                                            +
+                '(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}'       +
+                '|6[0-4][0-9]{3}|[1-5][0-9]{4}|[1-9][0-9]{1,3}|[0-9]):'      +
+                '(429496729[0-5]|42949672[0-8][0-9]|4294967[0-1][0-9]{2}'    +
+                '|429496[0-6][0-9]{3}|42949[0-5][0-9]{4}|4294[0-8][0-9]{5}|' +
+                '429[0-3][0-9]{6}|42[0-8][0-9]{7}|4[0-1][0-9]{8}|[1-3][0-9]{9}|'  +
+                '[1-9][0-9]{1,8}|[0-9])$';
+      }
+      type string {
+        // route-origin with Type 2
+        pattern 'route\-origin:'                                      +
+                '(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|'          +
+                '25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|'         +
+                '2[0-4][0-9]|25[0-5]):'                                +
+                '(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}' +
+                '|6[0-4][0-9]{3}|[1-5][0-9]{4}|[1-9][0-9]{1,3}|[0-9])';
+        oc-ext:posix-pattern '^route\-origin:'                                      +
+                '(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|'          +
+                '25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|'         +
+                '2[0-4][0-9]|25[0-5]):'                                +
+                '(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}' +
+                '|6[0-4][0-9]{3}|[1-5][0-9]{4}|[1-9][0-9]{1,3}|[0-9])$';
+      }
+      type string {
+        // 4-byte AS Type 1 route-origin
+        pattern 'route\-origin:'                                            +
+                '(429496729[0-5]|42949672[0-8][0-9]|4294967[0-1][0-9]{2}'    +
+                '|429496[0-6][0-9]{3}|42949[0-5][0-9]{4}|4294[0-8][0-9]{5}|' +
+                '429[0-3][0-9]{6}|42[0-8][0-9]{7}|4[0-1][0-9]{8}|[1-3][0-9]{9}|'  +
+                '[1-9][0-9]{1,8}|[0-9]):'                                    +
+                '(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}'       +
+                '|6[0-4][0-9]{3}|[1-5][0-9]{4}|[1-9][0-9]{1,3}|[0-9])';
+        oc-ext:posix-pattern '^route\-origin:'                                            +
+                '(429496729[0-5]|42949672[0-8][0-9]|4294967[0-1][0-9]{2}'    +
+                '|429496[0-6][0-9]{3}|42949[0-5][0-9]{4}|4294[0-8][0-9]{5}|' +
+                '429[0-3][0-9]{6}|42[0-8][0-9]{7}|4[0-1][0-9]{8}|[1-3][0-9]{9}|'  +
+                '[1-9][0-9]{1,8}|[0-9]):'                                    +
+                '(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}'       +
+                '|6[0-4][0-9]{3}|[1-5][0-9]{4}|[1-9][0-9]{1,3}|[0-9])$';
+      }
+      type string {
+        // Extended Color Community
+        pattern 'color:'                                                    +
+                '[0-1]{2}:'                                                  +
+                '(429496729[0-5]|42949672[0-8][0-9]|4294967[0-1][0-9]{2}'    +
+                '|429496[0-6][0-9]{3}|42949[0-5][0-9]{4}|4294[0-8][0-9]{5}|' +
+                '429[0-3][0-9]{6}|42[0-8][0-9]{7}|4[0-1][0-9]{8}|[1-3][0-9]{9}|'  +
+                '[1-9][0-9]{1,8}|[0-9])';
+        oc-ext:posix-pattern '^color:'                                                    +
+                '[0-1]{2}:'                                                  +
+                '(429496729[0-5]|42949672[0-8][0-9]|4294967[0-1][0-9]{2}'    +
+                '|429496[0-6][0-9]{3}|42949[0-5][0-9]{4}|4294[0-8][0-9]{5}|' +
+                '429[0-3][0-9]{6}|42[0-8][0-9]{7}|4[0-1][0-9]{8}|[1-3][0-9]{9}|'  +
+                '[1-9][0-9]{1,8}|[0-9])$';
+      }
+      type string {
+        // Extended Link Bandwidth Community
+        // link-bandwidth:<2 byte asn>:<bandwidth value in bits/sec,
+        //           optionally with Kilo/Mega/Giga suffix>
+        // Example: link-bandwidth:20:100M
+        pattern 'link-bandwidth:'                                                 +
+                '(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}'                        +
+                '|6[0-4][0-9]{3}|[1-5][0-9]{4}|[1-9][0-9]{1,3}|[0-9]):'           +
+                '(429496729[0-5]|42949672[0-8][0-9]|4294967[0-1][0-9]{2}'         +
+                '|429496[0-6][0-9]{3}|42949[0-5][0-9]{4}|4294[0-8][0-9]{5}|'      +
+                '429[0-3][0-9]{6}|42[0-8][0-9]{7}|4[0-1][0-9]{8}|[1-3][0-9]{9}|'  +
+                '[1-9][0-9]{1,8}|[0-9])(k|K|M|G)?';
+        oc-ext:posix-pattern '^link-bandwidth:'                                   +
+                '(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}'                        +
+                '|6[0-4][0-9]{3}|[1-5][0-9]{4}|[1-9][0-9]{1,3}|[0-9])$'           +
+                '(429496729[0-5]|42949672[0-8][0-9]|4294967[0-1][0-9]{2}'         +
+                '|429496[0-6][0-9]{3}|42949[0-5][0-9]{4}|4294[0-8][0-9]{5}|'      +
+                '429[0-3][0-9]{6}|42[0-8][0-9]{7}|4[0-1][0-9]{8}|[1-3][0-9]{9}|'  +
+                '[1-9][0-9]{1,8}|[0-9])(k|K|M|G)?$';
+      }
+
+    }
+    description
+      "Type definition for extended community attributes. In the case that
+      common communities are utilised, they are represented as a string
+      of the form:
+        - <2b AS>:<4b value> per RFC4360 section 3.1
+        - <4b IPv4>:<2b value> per RFC4360 section 3.2
+        - <4b AS>:<2b value> per RFC5668 section 2.
+        - route-target:<2b AS>:<4b value> per RFC4360 section 4
+        - route-target:<4b IPv4>:<2b value> per RFC4360 section 4
+        - route-origin:<2b ASN>:<4b value> per RFC4360 section 5
+        - route-origin:<4b IPv4>:<2b value> per RFC4360 section 5
+        - color:<CO bits>:<4b value> per draft-ietf-idr-segment-routing-te-policy
+          section 3
+        - link-bandwidth:<2 byte asn>:<bandwidth_value> per
+          draft-ietf-idr-link-bandwidth-07";
+
+    reference
+      "RFC 4360 - BGP Extended Communities Attribute
+       RFC 5668 - 4-Octet AS Specific BGP Extended Community
+       draft-ietf-idr-segment-routing-te-policy
+       draft-ietf-idr-link-bandwidth-07";
+  }
+
+  typedef bgp-ext-community-recv-type {
+    type union {
+      type bgp-ext-community-type;
+      type binary {
+        length 8;
+      }
+    }
+    description
+      "A type definition utilised to define the extended community
+      in a context where the system is receiving the extended
+      community from an external source, such that the value may be
+      unknown. In the case that the received extended community is
+      unknown it is defined to be a 8-octet quantity formatted
+      according to RFC4360:
+
+      Type Field: 1 or 2 octets.
+      Value Field: Remaining octets.
+
+      The high-order octet of the type field is encoded such that
+      bit 0 indicates whether the extended community type is IANA
+      assigned; and bit 1 indicates whether the extended community
+      is transitive.  The remaining bits of the high-order type
+      field must be interpreted to determine whether the low-order
+      type field should be parsed, or whether the entire remainder
+      of the extended community is a value.";
+    reference
+      "RFC 4360 - BGP Extended Communities Attribute
+       RFC 5668 - 4-Octet AS Specific BGP Extended Community";
+  }
+
+  typedef bgp-community-regexp-type {
+    type oc-types:posix-eregexp;
+    description
+      "Type definition for communities specified as regular
+      expression patterns.  The regular expression must be a
+      POSIX extended regular expression with some limitations
+      which are commonly found in device implementations described
+      in draft-ietf-idr-bgp-model.";
+    reference
+      "draft-ietf-idr-bgp-model";
+  }
+
+  typedef bgp-origin-attr-type {
+    type enumeration {
+      enum IGP {
+        description
+          "Origin of the NLRI is internal";
+      }
+      enum EGP {
+        description
+          "Origin of the NLRI is EGP";
+      }
+      enum INCOMPLETE {
+        description
+          "Origin of the NLRI is neither IGP or EGP";
+      }
+    }
+    description
+      "Type definition for standard BGP origin attribute";
+    reference "RFC 4271 - A Border Gateway Protocol 4 (BGP-4),
+      Sec 4.3";
+  }
+
+  typedef peer-type {
+    type enumeration {
+      enum INTERNAL {
+        description
+          "Internal (iBGP) peer";
+      }
+      enum EXTERNAL {
+        description
+          "External (eBGP) peer";
+      }
+    }
+    description
+      "Labels a peer or peer group as explicitly internal or
+      external";
+  }
+
+  identity REMOVE_PRIVATE_AS_OPTION {
+    description
+      "Base identity for options for removing private autonomous
+      system numbers from the AS_PATH attribute";
+  }
+
+  identity PRIVATE_AS_REMOVE_ALL {
+    base REMOVE_PRIVATE_AS_OPTION;
+    description
+      "Strip all private autonmous system numbers from the AS_PATH.
+      This action is performed regardless of the other content of the
+      AS_PATH attribute, and for all instances of private AS numbers
+      within that attribute.";
+  }
+
+  identity PRIVATE_AS_REPLACE_ALL {
+    base REMOVE_PRIVATE_AS_OPTION;
+    description
+      "Replace all instances of private autonomous system numbers in
+      the AS_PATH with the local BGP speaker's autonomous system
+      number. This action is performed regardless of the other
+      content of the AS_PATH attribute, and for all instances of
+      private AS number within that attribute.";
+  }
+
+  typedef remove-private-as-option {
+    type identityref {
+      base REMOVE_PRIVATE_AS_OPTION;
+    }
+    description
+      "Set of options for configuring how private AS path numbers
+      are removed from advertisements";
+  }
+
+  typedef rr-cluster-id-type {
+    type union {
+      type uint32;
+      type oc-inet:ipv4-address;
+    }
+    description
+      "Union type for route reflector cluster ids:
+      option 1: 4-byte number
+      option 2: IP address";
+  }
+
+  typedef community-type {
+    type enumeration {
+      enum STANDARD {
+        description "Send standard communities";
+      }
+      enum EXTENDED {
+        description "Send extended communities";
+      }
+      enum LARGE {
+        description "Send large communities";
+      }
+      enum BOTH {
+        description
+            "Send both standard and extended communities.
+            This value has been deprecated because the node is now
+            a leaf-list.";
+        status deprecated;
+      }
+      enum NONE {
+        description
+            "Do not send any community attribute.
+            This value has been deprecated because the node is now
+            a leaf-list.";
+        status deprecated;
+      }
+    }
+    description
+      "type describing variations of community attributes:
+      STANDARD: standard BGP community [rfc1997]
+      EXTENDED: extended BGP community [rfc4360]
+      LARGE: large BGP community [rfc8092]";
+  }
+
+
+  typedef as-path-segment-type {
+    type enumeration {
+      enum AS_SEQ {
+        description
+          "Ordered set of autonomous systems that a route in
+          the UPDATE message has traversed";
+      }
+      enum AS_SET {
+        description
+          "Unordered set of autonomous systems that a route in
+          the UPDATE message has traversed";
+      }
+      enum AS_CONFED_SEQUENCE {
+        description
+          "Ordered set of Member Autonomous
+          Systems in the local confederation that the UPDATE message
+          has traversed";
+      }
+      enum AS_CONFED_SET {
+        description
+          "Unordered set of Member Autonomous Systems
+          in the local confederation that the UPDATE message has
+          traversed";
+      }
+    }
+    description
+      "Defines the types of BGP AS path segments.";
+  }
+}

--- a/models/yang/common/openconfig-bgp.yang
+++ b/models/yang/common/openconfig-bgp.yang
@@ -1,0 +1,295 @@
+module openconfig-bgp {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/bgp";
+
+  prefix "oc-bgp";
+
+  // import some basic inet types
+  import openconfig-extensions { prefix oc-ext; }
+  import openconfig-rib-bgp { prefix oc-bgprib; }
+
+  // Include the OpenConfig BGP submodules
+  // Common: defines the groupings that are common across more than
+  //         one context (where contexts are neighbor, group, global)
+  include openconfig-bgp-common;
+  // Multiprotocol: defines the groupings that are common across more
+  //                than one context, and relate to Multiprotocol
+  include openconfig-bgp-common-multiprotocol;
+  // Structure: defines groupings that are shared but are solely used for
+  //            structural reasons.
+  include openconfig-bgp-common-structure;
+  // Include peer-group/neighbor/global - these define the groupings
+  // that are specific to one context
+  include openconfig-bgp-peer-group;
+  include openconfig-bgp-neighbor;
+  include openconfig-bgp-global;
+
+  // meta
+  organization
+    "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    netopenconfig@googlegroups.com";
+
+  description
+    "This module describes a YANG model for BGP protocol
+    configuration.It is a limited subset of all of the configuration
+    parameters available in the variety of vendor implementations,
+    hence it is expected that it would be augmented with vendor-
+    specific configuration data as needed. Additional modules or
+    submodules to handle other aspects of BGP configuration,
+    including policy, VRFs, VPNs, and additional address families
+    are also expected.
+
+    This model supports the following BGP configuration level
+    hierarchy:
+
+      BGP
+        |
+        +-> [ global BGP configuration ]
+          +-> AFI / SAFI global
+        +-> peer group
+          +-> [ peer group config ]
+          +-> AFI / SAFI [ per-AFI overrides ]
+        +-> neighbor
+          +-> [ neighbor config ]
+          +-> [ optional pointer to peer-group ]
+          +-> AFI / SAFI [ per-AFI overrides ]
+
+    Most BGP features can be configured at multiple levels in the BGP
+    configuration level hierarchy. The common inheritance model allows
+    the more specific configuration (e.g. neighbor) to inherit from or
+    override the less specific configuration (e.g. global).
+    Leaf present at one level overrides leafs present at higher levels,
+    whereas leaf not present inherits its value from the leaf present
+    at the next higher level in the hierarchy.";
+
+  oc-ext:openconfig-version "9.7.1";
+
+  revision "2023-12-28" {
+    description
+      "Clarification to last-prefix-limit-exceeded in description";
+          reference "9.7.1";
+  }
+
+  revision "2023-12-28" {
+    description
+      "Add support for controling use of link-bandwidth extended
+      community for BGP multipath.";
+          reference "9.7.0";
+  }
+
+  revision "2023-11-02" {
+    description
+      "Fix revision '2023-03-31': send-community-type was added to the
+       wrong grouping.
+      Allow configuring send-community per AFI-SAFI at
+       neighbor/peer-group.";
+    reference "9.6.0";
+  }
+
+  revision "2023-11-01" {
+    description
+      "Add default apply policy to global and per afi-safi config.";
+    reference "9.5.0";
+  }
+
+  revision "2023-06-27" {
+    description
+      "Clarify bgp remote-port description";
+    reference "9.4.1";
+  }
+
+  revision "2023-04-01" {
+    description
+      "Add support for BGP large communities [rfc8092] in
+      send-community.
+      Leaf send-community was replaced by the leaf-list
+      send-community-type to allow the combination of different
+      community types";
+    reference "9.4.0";
+  }
+
+  revision "2023-03-31" {
+    description
+      "Allow configuring send-community per AFI-SAFI at
+       neighbor/peer-group.";
+    reference "9.3.0";
+  }
+
+  revision "2022-12-12" {
+    description
+      "Removed the default of enabled leaf of AFI-SAFI
+      at neighbor/peer-group to support BGP inheritance model.";
+    reference "9.2.0";
+  }
+
+  revision "2022-05-21" {
+    description
+      "Added extended-next-hop-encoding leaf.";
+    reference "9.1.0";
+  }
+
+  revision "2022-04-26" {
+    description
+      "Transition decimal64 types to uint16 for various BGP timers";
+    reference "9.0.0";
+  }
+
+  revision "2022-03-21" {
+    description
+      "Add BGP port";
+    reference "8.1.0";
+  }
+
+  revision "2021-12-01" {
+    description
+      "Add prefix-limit-received, add prefix-limit
+      state nodes, change/relocate restart-timer";
+    reference "8.0.0";
+  }
+
+  revision "2021-10-21" {
+    description
+      "Removal of top-level /bgp container";
+    reference "7.0.0";
+  }
+
+  revision "2021-06-16" {
+    description
+      "Remove trailing whitespace";
+    reference "6.1.1";
+  }
+
+  revision "2021-03-17" {
+    description
+      "Add bfd support without augmentation.";
+    reference "6.1.0";
+  }
+
+  revision "2019-07-10" {
+    description
+      "Normalise timestamp units to nanoseconds.";
+    reference "6.0.0";
+  }
+
+  revision "2019-05-28" {
+    description
+      "Clarify prefix counter descriptions, add received-pre-policy
+      counter.";
+    reference "5.2.0";
+  }
+
+  revision "2019-04-16" {
+    description
+      "Add BGP RIB to the top-level BGP container";
+    reference "5.1.0";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "5.0.2";
+  }
+
+  revision "2018-08-20" {
+    description
+      "Correct description of AFI-SAFI enabled leaf.";
+    reference "5.0.1";
+  }
+
+  revision "2018-04-11" {
+    description
+      "Correct naming of BGP maximum prefix warning percentage leaf.";
+    reference "5.0.0";
+  }
+
+  revision "2018-03-20" {
+    description
+      "Added SR-TE policy SAFI";
+    reference "4.1.0";
+  }
+
+  revision "2017-07-30" {
+    description
+      "Clarification of add-paths send-max leaf";
+    reference "4.0.1";
+  }
+
+  revision "2017-07-10" {
+    description
+      "Add error notifications; moved add-paths config; add AS
+      prepend policy features; removed unneeded config leaves";
+    reference "4.0.0";
+  }
+
+  revision "2017-02-02" {
+    description
+      "Bugfix to remove remaining global-level policy data";
+    reference "3.0.1";
+  }
+
+  revision "2017-01-26" {
+    description
+      "Add dynamic neighbor support, migrate to OpenConfig types";
+    reference "3.0.0";
+  }
+
+  revision "2016-06-21" {
+    description
+      "OpenConfig BGP refactor";
+    reference "2.1.1";
+  }
+
+  revision "2016-06-06" {
+    description
+      "OpenConfig public release";
+    reference "2.1.0";
+  }
+
+  revision "2016-03-31" {
+    description
+      "OpenConfig public release";
+    reference "2.0.1";
+  }
+
+  // OpenConfig specific extensions for module metadata.
+  oc-ext:regexp-posix;
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  grouping bgp-top {
+    description
+      "Top-level grouping for the BGP model data";
+
+    container bgp {
+      description
+        "Top-level configuration and state for the BGP router";
+
+      container global {
+        description
+          "Global configuration for the BGP router";
+          uses bgp-global-base;
+      }
+
+      container neighbors {
+        description
+          "Configuration for BGP neighbors";
+        uses bgp-neighbor-list;
+      }
+
+      container peer-groups {
+        description
+          "Configuration for BGP peer-groups";
+        uses bgp-peer-group-list;
+      }
+
+      uses oc-bgprib:bgp-rib-top;
+    }
+  }
+
+}

--- a/models/yang/common/openconfig-evpn-types.yang
+++ b/models/yang/common/openconfig-evpn-types.yang
@@ -1,0 +1,305 @@
+module openconfig-evpn-types {
+  yang-version "1";
+
+  namespace "http://openconfig.net/yang/evpn-types";
+
+  prefix "oc-evpn-types";
+
+  import openconfig-extensions { prefix oc-ext; }
+  import openconfig-yang-types { prefix oc-yang; }
+
+  // TODO:
+  // Include definitions of EVPN error notifications
+  // include openconfig-bgp-errors;
+
+  // meta
+  organization
+    "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    netopenconfig@googlegroups.com";
+
+  description
+    "This module contains general data definitions for use in EVPN
+    policy. It can be imported by modules that make use of EVPN
+    attributes";
+
+  oc-ext:openconfig-version "0.2.0";
+
+  revision "2021-06-21" {
+    description
+      "Add types needed for BGP l2vpn evpn support";
+    reference "0.2.0";
+  }
+
+  revision "2021-06-16" {
+    description
+      "Remove trailing whitespace";
+    reference "0.1.1";
+  }
+
+  revision "2020-10-08" {
+    description
+      "Initial Revision";
+    reference "0.1.0";
+  }
+
+  // OpenConfig specific extensions for module metadata.
+  oc-ext:regexp-posix;
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  /* Identities */
+
+  identity EVPN_TYPE {
+    description "Base identity for a EVPN type";
+  }
+
+  identity VLAN_BASED {
+    base EVPN_TYPE;
+    description
+      "With this EVPN Type, an EVPN instance
+      consists of only a single broadcast domain.";
+     reference
+       "RFC 7432: BGP MPLS-Based Ethernet VPN, Section 6.1";
+  }
+
+  identity VLAN_BUNDLE {
+    base EVPN_TYPE;
+    description
+      "With this EVPN Type, an EVPN instance
+      corresponds to multiple broadcast domains.";
+     reference
+       "RFC 7432: BGP MPLS-Based Ethernet VPN, Section 6.2";
+  }
+
+  identity VLAN_AWARE {
+    base EVPN_TYPE;
+    description
+      "With this EVPN Type, an EVPN instance consists of multiple
+      broadcast domains (e.g., multiple VLANs) with each VLAN having its
+      own bridge table .";
+     reference
+       "RFC 7432: BGP MPLS-Based Ethernet VPN, Section 6.3";
+  }
+
+  identity EVPN_REDUNDANCY_MODE {
+    description
+      "Base identity for a EVPN capability";
+  }
+
+  identity SINGLE_ACTIVE {
+    base EVPN_REDUNDANCY_MODE;
+    description
+      "Indicates Single-Active redundancy mode for
+       a given Ethernet Segment (ES).";
+     reference
+       "RFC 7432: BGP MPLS-Based Ethernet VPN, Section 14.1.1";
+  }
+
+  identity ALL_ACTIVE {
+    base EVPN_REDUNDANCY_MODE;
+    description
+      "Indicates All-Active redundancy mode for
+       a given Ethernet Segment (ES).";
+     reference
+       "RFC 7432: BGP MPLS-Based Ethernet VPN, Section 14.1.2";
+  }
+
+  identity EVPN_CAPABILITY {
+    description "Base identity for a EVPN capability";
+  }
+
+  identity NVE {
+    base EVPN_CAPABILITY;
+    description
+      "An EVPN instance with the Network Virtualization Edge
+      the PE";
+    reference "draft-ietf-bess-evpn-inter-subnet-forwarding-10";
+  }
+
+  identity EVI {
+    base EVPN_CAPABILITY;
+    description
+      "An EVPN instance spanning the Provider Edge Devices
+      participating in that EVPN";
+    reference "RFC7432";
+  }
+
+  identity MAC_VRF {
+    base EVPN_CAPABILITY;
+    description
+      "A Virtual Routing and Forwarding table for Media Access
+      Control MAC addresses on a PE";
+    reference "RFC7432";
+  }
+
+  identity IP_VRF {
+    base EVPN_CAPABILITY;
+    description
+      "A VPN Routing and Forwarding table for IP routes on an NVE/
+      PE.  The IP routes could be populated by EVPN and IP-VPN address
+      families.  An IP-VRF is also an instantiation of a layer 3 VPN
+      in an NVE/PE";
+    reference "draft-ietf-bess-evpn-inter-subnet-forwarding-10";
+  }
+
+  identity IRB {
+    base EVPN_CAPABILITY;
+    description
+      "Integrated Routing and Bridging interface.  It connects an IP-
+      VRF to a BD or subnet";
+    reference "draft-ietf-bess-evpn-inter-subnet-forwarding-10";
+  }
+
+  typedef evi-id {
+    type uint32 {
+      range 1..16777215;
+    }
+    description
+      "Type definition representing a EVPN Instance Identifier";
+  }
+
+  typedef vni-id {
+    type uint32 {
+      range 1..16777215;
+    }
+    description
+      "Type definition representing a virtual network identifier";
+  }
+
+  typedef esi {
+    type oc-yang:hex-string {
+      length "20";
+    }
+    description
+      "10-octet Ethernet segment identifier (ESI)";
+  }
+
+  typedef esi-type {
+    type enumeration {
+      enum TYPE_0_OPERATOR_CONFIGURED {
+        value 0;
+        description
+          "Type 0 indicates the value must be provided.";
+      }
+      enum TYPE_1_LACP_BASED {
+        value 1;
+        description
+          "Type 1 when IEEE 802.1AX LACP is used between the PEs and CEs,
+          this ESI type indicates an auto-generated ESI value
+          determined from LACP.";
+      }
+      enum TYPE_2_BRIDGE_PROTOCOL_BASED {
+        value 2;
+        description
+          "Type 2 the ESI Value is auto-generated and determined based
+          on the Layer 2 bridge protocol";
+      }
+      enum TYPE_3_MAC_BASED {
+        value 3;
+        description
+          "Type 3 this type indicates a MAC-based ESI Value that can be auto-generated
+          or configured by the operator.";
+      }
+      enum TYPE_4_ROUTER_ID_BASED {
+        value 4;
+        description
+          "Type 4 this type indicates a router-ID ESI Value that can be auto-generated
+          or configured by the operator.";
+      }
+      enum TYPE_5_AS_BASED {
+        value 5;
+        description
+          "Type 5 this type indicates an Autonomous System (AS)-based ESI Value that can
+          be auto-generated or configured by the operator.";
+      }
+    }
+    description
+      "T-(ESI Type) is a 1-octet field (most significant octet) that
+      specifies the format of the remaining 9 octets (ESI Value).";
+    reference
+      "RFC 7432: BGP MPLS-Based Ethernet VPN page-16";
+  }
+
+  typedef mac-type {
+    type enumeration {
+      enum STATIC {
+        value 0;
+        description "Static MAC";
+      }
+      enum DYNAMIC {
+        value 1;
+        description "Dynamically learned MAC";
+      }
+      enum CONNECTED {
+        value 2;
+        description "Connected MAC";
+      }
+    }
+    description "Type of MAC, if it is static or has been learned";
+  }
+
+  // Mac origin type
+  typedef origin-type {
+    type enumeration {
+      enum LOCAL {
+        value 0;
+        description "Local MAC Address";
+      }
+      enum REMOTE {
+        value 1;
+        description "Remote MAC Address";
+      }
+      enum ALL {
+        value 2;
+        description "All MAC Address";
+      }
+    }
+    description "Origin of the MAC address";
+  }
+
+  typedef urib-nexthop-encap {
+    type enumeration {
+        enum NONE {
+            value 0;
+            description "Encapsulation not set";
+        }
+        enum VXLAN {
+            value 1;
+            description "VXLAN encapsulation";
+        }
+        enum INVALID {
+            value 2;
+            description "Encapsulation Invalid";
+        }
+    }
+    description "Type of encapsulation of the next hop";
+  }
+
+  typedef learning-mode {
+    type enumeration {
+      enum CONTROL_PLANE {
+        value 0;
+        description "Control Plane Learning";
+      }
+      enum DATA_PLANE {
+        value 1;
+        description "Data Plane Learning";
+      }
+    }
+    description
+      "Type of MAC address learning procedure";
+  }
+
+  typedef ethernet-tag {
+    type uint32;
+    description
+      "An Ethernet Tag ID is a 32-bit field containing either a 12-bit
+       or 24-bit identifier that identifies a particular broadcast
+       domain (e.g., a VLAN) in an EVPN instance.";
+    reference
+      "RFC 7432: BGP MPLS-Based Ethernet VPN page-10";
+  }
+}

--- a/models/yang/common/openconfig-evpn.yang
+++ b/models/yang/common/openconfig-evpn.yang
@@ -1,0 +1,1287 @@
+module openconfig-evpn {
+
+  // namespace
+  namespace "http://openconfig.net/yang/evpn";
+
+  prefix "oc-evpn";
+
+  import openconfig-yang-types { prefix oc-yang; }
+  import openconfig-extensions { prefix oc-ext; }
+  import openconfig-network-instance-types { prefix oc-ni-types; }
+  import openconfig-evpn-types { prefix oc-evpn-types; }
+  import openconfig-inet-types { prefix oc-inet; }
+  import openconfig-interfaces { prefix oc-if; }
+  import openconfig-bgp-types { prefix oc-bgp-types; }
+  import openconfig-types { prefix oc-types; }
+
+  // meta
+  organization
+    "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    netopenconfig@googlegroups.com";
+
+  description
+    "This module contains general data definitions for use in EVPN.
+    The model contains the configuration and state attributes
+    imported by the OpenConfig network instance module that is
+    the primary holder of these properties.
+
+    The module describes the configuration and state parameters
+    to support the instantiation of the MAC-VRF concept defined
+    in the RFC 7432: BGP MPLS-Based Ethernet VPN.
+    The EVPN concept allows the  Media Access Control (MAC) addresses
+    forwarding through the control plane on a PE.
+
+    Within the OpenConfig model, a single network instance represents
+    an individual MAC VRF. Whilst it is possible that there may be
+    cases where a single MAC VRF may support multiple broadcast
+    domains, this is not currently supported and requires an extension
+    of the model.";
+
+  oc-ext:openconfig-version "0.9.0";
+
+  revision "2024-05-14" {
+   description
+     "Add configuration of VPWS identifier
+     for EVPN Virtual Private Wire Services (RFC 8214)";
+     reference   "0.9.0";
+  }
+
+  revision "2024-04-03" {
+   description
+     "Add vni-peer-groups container";
+   reference   "0.8.0";
+  }
+
+  revision "2024-02-01" {
+   description
+     "Add counters under endpoint-peer and endpoint-vni";
+   reference   "0.7.0";
+  }
+
+  revision "2023-07-12" {
+   description
+     "Removed ethernet segment";
+   reference   "0.6.0";
+  }
+
+  revision "2023-03-08" {
+   description
+     "Change control-plane-vnis property to leaf-list";
+   reference   "0.5.0";
+  }
+
+  revision "2023-01-24" {
+   description
+     "Add control word support";
+   reference   "0.4.0";
+  }
+
+  revision "2021-06-28" {
+   description
+     "Add vxlan endpoint oper data";
+   reference   "0.3.0";
+  }
+
+  revision "2021-06-11" {
+   description
+     "Structural update for arp-proxy and
+     nd-proxy.";
+   reference "0.2.0";
+  }
+
+  revision "2020-11-24" {
+   description
+     "Initial revision.";
+   reference "0.1.0";
+  }
+
+  /* Groupings */
+
+  /* Groupings related to Ethernet-Segment Configuration*/
+
+  grouping evpn-config-top {
+    description
+      "Configuration attributes of the EVPN Instance";
+
+    container evpn-instances {
+      description
+        "Configuration attributes of the EVPN Instance";
+
+      list evpn-instance {
+        key "evi";
+        description
+          "An EVPN instance (EVI) comprises Customer Edge devices
+          (CEs) that are connected to Provider Edge devices (PEs). One
+          network instance (representing a single MAC VRF) can
+          participate in one or more EVPN Instances. For each EVPN instance
+          in which the forwarding instance participates an
+          EVPN instance needs to be created.
+
+          The model supports BGP MPLS-Based Ethernet VPNs
+          (RFC 7432) and  Network Virtualization Overlay Solution
+          Using Ethernet VPN (RFC 8365). The use of MPLS or VXLAN
+          is selected via the encapsulation container within
+          EVPN instance. One use case requiring participating in
+          two EVIs is the Interconnect Solution for EVPN Overlay
+          networks (see draft-ietf-bess-dci-evpn-overlay-10)";
+
+        leaf evi {
+          type leafref {
+            path "../config/evi";
+          }
+          description "EVPN Intance (EVI) identifier";
+        }
+
+        container config {
+          description
+            "EVPN Configuration parameters for
+            the participation in an EVPN Intance.";
+
+          uses evpn-evi-common-config;
+        }
+
+        container state {
+          config false;
+          description
+            "EVPN State parameters for
+            the participation in an EVPN Intance.";
+
+        uses evpn-evi-common-config;
+        }
+
+      uses evpn-import-export-policy-top;
+      uses evpn-evi-overlay-top;
+      uses evpn-evi-pbb-top;
+      }
+    }
+  }
+
+  grouping evpn-import-export-policy-top {
+    description
+      "Top Level grouping for the import and export
+      route targets in a EVPN Instance.";
+
+    container import-export-policy {
+      description
+        "Top container to set the import and export policies
+        associated with a EVI";
+
+      container config {
+        description
+          "Configuration parameters to set the import and export policies
+          associated with a EVI";
+        uses evpn-import-export-config;
+      }
+
+      container state {
+        config false;
+        description
+          "State parameters of the import and export policies
+          associated with a EVI";
+        uses evpn-import-export-config;
+      }
+    }
+  }
+
+
+
+  /* Groupings related to the Layer 2 forwarding (aka MAC-VRF)*/
+
+  grouping evpn-arp-proxy-top {
+    description
+      "Top Container related to ARP-Proxy";
+
+    container arp-proxy {
+      description
+        "Top Container related to ARP-Proxy";
+
+      container config {
+        description
+          "Configuration data related to ARP-Proxy.";
+
+        uses evpn-arp-proxy-config;
+      }
+
+      container state {
+        config false;
+        description
+          "State data related to ARP-Proxy.";
+
+        uses evpn-arp-proxy-config;
+      }
+    }
+  }
+
+  grouping evpn-nd-proxy-top {
+    description
+      "Top Container related to ND-Proxy";
+
+    container nd-proxy {
+      description
+        "Top Container related to ND-Proxy.";
+
+      container config {
+        description
+          "Configuration data related to ND-Proxy.";
+
+        uses evpn-nd-proxy-config;
+      }
+
+      container state {
+        config false;
+        description
+          "State data related to ND-Proxy.";
+
+        uses evpn-nd-proxy-config;
+      }
+    }
+  }
+
+  grouping evpn-arp-proxy-config {
+    description
+      "Configuration data related to ARP-Proxy";
+
+    leaf enable {
+      type boolean;
+      default false;
+      description
+        "Enable (TRUE) or disable (FALSE) ARP proxy. If true
+        a proxy server on the network answers the
+        Address Resolution Protocol (ARP) queries for an
+        IP address that is not on that network.";
+    }
+
+    leaf arp-suppression {
+      type boolean;
+      default false;
+      description
+        "Enable (TRUE) or disable (FALSE) ARP suppression. If true
+        the  Address Resolution Protocol (ARP) queries for an
+        IP address that is not on that network are suppressed.
+        Address Resolution Protocol (ARP) suppression is a
+        technique used to reduce the amount of ARP broadcast
+        flooding within individual VXLAN segments, that is between
+        VMs connected to the same logical switch.";
+      reference
+        "draft-ietf-bess-evpn-proxy-arp-nd-13
+        RFC 7432: BGP MPLS-Based Ethernet VPN";
+    }
+
+    leaf ip-mobility-threshold {
+      type uint16;
+      description
+        "Enable (TRUE) or disable (FALSE). It is possible for a given host
+        or end-station (as defined by its IP address) to move from one
+        Ethernet segment to another. The number of IP mobility events that
+        are detected for a given IP address within the detection-threshold
+        before it is identified as a duplicate IP address.
+        Once the detection threshold is reached, updates for the IP address
+        are suppressed.";
+    }
+
+    leaf duplicate-ip-detection-interval {
+      type uint16;
+      description
+        "The time interval used in detecting a duplicate IP address.
+        Duplicate ip detection number of host moves
+        allowed within interval period";
+    }
+  }
+
+  grouping evpn-nd-proxy-config {
+    description
+      "Configuration data related to Neighbor Discovery (ND)
+        proxy";
+
+    leaf enable {
+      type boolean;
+      default false;
+      description
+        "Enable (TRUE) or disable (FALSE) Neighbor Discovery (ND)
+        proxy. If true a proxy server on the network answers the
+        NDP packets for an IP address that is not on that network.";
+      reference
+        "draft-ietf-bess-evpn-proxy-arp-nd-13
+        RFC 7432: BGP MPLS-Based Ethernet VPN";
+    }
+
+    leaf nd-suppression {
+      type boolean;
+      default false;
+      description
+        "Enable (TRUE) or disable (FALSE) Neighbor Discovery suppression.
+        If true the NDP queries for an IP address that is not on that
+        network are suppressed. NDP suppression is a
+        technique used to reduce the amount of NDP Packets
+        flooding within individual VXLAN segments, that is between
+        VMs connected to the same logical switch.";
+    }
+
+    leaf ip-mobility-threshold {
+      type uint16;
+      description
+        "Enable (TRUE) or disable (FALSE). It is possible for a given host
+        or end-station (as defined by its IP address) to move from one
+        Ethernet segment to another. The number of IP mobility events that
+        are detected for a given IP address within the detection-threshold
+        before it is identified as a duplicate IP address.
+        Once the detection threshold is reached, updates for the IP address
+        are suppressed.";
+    }
+
+    leaf duplicate-ip-detection-interval {
+      type uint16;
+      description
+        "The time interval used in detecting a duplicate IP address.
+        Duplicate ip detection number of host moves
+        allowed within interval period";
+    }
+  }
+
+  grouping evpn-mac-vrf-config {
+    description
+      "Configuration data related to mac-vrf";
+
+    leaf anycast-gateway-mac {
+      type oc-yang:mac-address;
+      description
+        "Configure the anycast gateway MAC address that all VTEPs
+        use for the network instance. When a VM sends an Address
+        Resolution Protocol (ARP) request for the anycast gateway
+        IP address in a VXLAN virtual network, the VTEP responds
+        with the configured anycast MAC address.";
+    }
+
+    leaf flood-unknown-unicast-supression {
+      type boolean;
+      default false;
+      description
+        "Enable (TRUE) or disable (FALSE) the Unknown Unicast Flooding
+        Suppression. If the Unknown Unicast Flooding Suppression is on,
+        the unicast traffic towards an unknown host will be dropped.";
+    }
+  }
+
+  grouping evpn-mac-mobility-config {
+    description
+      "Configuration data related to mac-vrf";
+
+    leaf mac-mobility {
+      type boolean;
+      description
+        "Enable (TRUE) or disable (FALSE). It is possible for a given host
+        or end-station (as defined by its MAC address) to move from one
+        Ethernet segment to another; this is referred to as 'MAC Mobility'
+        or 'MAC move. The configuration attributes includes: mac-mobility-window
+        and mac-mobility-threshold";
+    }
+
+    leaf mac-mobility-window {
+      type uint16 {
+        range "0..600";
+      }
+      default 180;
+      description
+        "The time interval used in detecting a duplicate MAC address.
+        The value can be from 5 through 600 seconds.
+        The default is 180 seconds";
+      reference
+        "RFC 7432: BGP MPLS-Based Ethernet VPN section-15";
+    }
+
+    leaf mac-mobility-threshold {
+      type uint8 {
+        range "0..50";
+      }
+      default 5;
+      description
+        "The number of MAC mobility events that are detected for a
+        given MAC address within the detection-window before it is identified
+        as a duplicate MAC address. Once the detection threshold is reached,
+        updates for the MAC address are suppressed.";
+      reference
+        "RFC 7432: BGP MPLS-Based Ethernet VPN section-15";
+    }
+
+    leaf ip-mobility-threshold {
+      type uint16;
+      description
+        "Enable (TRUE) or disable (FALSE). It is possible for a given host
+        or end-station (as defined by its IP address) to move from one
+        Ethernet segment to another. The number of IP mobility events that
+        are detected for a given IP address within the detection-threshold
+        before it is identified as a duplicate IP address.
+        Once the detection threshold is reached, updates for the IP address
+        are suppressed.";
+    }
+
+    leaf duplicate-ip-detection-interval {
+      type uint16;
+      description
+        "The time interval used in detecting a duplicate IP address.
+        Duplicate ip detection number of host moves
+        allowed within interval period";
+    }
+  }
+
+  grouping evpn-mac-mobility-top {
+    description
+      "Top grouping the configuration and state data related to mac
+      mobility.";
+
+    container mac-mobility {
+      description
+        "Top grouping the configuration and state data related to mac
+        mobility.";
+
+      container config {
+        description
+          "Configuration data related to mac mobility.";
+        uses evpn-mac-mobility-config;
+      }
+
+      container state {
+        config false;
+        description
+          "State data related to mac mobility.";
+
+        uses evpn-mac-mobility-config;
+      }
+    }
+  }
+
+  /* Groupings related to the participation in an EVPN Instance*/
+
+  grouping evpn-evi-common-config {
+    description
+     "Top-Level parameters related the configuration of
+     EVPN to partipate in one EVPN instance";
+
+    leaf evi {
+      type string;
+      description
+        "EVPN Instance (EVI) identifier";
+    }
+
+    leaf encapsulation-type {
+      type identityref {
+        base oc-ni-types:ENCAPSULATION;
+      }
+      description
+        "The on-the-wire encapsulation that should be used when
+        exchanging traffic from this network instance to/from
+        destinations belonging to the EVI. The use of MPLS or
+        VXLAN is selected using this container.";
+    }
+
+    leaf service-type {
+      type identityref {
+        base oc-evpn-types:EVPN_TYPE;
+      }
+      description
+        "Specifies the type of EVPN that is being created according
+        to the values in the EVPN_TYPES identity.
+        The options are VLAN-based, VLAN-Bundle or VLAN-aware.
+        VLAN-Based services consists of an EVPN instance of only a
+        single broadcast domain, the proper network-instance type used
+        for this kind of services is L2VSI.";
+      reference
+        "RFC 7432: BGP MPLS-Based Ethernet VPN";
+    }
+
+    leaf multicast-group {
+     type oc-inet:ip-address;
+     description
+       "Multicast group address for BUM traffic";
+    }
+
+    leaf multicast-mask {
+      type oc-inet:ip-address;
+      description
+        "Multicast group address mask";
+    }
+
+    leaf replication-mode {
+      type enumeration {
+        enum STATIC_INGRESS_REPLICATION {
+          description
+            "Static ingress replication mode.";
+        }
+        enum BGP {
+          description
+            "BGP EVPN ingress replication mode. It includes the ability to
+            signal a P2MP LSP for the EVPN Inclusive Provider Tunnel
+            for BUM traffic";
+        }
+        enum MULTICAST {
+          description
+            "Multicast enabled in the underlay for BUM traffic";
+        }
+      }
+      description
+        "Replication mode to handle BUM traffic";
+    }
+
+    leaf route-distinguisher {
+      type union {
+        type oc-ni-types:route-distinguisher;
+        type enumeration {
+          enum AUTO {
+            description
+              "Enable auto route-distinguisher generation.
+              When used for evpn and if not configured, the
+              RD is auto-derived with the format <ip-address>:<evi> where
+              ip-address is the ipv4 address associated to the
+              system loopback or sub-interface.";
+          reference
+            "RFC 7432: BGP MPLS-Based Ethernet VPN page-18";
+          }
+        }
+      }
+      description
+        "Route Distinguisher (RD) associated to the EVPN-instance.
+        An RD MUST be assigned for a given EVPN-instance on a PE.
+        This RD MUST be unique across all EVPN-instances on a PE.
+        The route-distinguisher at this level overrides
+        the route-distinguisher value defined under
+        network-instance/config.";
+      reference
+        "RFC 7432: BGP MPLS-Based Ethernet VPN page-18";
+    }
+
+    leaf control-word-enabled {
+      type boolean;
+      description
+        "When true, the control word is signaled and sent.";
+      reference
+            "RFC8214 Virtual Private Wire Service Support
+            in Ethernet VPN
+            draft-ietf-bess-rfc7432bis-05 BGP MPLS-Based
+             Ethernet VPN";
+    }
+
+    leaf local-vpws-service-id {
+      type uint32 {
+        range "1..16777215";
+      }
+      description
+        "Indicates the local VPWS identifier assigned
+         to the Attachment Circuit (AC).";
+      reference
+        "RFC8214 Virtual Private Wire Service Support
+        in Ethernet VPN.";
+    }
+
+    leaf remote-vpws-service-id {
+      type uint32 {
+        range "1..16777215";
+      }
+      description
+        "Indicates the remote VPWS identifier assigned
+         to the Attachment Circuit (AC).";
+      reference
+        "RFC8214 Virtual Private Wire Service Support
+        in Ethernet VPN.";
+    }
+  }
+
+  grouping evpn-import-export-config {
+    description
+      "Parameters for import and export policy";
+
+    leaf-list export-route-target {
+      type union {
+        type oc-bgp-types:bgp-ext-community-type;
+        type enumeration {
+          enum AUTO {
+            description
+            "Enable auto route-target generation.
+            When used for EVPN and if not configured, the RT is auto-derived
+            with the format <asn>:<evi> where 'asn' is the autonomous-system
+            configured in the network-instance default.
+            Auto-derived route targets simplify the configuration of
+            VLAN services for EVPN, especially in VLAN-aware bundle
+            services where you can have multiple VLANs, multiple
+            bridge domains and the VLANS for a given service are
+            not present on all PE devices.";
+          }
+        }
+      }
+      description
+        "Export Route Target (RT) in the network-instance on a PE.";
+      reference
+        "RFC 7432: BGP MPLS-Based Ethernet VPN page-19";
+    }
+
+    leaf-list import-route-target {
+      type union {
+        type oc-bgp-types:bgp-ext-community-type;
+        type enumeration {
+          enum AUTO {
+            description
+            "Enable auto route-target generation.
+            When used for EVPN and if not configured, the RT is auto-derived
+            with the format <asn>:<evi> where 'asn' is the autonomous-system
+            configured in the network-instance default.
+            Auto-derived route targets simplify the configuration of
+            VLAN services for EVPN, especially in VLAN aware bundle
+            services where you can have multiple VLANs, multiple
+            bridge domains and the VLANS for a given service are
+            not present on all PE devices.";
+          }
+        }
+      }
+      description
+        "Import Route Target (RT) in the network-instance on a PE.";
+      reference
+        "RFC 7432: BGP MPLS-Based Ethernet VPN page-19";
+    }
+  }
+
+  grouping evpn-evi-overlay-top {
+    description
+      "Top grouping related the configuration of
+      Network Virtualization Overlay Solution
+      Using Ethernet VPN";
+
+    container vxlan {
+      description
+        "Top container related to Overlay Solution in EVPN.";
+
+      container config {
+        description
+          "Configuration data related to Overlay Solution in EVPN.";
+
+        uses evpn-evi-overlay-config;
+      }
+
+      container state {
+        config false;
+        description
+          "State data related to Overlay Solution in EVPN.";
+
+        uses evpn-evi-overlay-config;
+      }
+
+    uses evpn-vxlan-anycast-config;
+    }
+  }
+
+  grouping evpn-evi-overlay-config {
+    description
+      "Parameters related the configuration of Network Virtualization Overlay Solution
+      Using Ethernet VPN";
+
+    leaf vni {
+      type oc-evpn-types:vni-id;
+      description
+        "Virtual Network Identifier (VNI) associated to the EVI. This VNI is used for
+        ingress and egress in the VXLAN domain.";
+    }
+
+    leaf overlay-endpoint-network-instance {
+      type leafref {
+        path "/network-instances/network-instance/name";
+      }
+      description
+        "The network instance to resolve the overlay-endpoint within.";
+    }
+
+    leaf overlay-endpoint {
+      type leafref {
+        path "/network-instances" +
+        "/network-instance[name=current()/../overlay-endpoint-network-instance]" +
+        "/connection-points/connection-point/endpoints/endpoint/config/endpoint-id";
+      }
+      description
+        "Associate the EVI with an VXLAN Endpoint defined under connection
+        points. The network instance to resolve the overlay-endpoint within.";
+    }
+
+    leaf host-reachability-bgp {
+      type boolean;
+      description
+        "Enable or Disable the BGP control plane to be
+        used to exchange  updates from the NVE interface";
+    }
+
+    leaf multicast-group {
+     type oc-inet:ip-address;
+     description
+       "Multicast group address for BUM traffic";
+    }
+
+    leaf multicast-mask {
+      type oc-inet:ip-address;
+      description
+        "Multicast group address mask";
+    }
+  }
+
+  grouping evpn-vxlan-anycast-config {
+    description
+      "Anycast source interface top grouping";
+
+    container anycast-source-interface {
+      description
+        "Anycast source interface references";
+
+      container config {
+        description
+          "Anycast source interface configuration references";
+        uses oc-if:interface-ref-common;
+      }
+
+      container state {
+        config false;
+        description
+          "Anycast source interface state references";
+        uses oc-if:interface-ref-common;
+      }
+    }
+  }
+
+  grouping evpn-parameters-pbb-isid-config {
+    description
+      "I-component identifier configuration parameters.
+      In PBB-EVPN [RFC7623] the use of GWs where I-components and
+      associated B-components are part of EVI instances is required.";
+
+    leaf i-sid {
+      type uint32 {
+        range "0..16777215";
+      }
+      description
+        "Service Instance Identifier 24 bits and global within a PBB
+        network. I-SID defines the service instance that the frame should be
+        mapped to.";
+      reference
+        "RFC 7080: Virtual Private LAN Service (VPLS) Interoperability
+        with Provider Backbone Bridges.";
+    }
+  }
+
+  grouping evpn-parameters-pbb-config {
+    description
+      "I-component identifier configuration parameters.
+      In PBB-EVPN [RFC7623] the use of GWs where I-components and
+      associated B-components are part of EVI instances is required.
+      These parameters includes the association between I and B
+      components.";
+
+    leaf b-component-name {
+      type string;
+      description
+        "Type of the associated b-component";
+    }
+
+    leaf backbone-src-mac {
+      type oc-yang:mac-address;
+      description
+        "EVPN will run independently in both components,
+        the I-component MAC-VRF and B-component MAC-VRF.
+        The backbone-src-mac assigns the b-component MAC.";
+    }
+  }
+
+  grouping evpn-parameters-pbb-icomponent-config {
+    description
+      "Parameters to configure components contained
+      in a backbone edge bridge that containes the customer
+      space (customer MAC addresses,S-VLAN).";
+
+    container i-components {
+      description
+        "i-components container definition.";
+
+      list i-component {
+        key "i-sid";
+        description
+          "list of i-components";
+
+        leaf i-sid {
+          type leafref {
+            path '../config/i-sid';
+          }
+        description
+          "I-SID represents a unique service identifier associated with
+          service instances";
+        }
+
+        container config {
+          description
+            "Configuration variables for the i-sid";
+          uses evpn-parameters-pbb-isid-config;
+        }
+
+        container state {
+          config false;
+          description
+            "State variables for the i-sid";
+
+          uses evpn-parameters-pbb-isid-config;
+        }
+      }
+    }
+  }
+
+  grouping evpn-evi-pbb-config {
+    description
+      "Provider Backbone Bridging (PBB) parameters grouping";
+    reference
+      "IEEE 802.1ah Provider Backbone Bridge";
+
+    list b-component {
+      key "b-component-name";
+      description
+        "List of B-components. The b-component learns and forwards
+        traffic on the backbone in order to reduce the number of
+        BGP MAC Advertisement routes by aggregating Customer/Client
+        MAC (C-MAC) addresses via Provider Backbone MAC (B-MAC) address.";
+      reference
+        "RFC 7623: Provider Backbone Bridging Combined
+        with Ethernet VPN (PBB-EVPN).";
+
+      leaf b-component-name {
+      type leafref {
+        path '../config/b-component-name';
+      }
+      description
+        "Provider Backbone Bridging component name.";
+      }
+
+      container config {
+        description "Configuration variables for the b-components.";
+
+        uses evpn-parameters-pbb-config;
+      }
+
+      container state {
+        config false;
+        description "State variables for the b-components.";
+
+        uses evpn-parameters-pbb-config;
+      }
+
+      uses evpn-parameters-pbb-icomponent-config;
+    }
+  }
+
+  grouping evpn-evi-pbb-top {
+    description "Grouping for pbb configuration parameters";
+
+    container pbb {
+      uses evpn-evi-pbb-config;
+      description
+        "Container for EVPN with PBB PE functionality
+        for scaling over MPLS,";
+    }
+  }
+
+  /* Groupings related to the configuration of the Overlay
+  Endpoint when VXLAN is used*/
+
+  grouping evpn-vxlan-parameters-config {
+    description
+      "Type agnostic configuration parameters relating to the
+      overlay of the network instance";
+
+    leaf description {
+      type string;
+        description
+          "Description to identify the VXLAN tunnel endpoint It
+          is a unique name identifying the overlay endpoint";
+    }
+
+    leaf enabled {
+      type boolean;
+      description
+        "VXLAN tunnel endpoint administrative state.";
+    }
+
+    leaf source-interface {
+    type string;
+      description
+        "Source loopback interface name";
+    }
+  }
+
+  grouping evpn-overlays-grp-top {
+    description
+      "Parameters relating to the overlay tunnel endpoints";
+
+    container config {
+      description
+        "Configuration parameters relating to the overlay tunnel
+        endpoints of the network instance";
+
+      uses evpn-vxlan-parameters-config;
+    }
+
+    container state {
+      config false;
+      description
+        "State parameters relating to the overlay tunnel endpoints of
+        the network instance";
+
+      uses evpn-vxlan-parameters-config;
+    }
+
+    container endpoint-peers {
+      description
+        "Top level container for state information related to peer VXLAN Tunnel
+        Endpoints(VTEPs) learned by the local VTEP in the default network
+        instance";
+      config false;
+
+      list endpoint-peer {
+        key "peer-address";
+          description "List of VTEP peers and associated state information";
+
+        leaf peer-address {
+          type leafref {
+            path '../state/peer-address';
+          }
+          description "IP address for the VTEP peer";
+        }
+
+        container state {
+          config false;
+            description
+              "Container for state parameters related to this VTEP peer";
+            uses evpn-endpoint-peer-state;
+            uses evpn-endpoint-counters;
+        }
+        container vni-peer-groups {
+          config false;
+          description
+            "Container for associating ingress and egress VNIs to router MACs";
+          list vni-peer-group {
+            key "cp-vni egress-vni";
+            description
+              "List of VNI peer groups";
+            leaf cp-vni {
+              type leafref {
+                path "../state/cp-vni";
+              }
+              description
+                "A reference to the control-plane VNI for the VNI peer group";
+            }
+            leaf egress-vni {
+              type leafref {
+                path "../state/egress-vni";
+              }
+              description
+                "A reference to the egress VNI for the VNI peer group";
+            }
+
+            container state {
+              description "State container for the VNI peer group";
+              config false;
+
+              leaf cp-vni {
+                type oc-evpn-types:vni-id;
+                description
+                  "The control-plane VNI discovered behind this peer VTEP";
+              }
+              leaf egress-vni {
+                type oc-evpn-types:vni-id;
+                description "Egress VNI associated with the remote VTEP";
+              }
+              leaf router-mac {
+                type oc-yang:mac-address;
+                description "MAC address of the remote VTEP";
+              }
+            }
+          }
+        }
+      }
+    }
+
+    container endpoint-vnis {
+      description
+        "Top level container for state information related to Layer 2 virtual
+        network identifiers (L2VNIs) and Layer 3 virtual network identifiers
+        (L3VNIs) that are learned on the local VXLAN Tunnel End Point from
+        remote VTEPs in the default network instance";
+      config false;
+
+      list endpoint-vni {
+        key "vni";
+        description "List of L2VNIs and L3VNIs learned on the local VTEP";
+
+        leaf vni {
+          type leafref {
+            path '../state/vni';
+          }
+          description "L2VNI or L3VNI Identifier";
+        }
+
+        container state {
+          config false;
+          description
+            "Container for state parameters related to this L2VNI or L3VNI";
+          uses evpn-endpoint-vni-state;
+        }
+
+        uses ipv4-top;
+        uses ipv6-top;
+      }
+    }
+  }
+
+  grouping evpn-endpoint-peer-state {
+    description
+      "Grouping for state information related to peer VXLAN Tunnel
+      Endpoints(VTEPs) learned by the local VTEP";
+
+    leaf peer-address {
+      type oc-inet:ip-address;
+      description "IP address of the remote VXLAN Tunnel Endpoint peer";
+    }
+
+    leaf peer-state {
+      type enumeration {
+        enum UP {
+          description
+            "Operational status of the remote VTEP to indicate that the peer
+            status is UP";
+        }
+        enum DOWN {
+          description
+            "Operational status of the remote VTEP to indicate that the peer
+            status is DOWN";
+        }
+      }
+      description "State parameters related to the remote VTEP peer state";
+    }
+
+    leaf uptime {
+      type oc-types:timeticks64;
+      description
+        "This timestamp indicates the time elapsed relative to the moment that
+        the remote VTEP peer was discovered.";
+    }
+
+    leaf-list control-plane-vnis {
+      type oc-evpn-types:vni-id;
+      status deprecated;
+      description
+        "The control-plane VNIs are all of the VNIs that are discovered by the
+        control-plane behind this peer VTEP";
+    }
+
+    leaf router-mac {
+      type oc-yang:mac-address;
+      status deprecated;
+      description "MAC address of the remote VTEP";
+    }
+  }
+
+  grouping evpn-endpoint-counters {
+    description
+      "Grouping for Operational state regarding encapsulated traffic.";
+    container counters {
+      description
+        "Operational state regarding encapsulated traffic.";
+      leaf total-encap-pkts {
+        type oc-yang:counter64;
+        description
+          "The total number of encapsulated packets.";
+      }
+      leaf total-encap-bytes {
+        type oc-yang:counter64;
+        description
+          "The total number of encapsulated bytes.";
+      }
+      leaf bum-encap-pkts {
+        type oc-yang:counter64;
+        description
+          "The total number of encapsulated BUM packets.";
+      }
+      leaf total-decap-pkts {
+        type oc-yang:counter64;
+        description
+          "The total number of decapsulated packets.";
+      }
+      leaf total-decap-bytes {
+        type oc-yang:counter64;
+        description
+          "The total number of decapsulated bytes.";
+      }
+      leaf unicast-decap-pkts {
+        type oc-yang:counter64;
+        description
+          "The total number of decapsulated unicast packets.";
+      }
+      leaf bum-decap-pkts {
+        type oc-yang:counter64;
+        description
+          "The total number of decapsulated BUM packets.";
+      }
+      leaf bum-decap-multicast-pkts {
+        type oc-yang:counter64;
+        description
+          "The number of decapsulated BUM packets received via underlay multicast.";
+      }
+      leaf bum-decap-ir-pkts {
+        type oc-yang:counter64;
+        description
+          "The number of decapsulated BUM packets received via underlay ingress replication.";
+      }
+      leaf drop-decap-pkts {
+        type oc-yang:counter64;
+        description
+          "The total number of decapsulated packets that have been dropped locally.";
+      }
+      leaf except-decap-pkts {
+        type oc-yang:counter64;
+        description
+          "The total number of decapsulated packets that hit an exceptional condition.";
+      }
+    }
+  }
+
+  grouping ipv4-top {
+    description
+      "Grouping for Operational state of IPv4 address family.";
+    container ipv4 {
+      description
+        "Parameters for the IPv4 address family.";
+      container state {
+        config false;
+        description
+          "Top level IPv4 operational state data.";
+        uses evpn-endpoint-counters;
+      }
+    }
+  }
+
+  grouping ipv6-top {
+    description
+      "Grouping for Operational state of IPv6 address family.";
+    container ipv6 {
+      description
+        "Parameters for the IPv6 address family.";
+      container state {
+        config false;
+        description
+          "Top level IPv6 operational state data.";
+        uses evpn-endpoint-counters;
+      }
+    }
+  }
+
+  grouping evpn-endpoint-vni-state {
+    description
+      "Grouping for L2VNI and L3VNI state information learned on the
+      local VXLAN Tunnel End Point from remote VTEPs";
+
+    leaf vni {
+      type oc-evpn-types:evi-id;
+      description "L2VNI or L3VNI Identifier";
+    }
+
+    leaf multidestination-traffic {
+      type union {
+        type oc-inet:ip-address;
+        type enumeration {
+          enum STATIC_INGRESS_REPLICATION {
+            description
+              "Static ingress replication mode.";
+          }
+          enum BGP_INGRESS_REPLICATION {
+            description
+              "BGP EVPN ingress replication mode. It includes the ability to
+              signal a P2MP LSP for the EVPN Inclusive Provider Tunnel
+              for BUM traffic";
+          }
+        }
+      }
+      description
+        "The data plane for overlays needs to handle the transport of
+         multidestination traffic. Multidestination traffic is typically
+         referred to as (BUM) which stands for broadcast, unknown unicast,
+         or multicast. The two most common methods that can accommodate this
+         replication and transport in the underlay are IP multicast and
+         ingress replication
+         (also called head-end replication or unicast mode).";
+    }
+
+    leaf learning-mode {
+      type oc-evpn-types:learning-mode;
+      description
+        "Indicates whether the learning mode for this VNI is either
+        control-plane or data-plane";
+    }
+
+    leaf vni-type {
+      type enumeration {
+        enum L2 {
+          description
+            "This is a Layer 2 service virtual network identifier (L2VNI)
+            that is used for communication within the same subnet or
+            broadcast domain";
+        }
+        enum L3 {
+          description
+            "This is a Layer 3 service virtual network identifier (L3VNI)
+            or VRF VNI that is used for communication between subnets";
+        }
+      }
+      description "The type of virtual network identfier";
+    }
+
+    leaf vni-state {
+      type enumeration {
+        enum UP {
+          description
+            "Operational status of the virtual network identifier (VNI) to
+            indicate that it is UP";
+        }
+        enum DOWN {
+          description
+            "Operational status of the virtual network identifier (VNI) to
+            indicate that it is DOWN";
+        }
+      }
+      description "Operational state of the L2VNI or L3VNI";
+    }
+
+    leaf svi-state {
+      type enumeration {
+        enum UP {
+          description
+            "Operational status of the SVI mapped to the L3VNI used for routing
+            between subnets to indicate the SVI is UP";
+        }
+        enum DOWN {
+          description
+            "Operational status of the SVI mapped to the L3VNI used for routing
+            between subnets to indicate the SVI is DOWN";
+        }
+      }
+      description
+        "Operational status of the SVI mapped to the L3VNI that is used for
+        routing between subnets in the VXLAN fabric";
+    }
+
+    leaf bridge-domain {
+      type uint32;
+      description
+        "This reflects the configured VLAN or Bridge Domain that maps to this
+        L2VNI in the VXLAN fabric";
+    }
+
+    leaf l3-vrf-name {
+      type string;
+      description
+        "This refects the configured VRF instance that maps to this L3VNI
+        that is used for routing between subnets in the VXLAN fabric";
+    }
+
+  }
+}

--- a/models/yang/common/openconfig-extensions.yang
+++ b/models/yang/common/openconfig-extensions.yang
@@ -18,6 +18,20 @@ module openconfig-extensions {
     "This module provides extensions to the YANG language to allow
     OpenConfig specific functionality and meta-data to be defined.";
 
+  oc-ext:openconfig-version "0.5.1";
+
+  revision "2022-10-05" {
+    description
+      "Add missing version statement.";
+    reference "0.5.1";
+  }
+
+  revision "2020-06-16" {
+    description
+      "Add extension for POSIX pattern statements.";
+    reference "0.5.0";
+  }
+
   revision "2018-10-17" {
     description
       "Add extension for regular expression type.";
@@ -58,9 +72,11 @@ module openconfig-extensions {
         * z corresponds to a patch version.
       This version corresponds to the model file within which it is
       defined, and does not cover the whole set of OpenConfig models.
-      Where several modules are used to build up a single block of
-      functionality, the same module version is specified across each
-      file that makes up the module.
+
+      Individual YANG modules are versioned independently -- the
+      semantic version is generally incremented only when there is a
+      change in the corresponding file.  Submodules should always
+      have the same semantic version as their parent modules.
 
       A major version number of 0 indicates that this model is still
       in development (whether within OpenConfig or with industry
@@ -101,6 +117,21 @@ module openconfig-extensions {
       within the YANG module specified are conformant with the POSIX
       regular expression format rather than the W3C standard that is
       specified by RFC6020 and RFC7950.";
+  }
+
+  extension posix-pattern {
+    argument "pattern" {
+      yin-element false;
+    }
+    description
+      "Provides a POSIX ERE regular expression pattern statement as an
+      alternative to YANG regular expresssions based on XML Schema Datatypes.
+      It is used the same way as the standard YANG pattern statement defined in
+      RFC6020 and RFC7950, but takes an argument that is a POSIX ERE regular
+      expression string.";
+    reference
+      "POSIX Extended Regular Expressions (ERE) Specification:
+      https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap09.html#tag_09_04";
   }
 
   extension telemetry-on-change {

--- a/models/yang/common/openconfig-hashing.yang
+++ b/models/yang/common/openconfig-hashing.yang
@@ -1,0 +1,366 @@
+module openconfig-hashing {
+    yang-version "1";
+
+    // namespace
+    namespace "http://openconfig.net/yang/hashing";
+
+    prefix "oc-hashing";
+
+    // import some basic types
+    import openconfig-extensions { prefix oc-ext; }
+    import openconfig-system {prefix oc-sys;}
+    import openconfig-interfaces {prefix oc-intf;}
+
+    // meta
+    organization "OpenConfig working group";
+
+    contact
+        "OpenConfig working group
+        netopenconfig@googlegroups.com";
+
+    description
+        "Model for managing hashing policies that would be referenced by the
+        interfaces model.";
+
+
+    oc-ext:openconfig-version "0.1.0";
+
+    revision "2023-08-08" {
+        description "Initial hashing model.";
+        reference "0.1.0";
+    }
+
+    oc-ext:catalog-organization "openconfig";
+    oc-ext:origin "openconfig";
+
+    grouping hashing-inputs {
+        description
+            "Top level container for inputs to be used for hashing policies.";
+
+        leaf ingress-interface {
+            type boolean;
+            description
+                "Include the ingress subinterface identified in the
+                calculation of the hash.";
+        }
+        leaf ip-protocol-type {
+            type boolean;
+            description
+                "Include the IP protocol type in the calculation of the hash.";
+        }
+    }
+
+    grouping ipv4-ipv6-inputs-top {
+        description
+            "The top level container for ipv4 and ipv6 header
+            fields used for the hash computation.";
+
+        leaf src-addr {
+            type boolean;
+            description
+                "Use the source address in the calculation of the hash.";
+        }
+
+        leaf dst-addr {
+            type boolean;
+            description
+                "Use the destination address in the calculation of the hash.";
+        }
+
+        leaf src-port {
+            type boolean;
+            description
+                "Use the source port from the transport header in the calculation
+                of the hash.";
+        }
+
+        leaf dst-port {
+            type boolean;
+            description
+                "Use the destination port from the transport header in the
+                calculation of the hash.";
+        }
+    }
+
+    grouping ipv6-inputs-top {
+        description
+            "The top level container specifially for ipv6 header
+            fields used for the hash computation.";
+
+        leaf flow-label {
+            type boolean;
+            description
+                "Use the flow label in the IPv6 header
+                to calculate the hash.";
+        }
+    }
+
+    grouping hashing-policy-config {
+        description
+            "Configuration data for hashing policies.";
+
+        leaf name {
+            type string;
+            description
+                "The name of the hashing policy.
+                When a configured user-controlled policy is created by the
+                system, it is instantiated with the same name in the
+                /system/hashing-policies/hashing-policy/name list.";
+        }
+
+        leaf seed {
+            type uint64;
+            description
+                "The seed used to initialize the hash algorithm";
+        }
+
+        leaf algorithm {
+            type string;
+            description
+                "The name of hash algorithm. This algorithm MUST
+                be a supported algorithm";
+        }
+    }
+
+    grouping hashing-policy-top {
+        description
+            "Top level grouping for hashing configuration and operational state
+            data.";
+
+        container hashing-policies {
+            description
+                "Top level container for hashing, including configuration and
+                state data.";
+
+            list hashing-policy {
+                key "name";
+
+                description
+                    "The list of named policies to be used on the device.";
+
+                leaf name {
+                    type leafref {
+                        path "../config/name";
+                    }
+                    description
+                        "References the name of the hashing policy.";
+                }
+                container config {
+                    description
+                        "Configurable items at the global hash policy level.";
+
+                    uses hashing-policy-config;
+                }
+                container state {
+                    config false;
+                    description
+                        "Operational state data at the global hash policy
+                        level.";
+
+                    uses hashing-policy-config;
+                }
+
+                container hash-field-modes {
+                    description
+                        "Container for specifying inputs to be used when
+                        calculating the hash.";
+
+                    container config {
+                        description
+                            "Configurable items at the hashing inputs level.";
+                        uses hashing-inputs;
+                    }
+                    container state {
+                        config false;
+                        description
+                            "Operational state data at the hashing
+                            inputs level.";
+                        uses hashing-inputs;
+                    }
+
+                    container ipv4 {
+                        description
+                            "The IPv4 fields that should be used to
+                            compute the hash.";
+                        container config {
+                            description
+                                "Configurable data at the hashing
+                                inputs level for IPv4.";
+                            uses ipv4-ipv6-inputs-top;
+                        }
+
+                        container state {
+                            config false;
+                            description
+                                "Operational state data at the hashing
+                                inputs level for IPv4.";
+                            uses ipv4-ipv6-inputs-top;
+                        }
+                    }
+
+                    container ipv6 {
+                        description
+                            "The IPv6 fields that should be used to
+                            compute the hash.";
+
+                        container config {
+                            description
+                                "Configurable data at the hashing
+                                inputs level for IPv6.";
+
+                            uses ipv4-ipv6-inputs-top;
+                            uses ipv6-inputs-top;
+                        }
+
+                        container state {
+                            config false;
+                            description
+                                "Operational state data at the hashing
+                                inputs level for IPv6.";
+
+                            uses ipv4-ipv6-inputs-top;
+                            uses ipv6-inputs-top;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    grouping supported-algorithms-state {
+        description
+            "Top-level container for the supported algorithms.";
+        leaf name {
+            type string;
+            description
+                "Name of the supported algorithm.";
+        }
+        leaf description {
+            type string;
+            description
+                "Description of the supported algorithm.";
+        }
+    }
+    grouping supported-algorithms-top {
+        description
+            "Top-level container of the supported algorithms for supported
+            algorithms.  The list of algorithms are expected to be defined by
+            the target device.";
+        container algorithms {
+            description
+                "Container for vendor supported hashing algorithms.";
+            uses vendor-hashing-algorithms;
+        }
+    }
+
+    grouping hashing-algo-top {
+        description
+            "Top level container of the supported algorithms for supported
+            algorithms.";
+        container hashing-algorithms {
+            config false;
+            description
+                "Container of the supported algorithms for supported
+                algorithms.";
+            list hashing-algorithm {
+                key "name";
+
+                description
+                    "List of the supported algorithms for supported
+                    algorithms.";
+
+                leaf name {
+                    type leafref {
+                        path ../state/name;
+                    }
+                    description
+                        "Reference to the supported algorithm list key.";
+                }
+
+                container state {
+                    description
+                        "Operational data for the supported algorithm.";
+                    config false;
+
+                    leaf name {
+                        type string;
+                        description
+                            "Name of the supported algorithm.";
+                    }
+
+                    leaf description {
+                        type string;
+                        description
+                            "Description of the supported algorithm.";
+                    }
+                }
+            }
+        }
+    }
+
+    grouping vendor-hashing-algorithms {
+        description
+            "Supported hashing algorithms per vender.";
+        container vendor {
+            description
+                "Specify the vendor. Each vendor should have its own set of
+                supported algorithms. For each supported algorithm, a name
+                and a description should be defined. An implementation must
+                augment this model using the schema described in the
+                vendor_counter_guide reference.
+
+                e.g.
+                augment /system/hashing/vendor {
+                    container <vendor name> {
+                        container <platform name> {
+                            uses hashing-algo-top;
+                        }
+                    }
+                }";
+            reference
+                "https://github.com/openconfig/public/tree/master/doc/vendor_counter_guide.md";
+        }
+    }
+
+    grouping hashing-top {
+        description
+            "Top-level container for Hashing algorithms and hashing policies";
+        container hashing {
+            description
+                "Container for Hashing algorithms and hashing policies";
+            uses supported-algorithms-top;
+            uses hashing-policy-top;
+        }
+    }
+
+    augment "/oc-sys:system" {
+        description
+            "Augment for Hashing algorithms and hashing policies";
+
+        uses hashing-top;
+    }
+
+    augment "/oc-intf:interfaces/oc-intf:interface/oc-intf:config" {
+        description
+            "Augment for configuration data hashing policy on the interface.";
+        leaf hashing-policy {
+            type leafref {
+                path "/oc-sys:system/hashing/hashing-policies/hashing-policy/name";
+            }
+            description "The configuration data hashing policy to be used when
+                hashing packets coming in on the interface.";
+        }
+    }
+
+    augment "/oc-intf:interfaces/oc-intf:interface/oc-intf:state" {
+        description
+            "Augment for operational data hashing policy on the iinterface.";
+        leaf hashing-policy {
+            type leafref {
+                path "/oc-sys:system/hashing/hashing-policies/hashing-policy/name";
+            }
+            description "The operational data hashing policy to be used when
+                hashing packets coming in on the interface.";
+        }
+    }
+}

--- a/models/yang/common/openconfig-igmp-types.yang
+++ b/models/yang/common/openconfig-igmp-types.yang
@@ -1,0 +1,64 @@
+module openconfig-igmp-types {
+
+    yang-version "1";
+
+    // namespace
+    namespace "http://openconfig.net/yang/igmp/types";
+
+    prefix "oc-igmp-types";
+
+    // import some basic types
+    import openconfig-extensions { prefix "oc-ext"; }
+
+    // meta
+    organization
+      "OpenConfig working group";
+
+    contact
+      "OpenConfig working group
+      www.openconfig.net";
+
+    description
+      "This module defines types related to the IGMP protocol model.";
+
+    oc-ext:openconfig-version "0.1.1";
+
+    revision "2018-11-21" {
+      description
+        "Add OpenConfig module metadata extensions.";
+      reference "0.1.1";
+    }
+
+    revision "2018-02-19" {
+        description
+          "Initial revision.";
+        reference "0.1.0";
+    }
+
+  // OpenConfig specific extensions for module metadata.
+  oc-ext:regexp-posix;
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+    // typedef statements
+
+    typedef igmp-version {
+        type uint8 {
+            range 1..3;
+        }
+        description
+          "IGMP Version.";
+        reference "v1 = RFC1112, v2 = RFC2236, v3 = RFC3376";
+    }
+
+    typedef igmp-interval-type {
+        type uint16 {
+          range 1..1024;
+        }
+        units "seconds";
+        description
+          "Interval at which the router sends the IGMP query message toward
+          the upstream neighbor.";
+        reference "RFC3376 8.2 Page 40";
+    }
+}

--- a/models/yang/common/openconfig-igmp.yang
+++ b/models/yang/common/openconfig-igmp.yang
@@ -1,0 +1,447 @@
+module openconfig-igmp {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/igmp";
+
+  prefix "oc-igmp";
+
+  // import some basic types/interfaces
+  import openconfig-igmp-types { prefix oc-igmp-types; }
+  import openconfig-types { prefix "oc-types"; }
+  import openconfig-acl { prefix "oc-acl"; }
+  import openconfig-extensions { prefix "oc-ext"; }
+  import openconfig-interfaces { prefix oc-if; }
+  import ietf-inet-types { prefix "inet"; }
+
+  // meta
+  organization
+    "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "An OpenConfig model for Internet Group Management Protocol (IGMP).";
+
+  oc-ext:openconfig-version "0.3.1";
+
+  revision "2023-02-03" {
+    description
+      "Clarify use of interface-ref.";
+    reference "0.3.1";
+  }
+
+  revision "2021-05-17" {
+    description
+      "Add Static Mapping for IGMP at interface.";
+    reference "0.3.0";
+  }
+
+  revision "2019-07-09" {
+    description
+      "Re-indent module to two spaces.
+      Normalise timeticks64 usage to nanoseconds.";
+    reference "0.2.0";
+  }
+
+  revision "2018-11-21" {
+    description
+    "Add OpenConfig module metadata extensions.";
+    reference "0.1.1";
+  }
+
+  revision "2018-02-19" {
+    description
+      "Initial revision.";
+    reference "0.1.0";
+  }
+
+  // OpenConfig specific extensions for module metadata.
+  oc-ext:regexp-posix;
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  grouping admin-config {
+    description
+      "Re-usable grouping to enable or disable a particular feature.";
+
+    leaf enabled {
+      type boolean;
+      default false;
+      description
+        "When set to true, the functionality within which this
+        leaf is defined is enabled, when set to false it is
+        explicitly disabled.";
+    }
+  }
+
+  grouping igmp-interface-config {
+    description
+      "Configuration data for IGMP on each interface.";
+
+    leaf interface-id {
+      type oc-if:interface-id;
+      description
+        "Reference to an interface on which IGMP is enabled.";
+    }
+
+    uses admin-config;
+
+    leaf version {
+      type oc-igmp-types:igmp-version;
+      description
+        "IGMP Version.";
+    }
+
+    leaf query-interval {
+      type oc-igmp-types:igmp-interval-type;
+      description
+        "Interval at which the router sends the IGMP membership
+        queries.";
+    }
+
+    leaf filter-prefixes {
+      type string;
+      // TODO work out what this should be.
+      // On Juniper it's a "policy" and on Cisco a sort of "class map"
+      description
+        "List used to filter joins.";
+    }
+  }
+
+  grouping igmp-counters-per-version {
+    description
+      "Counters for each IGMP protocol version.";
+
+    container state {
+      config false;
+      description
+        "Counters for each IGMP protocol version.";
+
+      leaf v1 {
+        type uint32;
+        description
+          "IGMP v1.";
+      }
+      leaf v2 {
+        type uint32;
+        description
+          "IGMP v2.";
+      }
+      leaf v3 {
+        type uint32;
+        description
+          "IGMP v3.";
+      }
+    }
+  }
+
+  grouping igmp-interface-counters {
+    description
+      "State and session data for IGMP on each interface.";
+
+
+    container counters {
+      description
+        "Counters avaiable on a per interface bases for IGMP.";
+
+      container queries {
+        description
+          "IGMP membership queries.";
+
+        container sent {
+          description
+            "Number of IGMP membership queries sent.";
+          uses igmp-counters-per-version;
+        }
+
+        container received {
+          description
+            "Number of IGMP membership queries received.";
+          uses igmp-counters-per-version;
+        }
+      }
+
+      container reports {
+        description
+          "Number of IGMP membership reports received.";
+        uses igmp-counters-per-version;
+      }
+    }
+  }
+
+  grouping igmp-snooping-state {
+    description
+      "IGMP membership snooping state.";
+
+    leaf group {
+      type inet:ipv4-address;
+      description
+        "Multicast address.";
+    }
+
+    leaf source {
+      type inet:ipv4-address;
+      description
+        "Source address of multicast.";
+    }
+
+    leaf reporter {
+      type inet:ipv4-address;
+      description
+        "Address of the last reporter.";
+    }
+  }
+
+  grouping igmp-static-config {
+    description
+      "IGMP membership static configuration.";
+
+    leaf static-group {
+      type inet:ipv4-address;
+      description
+        "Multicast address.";
+    }
+
+    leaf source {
+      type inet:ipv4-address;
+      description
+        "Source address of multicast.";
+    }
+  }
+
+  grouping igmp-static-top {
+    description
+      "Top Container for the static IGMP membership.";
+
+      container static-membership-groups {
+      description
+        "List of IGMP Membership information.";
+
+      list static-groups {
+        key "static-group";
+        description
+          "Multicast group membership.";
+
+        leaf static-group {
+          type leafref {
+            path "../config/static-group";
+          }
+          description
+            "Multicast address.";
+        }
+
+        container config {
+          description
+            "Multicast group membership.";
+
+          uses igmp-static-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Multicast group membership.";
+
+          uses igmp-static-config;
+        }
+      }
+    }
+  }
+
+  grouping igmp-snooping-structural {
+    description
+      "IGMP membership information determined through snooping.";
+
+    container membership-groups {
+      description
+        "List of IGMP Membership information.";
+
+      list group {
+        key "group";
+        config false;
+        description
+          "Multicast group membership.";
+
+        leaf group {
+          type leafref {
+            path "../state/group";
+          }
+          description
+            "Multicast address.";
+        }
+
+        container state {
+          config false;
+          description
+            "Multicast group membership.";
+
+          uses igmp-snooping-state;
+        }
+      }
+    }
+  }
+
+  grouping igmp-interface-state {
+    description
+      "IGMP interface state.";
+
+    leaf query-expires {
+      type oc-types:timeticks64;
+       description
+      "This timestamp indicates the time that the next query is sent
+      expressed relative to the Unix Epoch (Jan 1, 1970 00:00:00 UTC).";
+    }
+  }
+
+  grouping igmp-interface-top {
+    description
+      "Configuration and state data for IGMP on each interface.";
+
+    container interfaces {
+      description
+        "The interfaces on which IGMP is configured.";
+
+      list interface {
+        key "interface-id";
+        description
+          "This container defines interface IGMP configuration and
+          state information.
+
+          The interface referenced is based on the interface and
+          subinterface leaves within the interface-ref container -
+          which reference an entry in the /interfaces/interface list -
+          and should not rely on the value of the list key.";
+
+        leaf interface-id {
+          type leafref {
+            path "../config/interface-id";
+          }
+          description
+            "Reference to an interface on which IGMP is enabled.";
+        }
+
+        container config {
+          description
+            "IGMP interface configuration.";
+
+          uses igmp-interface-config;
+        }
+
+        container state {
+          config false;
+          description
+            "This container defines state information for IGMP
+            interfaces.";
+
+          uses igmp-interface-state;
+          uses igmp-interface-config;
+        }
+
+        uses igmp-interface-counters;
+        uses igmp-snooping-structural;
+        uses igmp-static-top;
+        uses oc-if:interface-ref;
+      }
+    }
+  }
+
+  grouping igmp-ssm-maps-config {
+    description
+      "A Source Specific Multicast (SSM) mapping. This allows
+      IGMP v2 hosts to be able to join in SSM environments
+      by translating IGMP v2 reports into IGMP v3 reports.
+      The request in an IGMP v2 join is sent toward the source
+      address found by matching the multicast address.";
+
+    leaf source {
+      type inet:ipv4-address;
+      description
+        "Multicast source address.";
+    }
+
+    leaf ssm-ranges {
+      type leafref {
+        path "/oc-acl:acl/oc-acl:acl-sets/oc-acl:acl-set/" +
+          "oc-acl:config/oc-acl:name";
+      }
+      description
+        "List of accepted source specific multicast (SSM) address
+        ranges.";
+    }
+  }
+
+  grouping igmp-global-config {
+    description
+      "This grouping defines global config options for IGMP.";
+
+  }
+
+  grouping igmp-global-top {
+    description
+      "Top level grouping for global IGMP configuration.";
+
+    container ssm {
+      description
+        "Source specific multicast (SSM).";
+
+      container mappings {
+        description
+          "A list of source specific multicast (SSM) mappings.";
+
+        list mapping {
+          key "source";
+          description
+            "A Source Specific Multicast (SSM) mapping. This allows
+            IGMP v2 hosts to be able to join in SSM environments
+            by translating IGMP v2 reports into IGMP v3 reports.
+            The request in an IGMP v2 join is sent toward the source
+            address found by matching the multicast address.";
+
+          leaf source {
+            type leafref {
+              path "../config/source";
+            }
+            description
+              "Multicast source address.";
+          }
+
+          container config {
+            description
+              "Configuration for SSM maps.";
+            uses igmp-ssm-maps-config;
+          }
+          container state {
+            config false;
+            description
+              "State for SSM maps.";
+            uses igmp-ssm-maps-config;
+          }
+        }
+      }
+    }
+  }
+
+  grouping igmp-top {
+    description
+      "Top-level grouping for IGMP.";
+
+    container igmp {
+      description
+        "Top-level IGMP configuration and operational state.";
+
+      container global {
+        description
+          "Global IGMP configuration and operational state.";
+        uses igmp-global-top;
+      }
+
+      uses igmp-interface-top;
+    }
+  }
+
+  // data definition statements
+}

--- a/models/yang/common/openconfig-isis-lsdb-types.yang
+++ b/models/yang/common/openconfig-isis-lsdb-types.yang
@@ -1,0 +1,703 @@
+module openconfig-isis-lsdb-types {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/isis-lsdb-types";
+
+  prefix "oc-isis-lsdb-types";
+
+  import openconfig-extensions { prefix oc-ext; }
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This module contains general LSDB type definitions for use in
+    ISIS YANG model. ";
+
+  oc-ext:openconfig-version "0.4.2";
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "0.4.2";
+  }
+
+  revision "2018-06-05" {
+    description
+      "Fix bugs in when statements.";
+    reference "0.4.1";
+  }
+
+  revision "2018-05-14" {
+    description
+      "Update LSDB model to correct Extended IS reach TLV
+      bug. This change is backwards incompatible due to
+      adding an additional level of hierarchy to support
+      multiple instances of the TLV.";
+    reference "0.4.0";
+  }
+
+  revision "2017-07-26" {
+    description
+      "Update LSDB and fix bugs.";
+    reference "0.3.2";
+  }
+
+  revision "2017-05-15" {
+    description
+      "Refactor LSDB.";
+    reference "0.3.0";
+  }
+
+  revision "2017-01-13" {
+    description
+      "Remove top-level /isis container";
+    reference "0.2.1";
+  }
+
+  revision "2016-12-15" {
+    description
+      "Add segment routing to IS-IS module";
+    reference "0.2.0";
+  }
+
+  revision "2016-10-18" {
+    description
+      "Initial revision of IS-IS models.";
+    reference "0.1.0";
+  }
+
+  // OpenConfig specific extensions for module metadata.
+  oc-ext:regexp-posix;
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  identity ISIS_TLV_TYPE {
+    description
+      "Base identity for an ISIS TLV type.";
+  }
+
+  identity ISIS_SUBTLV_TYPE {
+    description
+      "Base identity for an ISIS SUB-TLV type.";
+  }
+
+  identity IS_REACHABILITY_SUBTLVS_TYPE {
+    base "ISIS_SUBTLV_TYPE";
+    description
+      "Base identity for an ISIS TLV 22, 23, 222, 223, 141 SUB-TLV
+      type.";
+  }
+
+  identity IP_REACHABILITY_SUBTLVS_TYPE {
+    base "ISIS_SUBTLV_TYPE";
+    description
+      "Base identity for an ISIS TLV 135, 235, 236, 237 SUB-TLV
+      type.";
+  }
+
+  identity ROUTER_CAPABILITY_SUBTLVS_TYPE {
+    base "ISIS_SUBTLV_TYPE";
+    description
+      "Base identity for an ISIS TLV 242 SUB-TLV type.";
+  }
+
+  identity AREA_ADDRESSES {
+    base "ISIS_TLV_TYPE";
+    description
+      "ISIS TLV 1. Intermediate System to Intermediate System Intra-
+      Domain Routeing Exchange Protocol for use in Conjunction with
+      the Protocol for Providing the Connectionless-mode Network
+      Service (ISO 8473), International Standard 10589: 2002, Second
+      Edition, 2002.";
+    reference
+      "ISO 10589";
+  }
+
+  identity IIS_NEIGHBORS {
+    base "ISIS_TLV_TYPE";
+    description
+      "ISIS TLV 2. Intermediate System to Intermediate System Intra-
+      Domain Routeing Exchange Protocol for use in Conjunction with
+      the Protocol for Providing the Connectionless-mode Network
+      Service (ISO 8473), International Standard 10589: 2002, Second
+      Edition, 2002.";
+    reference
+      "ISO 10589";
+  }
+
+  identity INSTANCE_ID {
+    base "ISIS_TLV_TYPE";
+    description
+      "ISIS TLV 7. An Instance Identifier (IID) to uniquely
+      identify an IS-IS instance. When the IID = 0, the list of
+      supported ITIDs MUST NOT be present. An IID-TLV with IID = 0
+      MUST NOT appear in an SNP or LSP. When the TLV appears (with a
+      non-zero IID) in an SNP or LSP, exactly one ITID. MUST be
+      present indicating the topology with which the PDU is
+      associated. If no ITIDs or multiple ITIDs are present or the
+      IID is zero, then the PDU MUST be ignored";
+    reference
+      "RFC6822: IS-IS Multi-Instance";
+  }
+
+  identity AUTHENTICATION {
+    base "ISIS_TLV_TYPE";
+    description
+      "ISIS TLV 10.Intermediate System to Intermediate System Intra-
+      Domain Routeing Exchange Protocol for use in Conjunction with
+      the Protocol for Providing the Connectionless-mode Network
+      Service (ISO 8473) International Standard 10589: 2002, Second
+      Edition, 2002.";
+    reference
+      "ISO 10589";
+  }
+
+  identity PURGE_OI {
+    base "ISIS_TLV_TYPE";
+    description
+      "ISIS TLV 13. If an IS generates a purge, it SHOULD include
+      this TLV in the purge with its own system ID.  If an IS
+      receives a purge that does not include this TLV, then it SHOULD
+      add this TLV with both its own system ID and the system ID of
+      the IS from which it received the purge.  This allows ISs
+      receiving purges to log the system ID of the originator, or the
+      upstream source of the purge.";
+    reference
+      "RFC6232: Purge Originator Identification TLV";
+  }
+
+  identity LSP_BUFFER_SIZE {
+   base "ISIS_TLV_TYPE";
+   description
+     "ISIS TLV 14. The maximum MTU that the advertising system can
+     receive, expressed in bytes.";
+   reference
+     "ISO 10589: LSP Buffer Size TLV";
+  }
+
+  identity EXTENDED_IS_REACHABILITY {
+    base "ISIS_TLV_TYPE";
+    description
+      "ISIS TLV 22. An extended IS reachability TLV that has a
+      different data structure to TLV 2 that introduces the use of
+      sub-TLV object-group.";
+    reference
+      "RFC5305: IS-IS Extensions for Traffic Engineering";
+  }
+
+  identity IS_NEIGHBOR_ATTRIBUTE {
+    base "ISIS_TLV_TYPE";
+    description
+      "ISIS TLV 23. Identical in format to TLV 22 and included in
+      Original LSPs or Extended LSPs. Regardless of the type of LSP
+      in which the TLVs appear, the information pertains to the
+      neighbor relationship between the Originating System and the IS
+      identified in the TLV";
+    reference
+      "RFC5311: Simplified Extension of Link State PDU (LSP) Space
+      for IS-IS";
+  }
+
+  identity ISIS_ALIAS_ID {
+    base "ISIS_TLV_TYPE";
+    description
+      "ISIS TLV 24. IS-Alias TLV which extension-capable ISs to
+      recognize the Originating System of an Extended LSP set. It
+      identifies the Normal system-id of the Originating System";
+    reference
+      "RFC5311: Simplified Extension of Link State PDU (LSP) Space
+      for IS-IS";
+  }
+
+  identity IPV4_INTERNAL_REACHABILITY {
+    base "ISIS_TLV_TYPE";
+    description
+      "ISIS TLV 128. TLV defines IP addresses within the routing
+      domain reachable directly via one or more interfaces on this
+      Intermediate system";
+    reference
+      "RFC1195: OSI ISIS for IP and Dual Environments. RFC5302:
+      Domain-Wide Prefix Distribution with Two-Level IS-IS";
+  }
+
+  identity NLPID {
+    base "ISIS_TLV_TYPE";
+    description
+      "ISIS TLV 129. TLV defines the set Network Layer Protocol
+      Identifiers for Network Layer protocols that this Intermediate
+      System is capable of relaying";
+    reference
+      "RFC1195: Use of OSI IS-IS for Routing in TCP/IP and
+      Dual Environments";
+  }
+
+  identity IPV4_EXTERNAL_REACHABILITY {
+    base "ISIS_TLV_TYPE";
+    description
+      "ISIS TLV 130. TLV defines IP addresses outside the routing
+      domain reachable via interfaces on this Intermediate system.
+      This is permitted to appear multiple times, and in an LSP with
+      any LSP number. However, this field must not appear in
+      pseudonode LSPs";
+    reference "
+      RFC1195: OSI ISIS for IP and Dual Environments.  RFC5302:
+      Domain-Wide Prefix Distribution with Two-Level IS-IS";
+  }
+
+  identity IPV4_INTERFACE_ADDRESSES {
+    base "ISIS_TLV_TYPE";
+    description
+      "ISIS TLV 132. The IP address of one or more interfaces
+      corresponding to the SNPAs enabled on this Intermediate system
+      (i.e., one or more IP addresses of this router). This is
+      permitted to appear multiple times, and in an LSP with any LSP
+      number.";
+    reference
+      "RFC1195: Use of OSI IS-IS for Routing in TCP/IP and Dual
+      Environments";
+  }
+
+  identity IPV4_TE_ROUTER_ID {
+    base "ISIS_TLV_TYPE";
+    description
+      "ISIS TLV 134. Traffic Engineering router ID TLV that contains
+      the 4-octet router ID of the router originating the LSP";
+    reference
+      "RFC5305: IS-IS Extensions for Traffic Engineering";
+  }
+
+  identity EXTENDED_IPV4_REACHABILITY {
+    base "ISIS_TLV_TYPE";
+    description
+      "ISIS TLV 135. Extended IP reachability TLV that provides for a
+      32-bit metric and adds one bit to indicate that a prefix has
+      been redistributed _down_ in the hierarchy";
+    reference
+      "RFC5305: IS-IS Extensions for Traffic Engineering";
+  }
+
+  identity DYNAMIC_NAME {
+    base "ISIS_TLV_TYPE";
+    description
+      "ISIS TLV 137. The Dynamic hostname TLV is optional.  This TLV
+      may be present in any fragment of a non-pseudonode LSP.  The
+      value field identifies the symbolic name of the router
+      originating the LSP.  This symbolic name can be the FQDN for the
+      router, it can be a subset of the FQDN, or it can be any string
+      operators want to use for the router.";
+    reference
+      "RFC6233: IS-IS Registry Extension for Purges, RFC 5301: Dynamic
+      Hostname Exchange Mechanism for IS-IS.";
+  }
+
+  identity IPV4_SRLG {
+    base "ISIS_TLV_TYPE";
+    description
+      "ISIS TLV 138. IPv4 Shared Risk Link Group TLV";
+    reference
+      "RFC5307: IS-IS Extensions in Support of Generalized
+      Multi-Protocol Label Switching (GMPLS)";
+  }
+
+  identity IPV6_SRLG {
+    base "ISIS_TLV_TYPE";
+    description
+      "ISIS TLV 139. IPv6 Shared Risk Link Group";
+    reference
+      "RFC6119: IPv6 Traffic Engineering in IS-IS";
+  }
+
+  identity IPV6_TE_ROUTER_ID {
+    base "ISIS_TLV_TYPE";
+    description
+      "ISIS TLV 140. The IPv6 TE Router ID TLV contains a 16-octet
+      IPv6 address. A stable global IPv6 address MUST be used, so that
+      the router ID provides a routable address, regardless of the
+      state of a node's interfaces. If a router does not implement
+      traffic engineering, it MAY include or omit the IPv6 TE Router
+      ID TLV.  If a router implements traffic engineering for IPv6, it
+      MUST include this TLV in its LSP.  This TLV MUST NOT be included
+      more than once in an LSP.";
+    reference
+      "RFC6119: IPv6 Traffic Engineering in IS-IS.";
+  }
+
+  identity MT_ISN {
+    base "ISIS_TLV_TYPE";
+    description
+      "ISIS TLV 222. TLV is aligned with extended IS reachability TLV
+      type 22 beside an additional two bytes in front at the beginning
+      of the TLV that. indicate MT membership.";
+    reference
+      "RFC5120: M-ISIS: Multi Topology (MT) Routing in Intermediate
+      System to Intermediate Systems (IS-ISs)";
+  }
+
+  identity MT_IS_NEIGHBOR_ATTRIBUTE {
+    base "ISIS_TLV_TYPE";
+    description
+      "ISIS TLV 223. Is is identical in format to TLV 222. In the
+      event that there is a need to advertise in Extended LSPs such
+      information associated with neighbors of the Originating System,
+      it is necessary to define new TLVs to carry the sub-TLV
+      information.";
+    reference
+      "RFC5311: Simplified Extension of Link State PDU (LSP) Space for
+      IS-IS";
+  }
+
+  identity MULTI_TOPOLOGY {
+    base "ISIS_TLV_TYPE";
+    description
+      "ISIS TLV 229. This MT TLV can advertise up to 127 MTs.  It is
+      announced in IIHs and LSP fragment 0, and can occur multiple
+      times.  The resulting MT set SHOULD be the union of all the MT
+      TLV occurrences in the packet. Any other IS-IS PDU occurrence of
+      this TLV MUST be ignored.  Lack of MT TLV in hellos and fragment
+      zero LSPs MUST be interpreted as participation of the
+      advertising interface or router in MT ID #0 only.  If a router
+      advertises MT TLV, it has to advertise all the MTs it
+      participates in, specifically including topology ID #0 also.";
+    reference
+      "RFC5120: M-ISIS: Multi Topology (MT) Routing in Intermediate
+      System to Intermediate Systems (IS-ISs)";
+  }
+
+  identity IPV6_INTERFACE_ADDRESSES {
+    base "ISIS_TLV_TYPE";
+    description
+      "ISIS TLV 232. IPv6 Interface Address TLV that maps directly to
+      the IP Interface Address TLV in [RFC1195]. We necessarily modify
+      the contents to be 0-15 16-octet IPv6 interface addresses
+      instead of 0-63 4-octet IPv4 interface addresses";
+    reference "RFC5308: Routing IPv6 with IS-IS.";
+  }
+
+  identity MT_IPV4_REACHABILITY {
+    base "ISIS_TLV_TYPE";
+    description
+      "ISIS TLV 235. TLV is aligned with extended IP reachability TLV
+      type 135 beside an additional two bytes in front to indicate MT
+      membership";
+    reference
+      "RFC5120: M-ISIS: Multi Topology (MT) Routing in Intermediate
+      System to Intermediate Systems (IS-ISs)";
+  }
+
+  identity IPV6_REACHABILITY {
+    base "ISIS_TLV_TYPE";
+    description
+      "ISIS TLV 236. The IPv6 Reachability TLV describes network
+      reachability through the specification of a routing prefix,
+      metric information, a bit to indicate if the prefix is being
+      advertised down from a higher level, a bit to indicate if the
+      prefix is being distributed from another routing protocol, and
+      OPTIONALLY the existence of Sub-TLVs to allow for later
+      extension.";
+    reference
+      "RFC5308: Routing IPv6 with IS-IS";
+  }
+
+  identity MT_IPV6_REACHABILITY {
+    base "ISIS_TLV_TYPE";
+    description
+      "ISIS TLV 237. TLV is aligned with IPv6 Reachability TLV type
+      236 beside an additional two bytes in front to indicate MT
+      membership.";
+    reference
+      "RFC5120: M-ISIS: Multi Topology (MT) Routing in Intermediate
+      System to Intermediate Systems (IS-ISs).";
+  }
+
+  identity ROUTER_CAPABILITY {
+    base "ISIS_TLV_TYPE";
+    description
+      "ISIS TLV 242. IS-IS TLV named CAPABILITY, formed of multiple
+      sub-TLVs, which allows a router to announce its capabilities
+      within an IS-IS level or the entire routing domain.";
+    reference
+      "RFC4971: Intermediate System to Intermediate System (IS-IS)
+      Extensions for Advertising Router Information.";
+  }
+
+  //sub-TLVs for TLVs 22, 23, 141, 222, 223
+
+  identity IS_REACHABILITY_ADMIN_GROUP {
+    base "IS_REACHABILITY_SUBTLVS_TYPE";
+    description
+      "sub-TLV 3. Administrative group(color).";
+    reference
+      "RFC5305: IS-IS Extensions for Traffic Engineering";
+  }
+
+  identity IS_REACHABILITY_LINK_ID {
+    base "IS_REACHABILITY_SUBTLVS_TYPE";
+    description
+      "sub-TLV 4. Link Local/Remote Identifiers.";
+    reference
+      "RFC5307: IS-IS Extensions in Support of Generalized
+      Multi-Protocol Label Switching (GMPLS)";
+  }
+
+  identity IS_REACHABILITY_IPV4_INTERFACE_ADDRESS {
+    base "IS_REACHABILITY_SUBTLVS_TYPE";
+    description
+      "sub-TLV 6. IPv4 Interface Address.";
+    reference
+      "RFC5305: IS-IS Extensions for Traffic Engineering.";
+  }
+
+  identity IS_REACHABILITY_IPV4_NEIGHBOR_ADDRESS {
+    base "IS_REACHABILITY_SUBTLVS_TYPE";
+    description
+      "sub-TLV 8. IPv4 Neighbor Address.";
+    reference
+      "RFC5305: IS-IS Extensions for Traffic Engineering.";
+  }
+
+  identity IS_REACHABILITY_MAX_LINK_BANDWIDTH {
+    base "IS_REACHABILITY_SUBTLVS_TYPE";
+    description
+      "sub-TLV 9. Maximum Link Bandwidth.";
+    reference
+      "RFC5305: IS-IS Extensions for Traffic Engineering.";
+  }
+
+  identity IS_REACHABILITY_MAX_RESERVABLE_BANDWIDTH {
+    base "IS_REACHABILITY_SUBTLVS_TYPE";
+    description
+      "sub-TLV 10. Maximum Reservable Bandwidth.";
+    reference
+      "RFC5305: IS-IS Extensions for Traffic Engineering.";
+  }
+
+  identity IS_REACHABILITY_UNRESERVED_BANDWIDTH {
+    base "IS_REACHABILITY_SUBTLVS_TYPE";
+    description
+      "sub-TLV 11. Unreserved bandwidth.";
+    reference
+      "RFC5305: IS-IS Extensions for Traffic Engineering.";
+  }
+
+  identity IS_REACHABILITY_IPV6_INTERFACE_ADDRESS {
+    base "IS_REACHABILITY_SUBTLVS_TYPE";
+    description
+      "sub-TLV 12. IPv6 Interface Address.";
+    reference
+      "RFC6119: IPv6 Traffic Engineering in IS-IS.";
+  }
+
+  identity IS_REACHABILITY_IPV6_NEIGHBOR_ADDRESS {
+    base "IS_REACHABILITY_SUBTLVS_TYPE";
+    description
+      "sub-TLV 13. IPv6 Neighbor Address.";
+    reference
+      "RFC6119: IPv6 Traffic Engineering in IS-IS.";
+  }
+
+  identity IS_REACHABILITY_EXTENDED_ADMIN_GROUP {
+    base "IS_REACHABILITY_SUBTLVS_TYPE";
+    description
+      "sub-TLV 14. Extended Administrative Group.";
+    reference
+      "RFC7308: Extended Administrative Groups in MPLS Traffic
+      Engineering (MPLS-TE).";
+  }
+
+  identity IS_REACHABILITY_TE_DEFAULT_METRIC {
+    base "IS_REACHABILITY_SUBTLVS_TYPE";
+    description
+      "sub-TLV 18. TE Default Metric.";
+    reference
+      "RFC5305: IS-IS Extensions for Traffic Engineering.";
+  }
+
+  identity IS_REACHABILITY_LINK_ATTRIBUTES {
+    base "IS_REACHABILITY_SUBTLVS_TYPE";
+    description
+      "sub-TLV 19. Link Attributes.";
+    reference
+      "RFC5209: Definition of an IS-IS Link Attribute Sub-TLV.";
+  }
+
+  identity IS_REACHABILITY_LINK_PROTECTION_TYPE {
+    base "IS_REACHABILITY_SUBTLVS_TYPE";
+    description
+      "sub-TLV 20. Link Protection Type.";
+    reference
+      "RFC5307: IS-IS Extensions in Support of Generalized
+      Multi-Protocol  Label Switching (GMPLS)";
+  }
+
+  identity IS_REACHABILITY_BANDWIDTH_CONSTRAINTS {
+    base "IS_REACHABILITY_SUBTLVS_TYPE";
+    description
+      "sub-TLV 22. Bandwidth Constraints.";
+    reference
+      "RFC4124: Protocol Extensions for Support of Diffserv-aware MPLS
+      Traffic Engineering.";
+  }
+
+  identity IS_REACHABILITY_UNCONSTRAINED_LSP {
+    base "IS_REACHABILITY_SUBTLVS_TYPE";
+    description
+      "sub-TLV 23. Unconstrained LSP.";
+    reference
+      "RFC5330: A Link-Type sub-TLV to Convey the Number of Traffic
+      Engineering Label Switched Paths Signalled with Zero
+      Reserved Bandwidth across a Link.";
+  }
+
+  identity IS_REACHABILITY_ADJ_SID {
+    base "IS_REACHABILITY_SUBTLVS_TYPE";
+    description
+      "sub-TLV 31. Adjacency Segment Identifier.";
+    reference
+      "draft-ietf-isis-segment-routing-extensions.";
+  }
+
+  identity IS_REACHABILITY_ADJ_LAN_SID {
+    base "IS_REACHABILITY_SUBTLVS_TYPE";
+    description
+      "sub-TLV 32. Adjacency LAN Segment Identifier.";
+    reference
+      "draft-ietf-isis-segment-routing-extensions.";
+  }
+
+  identity IS_REACHABILITY_LINK_DELAY {
+    base "IS_REACHABILITY_SUBTLVS_TYPE";
+    description
+      "sub-TLV 33. Unidirectional Link Delay.";
+    reference
+      "RFC7810: IS-IS Traffic Engineering (TE) Metric Extensions.";
+  }
+
+  identity IS_REACHABILITY_MIN_MAX_LINK_DELAY {
+    base "IS_REACHABILITY_SUBTLVS_TYPE";
+    description
+      "sub-TLV 34. Min/Max Unidirectional Link Delay.";
+    reference
+      "RFC7810: IS-IS Traffic Engineering (TE) Metric Extensions.";
+  }
+
+  identity IS_REACHABILITY_LINK_DELAY_VARIATION {
+    base "IS_REACHABILITY_SUBTLVS_TYPE";
+    description
+      "sub-TLV 35. Unidirectional Link Delay Variation.";
+    reference
+      "RFC7810: IS-IS Traffic Engineering (TE) Metric Extensions.";
+  }
+
+  identity IS_REACHABILITY_LINK_LOSS {
+    base "IS_REACHABILITY_SUBTLVS_TYPE";
+    description
+      "sub-TLV 36. Unidirectional Link Loss Delay.";
+    reference
+      "RFC7810: IS-IS Traffic Engineering (TE) Metric Extensions.";
+  }
+
+  identity IS_REACHABILITY_RESIDUAL_BANDWIDTH {
+    base "IS_REACHABILITY_SUBTLVS_TYPE";
+    description
+      "sub-TLV 37. Unidirectional Residual Bandwidth.";
+    reference
+      "RFC7810: IS-IS Traffic Engineering (TE) Metric Extensions.";
+  }
+
+  identity IS_REACHABILITY_AVAILABLE_BANDWIDTH {
+    base "IS_REACHABILITY_SUBTLVS_TYPE";
+    description
+      "sub-TLV 38. Unidirectional Available Bandwidth.";
+    reference
+      "RFC7810: IS-IS Traffic Engineering (TE) Metric Extensions.";
+  }
+
+  identity IS_REACHABILITY_UTILIZED_BANDWIDTH {
+    base "IS_REACHABILITY_SUBTLVS_TYPE";
+    description
+      "sub-TLV 39. Unidirectional Utilized Bandwidth.";
+    reference
+      "RFC7810: IS-IS Traffic Engineering (TE) Metric Extensions.";
+  }
+
+  //sub-TLVs for TLVs 135, 235, 236, 237
+  identity IP_REACHABILITY_TAG {
+    base "IP_REACHABILITY_SUBTLVS_TYPE";
+    description
+      "sub-TLV 1. 32-bit Administrative Tag.";
+    reference
+      "RFC7794: IS-IS Prefix Attributes for Extended IPv4 and IPv6
+      Reachability.";
+  }
+
+  identity IP_REACHABILITY_TAG64 {
+    base "IP_REACHABILITY_SUBTLVS_TYPE";
+    description
+      "sub-TLV 2. 64-bit Administrative Tag.";
+    reference
+      "RFC7794: IS-IS Prefix Attributes for Extended IPv4 and IPv6
+      Reachability.";
+  }
+
+  identity IP_REACHABILITY_PREFIX_SID {
+    base "IP_REACHABILITY_SUBTLVS_TYPE";
+    description
+      "sub-TLV 3. Prefix Segment Identifier.";
+    reference
+      "draft-ietf-isis-segment-routing-extension.";
+  }
+
+  identity IP_REACHABILITY_PREFIX_FLAGS {
+    base "IP_REACHABILITY_SUBTLVS_TYPE";
+    description
+      "sub-TLV 4. Prefix Attribute Flags.";
+    reference
+      "RFC7794: IS-IS Prefix Attributes for Extended IPv4 and IPv6
+      Reachability.";
+  }
+
+  identity IP_REACHABILITY_IPV4_ROUTER_ID {
+    base "IP_REACHABILITY_SUBTLVS_TYPE";
+    description
+      "sub-TLV 11. IPv4 Source Router ID.";
+    reference
+      "RFC7794: IS-IS Prefix Attributes for Extended IPv4 and IPv6
+      Reachability.";
+  }
+
+  identity IP_REACHABILITY_IPV6_ROUTER_ID {
+    base "IP_REACHABILITY_SUBTLVS_TYPE";
+    description
+      "sub-TLV 12. IPv6 Source Router ID.";
+    reference
+      "RFC7794: IS-IS Prefix Attributes for Extended IPv4 and IPv6
+      Reachability.";
+  }
+
+
+  //sub-TLVs for TLVs 242
+
+  identity ROUTER_CAPABILITY_SR_CAPABILITY {
+    base "ROUTER_CAPABILITY_SUBTLVS_TYPE";
+    description
+      "sub-TLV 2. Segment Routing Capability.";
+    reference
+      "draft-ietf-isis-segment-routing-extensions.";
+  }
+
+  identity ROUTER_CAPABILITY_SR_ALGORITHM {
+    base "ROUTER_CAPABILITY_SUBTLVS_TYPE";
+    description
+      "sub-TLV 19. Segment Routing Algorithm.";
+    reference
+      "draft-ietf-isis-segment-routing-extensions.";
+  }
+
+}

--- a/models/yang/common/openconfig-isis-lsp.yang
+++ b/models/yang/common/openconfig-isis-lsp.yang
@@ -1,0 +1,3724 @@
+submodule openconfig-isis-lsp {
+
+  belongs-to openconfig-isis {
+    prefix oc-isis;
+  }
+  import openconfig-extensions { prefix "oc-ext"; }
+  import openconfig-inet-types { prefix "inet"; }
+  import openconfig-isis-types { prefix "oc-isis-types"; }
+  import openconfig-isis-lsdb-types { prefix "oc-isis-lsdb-types"; }
+  import openconfig-types { prefix "oc-types"; }
+  import openconfig-mpls-types { prefix "oc-mplst"; }
+  // meta
+  organization
+    "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net ";
+
+  description
+    "This sub-module describes a YANG model for the IS-IS Link State
+    Database (LSDB).
+
+    Portions of this code were derived from IETF RFCs relating to the
+    IS-IS protocol.
+    Please reproduce this note if possible.
+    IETF code is subject to the following copyright and license:
+    Copyright (c) IETF Trust and the persons identified as authors of
+    the code.
+    All rights reserved.
+    Redistribution and use in source and binary forms, with or without
+    modification, is permitted pursuant to, and subject to the license
+    terms contained in, the Simplified BSD License set forth in
+    Section 4.c of the IETF Trust's Legal Provisions Relating
+    to IETF Documents (http://trustee.ietf.org/license-info).";
+
+  oc-ext:openconfig-version "1.7.0";
+
+  revision "2024-02-28" {
+    description
+      "ISIS graceful-restart timers and per-level configuration.";
+    reference "1.7.0";
+  }
+
+  revision "2024-02-20" {
+    description
+      "Fix typo in RFC reference for adjacency-state.";
+    reference "1.6.2";
+  }
+
+  revision "2023-11-01" {
+    description
+      "Refactor apply policy to separate default policy in it's own common
+      set of groupings";
+    reference "1.6.1";
+  }
+
+  revision "2023-05-01" {
+    description
+      "Add ISIS total-lsps counter.";
+    reference "1.6.0";
+  }
+
+  revision "2023-04-25" {
+    description
+      "Clarify use of the interface-ref type.";
+    reference "1.5.1";
+  }
+
+  revision "2023-03-27" {
+    description
+      "Add weighted ecmp.";
+    reference "1.5.0";
+  }
+
+  revision "2023-03-20" {
+    description
+      "Per-level global enabled configuration default false re-added to keep
+      backward compatibility.";
+    reference "1.4.1";
+  }
+
+  revision "2023-02-22" {
+    description
+      "Deprecate the instance leaf, and add a new instance-id leaf
+      that indicates the value to be used in the Instance Identifier
+      TLV.";
+    reference "1.4.0";
+  }
+
+  revision "2023-01-25" {
+    description
+      "Per-level global enabled configuration removed, since it duplicates
+      the level-capability leaf.";
+    reference "1.3.0";
+  }
+
+  revision "2023-01-04" {
+    description
+      "Add max ecmp paths for address family.";
+    reference "1.2.0";
+  }
+
+  revision "2022-09-20" {
+    description
+      "Add CSNP enable to IS-IS global configuration.";
+    reference "1.1.0";
+  }
+
+  revision "2022-05-10" {
+    description
+      "Modify internal/external route preference to unrestricted uint32
+      type.";
+    reference "1.0.0";
+  }
+
+  revision "2022-03-01" {
+    description
+      "Add simple key authentication support.";
+    reference "0.9.0";
+  }
+
+  revision "2022-02-24" {
+    description
+      "Add Hello PDU padding type to IS-IS global configuration.";
+    reference "0.8.0";
+  }
+
+  revision "2022-01-19" {
+    description
+      "Align revisions across modules.";
+    reference "0.7.1";
+  }
+
+  revision "2021-12-31" {
+    description
+      "Add support for per-interface hello authentication, and per-level
+      *SNP authentication.";
+    reference "0.7.0";
+  }
+
+  revision "2021-06-16" {
+    description
+      "Remove trailing whitespace";
+    reference "0.6.2";
+  }
+
+  revision "2020-03-24" {
+    description
+      "Support IGP-LDP sync per interface.";
+    reference "0.6.0";
+  }
+  revision "2020-02-04" {
+    description
+      "Consistent prefix for openconfig-mpls-types.";
+    reference "0.5.0";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "0.4.2";
+  }
+
+  revision "2018-06-05" {
+    description
+      "Fix bugs in when statements.";
+    reference "0.4.1";
+  }
+
+  revision "2018-05-14" {
+    description
+      "Update LSDB model to correct Extended IS reach TLV
+      bug. This change is backwards incompatible due to
+      adding an additional level of hierarchy to support
+      multiple instances of the TLV.";
+    reference "0.4.0";
+  }
+
+  revision "2017-07-26" {
+    description
+      "Update LSDB and fix bugs.";
+    reference "0.3.2";
+  }
+
+  revision "2017-05-15" {
+    description
+      "Refactor LSDB.";
+    reference "0.3.0";
+  }
+
+  revision "2017-01-13" {
+    description
+      "Remove top-level /isis container";
+    reference "0.2.1";
+  }
+
+  revision "2016-12-15" {
+    description
+      "Add segment routing to IS-IS module";
+    reference "0.2.0";
+  }
+
+  revision "2016-10-18" {
+    description
+      "Initial revision of IS-IS models.";
+    reference "0.1.0";
+  }
+
+  typedef isis-metric-flags {
+    type enumeration {
+      enum INTERNAL {
+        description
+          "When this flag is not set, internal metrics are in use.";
+      }
+      enum UNSUPPORTED {
+        description
+          "When this flag (referred to as the S-bit) is set, then
+          the metric is unsupported.";
+      }
+    }
+    description
+      "Type definition for flags used in IS-IS metrics";
+  }
+
+  grouping isis-lsdb-link-characteristics-a-bit {
+    description
+      "Definition of the A bit, as used in IS-IS link delay TLVs.";
+
+    leaf a-bit {
+      type boolean;
+      description
+        "The A bit is set when the measured value of this parameter
+        exceeds its configured maximum threshold. The A bit is cleared
+        when the measured value falls below its configured reuse
+        threshold.";
+    }
+  }
+
+  grouping isis-lsdb-tlv-nlpid-state {
+    description
+      "NLP ID parameters for IS-IS.";
+
+    leaf-list nlpid {
+      type enumeration {
+        enum IPV4 {
+          description "IPv4 Address family.";
+        }
+        enum IPV6 {
+          description "IPv6 Address family.";
+        }
+      }
+      description
+        "Protocol supported. IPv4 is defined as (0xcc) and IPv6 -
+        (0x8e)";
+      reference
+        "RFC1195: Use of OSI IS-IS for Routing in TCP/IP and
+        Dual Environments. TLV 129. ";
+    }
+  }
+
+  grouping isis-lsdb-subtlv-type-state {
+    description
+      "Per-subTLV type operational state parameters for ISIS.";
+
+    leaf type {
+      type identityref {
+        base oc-isis-lsdb-types:ISIS_SUBTLV_TYPE;
+      }
+      description
+        "The type of subTLV being described. The type of subTLV is
+        expressed as a canonical name.";
+    }
+  }
+
+  grouping isis-lsdb-tlv-type-state {
+    description
+      "Per-subTLV type operational state parameters for ISIS.";
+
+    leaf type {
+      type identityref {
+        base oc-isis-lsdb-types:ISIS_TLV_TYPE;
+      }
+      description
+        "The type of TLV being described. The type of TLV is
+        expressed as a canonical name.";
+    }
+  }
+
+  grouping is-reachability-neighbor-state {
+    description
+      "This grouping defines is-reachability neighbor.";
+
+    container subtlvs {
+      description
+        "This container describes IS Neighbor sub-TLVs.";
+
+      list subtlv {
+        key "type";
+
+        description
+          "List of subTLV types in the LSDB for the specified TLV.";
+
+        leaf type {
+          type leafref {
+            path "../state/type";
+          }
+          description
+            "Reference to the sub-TLV type.";
+        }
+
+        container state {
+          description
+            "State parameters of IS neighbor state";
+
+          uses isis-lsdb-subtlv-type-state;
+        }
+
+        container admin-group {
+          when "../state/type = " +
+               "'oc-isis-lsdb-types:IS_REACHABILITY_ADMIN_GROUP'" {
+            description
+              "Only include the administrative group container when
+              the sub-TLV is type 3";
+          }
+          description
+            "This container defines sub-TLV 3.";
+
+          container state {
+            description
+              "State parameters of sub-TLV 3.";
+
+            leaf-list admin-group {
+              type uint32;
+              description
+                "The administrative group sub-TLV contains a 4-octet
+                bit mask assigned by the network administrator.  Each
+                set bit corresponds to one administrative group
+                assigned to the interface. By convention, the least
+                significant bit is referred to as group 0, and the
+                most significant bit is referred to as group 31.";
+              reference
+                "RFC5305: IS-IS Extensions for Traffic Engineering.
+                sub-TLV 3: TLV 22,23,141,222, 223.";
+            }
+          }
+        }
+
+        container link-id {
+          when "../state/type = " +
+               "'oc-isis-lsdb-types:IS_REACHABILITY_LINK_ID'" {
+            description
+              "Only include the link identifier container when the
+              sub-TLV is type 4";
+          }
+          description
+            "This container defines sub-TLV 4.";
+
+          container state {
+            description
+              "State parameters of sub-TLV 4.";
+
+            leaf local {
+              type uint32;
+              description
+                "The value field of this sub-TLV contains 4 octets of
+                Link Local Identifier followed by 4 octets of Link
+                Remote Identifier.";
+              reference
+                "RFC5307: IS-IS Extensions in Support of Generalized
+                Multi-Protocol Label Switching (GMPLS). sub-TLV 3: TLV
+                22,23,141,222, 223.";
+            }
+
+            leaf remote {
+              type uint32;
+              description
+                "If the Link Remote Identifier is unknown, it is set
+                to 0.";
+              reference
+                "RFC5307: IS-IS Extensions in Support of Generalized
+                Multi-Protocol Label Switching (GMPLS). sub-TLV 3: TLV
+                22,23,141,222, 223.";
+            }
+          }
+        }
+
+        container ipv4-interface-address {
+          when "../state/type = " +
+               "'oc-isis-lsdb-types:IS_REACHABILITY_IPV4_INTERFACE_ADDRESS'" {
+            description
+              "Only include the IPv4 interface address group container
+              when the sub-TLV is type 6";
+          }
+          description
+            "This container defines sub-TLV 6.";
+
+          container state {
+            description
+              "State parameters of sub-TLV 6.";
+
+            leaf-list address {
+              type inet:ipv4-address;
+              description
+                "A 4-octet IPv4 address for the interface described by
+                the (main) TLV. This sub-TLV can occur multiple
+                times.";
+              reference
+                "RFC5305: IS-IS Extensions for Traffic Engineering.
+                sub-TLV 6: TLV 22,23,41,222,223.";
+            }
+          }
+        }
+
+        container ipv4-neighbor-address {
+          when "../state/type = " +
+               "'oc-isis-lsdb-types:IS_REACHABILITY_IPV4_NEIGHBOR_ADDRESS'" {
+            description
+              "Only include the IPv4 neighbor address container when
+              the sub-TLV is type 8.";
+          }
+          description
+            "This container defines sub-TLV 8.";
+
+          container state {
+            description
+              "State parameters of sub-TLV 8.";
+
+            leaf-list address {
+              type inet:ipv4-address;
+              description
+                "A single IPv4 address for a neighboring router on
+                this link. This sub-TLV can occur multiple times.";
+              reference
+                "RFC5305: IS-IS Extensions for Traffic Engineering.
+                sub-TLV 8: TLV 22,23, 141,222,223.";
+            }
+          }
+        }
+
+        container max-link-bandwidth {
+          when "../state/type = " +
+               "'oc-isis-lsdb-types:IS_REACHABILITY_MAX_LINK_BANDWIDTH'" {
+            description
+              "Only include the maximum link bandwidth container when
+              the sub-TLV is type 9.";
+          }
+          description
+            "This container defines sub-TLV 9.";
+
+          container state {
+            description
+              "State parameters of sub-TLV 9.";
+
+            leaf bandwidth {
+              type oc-types:ieeefloat32;
+              units "bytes per second";
+              description
+                "The maximum bandwidth that can be used on this link
+                in this direction (from the system originating the LSP
+                to its neighbors).  It is encoded in 32 bits in IEEE
+                floating point format.  The units are bytes (not
+                bits!) per second.";
+              reference
+                "RFC5305: IS-IS Extensions for Traffic Engineering.
+                sub-TLV 9: TLV 22,23,141,222,223.";
+            }
+          }
+        }
+
+        container max-reservable-link-bandwidth {
+          when "../state/type = " +
+               "'oc-isis-lsdb-types:IS_REACHABILITY_MAX_RESERVABLE_BANDWIDTH'" {
+            description
+              "Only include the maximum reservable link bandwidth
+              container when the sub-TLV type is 10.";
+          }
+          description
+            "This container defines sub-TLV 10.";
+
+          container state {
+            description
+              "State parameters of sub-TLV 10.";
+
+            leaf bandwidth {
+              type oc-types:ieeefloat32;
+              units "bytes per second";
+              description
+                "The maximum amount of bandwidth that can be reserved
+                in this direction on this link.  Note that for
+                oversubscription purposes,  this can be greater than
+                the bandwidth of the link. It is encoded  in 32 bits
+                in IEEE floating point format.  The units are bytes
+                (not bits!) per second.";
+              reference
+                "RFC5305: IS-IS Extensions for Traffic Engineering.
+                Sub-TLV 10: TLV 22,23,141,222,223.";
+            }
+          }
+        }
+
+        container unreserved-bandwidth {
+          when "../state/type = " +
+               "'oc-isis-lsdb-types:IS_REACHABILITY_UNRESERVED_BANDWIDTH'" {
+            description
+              "Only include the unreserved bandwidth container when
+              the sub-TLV type is 11.";
+          }
+          description
+            "This container defines unreserved-bandwidth. The units
+            are bytes per second.";
+
+          reference
+            "RFC5305: IS-IS Extensions for Traffic Engineering. sub-
+            TLV 11: TLV 22,23,141,222,223";
+
+          list setup-priority {
+            key "priority";
+
+            leaf priority {
+              type leafref {
+                path "../state/priority";
+              }
+              description
+                "Reference to the setup priority to which the
+                unreserved bandwidth corresponds.";
+            }
+
+            description
+              "Setup priority (0 through 7) for unreserved
+              bandwidth.";
+
+            container state {
+              description
+                "State parameters of IS Extended Reachability sub-TLV
+                11.";
+
+              leaf priority {
+                type uint8 {
+                  range "0..7";
+                }
+                description
+                  "Setup priority level of 0 through 7 to be used by
+                  Unreserved Bandwidth sub-TLV 11.";
+              }
+
+              leaf bandwidth {
+                type oc-types:ieeefloat32;
+                units "bytes per second";
+                description
+                  "The amount of bandwidth reservable in this
+                  direction on this link. Note that for
+                  oversubscription purposes, this can be greater than
+                  the bandwidth of the link. It contains eight 32-bit
+                  IEEE floating point numbers(one for each priority).
+                  The units are bytes (not bits!) per second. The
+                  values correspond to the bandwidth that can be
+                  reserved with a setup priority of 0 through 7,
+                  arranged in increasing order with priority 0
+                  occurring at the start of the sub-TLV, and priority
+                  7 at the end of the sub-TLV.";
+              }
+            }
+          }
+        }
+
+        container ipv6-interface-address {
+          when "../state/type = " +
+               "'oc-isis-lsdb-types:IS_REACHABILITY_IPV6_INTERFACE_ADDRESS'" {
+            description
+              "Only include the IPv6 interface address when the
+              sub-TLV type is 12.";
+          }
+          description
+            "This container defines sub-TLV 12.";
+
+          container state {
+            description
+              "State parameters of sub-TLV 12.";
+
+            leaf-list address {
+              type inet:ipv6-address;
+              description
+                "Contains a 16-octet IPv6 address for the interface
+                described by the containing  Extended IS Reachability
+                TLV. This sub-TLV can occur multiple times.";
+              reference
+                "RFC6119: IPv6 Traffic Engineering in IS-IS. sub-TLV
+                12: TLV 22,23,141,222,223.";
+            }
+          }
+        }
+
+        container ipv6-neighbor-address {
+          when "../state/type = " +
+               "'oc-isis-lsdb-types:IS_REACHABILITY_IPV6_NEIGHBOR_ADDRESS'" {
+            description
+              "Only include the IPv6 neighbor address when the
+              sub-TLV type is 13.";
+          }
+          description
+            "This container defines sub-TLV 13.";
+
+          container state {
+            description
+              "State parameters of sub-TLV 13.";
+
+            leaf-list address {
+              type inet:ipv6-address;
+              description
+                "Contains a 16-octet IPv6 address for a neighboring
+                router on the link described by the (main) TLV. This
+                sub-TLV can occur multiple times.";
+              reference
+                "RFC6119: IPv6 Traffic Engineering in IS-IS. sub-TLV
+                13: ISIS TLV 22,23,141,222,223.";
+            }
+          }
+        }
+
+        container extended-admin-group {
+          when "../state/type = " +
+               "'oc-isis-lsdb-types:IS_REACHABILITY_EXTENDED_ADMIN_GROUP'" {
+            description
+              "Only include the extended admin group when the
+              sub-TLV type is 14.";
+          }
+          description
+            "This container defines sub-TLV 14.";
+          container state {
+            description
+              "State parameters of sub-TLV 14.";
+
+            leaf-list extended-admin-group {
+              type uint32;
+              description
+                "The extended-admin-group sub-TLV is used in addition
+                to the Administrative Groups when it is desirable to
+                make more than 32 colors available for advertisement
+                in a network.";
+              reference
+                "RFC7308: Extended Administrative Groups in MPLS
+                Traffic Engineering (MPLS-TE). sub-TLV 14: TLV
+                22,23,141,222,223.";
+            }
+          }
+        }
+
+        container te-default-metric {
+          when "../state/type = " +
+               "'oc-isis-lsdb-types:IS_REACHABILITY_TE_DEFAULT_METRIC'" {
+            description
+              "Only include the default traffic engineering metric
+              container when the sub-TLV type is 18.";
+          }
+          description
+            "This container defines sub-TLV 18.";
+          container state {
+            description
+              "State parameters of sub-TLV 18.";
+
+            leaf metric {
+              type uint32;
+              description
+                "This metric is administratively assigned and can be
+                used to present a differently weighted topology to
+                traffic engineering SPF calculations. To preclude
+                overflow within a traffic engineering SPF
+                implementation, all metrics greater than or equal to
+                MAX_PATH_METRIC SHALL be considered to have a metric
+                of MAX_PATH_METRIC.";
+              reference
+                "RFC5305: IS-IS Extensions for Traffic Engineering.
+                sub-TLV 18: TLV 22,23,141,222,223.";
+            }
+          }
+        }
+
+        container link-attributes {
+          when "../state/type = " +
+               "'oc-isis-lsdb-types:IS_REACHABILITY_LINK_ATTRIBUTES'" {
+            description
+              "Only include the link attributes container when the
+              sub-TLV is type 19.";
+          }
+          description
+            "This container defines link-attributes.";
+
+          container state {
+            description
+              "State parameters of IS Extended Reachability sub-TLV
+              19.";
+
+            leaf-list local-protection {
+              type enumeration {
+                enum LOCAL_PROTECTION {
+                  description
+                    "If set, local protection is available for the
+                    link.";
+                }
+                enum LINK_EXCLUDED {
+                  description
+                    "If set, the link is excluded from local
+                    protection.";
+                }
+              }
+              description
+                "Link local-protection attributes.";
+
+              reference
+                "RFC5029: Definition of an IS-IS Link Attribute Sub-
+                TLV. TLV 22, sub-TLV 19.";
+            }
+          }
+        }
+
+        container link-protection-type {
+          when "../state/type = " +
+               "'oc-isis-lsdb-types:IS_REACHABILITY_LINK_PROTECTION_TYPE'" {
+            description
+              "Only include the link protection type container when
+              the sub-TLV type 20.";
+          }
+          description
+            "ISIS LSDB parameters relating to the type of link
+            protection offered.";
+
+          container state {
+            description
+              "State parameters of sub-TLV 20.";
+
+            leaf-list type {
+              type enumeration {
+                enum EXTRA_TRAFFIC {
+                  description
+                    "If set the link has extra traffic protection. If
+                    the link is of type Extra Traffic, it means that
+                    the link is protecting another link or links. The
+                    LSPs on a link of this type will be lost if any of
+                    the links it is protecting fail.";
+                }
+                enum UNPROTECTED {
+                  description
+                    "If set, the link is unprotected. If the link is
+                    of type Unprotected, it means that there is no
+                    other link protecting this link.  The LSPs on a
+                    link of this type will be lost if the link
+                    fails.";
+                }
+                enum SHARED {
+                  description
+                    "If set, the link has shared protection. If the
+                    link is of type Shared, it means that there are
+                    one or more disjoint links of type Extra Traffic
+                    that are protecting this link.  These Extra
+                    Traffic links are shared between one or more links
+                    of type Shared.";
+                }
+                enum ONE_ONE {
+                  description
+                    "If set, the link has dedicated 1:1 protection. If
+                    the link is of type Dedicated 1:1, it means that
+                    there is one dedicated disjoint link of type Extra
+                    Traffic that is protecting this link.";
+                }
+                enum PLUS_ONE {
+                  description
+                    "If set, the link has dedicated 1+1 protection. If
+                    the link is of type Dedicated 1+1, it means that a
+                    dedicated disjoint link is protecting this link.
+                    However, the protecting link is not advertised in
+                    the link state database and is therefore not
+                    available for the routing of LSPs.";
+                }
+                enum ENHANCED {
+                  description
+                    "If set the link has enhanced protection.  If the
+                    link is of type Enhanced, it means that a
+                    protection scheme that is more reliable than
+                    Dedicated 1+1, e.g., 4 fiber BLSR/MS-SPRING, is
+                    being used to protect this link.";
+                }
+              }
+              description
+                "Link protection capabilities.";
+              reference
+                "RFC5307: IS-IS Extensions in Support of Generalized
+                Multi-Protocol  Label Switching (GMPLS). sub-TLV 20:
+                TLV 22,23,141,222,223.";
+            }
+          }
+        }
+
+        container bandwidth-constraints {
+          when "../state/type =" +
+               "'oc-isis-lsdb-types:IS_REACHABILITY_BANDWIDTH_CONSTRAINTS'" {
+            description
+              "Only include the bandwidth constraints container when
+              the sub-TLV is type 22.";
+          }
+          description
+            "This container defines bandwidth-constraints. For DS-TE,
+            the existing Maximum Reservable link bandwidth parameter
+            is retained, but its semantics is generalized and
+            interpreted as the aggregate bandwidth constraint across
+            all Class-Types";
+
+          reference
+            "RFC4124: Protocol Extensions for Support of Diffserv-
+            aware MPLS Traffic Engineering. sub-TLV 22: TLV 22, 23,
+            141, 222,223";
+
+          list bandwidth-constraint {
+            key "model-id";
+
+            description
+              "List of the Bandwidth Constraints sub-TLV instances
+              present in the TLV.";
+
+            leaf model-id {
+              type leafref {
+                path "../state/model-id";
+              }
+              description
+                "Reference to the model ID associated with the
+                instance of the Bandwidth Constraints sub-TLV.";
+            }
+
+            container state {
+              description
+                "State parameters of IS Extended Reachability sub-TLV
+                22.";
+
+              leaf model-id {
+                type uint8;
+                description
+                  "Identifier for the Bandwidth Constraints  Model
+                  currently in use by the LSR initiating the IGP
+                  advertisement.";
+              }
+            }
+
+            container constraints {
+              description
+                "Constraints contained within the Bandwidth
+                Constraints sub-TLV";
+
+              list constraint {
+                key "constraint-id";
+
+                description
+                  "List of the constraints within the Bandwidth
+                  Constraints sub-TLV. The BC0 level is indicated by
+                  the constraint-id leaf being set to 0, with BCN
+                  being indicated by constraint-id N.";
+
+                leaf constraint-id {
+                  type leafref {
+                    path "../state/constraint-id";
+                  }
+                  description
+                    "Reference to the unique ID for the BCN level.";
+                }
+
+                container state {
+                  description
+                    "Operational state parameters of the BCN level";
+
+                  leaf constraint-id {
+                    type uint32;
+                    description
+                      "Unique reference for the bandwidth constraint level. BC0
+                      is indicated by this leaf being set to zero, with BCN
+                      represented by this leaf being set to N.";
+                  }
+
+                  leaf bandwidth {
+                    type oc-types:ieeefloat32;
+                    units "bytes per second";
+                    description
+                      "The bandwidth constraint, expressed as a 32-bit IEEE
+                      floating point number expressed in bytes per second.";
+                  }
+                }
+              }
+            }
+          }
+        }
+
+        container unconstrained-lsp {
+          when "../state/type = " +
+               "'oc-isis-lsdb-types:IS_REACHABILITY_UNCONSTRAINED_LSP'" {
+            description
+              "Only include the unconstrained LSP container when the
+              sub-TLV is type 23.";
+          }
+          description
+            "This container defines sub-TLV 23.";
+          container state {
+            description
+              "State parameters of sub-TLV 23.";
+
+            uses isis-lsdb-subtlv-type-state;
+
+            leaf count {
+              type uint16;
+              description
+                "Unconstrained TE LSP count(TE Label Switched Paths
+                (LSPs) signalled with zero bandwidth).";
+              reference
+                "RFC5330: A Link-Type sub-TLV to Convey the Number of
+                Traffic Engineering Label Switched Paths Signalled
+                with Zero Reserved Bandwidth across a Link. sub-TLV
+                23: TLV 22,23,141,222,223";
+            }
+          }
+        }
+
+        container adjacency-sids {
+          when "../state/type =   'oc-isis-lsdb-types:IS_REACHABILITY_ADJ_SID'" {
+            description
+              "Only include the adjacency SIDs container when the
+              sub-TLV type is 31";
+          }
+
+          description
+            "This container defines segment routing adjacency SIDs.";
+
+          list adjacency-sid {
+            key "value";
+
+            description
+              "Adjacency Segment-IDs List. An IGP-Adjacency Segment is
+              an IGP segment attached to a unidirectional adjacency or
+              a set of unidirectional adjacencies. By default, an IGP-
+              Adjacency Segment is local to the node which advertises
+              it.";
+
+            leaf value {
+              type leafref {
+                path "../state/value";
+              }
+              description
+                "Reference to the value of the Adjacency-SID.";
+            }
+
+            container state {
+              description
+                "State parameters of Adjacency-SID.";
+
+              leaf value {
+                type uint32;
+                description
+                  "Adjacency-SID value.";
+              }
+
+              leaf-list flags {
+                type enumeration {
+                  enum ADDRESS_FAMILY {
+                    description
+                      "Address-family flag. When unset, the Adj-SID
+                      refers to an adjacency with outgoing IPv4
+                      encapsulation. If set then the Adj-SID refers to
+                      an adjacency with outgoing IPv6 encapsulation.";
+                  }
+                  enum BACKUP {
+                    description
+                      "Backup flag. When set, the Adj-SID refers to an
+                      adjacency being protected (e.g.: using IPFRR or
+                      MPLS-FRR).";
+                  }
+                  enum VALUE {
+                    description
+                      "Value flag. When set, the SID carries a value
+                      (instead of an index). By default the flag is
+                      SET.";
+                  }
+                  enum LOCAL {
+                    description
+                      "Local flag. When set, the value/index carried
+                      by the SID has local significance. By default
+                      the flag is SET.";
+                  }
+                  enum SET {
+                    description
+                      "Set flag. When set, the S-Flag indicates that
+                      the Adj-SID refers to a set of adjacencies.";
+                  }
+                }
+                description
+                  "Flags associated with Adj-Segment-ID.";
+              }
+
+              leaf weight {
+                type uint8;
+                description
+                  "Value that represents the weight of the Adj-SID for
+                  the purpose of load balancing.";
+              }
+            }
+          }
+
+          reference
+            "draft-ietf-isis-segment-routing-extensions. sub-TLV 31:
+            TLV 22, 222, 223, 141. ";
+        }
+
+        container lan-adjacency-sids {
+          when "../state/type = " +
+               "'oc-isis-lsdb-types:IS_REACHABILITY_ADJ_LAN_SID'" {
+            description
+              "Only include the LAN adjacency SID container when
+              the sub-TLV is type 32.";
+          }
+          description
+            "This container defines segment routing LAN adjacency
+            SIDs";
+
+          list lan-adjacency-sid {
+            key "value";
+
+            description
+              "Adjacency Segment-IDs List. An IGP-Adjacency Segment is
+              an IGP segment attached to a unidirectional adjacency or
+              a set of unidirectional adjacencies. By default, an IGP-
+              Adjacency Segment is local to the node which advertises
+              it.";
+
+            leaf value {
+              type leafref {
+                path "../state/value";
+              }
+              description
+                "Reference to the value of the LAN Adjacency-SID.";
+            }
+
+            container state {
+              description
+                "State parameters of LAN Adjacency-SID.";
+
+              leaf value {
+                type uint32;
+                description
+                  "LAN Adjacency-SID value.";
+              }
+
+              leaf-list flags {
+                type enumeration {
+                  enum ADDRESS_FAMILY {
+                    description
+                      "Address-family flag. When unset, the Adj-SID
+                      refers to an adjacency with outgoing IPv4
+                      encapsulation. If set then the Adj-SID refers to
+                      an adjacency with outgoing IPv6 encapsulation.";
+                  }
+                  enum BACKUP {
+                    description
+                      "Backup flag. When set, the Adj-SID refers to an
+                      adjacency being protected (e.g.: using IPFRR or
+                      MPLS-FRR).";
+                  }
+                  enum VALUE {
+                    description
+                      "Value flag. When set, the SID carries a value
+                      (instead of an index). By default the flag is
+                      SET.";
+                  }
+                  enum LOCAL {
+                    description
+                      "Local flag. When set, the value/index carried
+                      by the SID has local significance. By default
+                      the flag is SET.";
+                  }
+                  enum SET {
+                    description
+                      "Set flag. When set, the S-Flag indicates that
+                      the Adj-SID refers to a set of adjacencies.";
+                  }
+                }
+                description
+                  "Flags associated with LAN-Adj-Segment-ID.";
+              }
+
+              leaf weight {
+                type uint8;
+                description
+                   "Value that represents the weight of the Adj-SID
+                   for the purpose of load balancing.";
+              }
+
+              leaf neighbor-id {
+                type oc-isis-types:system-id;
+                description
+                  "System ID of the neighbor associated with the LAN-
+                  Adj-Segment-ID value.";
+              }
+            }
+          }
+
+          reference
+            "draft-ietf-isis-segment-routing-extensions. sub-TLV 32:
+            TLV 22, 222, 223, 141.";
+        }
+
+        container link-delay {
+          when "../state/type = " +
+               "'oc-isis-lsdb-types:IS_REACHABILITY_LINK_DELAY'" {
+            description
+              "Include the link delay container only when the sub-TLV
+              type is type 33.";
+          }
+          description
+            "This container defines unidirectional link delay.";
+
+          reference
+            "RFC7810: IS-IS Traffic Engineering (TE) Metric
+            Extensions. sub-TLV 33: TLV 22, 23, 141, 222, 223.";
+
+          container state {
+            description
+              "State parameters of IS Extended Reachability sub-TLV
+              33.";
+
+            uses isis-lsdb-link-characteristics-a-bit;
+
+            leaf delay {
+              type uint32;
+              units microseconds;
+              description
+                "Average link delay value (in microseconds) between
+                two directly connected IS-IS neighbors over a
+                configurable interval.";
+            }
+          }
+        }
+
+        container min-max-link-delay {
+          when "../state/type = " +
+               "'oc-isis-lsdb-types:IS_REACHABILITY_MIN_MAX_LINK_DELAY'" {
+            description
+              "Only include the min/max link delay container when the
+              sub-TLV is type 34.";
+          }
+          description
+            "This container defines min/max link delay.";
+
+          reference
+            "RFC7810: IS-IS Traffic Engineering (TE) Metric
+            Extensions. sub-TLV 34: TLV 22, 23, 141, 222, 223.";
+
+          container state {
+            description
+              "State parameters of IS Extended Reachability sub-TLV
+              34.";
+
+            uses isis-lsdb-link-characteristics-a-bit;
+
+            leaf min-delay {
+              type uint32;
+              units microseconds;
+              description
+                "Minimum measured link delay value(in microseconds)
+                between two directly connected IS-IS neighbors over a
+                configurable interval.";
+            }
+
+            leaf max-delay {
+              type uint32;
+              units microseconds;
+              description
+                "Maximum measured link delay value(in microseconds)
+                between two directly connected IS-IS neighbors over a
+                configurable interval.";
+            }
+          }
+        }
+
+        container link-delay-variation {
+          when "../state/type = " +
+                "'oc-isis-lsdb-types:IS_REACHABILITY_LINK_DELAY_VARIATION'" {
+            description
+              "Only include the link delay variation container when
+              the sub-TLV is type 35.";
+          }
+          description
+            "This container defines unidirectional link delay
+            variation.";
+
+          reference
+            "RFC7810: IS-IS Traffic Engineering (TE) Metric
+            Extensions. sub-TLV 35: TLV 22,23,141,222,223.";
+
+          container state {
+            description
+              "State parameters of IS Extended Reachability sub-TLV
+              35.";
+
+            leaf delay {
+              type uint32;
+              units microseconds;
+              description
+                "Average link delay between two directly connected IS-
+                IS neighbors over a configurable interval.";
+            }
+          }
+        }
+
+        container link-loss {
+          when "../state/type = " +
+               "'oc-isis-lsdb-types:IS_REACHABILITY_LINK_LOSS'" {
+            description
+              "Only include the link loss container when the sub-TLV
+              is type 36.";
+          }
+          description
+            "This container defines unidirectional link loss delay.";
+
+          reference
+            "RFC7810: IS-IS Traffic Engineering (TE) Metric
+            Extensions. sub-TLV 36: TLV 22, 23, 141, 222, 223.";
+
+          container state {
+            description
+              "State parameters of IS Extended Reachability sub-TLV
+              36.";
+
+            uses isis-lsdb-link-characteristics-a-bit;
+
+            leaf link-loss {
+              type uint32;
+              description
+                "Link packet loss as a percentage of the total traffic
+                sent over a configurable interval. The basic unit is
+                0.000003%, where (2^24 - 2) is 50.331642%. This value
+                is the highest packet-loss percentage that can be
+                expressed (the assumption being that precision is more
+                important on high-speed links than the ability to
+                advertise loss rates greater than this, and that high-
+                speed links with over 50% loss are unusable).
+                Therefore, measured values that are larger than the
+                field maximum SHOULD be encoded as the maximum
+                value.";
+            }
+          }
+        }
+
+        container residual-bandwidth {
+          when "../state/type = " +
+               "'oc-isis-lsdb-types:IS_REACHABILITY_RESIDUAL_BANDWIDTH'" {
+            description
+              "Only include the resdiual bandwidth container when the
+              sub-TLV is type 37.";
+          }
+          description
+            "This container defines unidirectional residual
+            bandwidth.";
+
+          reference
+            "RFC7810: IS-IS Traffic Engineering (TE) Metric
+            Extensions. sub-TLV 37: TLV 22, 23, 141, 222, 223.";
+
+          container state {
+            description
+              "State parameters of IS Extended Reachability sub-TLV
+              37.";
+
+            leaf bandwidth {
+              type oc-types:ieeefloat32;
+              units "bytes per second";
+              description
+                "Residual bandwidth on a link,forwarding adjacency
+                [RFC4206], or bundled link in IEEE floating-point
+                format with units of bytes per second. For a link or
+                forwarding adjacency, residual bandwidth is defined to
+                be the Maximum Bandwidth [RFC5305] minus the bandwidth
+                currently allocated to RSVP-TE label switched paths.
+                For a bundled link, residual bandwidth is defined to
+                be the sum of the component link residual
+                bandwidths.";
+            }
+          }
+        }
+
+        container available-bandwidth {
+          when "../state/type = " +
+               "'oc-isis-lsdb-types:IS_REACHABILITY_AVAILABLE_BANDWIDTH'" {
+            description
+              "Only include the available bandwdith container when the
+              sub-TLV is type 38.";
+          }
+          description
+            "This container defines unidirectional lavailable
+            bandwidth.";
+
+          reference
+            "RFC7810: IS-IS Traffic Engineering (TE) Metric
+            Extensions. sub-TLV 38: TLV 22, 23, 141, 222, 223.";
+
+          container state {
+            description
+              "State parameters of IS Extended Reachability sub-TLV
+              38.";
+
+            uses isis-lsdb-subtlv-type-state;
+
+            leaf bandwidth {
+              type oc-types:ieeefloat32;
+              units "bytes per second";
+              description
+                "The available bandwidth on a link, forwarding
+                adjacency, or bundled link in IEEE floating-point
+                format with units of bytes per second. For a link or
+                forwarding adjacency, available bandwidth is defined
+                to be residual bandwidth minus the measured bandwidth
+                used for the actual forwarding of non-RSVP-TE label
+                switched path packets.  For a bundled link, available
+                bandwidth is defined to be the sum of the component
+                link available bandwidths minus the measured bandwidth
+                used for the actual forwarding of non-RSVP-TE label
+                switched path packets.  For a bundled link, available
+                bandwidth is defined to be the sum of the component
+                link available bandwidths.";
+            }
+          }
+        }
+
+        container utilized-bandwidth {
+          when "../state/type = " +
+               "'oc-isis-lsdb-types:IS_REACHABILITY_UTILIZED_BANDWIDTH'" {
+            description
+              "Only include the utilized bandwidth container when the
+              TLV is type 39.";
+          }
+          description
+            "This container defines unidirectional utilized
+            bandwidth.";
+
+          reference
+            "RFC7810: IS-IS Traffic Engineering (TE) Metric
+            Extensions. sub-TLV 39: TLV 22, 23, 141, 222, 223.";
+
+          container state {
+            description
+              "State parameters of IS Extended Reachability sub-TLV
+              39.";
+
+            uses isis-lsdb-subtlv-type-state;
+
+            leaf bandwidth {
+              type oc-types:ieeefloat32;
+              units "bytes per second";
+              description
+                "The bandwidth utilization on a link, forwarding
+                adjacency, or bundled link in IEEE floating-point
+                format with units of bytes per second.  For a link or
+                forwarding adjacency, bandwidth utilization represents
+                the actual utilization of the link (i.e., as measured
+                by the advertising node).  For a bundled link,
+                bandwidth utilization is defined to be the sum of the
+                component link bandwidth utilizations.";
+            }
+          }
+        }
+      }
+    }
+
+    uses isis-lsdb-undefined-subtlv;
+  }
+
+  grouping isis-lsdb-undefined-tlv {
+    description
+      "Grouping for unknown TLVs in the IS-IS LSDB";
+
+    container undefined-tlvs {
+      description
+        "Surrounding container for a list of unknown TLVs.";
+
+      list undefined-tlv {
+        key "type";
+        description
+          "List of TLVs that are not defined within the model, or are
+          not recognised by the system.";
+
+        leaf type {
+          type leafref {
+            path "../state/type";
+          }
+          description
+            "Reference to the undefined TLV's type";
+        }
+
+        container state {
+          description
+            "State parameters of the undefined TLV.";
+
+          uses undefined-tlv-state;
+        }
+      }
+    }
+  }
+
+  grouping isis-lsdb-undefined-subtlv {
+    description
+      "Grouping for unknown Sub-TLVs in the IS-IS LSDB.";
+
+    container undefined-subtlvs {
+      description
+        "This container describes undefined ISIS TLVs.";
+
+      list undefined-subtlv {
+        key "type";
+
+        description
+          "Sub-TLVs that are not defined in the model or not
+          recognised by system.";
+
+        leaf type {
+          type leafref {
+            path "../state/type";
+          }
+          description
+            "Reference to the type of the undefined sub-TLV";
+        }
+
+        container state {
+          description
+            "State parameters of the undefined sub-TLV.";
+
+          uses undefined-subtlv-state;
+        }
+      }
+    }
+  }
+
+  grouping isis-lsdb-prefix-state {
+    description
+      "This grouping defines prefix reachability.";
+
+     container subtlvs {
+      description
+        "This container describes IS prefix sub-TLVs.";
+
+      list subtlv {
+        key "type";
+
+        description
+          "List of subTLV types in the LSDB for the specified TLV.";
+
+        leaf type {
+          type leafref {
+            path "../state/type";
+          }
+          description
+            "Reference to the sub-TLV type";
+        }
+
+        container state {
+          description
+            "State parameters for a prefix.";
+
+          uses isis-lsdb-subtlv-type-state;
+        }
+
+      container tag {
+        when "../state/type = " +
+             "'oc-isis-lsdb-types:IP_REACHABILITY_TAG'" {
+          description
+            "Only include the tag container when the sub-TLV is type
+            1.";
+        }
+        description
+          "This container defines sub-TLV 1.";
+
+        container state {
+          description
+            "State parameters of sub-TLV 1.";
+
+          leaf-list tag32 {
+            type uint32;
+            description
+              "List of 32-bit tags associated with the prefix. Example
+              uses of these tags include carrying BGP standard (or
+              extended) communities and controlling redistribution
+              between levels and areas, different routing protocols,
+              or multiple instances of IS-IS running on the same
+              router.";
+            reference
+              "RFC5130: A Policy Control Mechanism in IS-IS Using
+              Administrative Tags. sub-TLV 1.";
+          }
+        }
+      }
+
+      container tag64 {
+        when "../state/type = " +
+             "'oc-isis-lsdb-types:IP_REACHABILITY_TAG64'" {
+          description
+            "Only include the tag64 container when the sub-TLV is type
+            2.";
+        }
+        description
+          "This container defines sub-TLV 2.";
+
+        container state {
+          description
+            "State parameters of sub-TLV 2.";
+
+          leaf-list tag64 {
+            type uint64;
+            description
+              "List of 64-bit tags associated with the prefix. Example
+              uses of these tags include carrying BGP standard (or
+              extended) communities and controlling redistribution
+              between levels and areas, different routing protocols,
+              or multiple instances of IS-IS running on the same
+              router.";
+            reference
+              "RFC5130: A Policy Control Mechanism in IS-IS Using
+              Administrative Tags. sub-TLV 2.";
+          }
+        }
+      }
+
+      container flags {
+        when "../state/type = " +
+             "'oc-isis-lsdb-types:IP_REACHABILITY_PREFIX_FLAGS'" {
+          description
+            "Only include the flags container when the sub-TLV is type
+            4.";
+        }
+        description
+          "This container defines sub-TLV 4.";
+
+        container state {
+          description
+            "State parameters of sub-TLV 4.";
+
+          uses isis-lsdb-subtlv-type-state;
+
+          leaf-list flags {
+            type enumeration {
+              enum EXTERNAL_FLAG {
+                description
+                  "External prefix flag. Set if the prefix has been
+                  redistributed from another protocol. This includes
+                  the case where multiple virtual routers are
+                  supported and the source of the redistributed prefix
+                  is another IS-IS instance.";
+              }
+              enum READVERTISEMENT_FLAG {
+                description
+                  "Readvertisement flag. Set when the prefix has been
+                  leaked from one level to another (upwards or
+                  downwards).";
+              }
+              enum NODE_FLAG {
+                description
+                  "Node flag. Set when the prefix identifies the
+                  advertising router, i.e., the prefix is a host
+                  prefix advertising  a globally reachable address
+                  typically associated with a loopback address.";
+              }
+            }
+            description
+              "Additional prefix reachability flags.";
+
+            reference
+              "RFC7794: IS-IS Prefix Attributes for Extended IPv4 and
+              IPv6 Reachability. sub-TLV 4.";
+            }
+          }
+        }
+
+        container ipv4-source-router-id {
+          when "../state/type = " +
+               "'oc-isis-lsdb-types:IP_REACHABILITY_IPV4_ROUTER_ID'" {
+            description
+              "Only include the IPv4 Source Router ID container when
+              the sub-TLV is type 11.";
+          }
+          description
+            "This container defines sub-TLV 11.";
+
+          container state {
+            description
+              "State parameters of sub-TLV 11.";
+
+            uses isis-lsdb-subtlv-type-state;
+
+            leaf router-id {
+              type inet:ipv4-address;
+              description
+                "IPv4 Source router ID address. In cases where the
+                advertisement is an identifier for the advertising
+                router (e.g., with the N-flag set in the Prefix
+                Attribute Flags sub-TLV), it may be useful for other
+                routers to know the source of the advertisement. When
+                reachability advertisement is leaked from one level to
+                another, Router ID advertised is always the Router ID
+                of the IS-IS instance that originated the
+                advertisement. This would be true even if the prefix
+                had been learned from another protocol.";
+              reference
+                "RFC7794: IS-IS Prefix Attributes for Extended IPv4
+                and IPv6 Reachability. sub-TLV 11";
+            }
+          }
+        }
+
+        container ipv6-source-router-id {
+          when "../state/type = " +
+               "'oc-isis-lsdb-types:IP_REACHABILITY_IPV6_ROUTER_ID'" {
+            description
+              "Only include the IPv6 Source Router ID container when
+              the sub-TLV is type 12.";
+          }
+          description
+            "This container defines sub-TLV 12.";
+
+          container state {
+            description
+              "State parameters of sub-TLV 12.";
+
+            uses isis-lsdb-subtlv-type-state;
+
+            leaf router-id {
+              type inet:ipv6-address;
+              description
+                "IPv6 Source router ID address. In cases where the
+                advertisement is an identifier for the advertising
+                router (e.g., with the N-flag set in the Prefix
+                Attribute Flags sub-TLV), it may be useful for other
+                routers to know the source of the advertisement. When
+                reachability advertisement is leaked from one level to
+                another, Router ID advertised is always the Router ID
+                of the IS-IS instance that originated the
+                advertisement. This would be true even if the prefix
+                had been learned from another protocol.";
+              reference
+                "RFC7794: IS-IS Prefix Attributes for Extended IPv4
+                and IPv6 Reachability. sub-TLV 12.";
+            }
+          }
+        }
+
+        uses isis-lsdb-prefix-sid-state;
+      }
+    }
+
+    uses isis-lsdb-undefined-subtlv;
+  }
+
+  grouping isis-lsdb-prefix-sid-state {
+    description
+      "This grouping defines ISIS Prefix SID.";
+
+    container prefix-sids {
+      when "../state/type = " +
+           "'oc-isis-lsdb-types:IP_REACHABILITY_PREFIX_SID'" {
+        description
+          "Only include the Prefix SID container when
+          the sub-TLV is type 3.";
+      }
+      description
+        "This container defines segment routing extensions for
+        prefixes.";
+
+      reference
+        "draft-ietf-isis-segment-routing-extensions. sub-TLV 3: TLV
+        135, 235, 236, 237.";
+
+      list prefix-sid {
+        key "value";
+
+        description
+         "Prefix Segment-ID list. IGP-Prefix Segment is an IGP segment
+         attached to an IGP prefix. An IGP-Prefix Segment is global
+         (unless explicitly advertised otherwise) within the SR/IGP
+         domain.";
+
+        leaf value {
+          type leafref {
+            path "../state/value";
+          }
+          description
+            "Reference to the value of the prefix SID.";
+        }
+
+        container state {
+          description
+            "State parameters for Prefix-SID.";
+
+          leaf value {
+            type uint32;
+            description
+              "IGP Prefix-SID value.";
+          }
+
+          leaf-list flags {
+            type enumeration {
+              enum READVERTISEMENT {
+                description
+                  "Readvertisment flag. When set, the prefix to which
+                  this Prefix-SID is attached, has been propagated by
+                  the router either from another level or from
+                  redistribution.";
+              }
+              enum NODE {
+                description
+                  "Node flag. When set, the Prefix-SID refers to the
+                  router identified by the prefix. Typically, the
+                  N-Flag is set on Prefix-SIDs attached to a router
+                  loopback address.";
+              }
+              enum NO_PHP {
+                description
+                  "Penultimate-Hop-Popping flag. When set, then the
+                  penultimate hop MUST NOT pop the Prefix-SID before
+                  delivering the packet to the node that advertised
+                  the Prefix-SID.";
+              }
+              enum EXPLICIT_NULL {
+                description
+                  "Explicit-Null flag. When set, any upstream neighbor
+                  of the Prefix-SID originator MUST replace the
+                  Prefix-SID with a Prefix-SID having an Explicit-NULL
+                  value (0 for IPv4 and 2 for IPv6) before forwarding
+                  the packet.";
+              }
+              enum VALUE {
+                description
+                  "Value flag. When set, the Prefix-SID carries a
+                  value (instead of an index). By default the flag is
+                  UNSET.";
+              }
+              enum LOCAL {
+                description
+                  "Local flag. When set, the value/index carried by
+                  the Prefix-SID has local significance. By default
+                  the flag is UNSET.";
+              }
+            }
+            description
+              "Flags associated with Prefix Segment-ID.";
+          }
+
+          leaf algorithm {
+            type uint8;
+            description
+              "Prefix-SID algorithm to be used for path computation.";
+          }
+        }
+      }
+    }
+  }
+
+  grouping isis-lsdb-common-metric-specification {
+    description
+      "Common definitions of the metric in IS-IS.";
+
+    container default-metric {
+      description
+        "This container defines ISIS Default Metric.";
+
+      container state {
+        description
+          "State parameters for default-metric.";
+
+        leaf flags {
+          type enumeration {
+            enum INTERNAL {
+              description
+                "When set to zero, indicates internal metrics.";
+            }
+          }
+          description
+            "ISIS Default-Metric Flags.";
+        }
+
+        leaf metric {
+          type oc-isis-types:narrow-metric;
+          description
+            "ISIS default metric value. This is a metric understood by
+            every Intermediate system in the domain. Each circuit
+            shall have a positive  integral value assigned for this
+            metric. The value may be associated with any  objective
+            function of the circuit, but by convention is intended to
+            measure the capacity of the circuit for handling traffic,
+            for example, its throughput in  bits-per-second. Higher
+            values indicate a lower capacity.";
+        }
+      }
+    }
+
+    container delay-metric {
+     description
+       "This container defines the ISIS delay metric.";
+
+      container state {
+        description
+          "State parameters of delay-metric.";
+
+        leaf metric {
+          type oc-isis-types:narrow-metric;
+          description
+            "ISIS delay metric value. This metric measures the transit
+            delay of the associated circuit. It is an optional metric,
+            which if assigned to a circuit shall have a positive
+            integral value. Higher values indicate a longer transit
+            delay.";
+        }
+
+        leaf-list flags {
+          type isis-metric-flags;
+          description
+            "ISIS Delay Metric Flags.";
+        }
+      }
+    }
+
+    container expense-metric {
+      description
+        "This container defines the ISIS expense metric.";
+
+      container state {
+        description
+          "State parameters of expense-metric.";
+
+        leaf metric {
+          type oc-isis-types:narrow-metric;
+          description
+            "ISIS expense metric value. This metric measures the
+            monetary cost of utilising the associated circuit. It is
+            an optional metric, which if assigned to a circuit shall
+            have a positive integral value1). Higher values indicate a
+            larger monetary expense.";
+        }
+
+        leaf-list flags {
+          type isis-metric-flags;
+          description
+            "ISIS Expense Metric Flags.";
+        }
+      }
+    }
+
+    container error-metric {
+      description
+        "This container defines the ISIS error metric.";
+
+      container state {
+        description
+          "State parameters of error-metric.";
+
+        leaf metric {
+          type oc-isis-types:narrow-metric;
+          description
+            "ISIS error metric value. This metric measures the
+            residual error probability of the associated circuit. It
+            is an optional metric, which if assigned to a circuit
+            shall have a non-zero value. Higher values indicate a
+            larger probability of undetected errors on the circuit.";
+        }
+
+        leaf-list flags {
+          type isis-metric-flags;
+          description
+            "IS-IS error metric flags.";
+        }
+      }
+    }
+  }
+
+  grouping isis-lsdb-neighbor {
+    description
+      "This grouping defines attributes of an ISIS standard
+      neighbor.";
+
+    container state {
+      description
+        "State parameters of IS standard neighbor.";
+
+      leaf system-id {
+        type oc-isis-types:system-id;
+        description
+          "System-ID of IS neighbor.";
+      }
+    }
+
+    uses isis-lsdb-common-metric-specification;
+
+  }
+
+  grouping ipv4-prefix-attributes-state {
+   description
+     "This group defines attributes of an IPv4 standard prefix.";
+
+    container state {
+     description
+       "State parameters of IPv4 standard prefix.";
+
+      leaf up-down {
+        type boolean;
+        description
+          "The up/down bit. Set if a prefix is advertised from a
+          higher level to a lower level (e.g., level 2 to level 1),
+          indicating that the prefix has traveled down the hierarchy.
+          Prefixes that have the up/down bit set may only be
+          advertised down the hierarchy, i.e., to lower levels. When a
+          prefix is first injected into IS-IS, the bit is UNSET.";
+      }
+
+      leaf prefix {
+        type inet:ipv4-prefix;
+        description
+          "IPv4 prefix contained within reachability TLVs.";
+      }
+    }
+
+    uses isis-lsdb-common-metric-specification;
+  }
+
+  grouping isis-lsdb-common-mt-id {
+    description
+      "Common definition of the multi-topology ID";
+
+    leaf mt-id {
+      type uint16 {
+        range "0..4095";
+      }
+      description
+        "Multi-topology ID";
+    }
+  }
+
+  grouping ipv4-prefix-extended-state {
+    description
+      "This grouping defines attributes of an IPv4 extended prefix.";
+
+    container state {
+      description
+        "State parameters of an IPv4 extended prefix.";
+      uses ipv4-prefix-extended-params-state;
+    }
+
+    uses isis-lsdb-prefix-state;
+  }
+
+  grouping ipv4-mt-prefix-extended-state {
+    description
+      "State parameters that relate to an IPv4 prefix in a
+      multi-topology context.";
+
+    container state {
+      description
+        "State parameters of an IPv4 extended prefix.";
+      uses ipv4-prefix-extended-params-state;
+      uses isis-lsdb-common-mt-id;
+    }
+
+    uses isis-lsdb-prefix-state;
+  }
+
+  grouping ipv4-prefix-extended-params-state {
+    description
+      "State parameters that relate to an IPv4 prefix";
+
+    leaf up-down {
+      type boolean;
+      description
+        "The up/down bit. Set if a prefix is advertised from a
+        higher level to a lower level (e.g., level 2 to level 1),
+        indicating that the prefix has traveled down the hierarchy.
+        Prefixes that have the up/down bit set may only be
+        advertised down the hierarchy, i.e., to lower levels. When a
+        prefix is first injected into IS-IS, the bit is UNSET.";
+    }
+
+    leaf s-bit {
+      type boolean;
+      description
+        "The Sub-TLV present bit. If UNSET, the octets of Sub-TLVs
+        are not present. Otherwise, the bit is set and the octet
+        following the prefix will contain the length of the Sub-TLV
+        portion of the structure.";
+    }
+
+    leaf prefix {
+      type inet:ipv4-prefix;
+      description
+        "IPv4 prefix contained within extended reachability TLVs.";
+    }
+
+    leaf metric {
+      type oc-isis-types:wide-metric;
+      description
+        "ISIS metric value.";
+    }
+  }
+
+  grouping ipv6-prefix-extended-state {
+    description
+      "State parameters relating to an IPv6 prefix.";
+
+    container state {
+      description
+        "State parameters of IPv6 prefix attributes";
+
+      uses ipv6-prefix-extended-params-state;
+    }
+
+    uses isis-lsdb-prefix-state;
+  }
+
+  grouping ipv6-mt-prefix-extended-state {
+    description
+      "State parameters relating to a multi-topology IPv6
+      prefix.";
+
+    container state {
+      description
+        "State parameters relating an IPv6 prefix attribute";
+      uses ipv6-prefix-extended-params-state;
+      uses isis-lsdb-common-mt-id;
+    }
+
+    uses isis-lsdb-prefix-state;
+  }
+
+  grouping ipv6-prefix-extended-params-state {
+    description
+      "Common parameters of an IPv6 extended prefix.";
+
+    leaf up-down {
+      type boolean;
+      description
+        "The up/down bit. Set if a prefix is advertised from a
+        higher level to a lower level (e.g., level 2 to level 1),
+        indicating that the prefix has traveled down the hierarchy.
+        Prefixes that have the up/down bit set may only be
+        advertised down the hierarchy, i.e., to lower levels. When a
+        prefix is first injected into IS-IS, the bit is UNSET.";
+    }
+
+    leaf x-bit {
+      type boolean;
+      description
+        "The external bit. Set when the prefix was distributed into
+        IS-IS from another routing protocol.";
+    }
+
+    leaf s-bit {
+      type boolean;
+      description
+        "The sub-tlv present bit. If UNSET, the octets of Sub-TLVs
+         are not present. Otherwise, the bit is set and the octet
+         following the prefix will contain the length of the Sub-TLV
+         portion of the structure.";
+    }
+
+    leaf prefix {
+      type inet:ipv6-prefix;
+      description
+        "IPv6 prefix contained within extended reachability TLVs.";
+    }
+
+    leaf metric {
+      type oc-isis-types:wide-metric;
+      description
+        "ISIS metric value.";
+    }
+  }
+
+  grouping isis-lsdb-common-extisreach-neighbors {
+    description
+      "Common structure for the Extended IS Reachability and IS
+      Reachability Neighbour attributes.";
+
+    container neighbors {
+      description
+        "This container describes IS neighbors.";
+
+      list neighbor {
+        key "system-id";
+        description
+          "This list describes ISIS extended neighbors and
+          reachability attributes.";
+
+        leaf system-id {
+          type leafref {
+            path "../state/system-id";
+          }
+          description
+            "Reference to the neighboring system's system ID.";
+        }
+
+        container state {
+          description
+            "State parameters corresponding to the extended
+            neighbour.";
+
+          leaf system-id {
+            type oc-isis-types:system-id;
+            description
+              "System-id of the neighbor.";
+          }
+        }
+
+        container instances {
+          description
+            "This list contains all instances of an adjacency
+            between the originating IS and the remote IS.
+            Multiple instances are used where there are
+            parallel adjacencies between two systems.";
+
+          list instance {
+            key "id";
+
+            description
+              "Instance of the TLV to the remote IS neighbor.";
+
+            leaf id {
+              type leafref {
+                path "../state/id";
+              }
+              description
+                "Reference to the unique identifier for
+                the instance of the extended IS
+                reachability sub-TLV.";
+            }
+
+            container state {
+              description
+                "State parameters of extended neighbor";
+
+              leaf id {
+                type uint64;
+                description
+                  "Unique identifier for the instance of the
+                  TLV for the IS neighbor. The instance
+                  ID is not required to be consistent across
+                  across readvertisements of the LSP.";
+              }
+
+              leaf metric {
+                type oc-isis-types:wide-metric;
+                description
+                  "Metric value.";
+              }
+            }
+            uses is-reachability-neighbor-state;
+          }
+        }
+      }
+    }
+  }
+
+  grouping isis-lsdb-mtis-common {
+    description
+      "Common grouping for structure used within the multi-topology IS
+      neighbour and multi-topology IS neighbour attribute TLVs.";
+
+    container neighbors {
+      description
+        "MT-IS neigbor attributes.";
+
+      list neighbor {
+        key "mt-id system-id";
+        description
+          "This container describes IS neighbors.";
+
+        leaf mt-id {
+          type leafref {
+            path "../state/mt-id";
+          }
+          description
+          "Reference to the topology that the neighbor is
+          within.";
+        }
+
+        leaf system-id {
+          type leafref {
+            path "../state/system-id";
+          }
+          description
+            "Reference to the System ID of the neighbor.";
+        }
+
+        container state {
+          description
+            "Operational state parameters related to the
+            MT ISN TLV.";
+
+          uses mt-isis-neighbor-state;
+        }
+
+        container instances {
+          description
+            "This list contains all instances of an adjacency
+            between the originating and remote IS. Multiple
+            instances are used to indicate where there are
+            parallel adjacencies between systems.";
+
+          list instance {
+            key "id";
+
+            description
+              "Instance of TLV-222 between the originating
+              and remote IS.";
+
+            leaf id {
+              type leafref {
+                path "../state/id";
+              }
+              description
+                "Reference to the unique identifier for the
+                instance of the multi-topology IS neighbor
+                TLV instance.";
+            }
+
+            uses mt-isis-neighbor-instance;
+          }
+        }
+      }
+    }
+  }
+
+  grouping mt-isis-neighbor-state {
+    description
+      "This grouping defines state parameters that are related to
+      each neighbour entry for the MT ISN TLV.";
+
+    leaf mt-id {
+      type uint16 {
+        range "0..4095";
+      }
+      description
+        "Identifier of a topology being announced.";
+    }
+
+    leaf system-id {
+      type oc-isis-types:system-id;
+      description
+        "System-id of the IS neighbor.";
+    }
+  }
+
+  grouping mt-isis-neighbor-instance {
+    description
+      "This grouping defines list of ISIS multi-topology neighbors for
+      extended ISIS LSP (multiple system IDs).";
+
+     container state {
+      description
+        "State parameters of MT neighbor.";
+
+      leaf metric {
+        type oc-isis-types:wide-metric;
+        description
+          "ISIS metric value.";
+      }
+
+      leaf id {
+        type uint64;
+        description
+          "Unique identifier for the TLV instance for the
+          neighbor. The ID is not required to be consistent
+          across readvertisements of the LSP.";
+      }
+    }
+    uses is-reachability-neighbor-state;
+  }
+
+  grouping isis-lsdb-generic-tlv {
+    description
+      "Generic TLV encoding grouping.";
+
+    leaf type {
+      type uint8;
+      description
+        "TLV Type.";
+    }
+
+    leaf length {
+      type uint8;
+      description
+        "TLV length.";
+    }
+
+    leaf value {
+      type binary;
+      description
+        "TLV value.";
+    }
+  }
+
+  grouping undefined-tlv-state {
+    description
+      "Generic grouping defining an unknown TLV.";
+
+    uses isis-lsdb-generic-tlv;
+  }
+
+  grouping undefined-subtlv-state {
+    description
+      "Generic grouping defining an unknown sub-TLV.";
+
+    uses isis-lsdb-generic-tlv;
+  }
+
+  grouping lsp-state {
+    description
+      "This grouping defines ISIS LSP state information.";
+
+    leaf lsp-id {
+     type leafref {
+        path "../state/lsp-id";
+      }
+
+      description
+        "A reference to the Link State PDU ID.";
+    }
+
+    container state {
+      description
+        "State parameters of Link State PDU.";
+
+      leaf lsp-id {
+        type oc-isis-types:lsp-id;
+        description
+          "LSP ID of the LSP.";
+      }
+
+      leaf maximum-area-addresses {
+        type uint8;
+        description
+          "Number of area addresses permitted for this ISs area. 0
+          indicates the IS only supports three area addresses (by
+          default). Any number inclusive of 1 and 254 indicates the
+          number of areas allowed.";
+      }
+
+      leaf version {
+        type uint8;
+        default 1;
+        description
+          "PDU version. This is set to 1.";
+      }
+
+      leaf version2 {
+        type uint8;
+        default 1;
+        description
+          "PDU version2. This is set to 1";
+      }
+
+      leaf id-length {
+        type uint8;
+        description
+          "Length of the ID field of NSAP addresses and NETs used in
+          this routing domain.";
+      }
+
+      leaf pdu-type {
+        type enumeration {
+          enum LEVEL_1 {
+            description "This enum describes ISIS level 1 PDU.";
+          }
+          enum LEVEL_2 {
+            description "This enum describes ISIS level 2 PDU.";
+          }
+        }
+         description
+           "Link State PDU type.";
+      }
+
+      leaf remaining-lifetime {
+         type uint16;
+         units "seconds";
+         description
+           "Remaining lifetime in seconds before the LSP expiration.";
+      }
+
+      leaf sequence-number {
+         type uint32;
+         description
+           "Sequence number of the LSP.";
+      }
+
+      leaf checksum {
+         type uint16;
+         description
+           "Checksum of the LSP.";
+      }
+
+      leaf pdu-length {
+         type uint16;
+         description
+           "Total length of the LSP.";
+      }
+
+      leaf-list flags {
+        type enumeration {
+          enum PARTITION_REPAIR {
+            description
+              "When set, the originator supports partition
+              repair.";
+          }
+          enum ATTACHED_ERROR {
+            description
+              "When set, the originator is attached to another
+              area using the referred metric.";
+          }
+          enum ATTACHED_EXPENSE {
+            description
+              "When set, the originator is attached to another
+              area using the referred metric.";
+          }
+          enum ATTACHED_DELAY {
+            description
+              "When set, the originator is attached to another
+              area using the referred metric.";
+          }
+          enum ATTACHED_DEFAULT {
+            description
+              "When set, the originator is attached to another
+              area using the referred metric.";
+          }
+          enum OVERLOAD {
+            description
+              "When set, the originator is overloaded, and must
+              be avoided in path calculation.";
+          }
+        }
+        description
+          "LSP Type-Block flags.";
+      }
+
+      leaf is-type {
+        type oc-isis-types:level-number;
+        description
+          "Type of neighboring system.";
+      }
+    }
+
+    container tlvs {
+      description
+        "This container defines Link State PDU State TLVs.";
+
+      list tlv {
+        key "type";
+
+        description
+          "List of TLV types in the LSDB for the specified LSP.";
+
+        leaf type {
+          type leafref {
+            path "../state/type";
+          }
+          description
+            "Reference to the TLV's type.";
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state parameters relating to the specified
+            LSP";
+
+          uses isis-lsdb-tlv-type-state;
+        }
+
+        container area-address {
+          when "../state/type = 'oc-isis-lsdb-types:AREA_ADDRESSES'" {
+            description
+              "Include area address parameters only when the TLV type
+              is TLV 1.";
+          }
+
+          description
+            "This container defines TLV 1.";
+
+          container state {
+            description
+              "State parameters of ISIS TLV 1.";
+
+            leaf-list address {
+              type oc-isis-types:area-address;
+              description
+                "Area adress(es) of the IS. Set of manual area
+                addresses of this IS.";
+             reference
+              "ISO 10589 Intermediate System to Intermediate System
+              Intra- Domain Routeing Exchange Protocol for use in
+              Conjunction with the Protocol for Providing the
+              Connectionless-mode Network Service (ISO 8473 )
+              International Standard 10589: 2002, Second Edition,
+              2002. TLV 1.";
+            }
+          }
+        }
+
+        container lsp-buffer-size {
+          when "../state/type = " +
+               "'oc-isis-lsdb-types:LSP_BUFFER_SIZE'" {
+            description
+              "Include the LSP buffer size parameters only when the
+              TLV type is TLV 14.";
+          }
+
+          description
+            "This container defines TLV 14 - the LSP Buffer Size
+            TLV.";
+
+          container state {
+            description
+              "State parameters of TLV 14.";
+
+            leaf size {
+              type uint16;
+              units "bytes";
+              description
+                "The maximum MTU that the advertising system can
+                receive, expressed in bytes.";
+              reference
+               "ISO 10589 Intermediate System to Intermediate System
+               Intra- Domain Routeing Exchange Protocol for use in
+               Conjunction with the Protocol for Providing the
+               Connectionless-mode Network Service (ISO 8473 )
+               International Standard 10589: 2002, Second Edition,
+               2002. TLV 14.";
+            }
+          }
+        }
+
+        container nlpid {
+          when "../state/type = 'oc-isis-lsdb-types:NLPID'" {
+            description
+              "Include NLPID specification only when the TLV type is
+              TLV 129.";
+          }
+
+          description
+            "This container defines TLV 129.";
+
+          container state {
+           description
+             "State parameters of ISIS TLV 129.";
+
+            uses isis-lsdb-tlv-nlpid-state;
+          }
+        }
+
+        container hostname {
+          when "../state/type = 'oc-isis-lsdb-types:DYNAMIC_NAME'" {
+            description
+              "Include the dynamic hostname TLV only when the TLV is
+              type 137.";
+          }
+          description
+            "This container defines TLV 137.";
+
+          container state {
+            description
+              "State parameters of ISIS TLV 137.";
+
+            leaf-list hostname {
+              type string;
+              description
+                "Name of the node.";
+
+              reference
+                "RFC6233: IS-IS Registry Extension for Purges, RFC
+                5301: Dynamic Hostname Exchange Mechanism for IS-IS.
+                TLV 137";
+           }
+         }
+        }
+
+        container ipv4-interface-addresses {
+          when "../state/type = " +
+               "'oc-isis-lsdb-types:IPV4_INTERFACE_ADDRESSES'" {
+            description
+              "Include the IPv4 interface addresses TLV only when the
+              TLV is type 132.";
+          }
+          description
+            "This container defines TLV 132.";
+
+          container state {
+            description
+              "State parameters of ISIS TLV 132.";
+
+            leaf-list address {
+              type inet:ipv4-address;
+              description
+                "IPv4 address(es) of the interface corresponding to
+                the SNPA over which this PDU is to be transmitted.";
+             reference
+              "RFC1195: Use of OSI IS-IS for Routing in TCP/IP and
+              Dual Environments. TLV 132.";
+            }
+          }
+        }
+
+        container ipv6-interface-addresses {
+          when "../state/type = " +
+                "'oc-isis-lsdb-types:IPV6_INTERFACE_ADDRESSES'" {
+            description
+              "Include the IPv6 interface addresses TLV only when the
+              TLV is type 232.";
+          }
+          description
+            "This container defines TLV 232.";
+
+          container state {
+            description
+              "State parameters of ISIS TLV 232.";
+
+            leaf-list address {
+              type inet:ipv6-address;
+              description
+                "IPv6 interface addresses of the node.  MUST contain
+                only the non-link-local IPv6 addresses assigned to the
+                IS.";
+              reference
+                "RFC5308: Routing IPv6 with IS-IS. TLV 232.";
+            }
+          }
+        }
+
+        container ipv4-te-router-id {
+          when "../state/type = " +
+               "'oc-isis-lsdb-types:IPV4_TE_ROUTER_ID'" {
+            description
+              "Include the IPv4 traffic engineering router ID TLV only
+              when the TLV is type 134.";
+          }
+          description
+            "This container defines TLV 134.";
+
+          container state {
+            description
+              "State parameters of ISIS TLV 134.";
+
+            leaf-list router-id {
+              type inet:ipv4-address;
+              description
+                "IPv4 Traffic Engineering router ID of the node. For
+                traffic engineering, it guarantees that we have a
+                single stable address that can always be referenced in
+                a path that will be reachable from multiple hops away,
+                regardless of the state of the node's interfaces.";
+             reference
+              "RFC5305: IS-IS Extensions for Traffic Engineering. TLV
+              134.";
+            }
+          }
+        }
+
+        container ipv6-te-router-id {
+          when "../state/type = " +
+               "'oc-isis-lsdb-types:IPV6_TE_ROUTER_ID'" {
+            description
+              "Include the IPv6 traffic engineering router ID TLV only
+              when the TLV is type 140.";
+          }
+          description
+            "This container defines TLV 140.";
+
+          container state {
+            description
+              "State parameters of ISIS TLV 140.";
+
+            leaf-list router-id {
+              type inet:ipv6-address;
+              description
+                "IPv6 Traffic Engineering router ID of the node. For
+                traffic engineering, it guarantees that we have a
+                single stable address that can always be referenced in
+                a path that will be reachable from multiple hops away,
+                regardless of the state of the node's interfaces.";
+              reference
+                "RFC6119: IPv6 Traffic Engineering in IS-IS. TLV
+                140.";
+            }
+          }
+        }
+
+        container instance-ids {
+          when "../state/type = 'oc-isis-lsdb-types:INSTANCE_ID'" {
+            description
+              "Include the ISIS Instance Identifier TLV only when the
+              TLV is type 7.";
+          }
+          description
+            "This container defines ISIS Instance Identifier TLV.";
+          reference "RFC6822: IS-IS Multi-Instance. TLV 7.";
+
+          list instance-id {
+            key "instance-id";
+
+            description
+              "A list of instance IDs received within TLV 7 within an
+              IS-IS LSP. In the case that more than one instance of
+              TLV 7 is included in the LSP, the instance IDs specified
+              within the instances are concatenated within this
+              list.";
+
+            leaf instance-id {
+              type leafref {
+                path "../state/instance-id";
+              }
+              description
+                "Reference to the unique instance ID.";
+            }
+            container state {
+              description
+                "State parameters of ISIS TLV 7.";
+
+              leaf instance-id {
+                type uint16;
+                description
+                  "An Instance Identifier (IID) to uniquely identify
+                  an IS-IS instance. When the IID = 0, the list of
+                  supported ITIDs MUST NOT be present. An IID-TLV with
+                  IID = 0 MUST NOT appear in an SNP or LSP. When the
+                  TLV appears (with a non-zero IID) in an SNP or LSP,
+                  exactly one ITID. MUST be present indicating the
+                  topology with which the PDU is associated. If no
+                  ITIDs or multiple ITIDs are present or the IID is
+                  zero, then the PDU MUST be ignored.";
+              }
+
+              leaf-list topology-id {
+                type uint16;
+                description
+                  "Instance-Specific Topology Identifiers (ITIDs).";
+              }
+            }
+          }
+        }
+
+        container ipv4-srlgs {
+          when "../state/type = 'oc-isis-lsdb-types:IPV4_SRLG'" {
+            description
+              "Include the IPv4 SRLG TLV only when the TLV is type
+              138.";
+          }
+         description
+           "This container defines ISIS SRLG TLV 138.";
+
+         reference
+            "RFC5307: IS-IS Extensions in Support of Generalized
+            Multi-Protocol Label Switching (GMPLS). TLV 138.";
+
+          list ipv4-srlg {
+            key "instance-number";
+
+            description
+              "Instance of the IPv4 SRLG TLV";
+
+            leaf instance-number {
+              type leafref {
+                path "../state/instance-number";
+              }
+              description
+                "Reference to the instance number of TLV 138.";
+            }
+
+            container state {
+              description
+                "State parameters of TLV 138.";
+
+              leaf instance-number {
+                type uint32;
+                description
+                  "An arbitrary unsigned 32-bit integer used to
+                  disambiguate the instance of TLV 138. The instance
+                  identifier is synthesised by the system
+                  and may be renumbered for the same SRLG definition
+                  in subsequent advertised LSPs if (and only if) the
+                  entire list of SRLGs is replaced.";
+              }
+
+              leaf system-id {
+                type oc-isis-types:system-id;
+                description
+                  "Neighbor system ID.";
+              }
+
+              leaf psn-number {
+                type uint8;
+                description
+                  "Pseudonode number if the neighbor is on a LAN
+                  interface.";
+              }
+
+              leaf-list flags {
+                type enumeration {
+                  enum NUMBERED {
+                    description
+                      "When set, the interface is numbered, whereas if
+                      unset indicates that the interface is
+                      unnumbered.";
+                  }
+                }
+                description
+                  "SRLG flags.";
+              }
+
+              leaf ipv4-interface-address {
+                type inet:ipv4-address;
+                description
+                  "IPv4 interface address.";
+              }
+
+              leaf ipv4-neighbor-address {
+                type inet:ipv4-address;
+                description
+                  "IPv4 neighbor address.";
+              }
+
+              leaf-list srlg-value {
+                type uint32;
+                description
+                  "List of SRLG values.";
+              }
+            }
+          }
+        }
+
+        container ipv6-srlgs {
+          when "../state/type = 'oc-isis-lsdb-types:IPV6_SRLG'" {
+            description
+              "Include the IPv6 SRLG TLV only when the TLV is type
+              139.";
+          }
+          description
+            "This container defines ISIS SRLG TLV.";
+
+          reference
+            "RFC6119: IPv6 Traffic Engineering in IS-IS. TLV 139.";
+
+          list ipv6-srlg {
+            key "instance-number";
+
+            description
+              "Instance of the IPv6 SRLG TLV.";
+
+            leaf instance-number {
+              type leafref {
+                path "../state/instance-number";
+              }
+              description
+                "Reference to the instance number of the IPv6 Shared
+                Risk Link Group (SRLG) TLV.";
+            }
+
+            container state {
+              description
+                "State parameters of TLV 139.";
+
+              leaf instance-number {
+                type uint32;
+                description
+                  "An arbitrary unsigned 32-bit integer used to
+                  disambiguate the instance of TLV 138. The instance
+                  identifier is synthesised by the system
+                  and may be renumbered for the same SRLG definition
+                  in subsequent advertised LSPs if (and only if) the
+                  entire list of SRLGs is replaced.";
+              }
+
+              leaf system-id {
+                type oc-isis-types:system-id;
+                description
+                  "Neighbor system ID.";
+              }
+
+              leaf psn-number {
+                type uint8;
+                description
+                  "Pseudonode number if the neighbor is on a LAN
+                  interface.";
+              }
+
+              leaf-list flags {
+                type enumeration {
+                  enum NA {
+                    description
+                      "When set, the IPv6 neighbour address is
+                      included, whereas if unset, it is omitted";
+                  }
+                }
+                description
+                  "IPv6 SRLG flags.";
+              }
+
+              leaf ipv6-interface-address {
+                type inet:ipv6-address;
+                description
+                  "IPv6 interface address or Link Local Identifier.";
+              }
+
+              leaf ipv6-neighbor-address {
+                type inet:ipv6-address;
+                description
+                  "IPv6 neighbor address or Link Remote Identifier.";
+              }
+
+              leaf-list srlg-value {
+                type uint32;
+                description
+                  "SRLG values.";
+              }
+            }
+          }
+        }
+
+        container purge-oi {
+          when "../state/type = 'oc-isis-lsdb-types:PURGE_OI'" {
+            description
+              "Only include the purge originator identitication TLV
+              when the TLV type is 13.";
+          }
+          description
+            "This container defines ISIS purge TLV.";
+
+          reference
+            "RFC6232: Purge Originator Identification TLV for IS-IS.
+            TLV 13.";
+
+          container state {
+            description
+              "State parameters of TLV 13.";
+
+            leaf system-id-count {
+              type uint8;
+              description
+                "Number of system IDs carried in this TLV.";
+            }
+
+            leaf source-system-id {
+              type oc-isis-types:system-id;
+              description
+                "System ID of the Intermediate System that inserted
+                this TLV.";
+            }
+
+            leaf received-system-id {
+              type oc-isis-types:system-id;
+              description
+                "System ID of the Intermediate System from which the
+                purge was received.";
+            }
+          }
+        }
+
+        container router-capabilities {
+          when "../state/type = " +
+               "'oc-isis-lsdb-types:ROUTER_CAPABILITY'" {
+            description
+              "Only include the router capability TLV when the TLV is
+              type 242.";
+          }
+          description
+            "This container defines router capabilities.";
+
+          list capability {
+            key "instance-number";
+
+            description
+              "This list describes IS Router capabilities.";
+
+            reference
+              "RFC4971: Intermediate System to Intermediate System
+              (IS-IS) Extensions for Advertising Router Information.
+              TLV 242.";
+
+            leaf instance-number {
+              type leafref {
+                path "../state/instance-number";
+              }
+              description
+                "Reference to the instance number of the router
+                capability TLV.";
+            }
+
+            container state {
+              description
+                "State parameters of TLV 242.";
+
+              leaf instance-number {
+                type uint32;
+                description
+                  "A unique instance number for the instance of the
+                  router capabilities TLV. The instance number should
+                  be autogenerated by the producer of the data and may
+                  be renumbered if the entire LSP contents are
+                  replaced in subsequent advertisements.";
+              }
+
+              leaf router-id {
+                type inet:ipv4-address;
+                description
+                  "IPv4 router-id.";
+              }
+
+              leaf-list flags {
+                type enumeration {
+                  enum FLOOD {
+                    description
+                      "When the S bit is set(1), the IS - IS Router
+                      CAPABILITY TLV MUST be flooded across the entire
+                      routing domain. When the S bit is not set(0),
+                      the TLV MUST NOT be leaked between levels . This
+                      bit MUST NOT be altered during the TLV
+                      leaking.";
+                  }
+                  enum DOWN {
+                    description
+                      "When the IS-IS Router CAPABILITY TLV is leaked
+                      from level - 2 to level-1, the Down bit MUST be
+                      set. Otherwise, this bit MUST be clear. IS - IS
+                      Router capability TLVs with the Down bit set
+                      MUST NOT be leaked from level - 1 to level-2.
+                      This is to prevent TLV looping.";
+                  }
+                }
+                description
+                  "Router capability flags.";
+              }
+            }
+
+            container subtlvs {
+              description
+                "This container describes router capability TLV
+                sub-TLVs";
+
+              list subtlv {
+                key "type";
+                description
+                  "List of subTLV types in the LSDB for the specified
+                  TLV";
+
+                leaf type {
+                  type leafref {
+                    path "../state/type";
+                  }
+                  description
+                    "Reference to the sub-TLV type";
+                }
+
+                container state {
+                  description
+                    "State parameters of IS Router Capabilities";
+
+                  uses isis-lsdb-subtlv-type-state;
+                 }
+
+                container segment-routing-algorithms {
+                  when "../state/type = " +
+                       "'oc-isis-lsdb-types:ROUTER_CAPABILITY_SR_ALGORITHM'" {
+                    description
+                      "Only include segment routing algorithm when the
+                      sub-TLV is type 19.";
+                  }
+                  description
+                    "This container defines SR algorithm sub-TLV 19.";
+
+                  reference
+                    "draft-ietf-isis-segment-routing-extensions.
+                     TLV 242, sub-TLV 19";
+
+                    container state {
+                      description
+                        "State parameters of sub-TLV 19 - Segment
+                        Routing Algorithm.";
+
+                      leaf-list algorithm {
+                        type enumeration {
+                          enum SPF {
+                            value 0;
+                            description
+                              "Shortest Path First (SPF) algorithm
+                              based on link metric.  This is the
+                              well-known shortest path algorithm as
+                              computed by the IS-IS Decision process.
+                              Consistent with the deployed practice
+                              for link-state protocols, algorithm 0
+                              permits any node to overwrite the SPF
+                              path with a different path based on
+                              local policy.";
+                          }
+                          enum STRICT_SPF {
+                            value 1;
+                            description
+                              "Strict Shortest Path First (SPF)
+                              algorithm based on link metric. The
+                              algorithm is identical to algorithm 0
+                              but algorithm 1 requires that all nodes
+                              along the path will honor the SPF
+                              routing decision. Local policy MUST NOT
+                              alter the forwarding decision computed
+                              by algorithm 1 at the node claiming to
+                              support algorithm 1.";
+                          }
+                        }
+                        description
+                          "The Segment Routing algorithm that is
+                          described by the TLV.";
+                      }
+                    }
+                }
+
+                container segment-routing-capability {
+                  when "../state/type = " +
+                       "'oc-isis-lsdb-types:ROUTER_CAPABILITY_SR_CAPABILITY'" {
+                    description
+                      "Only include the SR capability sub-TLV when
+                      the sub-TLV type is 2.";
+                  }
+                  description
+                    "This container defines SR Capability sub-TLV 2.";
+
+                  reference
+                    "draft-ietf-isis-segment-routing-extensions. TLV
+                    242, sub-TLV 2.";
+
+                  container state {
+                    description
+                      "State parameters of IS SR Router Capability";
+
+                    leaf-list flags {
+                      type enumeration {
+                        enum IPV4_MPLS {
+                          description
+                            "When set, the router is capable of
+                            processing SR MPLS encapsulated IPv4
+                            packets on all interfaces.";
+                        }
+                        enum IPV6_MPLS {
+                          description
+                            "When set, the router is capable of
+                            processing SR MPLS encapsulated IPv6
+                            packets on all interfaces.";
+                        }
+                        enum IPV6_SR {
+                          description
+                            "When set, the router is capable of
+                            processing the IPv6 Segment Routing Header
+                            on all interfaces.";
+                        }
+                      }
+                      description
+                        "Segment Routing Capability Flags.";
+                    }
+                  }
+
+                  container srgb-descriptors {
+                    description
+                      "SRGB Descriptors included within the SR
+                      capability sub-TLV";
+
+                    list srgb-descriptor {
+                      key "range";
+                      description
+                        "Descriptor entry within the SR capabilty
+                        sub-TLV";
+
+                      leaf range {
+                        type leafref {
+                          path "../state/range";
+                        }
+                        description
+                          "Reference to unique SRGB Descriptor.";
+                      }
+
+                      container state {
+                        description
+                          "State parameters of the SR range";
+
+                        leaf range {
+                          type uint32;
+                          description
+                            "Number of SRGB elements. The range
+                            value MUST be greater than 0.";
+                        }
+
+                        leaf label {
+                          type oc-mplst:mpls-label;
+                          description
+                            "The first value of the SRGB when
+                            expressed as an MPLS label.";
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            uses isis-lsdb-undefined-subtlv;
+          }
+        }
+
+        container is-reachability {
+          when "../state/type = 'oc-isis-lsdb-types:IIS_NEIGHBORS'" {
+            description
+              "Include IIS_NEIGHBORS sub-TLV when the TLV type is 2.";
+          }
+          description
+            "This container describes list of ISIS neighbors and
+            attributes.";
+
+           reference
+             "ISO 10589, Intermediate System to Intermediate System
+             Intra- Domain Routeing Exchange Protocol for use in
+             Conjunction with the Protocol for Providing the
+             Connectionless-mode Network Service (ISO 8473),
+             International Standard 10589: 2002, Second Edition,
+             2002. TLV 2.";
+
+          container neighbors {
+            description
+              "This container describes IS neighbors.";
+
+            list neighbor {
+              key "system-id";
+              description
+                "IS reachability neighbor attributes.";
+
+              leaf system-id {
+                type leafref {
+                  path "../state/system-id";
+                }
+                description
+                  "Reference to the system ID of the neighbor.";
+              }
+
+              uses isis-lsdb-neighbor;
+            }
+          }
+        }
+
+        container ipv4-internal-reachability {
+          when "../state/type = " +
+               "'oc-isis-lsdb-types:IPV4_INTERNAL_REACHABILITY'" {
+            description
+              "Include IPv4 internal reachability TLV when the TLV
+              type is specified as 128.";
+          }
+          description
+            "This container defines list of IPv4 internal reachability
+            information.";
+
+          reference
+            "RFC1195: OSI ISIS for IP and Dual Environments. RFC5302:
+            Domain-Wide Prefix Distribution with Two-Level IS-IS. TLV
+            128";
+
+          container prefixes {
+            description
+              "This container describes IS prefixes.";
+
+            list prefix {
+              key "prefix";
+
+              description
+                "IPv4 prefixes and internal reachability attributes.";
+
+              leaf prefix {
+                type leafref {
+                  path "../state/prefix";
+                }
+                description
+                  "Reference to the IPv4 prefix";
+              }
+
+              uses ipv4-prefix-attributes-state;
+            }
+          }
+        }
+
+        container ipv4-external-reachability {
+          when "../state/type = " +
+               "'oc-isis-lsdb-types:IPV4_EXTERNAL_REACHABILITY'" {
+            description
+              "Include IPv4 external reachability when the TLV type
+              is set to 130.";
+          }
+          description
+           "This container defines list of IPv4 external reachability
+            information.";
+
+          reference
+            "RFC1195: OSI ISIS for IP and Dual Environments.  RFC5302:
+            Domain-Wide Prefix Distribution with Two-Level IS-IS. TLV
+            130";
+
+          container prefixes {
+            description
+              "This container describes IS neighbors.";
+
+            list prefix {
+              key "prefix";
+
+              description
+                "IPv4 external prefixes and reachability attributes.";
+
+              leaf prefix {
+                type leafref {
+                  path "../state/prefix";
+                }
+                description
+                  "Reference to the IPv4 prefix.";
+              }
+
+              uses ipv4-prefix-attributes-state;
+            }
+          }
+        }
+
+        container authentication {
+          when "../state/type = 'oc-isis-lsdb-types:AUTHENTICATION'" {
+            description
+              "Only include the authentication TLV when the TLV is
+              type 10.";
+          }
+          description
+            "This container defines authentication information of the
+            node.";
+
+          reference
+            "ISO 10589 Intermediate System to Intermediate System
+            Intra- Domain Routeing Exchange Protocol for use in
+            Conjunction with the Protocol for Providing the
+            Connectionless-mode Network Service (ISO 8473)
+            International Standard 10589: 2002, Second Edition, 2002.
+            TLV 10.";
+
+          container state {
+            description
+              "State parameters of TLV 10.";
+
+            leaf crypto-type {
+              type enumeration {
+                enum HMAC_MD5 {
+                  description
+                    "HMAC-MD5 Authentication type.";
+                }
+                enum CLEARTEXT {
+                  description
+                    "Cleartext Authentication type.";
+                }
+               }
+               description
+                 "Authentication type to be used.";
+            }
+
+            leaf authentication-key {
+              type string;
+              description
+                "Authentication key to be used.";
+            }
+          }
+        }
+
+        container extended-is-reachability {
+          when "../state/type = " +
+               "'oc-isis-lsdb-types:EXTENDED_IS_REACHABILITY'" {
+            description
+              "Only included the extended IS reachability TLV when the
+              TLV is type 22.";
+          }
+
+          description
+            "This container defines list of ISIS extended reachability
+            neighbors.";
+
+          reference
+            "RFC5305: IS-IS Extensions for Traffic Engineering. TLV
+            22.";
+
+          uses isis-lsdb-common-extisreach-neighbors;
+        }
+
+        container extended-ipv4-reachability {
+          when "../state/type = " +
+               "'oc-isis-lsdb-types:EXTENDED_IPV4_REACHABILITY'" {
+            description
+              "Only include the extended IPv4 reachability container
+              when the TLV type is 135.";
+          }
+          description
+            "This container defines list of IPv4 extended reachability
+            information.";
+
+          reference
+            "RFC5305: IS-IS Extensions for Traffic Engineering. TLV
+            135";
+
+          container prefixes {
+            description
+              "This container describes IS prefixes.";
+
+            list prefix {
+              key "prefix";
+
+              description
+                "This list describes IPv4 extended prefixes and
+                attributes.";
+
+              leaf prefix {
+                type leafref {
+                  path "../state/prefix";
+                }
+                description
+                  "Reference to the IPv4 prefix that the TLV describes
+                  the attributes of.";
+              }
+
+              uses ipv4-prefix-extended-state;
+            }
+          }
+        }
+
+        container ipv6-reachability {
+          when "../state/type = " +
+               "'oc-isis-lsdb-types:IPV6_REACHABILITY'" {
+            description
+              "Only include the IPv6 reachability container when the
+              TLV type is 236.";
+          }
+          description
+            "This container defines list of IPv6 reachability
+            information.";
+
+          reference
+            "RFC5308: Routing IPv6 with IS-IS. TLV 236";
+
+          container prefixes {
+            description
+              "This container describes IS prefixes.";
+
+            list prefix {
+              key "prefix";
+
+              description
+                "This list defines IPv6 extended prefix attributes.";
+
+              leaf prefix {
+                type leafref {
+                  path "../state/prefix";
+                }
+                description
+                  "Reference to the IPv6 prefix that the TLV
+                  corresponds to.";
+              }
+
+              uses ipv6-prefix-extended-state;
+            }
+          }
+        }
+
+        container multi-topology {
+          when "../state/type = 'oc-isis-lsdb-types:MULTI_TOPOLOGY'" {
+            description
+              "Only include the multi-topology container when the TLV
+              is type 229.";
+          }
+
+          description
+            "This container defines the topology supported.";
+
+          reference
+            "RFC5120: M-ISIS: Multi Topology (MT) Routing in
+            Intermediate System to Intermediate Systems (IS-ISs). TLV
+            229";
+
+          container topologies {
+            description
+              "This container describes IS topologies.";
+
+            list topology {
+              key "mt-id";
+
+              description
+                "This list describes a topology.";
+
+              leaf mt-id {
+                type leafref {
+                  path "../state/mt-id";
+                }
+                description
+                  "Reference to the multi-topology ID being described
+                  by the list entry.";
+              }
+
+              container state {
+                description
+                  "State parameters of IS multi-topology TLV 229.";
+
+                leaf mt-id {
+                  type uint16 {
+                    range "0 .. 4095";
+                  }
+                  description
+                    "Multi-topology ID.";
+                }
+
+                leaf attributes {
+                  type enumeration {
+                    enum OVERLOAD {
+                      description
+                        "When set, node is overloaded, still part of
+                        the topology but cannot be used for transit.";
+                    }
+                    enum ATTACHED {
+                      description
+                        "When set, node is attached to another area
+                        using the referred metric and can be used as
+                        default gateway.";
+                    }
+                  }
+                  description
+                    "Attributes of the LSP for the associated
+                    topology.";
+                }
+              }
+            }
+          }
+        }
+
+        container isis-neighbor-attribute {
+          when "../state/type = " +
+               "'oc-isis-lsdb-types:IS_NEIGHBOR_ATTRIBUTE'" {
+            description
+              "Only include the neighbor attribute container when the
+              TLV is type 23.";
+          }
+          description
+            "This container defines list of ISIS topology neighbors
+            for extended ISIS LSP (multiple system IDs). ";
+
+          reference
+            "RFC5311: Simplified Extension of Link State PDU (LSP)
+            Space for IS-IS. TLV 23. It is identical in format  to the
+            extended IS reachability TLV 22.";
+
+          uses isis-lsdb-common-extisreach-neighbors;
+        }
+
+        container is-alias-id {
+          when "../state/type = 'oc-isis-lsdb-types:ISIS_ALIAS_ID'" {
+            description
+              "Only include the ISIS alias ID container when the TLV
+              is type 24.";
+          }
+
+          description
+            "This container defines the IS-Alias TLV which allows
+             extension-capable ISs to recognize the Originating System
+             of an Extended LSP set. It identifies the Normal system-
+             id of the Originating System.";
+
+          reference
+            "RFC5311: Simplified Extension of Link State PDU (LSP)
+             Space for IS-IS TLV 24.";
+
+          container state {
+            config false;
+            description
+              "State parameters of alias ID.";
+
+            leaf alias-id {
+              type oc-isis-types:system-id;
+              description
+                "List of alias ID(s).";
+            }
+          }
+        }
+
+        container mt-isn {
+          when "../state/type = 'oc-isis-lsdb-types:MT_ISN'" {
+            description
+              "Only include the MT ISN container when the TLV is type
+              222.";
+          }
+          description
+            "This container defines list of ISIS multi-topology
+            neighbors.";
+
+          reference
+            "RFC5120: M-ISIS: Multi Topology (MT) Routing in
+            Intermediate System to Intermediate Systems (IS-ISs). TLV
+            222.";
+
+          uses isis-lsdb-mtis-common;
+        }
+
+        container mt-isis-neighbor-attribute {
+          when "../state/type = " +
+               "'oc-isis-lsdb-types:MT_IS_NEIGHBOR_ATTRIBUTE'" {
+            description
+              "Only include the MT ISIS neighbor attribute container
+              when the TLV is type 223.";
+          }
+
+          description
+            "This container defines list of ISIS multi-topology
+            neighbors.";
+
+          reference
+            "RFC5311: Simplified Extension of Link State PDU (LSP)
+            Space for IS-IS. TLV 223. It is identical in format to the
+            MT-ISN TLV 222.";
+
+          uses isis-lsdb-mtis-common;
+        }
+
+        container mt-ipv4-reachability {
+          when "../state/type = " +
+               "'oc-isis-lsdb-types:MT_IPV4_REACHABILITY'" {
+            description
+              "Only include the multi-topology IPv4 reachability
+              container when the TLV is type 235.";
+          }
+          description
+            "This container defines list of IPv4 reachability
+            Information in multi-topology environment.";
+
+          reference
+            "RFC5120: M-ISIS: Multi Topology (MT) Routing in
+            Intermediate System to Intermediate Systems (IS-ISs). TLV
+            235.";
+
+          container prefixes {
+            description
+              "This container describes IS prefixes.";
+
+            list prefix {
+              key "mt-id prefix";
+
+              leaf mt-id {
+                type leafref {
+                  path "../state/mt-id";
+                }
+                description
+                  "Reference to the topology ID of the topology that
+                  the prefix is within.";
+              }
+
+              leaf prefix {
+                type leafref {
+                  path "../state/prefix";
+                }
+                description
+                  "Reference to the prefix to which reachability is
+                  being advertised.";
+              }
+
+              description
+                "IPv4 prefixes that are contained within MT
+                reachability TLV.";
+
+              uses ipv4-mt-prefix-extended-state;
+            }
+          }
+        }
+
+        container mt-ipv6-reachability {
+          when "../state/type = " +
+               "'oc-isis-lsdb-types:MT_IPV6_REACHABILITY'" {
+            description
+              "Only include the multi-topology IPv6 reachability
+              container when the TLV is type 237.";
+          }
+          description
+            "This container defines list of IPv6 reachability
+            information in multi - topology environment.";
+
+          reference
+            "RFC5120: M-ISIS: Multi Topology (MT) Routing in
+            Intermediate System to Intermediate Systems (IS-ISs). TLV
+            237.";
+
+          container prefixes {
+            description
+              "This container describes IS prefixes.";
+
+            list prefix {
+              key "prefix mt-id";
+              description
+                  "List of IPv6 prefixes contained within MT
+                  reachability TLV.";
+
+              leaf prefix {
+                type leafref {
+                  path "../state/prefix";
+                }
+                description
+                  "Reference to the IPv6 prefix described by the
+                  TLV.";
+              }
+
+              leaf mt-id {
+                type leafref {
+                  path "../state/mt-id";
+                }
+                description
+                  "Reference to the multi-topology ID.";
+              }
+
+              uses ipv6-mt-prefix-extended-state;
+            }
+          }
+        }
+      }
+    }
+
+    uses isis-lsdb-undefined-tlv;
+  }
+}

--- a/models/yang/common/openconfig-isis-policy.yang
+++ b/models/yang/common/openconfig-isis-policy.yang
@@ -1,0 +1,242 @@
+module openconfig-isis-policy {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/openconfig-isis-policy";
+
+  prefix "oc-isis-pol";
+
+  // import some basic types
+  import openconfig-routing-policy {prefix rpol; }
+  import openconfig-extensions { prefix oc-ext; }
+  import openconfig-isis-types { prefix isis-types; }
+
+
+  // meta
+  organization
+    "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net ";
+
+  description
+    "This module contains data definitions for ISIS routing policy.
+    It augments the base routing-policy module with BGP-specific
+    options for conditions and actions.";
+
+  oc-ext:openconfig-version "0.8.0";
+
+  revision "2023-11-02" {
+    description
+      "Fixing metric type leafs for action and condition branches.";
+    reference "0.8.0";
+  }
+
+  revision "2023-04-28" {
+    description
+      "Adding set metric-type leaf";
+    reference "0.7.0";
+  }
+
+  revision "2023-02-27" {
+    description
+      "Fixing type for set-metric-type leaf";
+    reference "0.6.0";
+  }
+
+  revision "2020-02-04" {
+    description
+      "Consistent prefix for openconfig-mpls-types.";
+    reference "0.5.0";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "0.4.2";
+  }
+
+  revision "2018-06-05" {
+    description
+      "Fix bugs in when statements.";
+    reference "0.4.1";
+  }
+
+  revision "2018-05-14" {
+    description
+      "Update LSDB model to correct Extended IS reach TLV
+      bug. This change is backwards incompatible due to
+      adding an additional level of hierarchy to support
+      multiple instances of the TLV.";
+    reference "0.4.0";
+  }
+
+  revision "2017-07-26" {
+    description
+      "Update LSDB and fix bugs.";
+    reference "0.3.2";
+  }
+
+  revision "2017-05-15" {
+    description
+      "Refactor LSDB.";
+    reference "0.3.0";
+  }
+
+  revision "2017-01-13" {
+    description
+      "Remove top-level /isis container";
+    reference "0.2.1";
+  }
+
+  revision "2016-12-15" {
+    description
+      "Add segment routing to IS-IS module";
+    reference "0.2.0";
+  }
+
+  revision "2016-10-18" {
+    description
+      "Initial revision of IS-IS models.";
+    reference "0.1.0";
+  }
+
+  // OpenConfig specific extensions for module metadata.
+  oc-ext:regexp-posix;
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  // extension statements
+
+  // feature statements
+
+  // identity statements
+
+  // typedef statements
+
+  // grouping statements
+
+   grouping isis-match-conditions {
+    description
+      "Criteria used to match IS-IS routes within the policy";
+
+    container isis-conditions {
+      description
+        "Match conditions relating to the IS-IS protocol";
+
+      container config {
+        description
+          "Configuration parameters relating to IS-IS match
+          conditions";
+
+        uses isis-match-conditions-config;
+      }
+
+      container state {
+        config false;
+        description
+          "Operational state parameters relating to IS-IS match
+          conditions";
+        uses isis-match-conditions-config;
+      }
+    }
+  }
+
+  grouping isis-match-conditions-config {
+    description
+      "Match conditions for IS-IS";
+
+    leaf level-eq {
+      type isis-types:level-number;
+      description
+        "Match the level that the IS-IS prefix is within. This can
+        be used in the case that import or export policies refer
+        to an IS-IS instance that has multiple levels configured
+        within it";
+    }
+
+    leaf match-metric-type {
+      type isis-types:metric-type;
+      description
+        "Matches the type of the route to redistribute to INTERNAL or EXTERNAL";
+    }
+  }
+
+  grouping isis-actions {
+    description
+      "Actions supplied by the IS-IS protocol to be set on a
+      route within the policy";
+
+    container isis-actions {
+      description
+        "Actions that can be performed by IS-IS within a policy";
+
+      container config {
+        description
+          "Configuration parameters relating to IS-IS actions";
+
+        uses isis-actions-config;
+      }
+
+      container state {
+        config false;
+        description
+          "Operational state associated with IS-IS actions";
+
+        uses isis-actions-config;
+      }
+    }
+  }
+
+  grouping isis-actions-config {
+    description
+      "Actions for IS-IS";
+
+    leaf set-level {
+      type isis-types:level-number;
+      description
+        "Set the level that a prefix is to be imported into.";
+    }
+
+    leaf set-metric-type {
+      type isis-types:metric-type;
+      description
+        "This leaf sets the type of metric that is to be specified
+        when the set-metric leaf is specified";
+    }
+
+    leaf set-metric-style-type {
+      type isis-types:metric-style;
+      description
+        "Set the style of the metric";
+    }
+
+    leaf set-metric {
+      type isis-types:wide-metric;
+      description
+        "Set the metric of the IS-IS prefix";
+    }
+  }
+
+  // augment statements
+ augment "/rpol:routing-policy/rpol:policy-definitions/" +
+    "rpol:policy-definition/rpol:statements/rpol:statement/" +
+    "rpol:actions" {
+    description "This augments igp-actions with ISIS conditions";
+    uses isis-actions;
+
+  }
+
+  augment "/rpol:routing-policy/rpol:policy-definitions/" +
+    "rpol:policy-definition/rpol:statements/rpol:statement/" +
+    "rpol:conditions" {
+    description "This augments igp-conditions with ISIS conditions";
+    uses isis-match-conditions;
+  }
+
+  // rpc statements
+
+  // notification statements
+}

--- a/models/yang/common/openconfig-isis-routing.yang
+++ b/models/yang/common/openconfig-isis-routing.yang
@@ -1,0 +1,536 @@
+submodule openconfig-isis-routing {
+
+  belongs-to openconfig-isis {
+    prefix "oc-isis";
+  }
+
+  // import some basic types
+  import openconfig-isis-types { prefix oc-isis-types; }
+  import openconfig-extensions { prefix oc-ext; }
+  import openconfig-mpls-types { prefix oc-mplst; }
+  import openconfig-segment-routing { prefix oc-sr; }
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This module describes YANG model for ISIS Routing";
+
+  oc-ext:openconfig-version "1.7.0";
+
+  revision "2024-02-28" {
+    description
+      "ISIS graceful-restart timers and per-level configuration.";
+    reference "1.7.0";
+  }
+
+  revision "2024-02-20" {
+    description
+      "Fix typo in RFC reference for adjacency-state.";
+    reference "1.6.2";
+  }
+
+  revision "2023-11-01" {
+    description
+      "Refactor apply policy to separate default policy in it's own common
+      set of groupings";
+    reference "1.6.1";
+  }
+
+  revision "2023-05-01" {
+    description
+      "Add ISIS total-lsps counter.";
+    reference "1.6.0";
+  }
+
+  revision "2023-04-25" {
+    description
+      "Clarify use of the interface-ref type.";
+    reference "1.5.1";
+  }
+
+  revision "2023-03-27" {
+    description
+      "Add weighted ecmp.";
+    reference "1.5.0";
+  }
+
+  revision "2023-03-20" {
+    description
+      "Per-level global enabled configuration default false re-added to keep
+      backward compatibility.";
+    reference "1.4.1";
+  }
+
+  revision "2023-02-22" {
+    description
+      "Deprecate the instance leaf, and add a new instance-id leaf
+      that indicates the value to be used in the Instance Identifier
+      TLV.";
+    reference "1.4.0";
+  }
+
+  revision "2023-01-25" {
+    description
+      "Per-level global enabled configuration removed, since it duplicates
+      the level-capability leaf.";
+    reference "1.3.0";
+  }
+
+  revision "2023-01-04" {
+    description
+      "Add max ecmp paths for address family.";
+    reference "1.2.0";
+  }
+
+  revision "2022-09-20" {
+    description
+      "Add CSNP enable to IS-IS global configuration.";
+    reference "1.1.0";
+  }
+
+  revision "2022-05-10" {
+    description
+      "Modify internal/external route preference to unrestricted uint32
+      type.";
+    reference "1.0.0";
+  }
+
+  revision "2022-03-01" {
+    description
+      "Add simple authentication key support.";
+    reference "0.9.0";
+  }
+
+  revision "2022-02-24" {
+    description
+      "Add Hello PDU padding type to IS-IS global configuration.";
+    reference "0.8.0";
+  }
+
+  revision "2022-01-19" {
+    description
+      "Align revisions across modules.";
+    reference "0.7.1";
+  }
+
+  revision "2021-12-31" {
+    description
+      "Add support for per-interface hello authentication, and per-level
+      *SNP authentication.";
+    reference "0.7.0";
+  }
+
+  revision "2021-06-16" {
+    description
+      "Remove trailing whitespace";
+    reference "0.6.2";
+  }
+
+  revision "2021-03-17" {
+    description
+      "Add bfd support without augmentation.";
+    reference "0.6.1";
+  }
+
+  revision "2020-03-24" {
+    description
+      "Support IGP-LDP sync per interface.";
+    reference "0.6.0";
+  }
+
+  revision "2020-02-04" {
+    description
+      "Consistent prefix for openconfig-mpls-types.";
+    reference "0.5.0";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "0.4.2";
+  }
+
+  revision "2018-06-05" {
+    description
+      "Fix bugs in when statements.";
+    reference "0.4.1";
+  }
+
+  revision "2018-05-14" {
+    description
+      "Update LSDB model to correct Extended IS reach TLV
+      bug. This change is backwards incompatible due to
+      adding an additional level of hierarchy to support
+      multiple instances of the TLV.";
+    reference "0.4.0";
+  }
+
+  revision "2017-07-26" {
+    description
+      "Update LSDB and fix bugs.";
+    reference "0.3.2";
+  }
+
+  revision "2017-05-15" {
+    description
+      "Refactor LSDB.";
+    reference "0.3.0";
+  }
+
+  revision "2017-01-13" {
+    description
+      "Remove top-level /isis container";
+    reference "0.2.1";
+  }
+
+  revision "2016-12-15" {
+    description
+      "Add segment routing to IS-IS module";
+    reference "0.2.0";
+  }
+
+  revision "2016-10-18" {
+    description
+      "Initial revision of IS-IS models.";
+    reference "0.1.0";
+  }
+
+  // extension statements
+
+  // feature statements
+
+  // identity statements
+
+  // typedef statements
+
+  // grouping statements
+
+  grouping rt-admin-config {
+    description
+      "Re-usable grouping to enable or disable a particular IS-IS feature.";
+
+    leaf enabled {
+      type boolean;
+      description
+        "When set to true, the functionality within which this leaf is
+        defined is enabled, when set to false it is explicitly disabled.";
+    }
+  }
+
+  grouping isis-afi-safi-config {
+    description
+      "This grouping defines Address-Family configuration parameters";
+
+    leaf afi-name {
+      type identityref {
+        base oc-isis-types:AFI_TYPE;
+      }
+      description
+        "Address-family type.";
+    }
+
+    leaf safi-name {
+      type identityref {
+        base oc-isis-types:SAFI_TYPE;
+      }
+      description
+        "Subsequent address-family type.";
+    }
+  }
+
+  grouping isis-shortcuts-afi-config {
+    description
+      "This grouping defines ISIS Shortcuts configuration parameters";
+
+    leaf afi-name {
+      type identityref {
+        base oc-isis-types:AFI_TYPE;
+      }
+      description "Address-family type.";
+    }
+
+    leaf-list nh-type {
+      type identityref {
+        base oc-mplst:PATH_SETUP_PROTOCOL;
+      }
+      description "Tunnel NH Type(RSVP,SR). When present it implies
+      	that nh-type shortcut is enabled for a specified AFI.";
+    }
+  }
+
+  grouping isis-shortcuts-config {
+    description
+      "This grouping defines ISIS Shortcuts consfiguration parameters";
+
+    container config {
+      description "This container defines ISIS shortcuts configuration.";
+      uses rt-admin-config;
+    }
+
+    container state {
+      config false;
+      description "This container defines state for ISIS shortcuts.";
+      uses rt-admin-config;
+    }
+  }
+
+  grouping isis-mt-config {
+    description
+      "This grouping defines ISIS multi-topology configuration parameters";
+
+    leaf afi-name {
+      type identityref {
+        base oc-isis-types:AFI_TYPE;
+      }
+      description
+        "Address-family type.";
+    }
+    leaf safi-name {
+      type identityref {
+        base oc-isis-types:SAFI_TYPE;
+      }
+      description
+        "Subsequent address-family type.";
+    }
+    //prefer single topology
+  }
+
+
+
+  // *********** STRUCTURE GROUPINGS **********************
+
+  grouping isis-metric-config {
+    description
+      "This grouping defines ISIS metric configuration";
+
+    leaf metric {
+      type uint32;
+      default 10;
+      description "ISIS metric value(default=10).";
+    }
+  }
+  grouping isis-ecmp-config {
+    description
+      "This grouping defines ISIS ecmp configuration.";
+
+    leaf max-ecmp-paths {
+      type uint8;
+      description
+        "ISIS max-paths count.";
+    }
+
+  }
+
+  grouping isis-afi-safi-list {
+    description
+      "This grouping defines address-family configuration and state
+      information";
+
+    list af {
+      key "afi-name safi-name";
+
+      description
+            "Address-family/Subsequent Address-family list.";
+
+      leaf afi-name {
+        type leafref {
+          path "../config/afi-name";
+        }
+        description
+           "Reference to address-family type";
+      }
+
+      leaf safi-name {
+        type leafref {
+          path "../config/safi-name";
+        }
+        description
+           "Reference to subsequent address-family type";
+      }
+
+      container config {
+        description
+          "This container defines AFI-SAFI configuration parameters";
+
+        uses isis-afi-safi-config;
+        uses isis-metric-config;
+        uses rt-admin-config;
+        uses isis-ecmp-config;
+      }
+
+      container state {
+        config false;
+        description
+          "This container defines AFI-SAFI State information";
+
+        uses isis-afi-safi-config;
+        uses isis-metric-config;
+        uses rt-admin-config;
+        uses isis-ecmp-config;
+      }
+
+      uses isis-mt-list;
+    }
+  }
+
+  grouping isis-if-afi-safi-list {
+    description
+      "This grouping defines address-family configuration and state
+      information";
+
+    list af {
+      key "afi-name safi-name";
+
+      description
+            "Address-family/Subsequent Address-family list.";
+
+      leaf afi-name {
+        type leafref {
+          path "../config/afi-name";
+        }
+        description
+           "Reference to address-family type";
+      }
+
+      leaf safi-name {
+        type leafref {
+          path "../config/safi-name";
+        }
+        description
+           "Reference to subsequent address-family type";
+      }
+
+      container config {
+        description
+           "This container defines AFI-SAFI configuration parameters. Single
+            topology is the default setting.";
+        uses isis-afi-safi-config;
+        uses isis-metric-config;
+        uses rt-admin-config;
+      }
+
+      container state {
+        config false;
+        description
+           "This container defines AFI-SAFI State information";
+        uses isis-afi-safi-config;
+        uses isis-metric-config;
+        uses rt-admin-config;
+      }
+
+      uses oc-sr:sr-igp-interface-top;
+    }
+  }
+
+  grouping isis-if-global-afi-safi-list {
+    description
+      "This grouping defines address-family configuration and state
+      information";
+
+    list af {
+      key "afi-name safi-name";
+
+      description
+            "Address-family/Subsequent Address-family list.";
+
+      leaf afi-name {
+        type leafref {
+          path "../config/afi-name";
+        }
+        description
+           "Reference to address-family type";
+      }
+
+      leaf safi-name {
+        type leafref {
+          path "../config/safi-name";
+        }
+        description
+           "Reference to subsequent address-family type";
+      }
+
+      container config {
+        description
+           "This container defines AFI-SAFI configuration parameters. Single
+            topology is the default setting.";
+        uses isis-afi-safi-config;
+        uses rt-admin-config;
+      }
+
+      container state {
+        config false;
+        description
+           "This container defines AFI-SAFI State information";
+        uses isis-afi-safi-config;
+        uses rt-admin-config;
+      }
+    }
+  }
+
+  grouping isis-shortcuts-afi-list {
+    description
+      "This grouping defines ISIS Shorcuts configuration and
+      state information";
+
+    list afi {
+      key "afi-name";
+
+      description
+        "Address-family list.";
+
+      leaf afi-name {
+        type leafref {
+          path "../config/afi-name";
+        }
+        description
+          "Reference to address-family type.";
+      }
+
+      container config {
+        description
+          "This container defines ISIS Shortcuts configuration parameters";
+        uses isis-shortcuts-afi-config;
+      }
+
+      container state {
+        config false;
+        description
+          "This container defines ISIS Shortcuts state information";
+        uses isis-shortcuts-afi-config;
+      }
+    }
+  }
+
+  grouping isis-mt-list {
+    description
+      "This grouping defines multi-topology address-family configuration and
+      state information. MT0 - IPv4 Unicast, MT2 - IPv6 Unicast, MT3 -
+      IPv4 Multicast, MT4 - IPv6 Multicast";
+
+    container multi-topology {
+      description
+        "This container defines multi-topology address-family configuration
+        and state information. ISIS TLV 235, 237.";
+
+      container config {
+      description
+        "This container defines AFI-SAFI multi-topology configuration
+        parameters";
+      uses isis-mt-config;
+      }
+
+      container state {
+      config false;
+      description
+        "This container defines AFI-SAFI multi-topology state information";
+      uses isis-mt-config;
+      uses rt-admin-config;
+      }
+    }
+  }
+}

--- a/models/yang/common/openconfig-isis-types.yang
+++ b/models/yang/common/openconfig-isis-types.yang
@@ -1,0 +1,401 @@
+module openconfig-isis-types {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/isis-types";
+
+  prefix "oc-isis-types";
+
+  import openconfig-extensions { prefix oc-ext; }
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This module contains general data definitions for use in ISIS YANG
+    model.";
+
+  oc-ext:openconfig-version "0.6.0";
+
+  revision "2022-02-11" {
+    description
+      "Add simple authentication key support.";
+    reference "0.6.0";
+  }
+
+  revision "2021-08-12" {
+    description
+      "Make pattern regexes conform to RFC7950, remove
+      oc-ext:regexp-posix, and fix broken regex for area
+      address. This change is backwards incompatible
+      because it changes the area address regex.";
+    reference "0.5.0";
+  }
+
+  revision "2020-06-30" {
+    description
+      "Add OpenConfig POSIX pattern extensions.";
+    reference "0.4.3";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "0.4.2";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "0.4.1";
+  }
+
+  revision "2018-05-14" {
+    description
+      "Update LSDB model to correct Extended IS reach TLV
+      bug. This change is backwards incompatible due to
+      adding an additional level of hierarchy to support
+      multiple instances of the TLV.";
+    reference "0.4.0";
+  }
+
+  revision "2017-07-26" {
+    description
+      "Update LSDB and fix bugs.";
+    reference "0.3.2";
+  }
+
+  revision "2017-05-15" {
+    description
+      "Refactor LSDB.";
+    reference "0.3.0";
+  }
+
+  revision "2017-01-13" {
+    description
+      "Remove top-level /isis container";
+    reference "0.2.1";
+  }
+
+  revision "2016-12-15" {
+    description
+      "Add segment routing to IS-IS module";
+    reference "0.2.0";
+  }
+
+  revision "2016-10-18" {
+    description
+      "Initial revision of IS-IS models.";
+    reference "0.1.0";
+  }
+
+  // OpenConfig specific extensions for module metadata.
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  // identity statements
+  identity OVERLOAD_RESET_TRIGGER_TYPE {
+    description
+      "Base identify type for triggers that reset Overload Bit";
+  }
+
+  identity WAIT_FOR_BGP {
+    base OVERLOAD_RESET_TRIGGER_TYPE;
+    description
+      "Base identity type for resetting Overload Bit when BGP has converged. ";
+  }
+
+  identity WAIT_FOR_SYSTEM {
+    base OVERLOAD_RESET_TRIGGER_TYPE;
+    description
+      "Base identity type for resetting Overload Bit when system resources have
+      been restored. ";
+  }
+
+  identity MT_TYPE {
+    description
+      "Base identify type for multi-topology";
+  }
+
+  identity SAFI_TYPE {
+    description
+      "Base identify type for SAFI";
+  }
+
+  identity AFI_TYPE {
+    description
+      "Base identify type for AFI";
+  }
+
+  identity AFI_SAFI_TYPE {
+    description
+      "Base identify type for AFI/SAFI";
+  }
+
+  identity IPV4_UNICAST {
+    base AFI_SAFI_TYPE;
+    description
+      "Base identify type for IPv4 Unicast address family";
+  }
+
+  identity IPV6_MULTICAST {
+    base AFI_SAFI_TYPE;
+    description
+      "Base identify type for IPv6 multicast address family";
+  }
+
+  identity IPV4_MULTICAST {
+    base AFI_SAFI_TYPE;
+    description
+      "Base identify type for IPv4 multicast address family";
+  }
+
+  identity IPV6_UNICAST {
+    base AFI_SAFI_TYPE;
+    description
+      "Base identify type for IPv6 unicast address family";
+  }
+
+  identity UNICAST {
+    base SAFI_TYPE;
+    description
+      "Base identify type for IPv4 Unicast address family";
+  }
+
+  identity MULTICAST {
+    base SAFI_TYPE;
+    description
+      "Base identify type for IPv6 multicast address family";
+  }
+
+  identity IPV4 {
+    base AFI_TYPE;
+    description
+      "Base identify type for IPv4 address family";
+  }
+
+  identity IPV6 {
+    base AFI_TYPE;
+    description
+      "Base identify type for IPv6 address family";
+  }
+
+  identity AUTH_MODE {
+    description
+      "Base identify to define the authentication mode";
+  }
+
+  identity TEXT {
+    base AUTH_MODE;
+      description
+        "Simple Text Authentication";
+      reference "RFC1195";
+  }
+
+  identity MD5 {
+    base AUTH_MODE;
+      description
+        "HMAC-MD5 Authentication";
+      reference "RFC5304";
+  }
+
+  // typedef statements
+  typedef level-type {
+    type enumeration {
+      enum LEVEL_1 {
+        description "This enum describes ISIS level 1";
+      }
+      enum LEVEL_2 {
+        description "This enum describes ISIS level 2";
+      }
+      enum LEVEL_1_2 {
+        description "This enum describes ISIS level 1-2";
+      }
+    }
+    description
+        "This type defines ISIS level types";
+  }
+
+  typedef level-number {
+    type uint8 {
+      range "1..2";
+    }
+    description
+        "This type defines ISIS level.";
+  }
+
+  typedef adaptive-timer-type {
+    type enumeration {
+      enum LINEAR {
+        description "This enum describes linear algorithm timer";
+      }
+      enum EXPONENTIAL {
+        description "This enum describes exponential algorithm timer";
+      }
+    }
+    description
+        "This type defines ISIS adaptive timer types";
+  }
+
+  typedef hello-padding-type {
+    type enumeration {
+      enum STRICT {
+        description "This enum describes strict padding";
+      }
+      enum LOOSE {
+        description "This enum describes loose padding";
+      }
+      enum ADAPTIVE {
+        description "This enum describes adaptive padding";
+      }
+      enum DISABLE {
+        description "This enum disables padding";
+      }
+    }
+    description
+        "This type defines ISIS hello padding type";
+  }
+
+  typedef circuit-type {
+    type enumeration {
+      enum POINT_TO_POINT {
+        description "This enum describes a point-to-point interface";
+      }
+      enum BROADCAST {
+        description "This enum describes a broadcast interface";
+      }
+    }
+    description
+        "This type defines ISIS interface types ";
+  }
+
+  typedef metric-type {
+    type enumeration {
+      enum INTERNAL {
+        description "This enum describes internal route type";
+      }
+      enum EXTERNAL {
+        description "This enum describes external route type";
+      }
+    }
+    description
+      "This type defines ISIS metric type";
+  }
+
+  typedef wide-metric {
+    type uint32 {
+      range "1..16777215";
+    }
+    description
+        "This type defines ISIS wide metric.";
+  }
+
+  typedef narrow-metric {
+    type uint8 {
+      range "1..63";
+    }
+    description
+        "This type defines ISIS narrow metric.";
+  }
+
+  typedef metric-style {
+    type enumeration {
+      enum NARROW_METRIC {
+        description
+                "This enum describes narrow metric style";
+        reference "RFC1195";
+      }
+      enum WIDE_METRIC {
+        description
+                "This enum describes wide metric style";
+        reference "RFC5305";
+      }
+    }
+    description
+        "This type defines ISIS metric styles";
+  }
+
+  typedef isis-interface-adj-state {
+    type enumeration {
+      enum UP {
+        description
+          "This state describes that adjacency is established.";
+      }
+      enum DOWN {
+        description
+          "This state describes that adjacency is NOT established.";
+      }
+      enum INIT {
+        description
+          "This state describes that adjacency is establishing.";
+      }
+      enum FAILED {
+        description
+          "This state describes that adjacency is failed.";
+      }
+    }
+    description
+      "This type defines the state of the interface.";
+  }
+
+  typedef net {
+    type string {
+      pattern '[a-fA-F0-9]{2}(\.[a-fA-F0-9]{4}){3,9}\.[a-fA-F0-9]{2}';
+      oc-ext:posix-pattern '^[a-fA-F0-9]{2}(\.[a-fA-F0-9]{4}){3,9}\.[a-fA-F0-9]{2}$';
+    }
+    description
+      "This type defines OSI NET address. A NET should should be in
+      the form xx.yyyy.yyyy.yyyy.00 with up to 9 sets of yyyy.";
+  }
+
+  typedef area-address {
+    type string {
+      pattern '[0-9A-Fa-f]{2}(\.[0-9A-Fa-f]{4}){0,3}';
+      oc-ext:posix-pattern '^[0-9A-Fa-f]{2}(\.[0-9A-Fa-f]{4}){0,3}$';
+    }
+    description
+        "This type defines the ISIS area address.";
+  }
+
+  typedef system-id {
+    type string {
+      pattern '[0-9A-Fa-f]{4}\.[0-9A-Fa-f]{4}\.[0-9A-Fa-f]{4}';
+      oc-ext:posix-pattern '^[0-9A-Fa-f]{4}\.[0-9A-Fa-f]{4}\.[0-9A-Fa-f]{4}$';
+    }
+    description
+      "This type defines ISIS system id using pattern, system id looks
+       like : 0143.0438.AeF0";
+  }
+
+  typedef extended-circuit-id {
+    type uint32;
+    description
+      "This type defines interface circuit ID.";
+  }
+
+  typedef lsp-id {
+    type string {
+      pattern
+            '[0-9A-Fa-f]{4}\.[0-9A-Fa-f]{4}\.[0-9A-Fa-f]'
+      +      '{4}\.[0-9][0-9]-[0-9][0-9]';
+      oc-ext:posix-pattern
+            '^[0-9A-Fa-f]{4}\.[0-9A-Fa-f]{4}\.[0-9A-Fa-f]'
+      +      '{4}\.[0-9][0-9]-[0-9][0-9]$';
+    }
+    description
+      "This type defines ISIS LSP ID. ISIS LSP ID type should be in
+      the form of xxxx.xxxx.xxxx.xx-xx";
+  }
+  typedef snpa {
+    type string {
+      length "0 .. 20";
+    }
+    description
+      "This type defines Subnetwork Point of Attachment format.";
+  }
+}

--- a/models/yang/common/openconfig-isis.yang
+++ b/models/yang/common/openconfig-isis.yang
@@ -1,0 +1,2359 @@
+module openconfig-isis {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/openconfig-isis";
+
+  prefix "oc-isis";
+
+  // import some basic types
+  import openconfig-types { prefix "oc-types"; }
+  import openconfig-inet-types { prefix "oc-inet"; }
+  import openconfig-yang-types { prefix "oc-yang"; }
+  import openconfig-isis-types { prefix "oc-isis-types"; }
+  import openconfig-routing-policy { prefix "oc-rpol"; }
+  import openconfig-extensions { prefix "oc-ext"; }
+  import openconfig-interfaces { prefix "oc-if"; }
+  import openconfig-segment-routing { prefix "oc-sr"; }
+  import openconfig-bfd { prefix "oc-bfd"; }
+  import openconfig-keychain { prefix "oc-keychain"; }
+  import openconfig-keychain-types { prefix "oc-keychain-types"; }
+
+  // Include submodules:
+  // IS-IS LSP is the LSDB for IS-IS.
+  include openconfig-isis-lsp;
+  // IS-IS RT is routing-related features for IS-IS
+  include openconfig-isis-routing;
+
+  // meta
+  organization
+    "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net ";
+
+  description
+    "This module describes a YANG model for ISIS protocol configuration.
+    It is a limited subset of all of the configuration parameters
+    available in the variety of vendor implementations, hence it is
+    expected that it would be augmented with vendor - specific configuration
+    data as needed. Additional modules or submodules to handle other
+    aspects of ISIS configuration, including policy, routing, types,
+    LSDB and additional address families are also expected. This model
+    supports the following ISIS configuration level hierarchy:
+
+    ISIS
+    +-> { global ISIS configuration}
+        +-> levels +-> { level config}
+            +-> { system-level-counters }
+            +-> { level link-state-database}
+        +-> interface +-> { interface config }
+            +-> { circuit-counters }
+            +-> { levels config }
+            +-> { level adjacencies }";
+
+  oc-ext:openconfig-version "1.7.0";
+
+  revision "2024-02-28" {
+    description
+      "ISIS graceful-restart timers and per-level configuration.";
+    reference "1.7.0";
+  }
+
+  revision "2024-02-20" {
+    description
+      "Fix typo in RFC reference for adjacency-state.";
+    reference "1.6.2";
+  }
+
+  revision "2023-11-01" {
+    description
+      "Refactor apply policy to separate default policy in it's own common
+      set of groupings";
+    reference "1.6.1";
+  }
+
+  revision "2023-05-01" {
+    description
+      "Add ISIS total-lsps counter.";
+    reference "1.6.0";
+  }
+
+  revision "2023-04-25" {
+    description
+      "Clarify use of the interface-ref type.";
+    reference "1.5.1";
+  }
+
+  revision "2023-03-27" {
+    description
+      "Add weighted ecmp.";
+    reference "1.5.0";
+  }
+
+  revision "2023-03-20" {
+    description
+      "Per-level global enabled configuration default false re-added to keep
+      backward compatibility.";
+    reference "1.4.1";
+  }
+
+  revision "2023-02-22" {
+    description
+      "Deprecate the instance leaf, and add a new instance-id leaf
+      that indicates the value to be used in the Instance Identifier
+      TLV.";
+    reference "1.4.0";
+  }
+
+  revision "2023-01-25" {
+    description
+      "Per-level global enabled configuration removed, since it duplicates
+      the level-capability leaf.";
+    reference "1.3.0";
+  }
+
+  revision "2023-01-04" {
+    description
+      "Add max ecmp paths for address family.";
+    reference "1.2.0";
+  }
+
+  revision "2022-09-20" {
+    description
+      "Add CSNP enable to IS-IS global configuration.";
+    reference "1.1.0";
+  }
+
+  revision "2022-05-10" {
+    description
+      "Modify internal/external route preference to unrestricted uint32
+      type.";
+    reference "1.0.0";
+  }
+
+  revision "2022-03-01" {
+    description
+      "Add simple authentication key support.";
+    reference "0.9.0";
+  }
+
+  revision "2022-02-24" {
+    description
+      "Add Hello PDU padding type to IS-IS global configuration.";
+    reference "0.8.0";
+  }
+
+  revision "2022-01-19" {
+    description
+      "Align revisions across modules.";
+    reference "0.7.1";
+  }
+
+  revision "2021-12-31" {
+    description
+      "Add support for per-interface hello authentication, and per-level
+      *SNP authentication.";
+    reference "0.7.0";
+  }
+
+  revision "2021-06-16" {
+    description
+      "Remove trailing whitespace";
+    reference "0.6.2";
+  }
+
+  revision "2021-03-17" {
+    description
+      "Add bfd support without augmentation.";
+    reference "0.6.1";
+  }
+
+  revision "2020-03-24" {
+    description
+      "Support IGP-LDP sync per interface.";
+    reference "0.6.0";
+  }
+
+  revision "2020-02-04" {
+    description
+      "Consistent prefix for openconfig-mpls-types.";
+    reference "0.5.0";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "0.4.2";
+  }
+
+  revision "2018-06-05" {
+    description
+      "Fix bugs in when statements.";
+    reference "0.4.1";
+  }
+
+  revision "2018-06-05" {
+    description
+      "Fix bugs in when statements.";
+    reference "0.4.1";
+  }
+
+  revision "2018-05-14" {
+    description
+      "Update LSDB model to correct Extended IS reach TLV
+      bug. This change is backwards incompatible due to
+      adding an additional level of hierarchy to support
+      multiple instances of the TLV.";
+    reference "0.4.0";
+  }
+
+  revision "2017-07-26" {
+    description
+      "Update LSDB and fix bugs.";
+    reference "0.3.2";
+  }
+
+  revision "2017-05-15" {
+    description
+      "Refactor LSDB.";
+    reference "0.3.0";
+  }
+
+  revision "2017-01-13" {
+    description
+      "Remove top-level /isis container";
+    reference "0.2.1";
+  }
+
+  revision "2016-12-15" {
+    description
+      "Add segment routing to IS-IS module";
+    reference "0.2.0";
+  }
+
+  revision "2016-10-18" {
+    description
+      "Initial revision of IS-IS models.";
+    reference "0.1.0";
+  }
+
+  // OpenConfig specific extensions for module metadata.
+  oc-ext:regexp-posix;
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  // extension statements
+
+  // feature statements
+
+  // identity statements
+
+  // typedef statements
+
+  // grouping statements
+
+  grouping isis-global-config {
+    description
+      "This grouping defines global configuration options for ISIS router.";
+
+    leaf instance {
+      type string;
+      default 0;
+      description
+        "ISIS Instance. This leaf has been deprecated. The instance name
+        is specified within the
+        /network-instances/network-instance/protocols/protocol/config/name
+        leaf (list key). If a user requires a specific instance identifier
+        used in the Instance Identifier TLV to be configured the instance-id
+        leaf is used.";
+      status deprecated;
+    }
+
+    leaf instance-id {
+      type uint16;
+      description
+        "When specified, this leaf explicitly indicates the instance identifier
+        that is to be used for the IS-IS instance. The value should be included
+        in the Instance Identifier (IID) TLV.";
+      reference "RFC6822: IS-IS Multi-Instance";
+    }
+
+
+    leaf-list net {
+      type oc-isis-types:net;
+      description
+        "ISIS network entity title (NET). The first 8 bits are usually
+        49 (private AFI), next 16 bits represent area, next 48 bits represent
+        system id and final 8 bits are set to 0.";
+      reference
+        "International Organization for Standardization, Information
+        technology - Open Systems Interconnection-Network service
+        Definition - ISO/ IEC 8348:2002.";
+    }
+
+    leaf maximum-area-addresses {
+      type uint8;
+      default 3;
+      description
+        "Maximum areas supported.";
+    }
+
+    leaf level-capability {
+      type oc-isis-types:level-type;
+      default "LEVEL_1_2";
+      description
+        "ISIS level capability(level-1, level-2, level-1-2).";
+    }
+
+    leaf max-ecmp-paths {
+      type uint8;
+      description
+        "ISIS max-paths count.";
+    }
+
+    leaf weighted-ecmp {
+      type boolean;
+      default "false";
+      description
+        "When set to true, all eligible multipath IS-IS routes associated with
+        the instance are programmed to use weighted ECMP. An IS-IS route is
+        eligible for weighted ECMP if all the next-hop interfaces in the
+        multipath set have a load-balancing-weight other than 'none'.";
+    }
+
+    leaf poi-tlv {
+      type boolean;
+      default false;
+      description
+        "ISIS purge TLV. When set to true, a TLV is added to purges to record
+         the system ID  of the IS generating the purge.";
+      reference "RFC6232: Purge Originator Identification TLV for IS-IS. TLV 13.";
+    }
+
+    leaf iid-tlv {
+      type boolean;
+      default false;
+      description
+        "ISIS Instance Identifier TLV. When set to trues, the IID-TLV identifies
+        the unique instance as well as the topology/topologies to which the
+        PDU applies.";
+      reference "RFC6822: IS-IS Multi-Instance. TLV 7";
+    }
+
+    leaf fast-flooding {
+      type boolean;
+      default true;
+      description
+        "When set to true, IS will always flood the LSP that triggered an SPF
+     before the router actually runs the SPF computation.";
+    }
+
+    leaf csnp-enable-on-p2p-links {
+      type boolean;
+      default true;
+      description
+        "When set to true, ISIS will always enable CSNP on P2P Links.";
+    }
+
+    leaf hello-padding {
+      type oc-isis-types:hello-padding-type;
+      default "STRICT";
+      description
+        "Controls the padding type for IS-IS Hello PDUs on a global level.";
+    }
+  }
+
+  grouping admin-config {
+    description
+      "Re-usable grouping to enable or disable a particular IS-IS feature.";
+
+    leaf enabled {
+      type boolean;
+      default false;
+      description
+        "When set to true, the functionality within which this leaf is
+        defined is enabled, when set to false it is explicitly disabled.";
+    }
+  }
+
+  grouping admin-config-deprecated {
+    description
+      "Re-usable grouping for the enabled leaf in contexts where it is deprecated.";
+
+    leaf enabled {
+      type boolean;
+      default false;
+      status deprecated;
+      description
+        "Formerly this leaf was used to enable or disable the functionality
+        within the context specified. This leaf is DEPRECATED.";
+    }
+  }
+
+  grouping isis-authentication-check-config {
+    description
+      "This grouping defines ISIS authentication check.";
+
+    leaf authentication-check {
+      type boolean;
+      default true;
+      description
+        "When set to true, reject all ISIS protocol PDUs that either have a mismatch
+        in authentication-type or authentication-key.";
+    }
+  }
+
+  grouping isis-authentication-type-config {
+    description
+      "This grouping defines the ISIS authentication type.";
+
+    leaf auth-type {
+      type identityref {
+        base oc-keychain-types:AUTH_TYPE;
+      }
+      description
+        "The type of authentication used in the applicable IS-IS PDUs
+        (simple_key, keychain).";
+    }
+  }
+
+  grouping isis-simple-key-authentication-config {
+    description
+      "This grouping defines ISIS simple authentication config.";
+
+    leaf auth-mode {
+      type identityref {
+        base oc-isis-types:AUTH_MODE;
+      }
+      description
+        "The type of authentication used in the applicable IS-IS PDUs.
+
+        This leaf along with the sibling leaf 'auth-password' can be used
+        to configure the simple key authentication.";
+    }
+
+    leaf auth-password {
+      type oc-types:routing-password;
+      description
+        "The authentication key used in the applicable IS-IS PDUs. The key in the
+        packet may be encrypted according to the configured authentication type.";
+    }
+  }
+  grouping isis-metric-style-config {
+    description
+      "This grouping defines ISIS metric style.";
+
+    leaf metric-style {
+      type oc-isis-types:metric-style;
+      description
+        "ISIS metric style types(narrow, wide).";
+    }
+  }
+
+  grouping isis-hello-authentication-config {
+    description
+      "Configuration options for IS-IS hello authentication.";
+
+    leaf enabled {
+      type boolean;
+      default false;
+      description
+        "Enabled or disable ISIS Hello authentication. Hello authentication
+        is used on a per-interface basis to authenticate adjacencies on the
+        interface.";
+    }
+
+    leaf keychain {
+      type oc-keychain:keychain-ref;
+      description
+        "Reference to a keychain that should be used for hello authentication.";
+    }
+  }
+
+  grouping isis-hello-authentication-group {
+    description
+      "This grouping defines ISIS hello-authentication.";
+
+    container config {
+      description
+        "This container defines ISIS authentication configuration.";
+
+      uses isis-hello-authentication-config;
+      uses isis-authentication-type-config;
+      uses isis-simple-key-authentication-config;
+    }
+
+    container state {
+      config false;
+      description
+        "This container defines ISIS authentication state.";
+
+      uses isis-hello-authentication-config;
+      uses isis-authentication-type-config;
+      uses isis-simple-key-authentication-config;
+    }
+  }
+
+  grouping isis-ldp-igp-config {
+    description
+      "This grouping defines ISIS/LDP Synchronization configuration.";
+
+    leaf enabled {
+      type boolean;
+      default true;
+      description
+        "When set to true, rely on IGP/LDP synchronization. IGP cost for
+     link is maintained at max until LDP adjacencies are established ";
+      reference "RFC5443: LDP IGP Synchronization.";
+    }
+
+    leaf post-session-up-delay {
+      type uint16;
+      units seconds;
+      description
+        "Specifies a delay, expressed in units of seconds,
+        between the LDP session to the IGP neighbor being established, and
+        it being considered synchronized by the IGP.";
+    }
+  }
+
+  grouping isis-te-config {
+    description
+      "This grouping defines ISIS Traffic Engineering configuration.";
+
+    leaf ipv4-router-id {
+      type oc-inet:ipv4-address;
+      description
+        "IPv4 MPLS Traffic Engineering Router-ID.";
+    }
+
+    leaf ipv6-router-id {
+      type oc-inet:ipv6-address;
+      description
+        "IPv6 MPLS Traffic Engineering Router-ID.";
+    }
+  }
+
+  grouping isis-reference-bandwidth-config {
+    description
+      "This grouping defines ISIS Reference Bandwidth Configuration.";
+
+    leaf reference-bandwidth {
+      type uint32;
+      description
+        "ISIS Reference Bandwidth value";
+    }
+  }
+
+  grouping isis-overload-bit-set-config {
+    description
+      "This grouping defines ISIS Overload Bit.";
+
+    leaf set-bit {
+      type boolean;
+      default false;
+      description
+        "When set to true, IS-IS overload bit is set.";
+    }
+
+    leaf set-bit-on-boot {
+      type boolean;
+      default false;
+      description
+        "When set to true, the IS-IS overload bit is set on system boot.";
+    }
+
+    leaf advertise-high-metric {
+      type boolean;
+      default false;
+      description
+        "When set to true, the local IS advertises links with the highest
+        available metric regardless of their configured metric. The metric
+        value is based on the metric style - if wide metrics are utilised
+        the metric is advertised as 16777214, otherwise they are advertised
+        with a value of 63.";
+    }
+  }
+
+  grouping isis-overload-bit-reset-config {
+    description
+      "This grouping defines ISIS Overload Bit Reset Triggers";
+
+    leaf reset-trigger {
+      type identityref {
+          base oc-isis-types:OVERLOAD_RESET_TRIGGER_TYPE;
+      }
+      description
+        "In the case that the system sets the overload bit on start, the
+        system should reset the bit (i.e., clear the overload bit) upon
+        the specified trigger.";
+    }
+
+    leaf delay {
+      type uint16;
+      units seconds;
+      description
+        "If a reset trigger is specified, the system should delay resetting
+        the overload bit for the specified number of seconds after the
+        trigger occurs.";
+    }
+  }
+
+  grouping isis-attached-bit-config {
+    description
+      "This grouping defines ISIS Attached Bit";
+
+    leaf ignore-bit {
+      type boolean;
+      default false;
+      description
+        "When set to true, if the attached bit is set on an incoming Level 1
+        IS-IS, the local system ignores it. In this case the local system
+        does not set a default route to the L1L2 router advertising the PDU
+        with the attached bit set.";
+    }
+
+    leaf suppress-bit {
+      type boolean;
+      default false;
+      description
+        "When set to true, if the local IS acts as a L1L2 router, then the
+        attached bit is not advertised in locally generated PDUs.";
+    }
+  }
+
+  grouping overload-bit-group {
+    description
+      "This grouping defines ISIS Overload Bit.";
+
+    container config {
+      description
+        "This container defines ISIS Overload Bit configuration.";
+
+      uses isis-overload-bit-set-config;
+    }
+
+    container state {
+      config false;
+      description
+        "This container defines state for ISIS Overload Bit.";
+
+      uses isis-overload-bit-set-config;
+    }
+
+    container reset-triggers {
+      description
+        "This container defines state for ISIS Overload Bit reset triggers";
+
+      list reset-trigger {
+        key "reset-trigger";
+
+        description
+          "This list describes ISIS Overload reset trigger reasons.";
+
+        leaf reset-trigger {
+          type leafref {
+            path "../config/reset-trigger";
+          }
+          description
+            "Reference to the reset trigger reason";
+        }
+
+        container config {
+          description
+            "This container defines ISIS Overload Bit reset trigger
+            configuration.";
+
+          uses isis-overload-bit-reset-config;
+        }
+
+        container state {
+          config false;
+          description
+            "This container defines state for ISIS Overload Bit reset
+            triggers.";
+
+          uses isis-overload-bit-reset-config;
+        }
+      }
+    }
+  }
+
+
+  grouping isis-base-level-config {
+    description
+      "This grouping defines ISIS Level configuration.";
+
+    leaf level-number {
+      type oc-isis-types:level-number;
+      description
+        "ISIS level number (level-1, level-2).";
+    }
+  }
+
+  grouping isis-interface-level-config {
+    description
+      "This grouping defines ISIS Interface Level configuration.";
+
+    leaf level-number {
+      type oc-isis-types:level-number;
+      description
+        "ISIS level number(level-1, level-2).";
+    }
+
+    leaf passive {
+      type boolean;
+      default false;
+      description
+        "ISIS passive interface admin enable/disable function.";
+    }
+
+    leaf priority {
+      type uint8 {
+        range "0 .. 127";
+      }
+      description
+        "ISIS neighbor priority(LAN hello PDU only).";
+    }
+  }
+
+  grouping isis-hello-timers-config {
+    description
+      "This grouping defines ISIS hello timers configuration.";
+
+    leaf hello-interval {
+      type uint32;
+      description
+        "ISIS hello-interval value.";
+    }
+
+    leaf hello-multiplier {
+      type uint8;
+      description
+        "ISIS hello-multiplier value.";
+    }
+  }
+
+  grouping isis-interface-config {
+    description
+      "This grouping defines ISIS interface configuration.";
+
+    leaf interface-id {
+      type oc-if:interface-id;
+      description
+        "Interface for which ISIS configuration is to be applied.";
+    }
+
+    leaf passive {
+      type boolean;
+      default false;
+      description
+        "When set to true, the referenced interface is a passive interface
+        such that it is not eligible to establish adjacencies with other
+        systems, but is advertised into the IS-IS topology.";
+    }
+
+    leaf hello-padding {
+      type oc-isis-types:hello-padding-type;
+      description
+        "Controls the padding type for IS-IS Hello PDUs.";
+    }
+
+    leaf circuit-type {
+      type oc-isis-types:circuit-type;
+      description
+        "ISIS circuit type (p2p, broadcast).";
+    }
+  }
+
+  grouping isis-adaptive-timers-state {
+    description
+      "This grouping defines ISIS adaptive timers state";
+
+    leaf adaptive-timer {
+      type oc-isis-types:adaptive-timer-type;
+        description
+          "ISIS adaptive timer types (linear, exponential).";
+    }
+  }
+
+  grouping isis-lsp-generation-timers-config {
+    description
+      "This grouping defines ISIS LSP Generation timers configuration";
+
+    leaf lsp-max-wait-interval {
+      type uint64;
+      units milliseconds;
+      description
+        "Time interval in milliseconds that specifies max interval between
+         two consecutive occurrences of an LSP being generated.";
+    }
+
+    leaf lsp-first-wait-interval {
+      type uint64;
+      units milliseconds;
+      description
+        "Time interval in milliseconds that specifies the first LSP generation
+        delay.";
+    }
+
+    leaf lsp-second-wait-interval {
+      type uint64;
+      units milliseconds;
+      description
+        "Time interval in milliseconds that specifies the millisecond LSP
+         generation delay.";
+    }
+  }
+
+  grouping isis-lsp-timers-config {
+    description
+      "This grouping defines ISIS LSP timers configuration";
+
+    leaf lsp-lifetime-interval {
+      type uint16;
+      units seconds;
+      default 1200;
+      description
+        "Time interval in seconds that specifies how long an LSP remains in
+        LSDB without being refreshed.";
+    }
+
+    leaf lsp-refresh-interval {
+      type uint16;
+      units seconds;
+      description
+        "Time interval in seconds that specifies how often route topology
+         that a device originates is transmitted in LSPs.";
+    }
+  }
+
+  grouping isis-spf-timers-config {
+    description
+      "This grouping defines ISIS SPF timers configuration.";
+
+    leaf spf-hold-interval {
+      type uint64;
+      units milliseconds;
+      default 5000;
+      description
+        "SPF Hold Down time interval in milliseconds.";
+    }
+
+    leaf spf-first-interval {
+      type uint64;
+      units milliseconds;
+      description
+        "Time interval in milliseconds between the
+        detection of topology change and when the SPF algorithm runs.";
+    }
+    leaf spf-second-interval {
+      type uint64;
+      units milliseconds;
+      description
+        "Time interval in milliseconds between the first and second
+         SPF calculation.";
+    }
+  }
+
+  grouping isis-interface-timers-config {
+    description
+      "This grouping defines ISIS interface timers configuration.";
+
+    leaf csnp-interval {
+      type uint16;
+      units seconds;
+      description
+        "The interval, specified in seconds, at which periodic CSNP packets
+        should be transmitted by the local IS.";
+    }
+
+    leaf lsp-pacing-interval {
+      type uint64;
+      units milliseconds;
+      description
+        "The interval interval in milliseconds between the
+        detection of topology change and when the SPF algorithm runs.";
+    }
+  }
+
+  grouping isis-interface-weighted-ecmp-config {
+    description
+      "This grouping defines ISIS weighted ECMP configuration";
+
+    leaf load-balancing-weight {
+      description
+        "The load-balancing weight of the interface, which applies when
+        weighted ECMP is enabled and the interface is part of a multipath set.";
+      type union {
+        type uint32 {
+          range "1..4294967295";
+        }
+        type enumeration {
+          enum "auto" {
+              description "Load-balancing weight is based on the bandwidth of
+              the parent interface (port or LAG)";
+          }
+          enum "none" {
+              description "The interface should not participate in weighted
+              ECMP";
+          }
+        }
+      }
+      default "auto";
+    }
+  }
+
+  grouping isis-transport-config {
+    description
+      "This grouping defines configuration parameters relating to the
+      transport protocol used by the ISIS.";
+
+    leaf lsp-mtu-size {
+      type uint16;
+      description
+        "The maximum size in bytes of an IS-IS Link state PDU.";
+    }
+  }
+
+  grouping isis-graceful-restart-config {
+    description
+      "This grouping defines ISIS graceful restart configuration.";
+
+    leaf helper-only {
+      type boolean;
+      description
+        "Enable or disable the IS-IS graceful restart helper function. When
+        this leaf is set, the local system does not utilise the IS-IS
+        graceful restart procedures during its own restart, but supports
+        retaining forwarding information during a remote speaker's restart.";
+    }
+
+    leaf non-planned-only {
+      type boolean;
+      description
+        "When this leaf is set to TRUE, planned restart procedures as
+        described in RFC 8706 are not used.";
+      reference
+      "RFC 5706: Restart Signaling for IS-IS";
+    }
+
+    reference
+      "RFC 5306: Restart Signaling for IS-IS; RFC 5706: Restart Signaling
+      for IS-IS";
+  }
+
+  grouping isis-graceful-restart-level-config {
+    description
+      "This grouping defines ISIS graceful restart configuration relevant
+      for ISIS level/LSDB";
+
+    leaf restart-time {
+      type uint16;
+      default 30;
+      description
+        "Value of RFC5306/RFC8706 T2 timer";
+    }
+
+    reference
+      "RFC 5306: Restart Signaling for IS-IS; RFC 5706: Restart Signaling
+      for IS-IS";
+  }
+
+  grouping isis-graceful-restart-interface-config {
+    description
+      "This grouping defines ISIS graceful restart configuration relevant
+      for ISIS interface/adjacency";
+
+    leaf interface-timer {
+      type uint16;
+      description
+        "Value of RFC5306/RFC8706 T1 timer";
+    }
+
+    leaf interface-time-expirations {
+      type int64;
+      description
+        "Number of times T1 expires before IIH without Restart TLV's RR flag
+        set is sent. That is GR helper is not supported by adjacents
+        Inermediate System";
+    }
+
+    reference
+      "RFC 5306: Restart Signaling for IS-IS; RFC 5706: Restart Signaling
+      for IS-IS";
+  }
+
+  // configuration context containers
+  grouping inter-level-propagation-policies-structural {
+    description
+      "Propagate prefixes between IS-IS levels.";
+
+    container inter-level-propagation-policies {
+      description
+        "Policies to propagate prefixes between IS-IS levels.";
+
+      container level1-to-level2 {
+        description
+          "Policies relating to prefixes to be propagated from
+          Level 1 to Level 2.";
+
+        container config {
+          description
+            "Configuration parameters relating to the propagation
+            of prefixes from IS-IS Level 1 to Level 2.";
+
+          uses inter-level-propagation-policy-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state parameters relating to the
+            propagation of prefixes from IS-IS Level 1 to Level 2.";
+
+          uses inter-level-propagation-policy-config;
+        }
+
+      }
+
+      container level2-to-level1 {
+        description
+          "Policies relating to prefixes to be propagated from
+           Level2 to Level 1.";
+
+        container config {
+          description
+            "Configuration parameters relating to the propagation
+            of prefixes from IS-IS Level 2 to Level 1.";
+
+          uses inter-level-propagation-policy-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state parameters relating to the propagation
+            of prefixes from IS-IS Level 2 to Level 1.";
+
+          uses inter-level-propagation-policy-config;
+        }
+      }
+    }
+  }
+
+  grouping inter-level-propagation-policy-config {
+    description
+      "Policy governing the propagation of prefixes between levels.";
+
+    uses oc-rpol:apply-policy-import-config;
+    uses oc-rpol:default-policy-import-config;
+  }
+
+  grouping isis-mpls-config {
+    description
+      "This grouping defines MPLS-related features in IS-IS";
+
+    container mpls {
+      description
+        "Configuration and operational state relating to MPLS-related
+        features in IS-IS";
+
+      container igp-ldp-sync {
+        description
+          "Configuration and operational state relating to synchronisation
+          between the LDP and IS-IS";
+
+        container config {
+          description
+            "This container defines ISIS/IGP configuration.";
+
+          uses isis-ldp-igp-config;
+        }
+
+        container state {
+          config false;
+          description
+            "This container defines state information for ISIS/LDP Sync.";
+
+          uses isis-ldp-igp-config;
+        }
+      }
+    }
+  }
+
+  grouping isis-global-base {
+    description
+      "This grouping describes ISIS Global router.";
+
+    container config {
+      description
+        "This container defines ISIS global configuration router.";
+
+      uses isis-authentication-check-config;
+      uses isis-global-config;
+    }
+
+    container state {
+      config false;
+      description
+        "This container defines state for ISIS global router.";
+
+      uses isis-authentication-check-config;
+      uses isis-global-config;
+    }
+
+    container lsp-bit {
+      description
+        "This container defines ISIS LSP Operational Bits.";
+
+      container overload-bit {
+        description
+          "This container defines Overload Bit configuration.";
+        uses overload-bit-group;
+      }
+
+      container attached-bit {
+        description
+          "This container defines Attached Bit.";
+
+        container config {
+          description
+            "This container defines Attached Bit configuration.";
+
+          uses isis-attached-bit-config;
+        }
+
+        container state {
+          config false;
+          description
+            "This container defines state for Link State PDU Bit.";
+
+          uses isis-attached-bit-config;
+        }
+      }
+    }
+
+    container reference-bandwidth {
+      description
+        "This container defines ISIS Reference Bandwidth.";
+
+      container config {
+        description
+          "This container defines Reference Bandwidth configuration";
+        uses isis-reference-bandwidth-config;
+      }
+
+      container state {
+        config false;
+        description
+          "This container defines state for Reference Bandwidth.";
+
+        uses isis-reference-bandwidth-config;
+      }
+    }
+
+    container nsr {
+      description
+        "This container defines ISIS Non-Stop Routing.";
+
+      container config {
+        description
+          "This container defines Non-Stop-Routing configuration.";
+
+        uses admin-config;
+      }
+
+      container state {
+        config false;
+        description
+          "This container defines state for Non-Stop-Routing";
+
+        uses admin-config;
+      }
+    }
+
+    container graceful-restart {
+      description
+        "This container defines ISIS Graceful Restart.";
+
+      container config {
+        description
+          "This container defines ISIS graceful-restart configuration.";
+
+        uses admin-config;
+        uses isis-graceful-restart-config;
+        uses isis-graceful-restart-level-config;
+        uses isis-graceful-restart-interface-config;
+      }
+
+      container state {
+        config false;
+        description
+          "This container defines state information for ISIS graceful-restart.";
+
+        uses admin-config;
+        uses isis-graceful-restart-config;
+        uses isis-graceful-restart-level-config;
+        uses isis-graceful-restart-interface-config;
+      }
+    }
+
+    container timers {
+      description
+        "This container defines ISIS timers.";
+
+      container config {
+        description
+          "This container defines ISIS global timers configuration.";
+
+        uses isis-lsp-timers-config;
+      }
+
+      container state {
+        config false;
+        description
+          "This container defines state information for ISIS global timers.";
+
+        uses isis-lsp-timers-config;
+      }
+
+      container spf {
+        description
+          "This container defines ISIS SPF timer settings.";
+
+        container config {
+          description
+            "This container defines ISIS SPF timers configuration.";
+
+          uses isis-spf-timers-config;
+        }
+
+        container state {
+         config false;
+         description
+          "This container defines state information for ISIS SPF timers.";
+
+         uses isis-spf-timers-config;
+         uses isis-adaptive-timers-state;
+       }
+      }
+
+      container lsp-generation {
+        description
+          "This container defines ISIS LSP Generation.";
+
+        container config {
+          description
+            "This container defines ISIS LSP Generation timers
+            configuration.";
+
+          uses isis-lsp-generation-timers-config;
+        }
+
+        container state {
+          config false;
+          description
+            "This container defines state information for ISIS LSP Generation
+            timers.";
+
+          uses isis-lsp-generation-timers-config;
+          uses isis-adaptive-timers-state;
+        }
+      }
+    }
+
+    container transport {
+      description
+        "This container defines ISIS transport.";
+
+      container config {
+        description
+          "This container defines ISIS transport related configuration.";
+
+        uses isis-transport-config;
+      }
+
+      container state {
+        config false;
+        description
+          "This container defines state information for ISIS transport
+          parameters.";
+
+        uses isis-transport-config;
+      }
+    }
+
+    uses isis-mpls-config;
+
+    container igp-shortcuts {
+      description
+        "This container defines IGP shortcuts configuration and state
+        information.";
+
+      uses isis-shortcuts-afi-list;
+    }
+
+    container afi-safi {
+      description
+        "This container defines address-family specific configuration
+        and state information.";
+
+      uses isis-afi-safi-list;
+    }
+
+    uses oc-sr:sr-igp-top;
+  }
+
+  grouping isis-route-preference-config {
+    description
+      "This grouping defines ISIS route preference configuration";
+
+    leaf external-route-preference {
+      type uint32;
+      description
+        "Administrative Distance (preference) for external ISIS routes.";
+    }
+
+    leaf internal-route-preference {
+      type uint32;
+      description
+        "Administrative Distance (preference) for internal ISIS routes.";
+    }
+  }
+
+  grouping isis-interfaces {
+    description
+      "This grouping defines ISIS interfaces configured on local system.";
+
+    list interface {
+      key "interface-id";
+
+      description
+        "This list contains ISIS interfaces.
+
+        The interface referenced is based on the interface and
+        subinterface leaves within the interface-ref container -
+        which reference an entry in the /interfaces/interface list -
+        and should not rely on the value of the list key.";
+
+      leaf interface-id {
+        type leafref {
+          path "../config/interface-id";
+        }
+        description
+          "Reference to interface-id";
+      }
+
+      uses isis-interface-group;
+      uses isis-mpls-config;
+      uses oc-if:interface-ref;
+    }
+  }
+
+  grouping isis-interface-group {
+    description
+      "This grouping defines ISIS interfaces configured on local system.";
+
+    container config {
+      description
+        "This container defines ISIS interface configuration.";
+
+      uses admin-config;
+      uses isis-interface-config;
+    }
+
+    container state {
+      config false;
+      description
+        "This container defines state information for ISIS interfaces.";
+
+      uses admin-config;
+      uses isis-interface-config;
+    }
+
+    container circuit-counters {
+      description
+        "This container defines state information for ISIS circuit counters.";
+
+      uses circuit-counters-structural;
+    }
+
+    container authentication {
+      description
+        "This container defines ISIS authentication.";
+
+      uses isis-hello-authentication-group;
+    }
+
+    container afi-safi {
+      description
+        "This container defines address-family specific configuration
+        and state information.";
+
+      uses isis-if-global-afi-safi-list;
+    }
+
+    container levels {
+      description
+        "This container defines ISIS level specific configuration and
+        state information.";
+
+      uses isis-interface-levels;
+    }
+
+    container timers {
+      description
+        "This container describes ISIS interface timers configuration";
+
+      container config {
+        description
+          "Configuration parameters relating to interface
+          timers for IS-IS";
+
+        uses isis-interface-timers-config;
+      }
+
+      container state {
+        config false;
+        description
+          "This container defines state information for ISIS interface timers.";
+
+        uses isis-interface-timers-config;
+      }
+    }
+
+    container weighted-ecmp {
+      description
+        "This container defines ISIS interface weighted ECMP options";
+
+      container config {
+        description
+          "Configuration parameters relating to weighted ecmp";
+        uses isis-interface-weighted-ecmp-config;
+      }
+
+      container state {
+        config false;
+        description
+          "This container defines state information for weighted ecmp";
+        uses isis-interface-weighted-ecmp-config;
+      }
+    }
+
+    uses oc-bfd:bfd-enable;
+    container bfd {
+      description
+        "This container defines BFD.";
+
+      container config {
+        description
+          "This container defines BFD configuration parameters.";
+
+        uses isis-bfd-config;
+      }
+
+      container state {
+        config false;
+        description
+          "This container defines BFD state information.";
+
+        uses isis-bfd-config;
+      }
+    }
+    container graceful-restart {
+      description
+        "This container defines ISIS Graceful Restart for interface";
+
+      container config {
+        description
+          "This container defines interface config parameters for ISIS
+          graceful-restart.";
+
+        uses isis-graceful-restart-interface-config;
+      }
+      container state {
+        config false;
+        description
+          "This container defines information for ISIS graceful-restart.";
+
+        uses isis-graceful-restart-interface-config;
+      }
+    }
+  }
+
+  grouping isis-bfd-config {
+    description
+      "This grouping defines Bidirectionl-Forwarding-Detection
+      configuration.";
+
+    //There is also BFD state under adjacency
+    leaf bfd-tlv {
+      type boolean;
+      description
+        "When set to true, BFD TLV is used. This enables support for the IS-IS
+        BFD TLV options, which specify that a BFD session must be established
+        before an IS-IS adjacency can transition to the established state.
+        This option should be enabled on all IS-IS neighbors on a shared
+        interface.";
+      reference "RFC6213. TLV 148";
+    }
+    reference "RFC5880: Bidirectional Forwarding Detection (BFD).";
+  }
+
+
+  grouping isis-levels {
+    description
+      "This grouping defines global ISIS Levels.";
+
+    list level {
+      key "level-number";
+
+      description
+        "Configuration and operational state parameters related to a
+        particular level within the IS-IS protocol instance";
+
+      leaf level-number {
+        type leafref {
+          path "../config/level-number";
+        }
+        description
+          "Reference to ISIS level-number.";
+      }
+
+      uses isis-level-group;
+    }
+  }
+
+  grouping isis-interface-levels {
+    description
+      "This grouping defines ISIS interface Levels.";
+
+    list level {
+      key "level-number";
+      description
+        "Configuration and operational state parameters related to a
+        particular level on an IS-IS enabled interface.";
+
+      leaf level-number {
+        type leafref {
+          path "../config/level-number";
+        }
+        description
+          "Reference to ISIS level-number.";
+      }
+
+      uses isis-interface-level-group;
+    }
+  }
+
+  grouping isis-level-group {
+    description
+      "This grouping defines ISIS level configuration and state
+      information.";
+
+    container config {
+      description
+        "This container defines ISIS level based configuration.";
+
+      uses admin-config-deprecated;
+      uses isis-base-level-config;
+      uses isis-metric-style-config;
+      uses isis-authentication-check-config;
+    }
+
+    container state {
+      config false;
+      description
+        "This container defines ISIS level state information.";
+
+      uses admin-config;
+      uses isis-base-level-config;
+      uses isis-metric-style-config;
+      uses isis-authentication-check-config;
+    }
+
+    container graceful-restart {
+      description
+        "This container defines ISIS Graceful Restart.";
+
+      container config {
+        description
+          "This container defines ISIS graceful-restart configuration.";
+
+        uses admin-config;
+        uses isis-graceful-restart-level-config;
+      }
+
+      container state {
+        config false;
+        description
+          "This container defines state information for ISIS graceful-restart.";
+
+        uses admin-config;
+        uses isis-graceful-restart-level-config;
+      }
+    }
+
+    container system-level-counters {
+      description
+        "This container defines ISIS system level counters.";
+
+      uses system-level-counters-structural;
+    }
+
+    container link-state-database {
+      config false;
+      description
+        "This container defines ISIS LSDB.";
+
+      list lsp {
+        key "lsp-id";
+        description
+          "This list describes LSPs in the LSDB.";
+        uses lsp-state;
+      }
+    }
+
+    container traffic-engineering {
+      description
+        "This container defines ISIS TE.";
+
+      container config {
+        description
+          "This container defines ISIS TE configuration.";
+
+        uses admin-config;
+        uses isis-te-config;
+      }
+
+      container state {
+        config false;
+        description
+          "This container defines ISIS TE state information.";
+
+        uses admin-config;
+        uses isis-te-config;
+      }
+    }
+
+    container route-preference {
+      description
+        "This container defines Administrative Distance (or preference)
+        assigned to ISIS routes (level1 internal, level2 internal, level1
+        external, level2 external).";
+
+      container config {
+        description
+          "This container defines route preference configuration.";
+        uses isis-route-preference-config;
+      }
+
+      container state {
+        config false;
+        description
+          "This container defines ISIS route preference state information.";
+        uses isis-route-preference-config;
+      }
+    }
+
+    container authentication {
+      description
+        "This container defines ISIS authentication.";
+      uses isis-level-authentication-group;
+    }
+  }
+
+  grouping isis-level-authentication-group {
+    description
+      "Grouping containing structural elements for authentication in IS-IS.";
+
+    container config {
+      description
+        "Configuration parameters relating to IS-IS authentication.";
+
+      uses isis-level-authentication-config;
+      uses isis-authentication-type-config;
+      uses isis-simple-key-authentication-config;
+    }
+
+    container state {
+      config false;
+      description
+        "Operational state parameters relating to IS-IS authentication.";
+      uses isis-level-authentication-config;
+      uses isis-authentication-type-config;
+      uses isis-simple-key-authentication-config;
+    }
+  }
+
+  grouping isis-level-authentication-config {
+    description
+      "Configuration leaves for IS-IS authentication.";
+
+    leaf enabled {
+      type boolean;
+      default false;
+      description
+        "When this leaf is set to true, authentication of IS-IS PSNP, CSNP and
+        LSP packets is enabled using the specified authentication details in
+        the sibling leaves.
+
+        The sibling 'disable-<type>' leaves can be used to override the value
+        of this leaf and disable authentication for a specific packet type.";
+    }
+
+    leaf disable-csnp {
+      type boolean;
+      default false;
+      description
+        "When this leaf is set to true, authentication is disabled for CSNP
+        packets, overriding the value of the enabled leaf in this context.";
+    }
+
+    leaf disable-psnp {
+      type boolean;
+      default false;
+      description
+        "When this leaf is set to true, authentication is disabled for PSNP
+        packets, overriding the value of the enabled leaf in this context.";
+    }
+
+    leaf disable-lsp {
+      type boolean;
+      default false;
+      description
+        "When this leaf is set to true, authentication is disabled for LSP
+        packets, overriding the value of the enabled leaf in this context.";
+    }
+
+    leaf keychain {
+      type oc-keychain:keychain-ref;
+      description
+        "Reference to the keychain that should be used for authenticating IS-IS
+        packets - the keychain may contain either a simple password, or
+        HMAC-MD5 key that is used for authenticating CSNP, PSNP and LSP packets
+        within the specified IS-IS level.";
+    }
+  }
+
+  grouping isis-interface-level-group {
+    description
+      "This grouping defines ISIS interface level.";
+
+    container config {
+      description
+        "This container defines interface ISIS level configuration.";
+
+      uses isis-interface-level-config;
+      uses admin-config;
+    }
+
+    container state {
+      config false;
+      description
+        "This container defines interface ISIS level state information.";
+
+      uses isis-interface-level-config;
+      uses admin-config;
+    }
+
+    container packet-counters {
+      description
+        "This container defines ISIS interface packet counters.";
+
+      uses packet-counters-structural;
+    }
+
+    container adjacencies {
+      config false;
+      description
+        "This container defines ISIS adjacencies.";
+
+      list adjacency {
+        key "system-id";
+
+        description
+          "List of the local system's IS-IS adjacencies.";
+
+        leaf system-id {
+          type leafref {
+            path "../state/system-id";
+          }
+          description
+            "Reference to the IS neighbor.";
+        }
+
+        container state {
+          description
+            "Operational state relating to the IS-IS adjacency with the
+            remote system";
+
+          uses adjacency-state;
+        }
+      }
+    }
+
+    container timers {
+      description
+        "This container defines ISIS timers.";
+
+      container config {
+        description
+          "This container defines ISIS interface hello-timers configuration.";
+
+        uses isis-hello-timers-config;
+      }
+
+      container state {
+        config false;
+        description
+          "This container defines ISIS interface hello-timers state.";
+
+        uses isis-hello-timers-config;
+      }
+    }
+
+    container afi-safi {
+      description
+        "This container defines address-family specific configuration
+        and state information.";
+
+      uses isis-if-afi-safi-list;
+    }
+
+    container hello-authentication {
+      description
+        "This container defines ISIS authentication.";
+
+      uses isis-hello-authentication-group;
+    }
+  }
+
+
+  grouping isis-top {
+    description
+      "This grouping define top-level ISIS model data.";
+
+    container isis {
+      description
+        "This container defines top-level ISIS configuration and state
+        information.";
+
+      container global {
+        description
+          "This container defines global ISIS configuration and state
+          information.";
+
+        uses isis-global-base;
+        uses inter-level-propagation-policies-structural;
+      }
+
+      container levels {
+        description
+          "This container defines ISIS level configuration and state
+          information.";
+        uses isis-levels;
+      }
+
+      container interfaces {
+        description
+          "This container defines global ISIS interface configuration and
+          state information.";
+        uses isis-interfaces;
+      }
+    }
+  }
+
+  grouping adjacency-state {
+    description
+      "This grouping defines ISIS adjacency.";
+
+    leaf system-id {
+     type oc-isis-types:system-id;
+      description
+        "ISIS neighbor system-id.";
+    }
+
+    leaf neighbor-ipv4-address {
+      type oc-inet:ipv4-address;
+      description
+        "ISIS Neighbor IPv4 address.";
+    }
+
+    leaf neighbor-ipv6-address {
+      type oc-inet:ipv6-address;
+      description
+        "ISIS Neighbor IPv6 address.";
+    }
+
+    leaf neighbor-snpa {
+      type oc-isis-types:snpa;
+      description
+        "ISIS neighbor SNPA.";
+    }
+
+    leaf local-extended-circuit-id {
+      type oc-isis-types:extended-circuit-id;
+      description
+        "Local extended circuit ID.";
+    }
+    leaf neighbor-extended-circuit-id {
+      type oc-isis-types:extended-circuit-id;
+      description
+        "ISIS neighbor extended circuit ID.";
+    }
+
+    leaf priority {
+      type uint8 {
+        range "0..127";
+      }
+      description
+        "Priority of the neighboring IS(LAN Hello only).";
+    }
+
+    leaf dis-system-id {
+      type oc-isis-types:system-id;
+      description
+        "DIS System ID(LAN hello only).";
+    }
+
+    leaf neighbor-circuit-type {
+      type oc-isis-types:level-type;
+      description
+        "Received ISIS circuit type (level-1, level-2, level-1-2).";
+    }
+
+    leaf adjacency-type {
+      type oc-isis-types:level-type;
+      description
+        "Formed ISIS adjacency type(level-1, level-2, level-1-2).";
+    }
+
+    leaf adjacency-state {
+      type oc-isis-types:isis-interface-adj-state;
+      description
+        "P2P 3-way ISIS adjacency state(up, down, init, failed).";
+      reference "RFC5303: TLV 240.";
+    }
+
+    leaf up-timestamp {
+      type oc-types:timeticks64;
+      description
+        "Time at which the adjacency transitioned into the up state, expressed
+        as number of nanoseconds since the Unix epoch (Jan 1, 1970 00:00:00
+        UTC).";
+    }
+
+    leaf multi-topology {
+      type boolean;
+      description
+        "When set to true, ISIS multi-topology is supported.";
+      reference "RFC5129. TLV 229.";
+    }
+
+    leaf-list topology {
+      type identityref {
+        base oc-isis-types:AFI_SAFI_TYPE;
+      }
+      description
+        "ISIS topology type support(ipv4-unicast, ipv6-unicast,
+        ipv4-multicast, ipv6-multicast).";
+    }
+
+    leaf restart-support {
+      type boolean;
+      description
+        "When set to true, Graceful-restart signaling is supported.";
+    }
+
+    leaf restart-suppress {
+      type boolean;
+      description
+        "When set to true, adjacency is not advertised. The SA bit is used by a
+        starting router to  request that its neighbor suppress advertisement of
+        the adjacency  to the starting router in the neighbor's LSPs.";
+    }
+
+    leaf restart-status {
+      type boolean;
+      description
+        "When set to true, neighbor is being helped. The RR bit is used by a
+        (re)starting router to signal to its neighbors that a (re)start is in
+        progress.";
+    }
+
+    leaf-list area-address {
+      type oc-isis-types:area-address;
+      description
+        "List of ISIS area-address(es).";
+    }
+
+    leaf-list nlpid {
+      type enumeration {
+        enum IPV4 {
+          description
+      "IPv4 Address family.";
+        }
+        enum IPV6 {
+          description
+      "IPv6 Address family.";
+        }
+      }
+      description
+        "Supported Protocol. IPv4 is defined as (0xcc)
+        and IPv6 - (0x8e). ISIS reference is TLV 129.";
+    }
+
+    // TODO(bogdanov): update when BFD model is integrated.
+    //leaf ipv4-bfd-status {
+      //type oc-isis-types:bfd-state;
+      //description
+      //  "IPv4 BFD session status.";
+    //}
+    //leaf ipv6-bfd-status {
+      //type oc-isis-types:bfd-state;
+      //description
+      //  "IPv4 BFD session status. ";
+    //}
+
+  }
+
+  grouping packet-counters-generic-state {
+    description
+      "Operational state parameters relating to LSP packet counters.";
+
+    leaf received {
+      type oc-yang:counter32;
+      description
+        "The number of the specified type of PDU received on the interface.";
+    }
+    leaf processed {
+      type oc-yang:counter32;
+      description
+        "The number of the specified type of PDU received on the interface
+        that have been processed by the local system.";
+    }
+    leaf dropped {
+      type oc-yang:counter32;
+      description
+        "The number of the specified type of PDU received on the interface
+        that have been dropped.";
+    }
+
+    leaf sent {
+      type oc-yang:counter32;
+      description
+        "The number of the specified type of PDU that have been sent by the
+        local system on the interface.";
+    }
+
+    leaf retransmit {
+      type oc-yang:counter32;
+      description
+        "The number of the specified type of PDU that that have been
+        retransmitted by the local system on the interface.";
+    }
+  }
+
+  grouping packet-counters-structural {
+    description
+      "This grouping defines ISIS packet counter state.";
+
+    container lsp {
+      description
+        "This container defines LSP packet counters.";
+
+     container state {
+      config false;
+      description
+        "This container defines LSP PDU counters.";
+
+      uses packet-counters-generic-state;
+     }
+    }
+
+    container iih {
+      description
+        "This container defines IIH packet counters.";
+
+      container state {
+        config false;
+        description
+          "Operational counters relating to IIH PDUs";
+
+        uses packet-counters-generic-state;
+      }
+    }
+
+    container ish {
+      description
+        "This container defines ISH packet counters.";
+
+     container state {
+      config false;
+      description
+        "Operational state relating to ISH PDUs.";
+
+      uses packet-counters-generic-state;
+     }
+    }
+
+    container esh {
+     description
+       "This container defines ESH packet counters.";
+     container state {
+      config false;
+      description
+        "Operational state relating to ESH PDUs";
+
+      uses packet-counters-generic-state;
+     }
+    }
+
+    container psnp {
+     description
+      "This container defines PSNP packet counters.";
+
+      container state {
+        config false;
+        description
+          "Packet counters relating to PSNPs.";
+
+        uses packet-counters-generic-state;
+      }
+    }
+
+    container csnp {
+      description
+        "Operational state parameters relating to CSNPs.";
+
+      container state {
+        config false;
+        description
+          "Packet counters relating to CSNPs.";
+
+        uses packet-counters-generic-state;
+      }
+    }
+
+    container unknown {
+      description
+        "Operational state parameters relating to IS-IS PDUs that are not
+        otherwise classified - referred to as Unknown PDUs.";
+
+      container state {
+        config false;
+        description
+          "Packet counters relating to unknown PDUs.";
+
+        uses packet-counters-generic-state;
+      }
+    }
+  }
+
+  grouping system-level-counters-state {
+    description
+      "IS-IS counters that are relevant to the system IS-IS context.";
+
+    leaf total-lsps {
+      type oc-yang:counter32;
+      description
+        "Number of LSPs in the database at the system level.";
+    }
+
+    leaf corrupted-lsps {
+      type oc-yang:counter32;
+      description
+        "Number of corrupted in-memory LSPs detected. LSPs received from the
+        wire with a bad checksum are silently dropped and not counted. LSPs
+        received from the wire with parse errors are counted by lsp-errors. MIB
+        Entry: SysCorrLSPs.";
+    }
+
+    leaf database-overloads {
+      type oc-yang:counter32;
+      description
+        "Number of times the database has become
+        overloaded.
+        MIB entry: SysLSPL(Level)DbaseOloads.";
+    }
+
+    leaf manual-address-drop-from-areas {
+      type oc-yang:counter32;
+      description
+        "Number of times a manual address has been dropped from area.
+        MIB Entry: SysManAddrDropFromAreas.";
+    }
+
+    leaf exceed-max-seq-nums {
+      type oc-yang:counter32;
+      description
+        "The number of times the system has attempted to exceed the maximum
+        sequence number. MIB Entry: SysAttmptToExMaxSeqNums.";
+    }
+    leaf seq-num-skips {
+      type oc-yang:counter32;
+      description
+        "Number of times a sequence number skip has occurred. MIB Entry:
+        SysSeqNumSkips.";
+    }
+
+    leaf own-lsp-purges {
+      type oc-yang:counter32;
+      description
+        "Number of times a zero-aged copy of the system's
+        own LSP is received from some other node.
+        MIB Entry: isisSysOwnLSPPurges.";
+    }
+
+    leaf id-len-mismatch {
+      type oc-yang:counter32;
+      description
+        "Number of times a PDU is received with a different value for ID field
+        length from that of the receiving system. MIB Entry:
+        isisSysIDFieldLenMismatches.";
+    }
+
+    leaf part-changes {
+      type oc-yang:counter32;
+      description
+        "The number of partition changes detected. MIB Entry: SysPartChanges.";
+    }
+
+    leaf max-area-address-mismatches {
+      type oc-yang:counter32;
+      description
+        "Number of times a PDU is received with a different value for
+        MaximumAreaAddresses from that of the receiving system. MIB Entry:
+        SysMaxAreaAddrMismatches.";
+    }
+
+    leaf auth-fails {
+      type oc-yang:counter32;
+      description
+        "The number of authentication key failures.
+         MIB Entry: SysAuthFails.";
+    }
+
+    leaf spf-runs {
+      type oc-yang:counter32;
+      description
+        "The number of times SPF was ran at this level.";
+    }
+
+    leaf auth-type-fails {
+      type oc-yang:counter32;
+      description
+        "The number of authentication type mismatches.";
+    }
+
+    leaf lsp-errors {
+      type oc-yang:counter32;
+      description
+        "The number of received LSPs with errors.";
+    }
+  }
+
+  grouping system-level-counters-structural {
+    description
+      "This grouping defines system level counters.";
+
+    container state {
+      config false;
+      description
+        "The container defines a list of system counters for the IS.";
+
+      uses system-level-counters-state;
+    }
+  }
+
+  grouping circuit-counters-state {
+    description
+      "Operational state parameters relating to counters specific to one
+      interface or circuit.";
+
+    leaf adj-changes {
+      type oc-yang:counter32;
+      description
+        "Number of times an adjacency state change has occurred on this circuit.
+        MIB Entry: CircAdjChanges.";
+    }
+
+    leaf init-fails {
+      type oc-yang:counter32;
+      description
+        "Number of times initialization of this circuit has failed. This counts
+        events such as PPP NCP failures. MIB Entry: CircInitFails.";
+    }
+
+    leaf rejected-adj {
+      type oc-yang:counter32;
+      description
+        "Number of times an adjacency has been rejected on this circuit. MIB
+        Entry: CircRejAdjs.";
+    }
+
+    leaf id-field-len-mismatches {
+      type oc-yang:counter32;
+      description
+        "Number of times an IS-IS control PDU with an ID field length different
+        from that for this system has been received.
+        MIB Entry: CircIDFieldLenMismatches.";
+    }
+
+    leaf max-area-address-mismatches {
+      type oc-yang:counter32;
+      description
+        "Number of times an IS-IS control PDU with a max area address field
+        different from that for this system has been received. MIB Entry:
+        CircMaxAreaAddrMismatches.";
+    }
+
+    leaf auth-type-fails {
+      type oc-yang:counter32;
+      description
+        "Number of times an IS-IS control PDU with an auth type field different
+        from that for this system has been received. MIB Entry:
+        CircAuthTypeFails.";
+    }
+
+    leaf auth-fails {
+      type oc-yang:counter32;
+      description
+        "Number of times an IS-IS control PDU with the correct auth type has
+        failed to pass authentication validation. MIB Entry: CircAuthFails.";
+    }
+
+    leaf lan-dis-changes {
+      type oc-yang:counter32;
+      description
+        "Number of times the Designated IS has changed on this circuit at this
+        level. If the circuit is point to point, this count is zero. MIB Entry:
+        CircLANDesISChanges.";
+    }
+
+    leaf adj-number {
+      type uint32;
+      description
+        "Number of adjacencies on this circuit.
+        MIB Entry: CircNumAdj.";
+    }
+  }
+
+  grouping circuit-counters-structural {
+    description
+      "This grouping defines circuit counters.";
+
+    container state {
+      config false;
+      description
+          "The container defines a list of counters for IS circuit.";
+
+     uses circuit-counters-state;
+    }
+  }
+}

--- a/models/yang/common/openconfig-keychain-types.yang
+++ b/models/yang/common/openconfig-keychain-types.yang
@@ -1,0 +1,140 @@
+module openconfig-keychain-types {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/oc-keychain-types";
+
+  prefix "oc-keychain-types";
+
+  import openconfig-extensions { prefix oc-ext; }
+
+  // meta
+  organization
+    "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This module contains general data definitions for use in
+    keychain-based authentication.";
+
+  oc-ext:openconfig-version "0.2.0";
+
+  revision "2022-03-01" {
+    description
+      "Remove NONE identity from AUTH_TYPE";
+    reference "0.2.0";
+  }
+
+  revision "2021-10-01" {
+    description
+      "Initial revision of types for keychain model";
+    reference "0.1.0";
+  }
+
+
+  identity AUTH_TYPE {
+    description
+    "Base identify to define the type of authentication";
+  }
+
+  identity SIMPLE_KEY {
+    base AUTH_TYPE;
+    description
+    "Authentication is provided via a simple authentication key. The
+    key is configured at each end, and the exchange of the key may be
+    encrypted or not";
+  }
+
+  identity KEYCHAIN {
+    base AUTH_TYPE;
+    description
+    "This identity indicates that the authentication is selected
+    from a keychain.";
+  }
+
+  identity CRYPTO_TYPE {
+    description
+      "Base identify for the cryptographic algorithm";
+  }
+
+  identity CRYPTO_NONE{
+    base CRYPTO_TYPE;
+      description
+        "No encryption is used";
+  }
+
+  identity MD5 {
+    base CRYPTO_TYPE;
+      description
+        "MD5 message-digest algorithm produces a 128-bit hash value.";
+      reference
+        "RFC 1321 - The MD5 Message-Digest Algorithm";
+  }
+
+  identity HMAC_MD5 {
+    base CRYPTO_TYPE;
+      description
+        "HMAC-MD5 keyed hash algorithm constructed from MD5 hash
+        function and used as a HMAC.";
+      reference
+        "RFC 2104 - HMAC: Keyed-Hashing for Message Authentication";
+  }
+
+  identity SHA_1 {
+    base CRYPTO_TYPE;
+      description
+        "SHA-1 cryptographic hash function that produces a 160-bit hash value.";
+      reference
+        "RFC 3174 - US Secure Hash Algorithm 1 (SHA1)";
+  }
+  identity HMAC_SHA_1 {
+    base CRYPTO_TYPE;
+      description
+        "HMAC-SHA-1 keyed hash algorithm constructed from SHA-1 hash
+        function and used as a HMAC.";
+  }
+
+  identity HMAC_SHA_1_12 {
+    base CRYPTO_TYPE;
+      description
+        "HMAC-SHA-1-12 algorithm";
+  }
+
+  identity HMAC_SHA_1_20 {
+    base CRYPTO_TYPE;
+      description
+        "HMAC-SHA-1-20 algorithm";
+  }
+
+  identity HMAC_SHA_1_96 {
+    base CRYPTO_TYPE;
+      description
+        "HMAC-SHA-1-96 keyed hash algorithm constructed from SHA-1 hash
+        function and used as a HMAC, operating on 64-byte blocks of data.";
+      reference
+        "RFC 2404 - The Use of HMAC-SHA-1-96 within ESP and AH";
+  }
+
+  identity HMAC_SHA_256 {
+    base CRYPTO_TYPE;
+      description
+        "HMAC-SHA-256 keyed hash algorithm constructed from the secure
+        SHA-256 hash function and used as a HMAC.";
+      reference
+        "RFC 6234 - US Secure Hash Algorithms (SHA and SHA-based
+        HMAC and HKDF)";
+  }
+
+  identity AES_28_CMAC_96 {
+    base CRYPTO_TYPE;
+      description
+        "AES-128-CMAC-96 keyed hash function based on a AES-128 block
+        cipher.";
+      reference
+        "RFC 4494 - The AES-CMAC-96 Algorithm and Its Use with IPsec";
+  }
+}

--- a/models/yang/common/openconfig-keychain.yang
+++ b/models/yang/common/openconfig-keychain.yang
@@ -1,0 +1,320 @@
+module openconfig-keychain {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/oc-keychain";
+
+  prefix "oc-keychain";
+
+  import openconfig-extensions { prefix oc-ext; }
+  import openconfig-keychain-types { prefix oc-keychain-types; }
+  import openconfig-types { prefix oc-types; }
+  import openconfig-yang-types { prefix oc-yang; }
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This module describes a YANG model for keychain configuration
+    and management. These keys can be changed frequently to
+    increase security in long-lived connections. A keychain can be used
+    for authenticaion in a number of scenarios, including in routing protocols
+    (e.g. BGP, IS-IS, OSPF).  A keychain provides a solution for storing
+    a number of different keys, each key string value is associated with a
+    specific key id, name, the lifetime that the key is valid and an
+    encryption algorithm.
+
+    This model defines a central location for defining named keychains,
+    which may be then referenced by other models such as routing protocol
+    management.";
+
+  oc-ext:openconfig-version "0.5.0";
+
+revision "2024-05-30" {
+    description
+      "Update key-id to a union of hex-string-prefixed and uint64.";
+    reference "0.5.0";
+  }
+
+  revision "2022-11-05" {
+    description
+      "Update key-id to a union of hex-string and uint64.";
+    reference "0.4.0";
+  }
+
+  revision "2022-03-05" {
+    description
+      "Add prefix qualification to keychain-ref";
+    reference "0.3.0";
+  }
+
+  revision "2021-12-31" {
+    description
+      "Add keychain-ref type to allow for a resuable reference to a keychain.";
+    reference "0.2.0";
+  }
+
+  revision "2021-10-01" {
+    description
+      "Initial revision of keychain model.";
+    reference "0.1.0";
+  }
+
+  typedef keychain-ref {
+    type leafref {
+      path "/oc-keychain:keychains/oc-keychain:keychain/" +
+           "oc-keychain:config/oc-keychain:name";
+    }
+    description
+      "A reference to a keychain defined on the system that can be used by
+      modules that require access to keychains.";
+  }
+
+  grouping valid-lifetime-config {
+    description
+      "This grouping defines key begin lifetime parameters.";
+
+    leaf start-time {
+      type oc-types:timeticks64;
+      description
+        "The time at which the key becomes valid for use.
+        The value is the timestamp in nanoseconds relative to
+        the Unix Epoch (Jan 1, 1970 00:00:00 UTC).";
+    }
+
+    leaf end-time {
+      type oc-types:timeticks64;
+      description
+        "The time at which the key becomes invalid for use.
+        The value is the timestamp in nanoseconds relative to
+        the Unix Epoch (Jan 1, 1970 00:00:00 UTC).
+
+        Leaving this value unset, or setting it to 0, indicates that
+        the key remains valid forever (no end time).";
+    }
+  }
+
+  grouping lifetime-symmetry-config {
+    description
+      "Grouping to define configuration data for managing how
+      send and receive lifetime are specified.";
+
+    leaf send-and-receive {
+      type boolean;
+      description
+        "When this is set to true (the default value), the specified
+        send lifetime is also used in the receive direction.  When set
+        to false, the device should use the specified receive-lifetime
+        for the receive direction (asymmetric mode).  If send-and-receive
+        is false, and the device does not support asymmetric configuration,
+        the config should be rejected as unsupported.";
+      default true;
+    }
+  }
+
+  grouping lifetime-base {
+    description
+      "This grouping defines key lifetime parameters.";
+
+    container send-lifetime {
+      description
+        "Specifies the lifetime of the key for sending authentication
+        information to the peer.";
+
+      container config {
+        description
+          "Configuration data for key send lifetime.";
+
+        uses valid-lifetime-config;
+        uses lifetime-symmetry-config;
+      }
+
+      container state {
+        config false;
+        description
+          "Operational state data for key send lifetime.";
+
+        uses valid-lifetime-config;
+        uses lifetime-symmetry-config;
+      }
+    }
+
+    container receive-lifetime {
+      description
+        "Specify the validity lifetime of the key in the receive direction.
+        Some platforms may only support symmetric send and receive lifetimes,
+        in which case the receive-lifetime is typically not specified.";
+
+      container config {
+        description
+          "Configuration data for key receive lifetime.";
+
+        uses valid-lifetime-config;
+      }
+
+      container state {
+        config false;
+        description
+          "Operational state data for key receive lifetime.";
+
+        uses valid-lifetime-config;
+      }
+    }
+  }
+
+  grouping keychain-base-config {
+    description
+      "This grouping defines key-chain parameters.";
+
+    leaf name {
+      type string;
+      description
+        "Keychain name.";
+    }
+
+    leaf tolerance {
+      type union {
+        type enumeration {
+          enum FOREVER {
+            description
+              "Receive key does not expire (equivalent to infinite tolerance).";
+          }
+        }
+        type uint32;
+      }
+      description
+        "Tolerance (overlap time) that a receive key should be accepted.  May be
+        expressed as range in seconds, or using the FOREVER value to indicate
+        that the key does not expire.  The default value should be 0, i.e., no
+        tolerance.";
+    }
+  }
+
+  grouping keychain-key-config {
+    description "This grouping defines key-chain key parameters.";
+
+    leaf key-id {
+      type union {
+        type oc-yang:hex-string-prefixed {
+          length "3..66";
+        }
+        type uint64;
+      }
+      description
+        "Identifier for the key within the keychain.  Note that the
+        hex-string type is deprecated and will be removed from a future
+        version of this model. Implementations should transition to using
+        the hex-string-prefixed type.";
+    }
+
+    leaf secret-key {
+      type string;
+      description
+        "Authentication key supplied as an encrypted value.  The system should store and
+        return the key in encrypted form.";
+    }
+
+    leaf crypto-algorithm {
+      type identityref {
+        base oc-keychain-types:CRYPTO_TYPE;
+      }
+      description
+        "Cryptographic algorithm associated with the key.  Note that not all cryptographic
+        algorithms are available in all contexts (e.g., across different protocols).";
+    }
+  }
+
+  grouping keychain-key-base {
+    description
+      "This grouping defines keychain parameters";
+
+  container keys {
+    description
+    "list of keys to be stored";
+      list key {
+        key "key-id";
+        description
+          "List of configured keys for the keychain.";
+
+        leaf key-id {
+          type leafref {
+            path "../config/key-id";
+          }
+          description
+            "Reference to key id.";
+        }
+
+        container config {
+          description
+            "This container defines keychain key configuration.";
+
+          uses keychain-key-config;
+        }
+
+        container state {
+          config false;
+          description
+            "This container defines keychain key state.";
+
+          uses keychain-key-config;
+        }
+
+        uses lifetime-base;
+        }
+    }
+  }
+
+  grouping keychain-common-base {
+    description
+      "This grouping defines keychain parameters";
+
+    container config {
+      description
+        "This container defines keychain configuration.";
+
+      uses keychain-base-config;
+    }
+
+    container state {
+      config false;
+      description
+        "This container defines keychain state information.";
+
+      uses keychain-base-config;
+    }
+  }
+
+  grouping keychain-top {
+    description
+      "This grouping define top level structure.";
+
+    container keychains {
+      description
+        "This container defines keychains.";
+
+      list keychain {
+        key "name";
+        description
+          "List of defined keychains.";
+
+        leaf name {
+          type leafref {
+            path "../config/name";
+          }
+          description
+            "Reference to configured keychain name";
+        }
+
+        uses keychain-common-base;
+        uses keychain-key-base;
+      }
+    }
+  }
+
+  uses keychain-top;
+}

--- a/models/yang/common/openconfig-license.yang
+++ b/models/yang/common/openconfig-license.yang
@@ -1,0 +1,177 @@
+module openconfig-license {
+
+  yang-version "1";
+
+  namespace "http://openconfig.net/yang/license";
+
+  prefix "oc-license";
+
+  import openconfig-extensions { prefix oc-ext; }
+
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This module defines configuration and operational
+    state data for licenses.";
+
+  oc-ext:openconfig-version "0.2.0";
+
+  revision "2020-04-22" {
+    description
+      "Make license-data a union of a string or binary.";
+    reference "0.2.0";
+  }
+
+  revision "2020-01-07" {
+    description
+      "Initial revision";
+    reference "0.1.0";
+  }
+
+  // OpenConfig specific extensions for module metadata.
+  oc-ext:regexp-posix;
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+
+  grouping license-config {
+    description
+      "Configuration data for license";
+
+    leaf license-id {
+      type string;
+      description
+        "License ID. A string that uniquelly identifies the license. The
+         platform should list all the licenses it supports being activated.";
+    }
+
+    leaf license-data {
+      type union {
+        type binary;
+        type string;
+      }
+      description
+        "The contents of the licence (if required) - which may be
+         supplied as a binary blob, or a simple string value. If this
+         value is considered sensitive, it may be read as an empty value.";
+    }
+
+    leaf active {
+      type boolean;
+      default false;
+      description
+        "The activation state of the license.";
+    }
+
+  }
+
+  grouping license-state {
+    description
+    "State data for license";
+
+    leaf description {
+      type string;
+      description
+        "The license description.";
+    }
+
+    leaf issue-date {
+      type uint64;
+      description
+        "The date and time at which the license was issued, expressed as the
+         number of nanoseconds since the Unix Epoch
+         (January 1, 1970, 00:00 UTC).";
+    }
+
+    leaf expiration-date {
+      type uint64;
+      description
+        "The date and time at which the license will expire, expressed as the
+         number of nanoseconds since the Unix Epoch
+         (January 1, 1970, 00:00 UTC). Zero if it does not expire.";
+    }
+
+    leaf in-use {
+      type boolean;
+      description
+        "The license is in use. Different from active. This states that the
+         license is effectively being used in addition to being active. If
+         license for feature X was activated but feature X is not being used,
+         then this should be false.";
+    }
+
+    leaf expired {
+      type boolean;
+      description
+        "The license has expired.";
+    }
+
+    leaf valid {
+      type boolean;
+      description
+        "The license is valid. Can be activated in the system or platform.";
+    }
+
+  }
+
+  grouping licenses-top {
+    description
+      "Top-level grouping for licenses.";
+
+    container licenses {
+      description
+        "Enclosing container for list of licenses";
+
+      list license {
+        key "license-id";
+        description
+          "List of licenses.";
+
+        leaf license-id {
+          type leafref {
+            path "../config/license-id";
+          }
+          description
+            "Reference to license id list key";
+        }
+
+        container config {
+          description
+            "Configuration data for license";
+
+          uses license-config;
+        }
+
+        container state {
+
+          config false;
+
+          description
+            "Operational state data for license.";
+
+          uses license-config;
+          uses license-state;
+        }
+      }
+    }
+
+  }
+
+  grouping license-top {
+    description
+      "Top-level for the license model";
+
+    container license {
+      description
+        "Container for license model";
+
+      uses licenses-top;
+
+    }
+  }
+
+}

--- a/models/yang/common/openconfig-local-routing.yang
+++ b/models/yang/common/openconfig-local-routing.yang
@@ -1,0 +1,428 @@
+module openconfig-local-routing {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/local-routing";
+
+  prefix "oc-loc-rt";
+
+  // import some basic types
+  import openconfig-inet-types { prefix inet; }
+  import openconfig-policy-types { prefix oc-pt; }
+  import openconfig-extensions { prefix oc-ext; }
+  import openconfig-interfaces { prefix oc-if; }
+  import openconfig-bfd { prefix oc-bfd; }
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This module describes configuration and operational state data
+    for routes that are locally generated, i.e., not created by
+    dynamic routing protocols.  These include static routes, locally
+    created aggregate routes for reducing the number of constituent
+    routes that must be advertised, summary routes for IGPs, etc.
+
+    This model expresses locally generated routes as generically as
+    possible, avoiding configuration of protocol-specific attributes
+    at the time of route creation.  This is primarily to avoid
+    assumptions about how underlying router implementations handle
+    route attributes in various routing table data structures they
+    maintain.  Hence, the definition of locally generated routes
+    essentially creates 'bare' routes that do not have any protocol-
+    specific attributes.
+
+    When protocol-specific attributes must be attached to a route
+    (e.g., communities on a locally defined route meant to be
+    advertised via BGP), the attributes should be attached via a
+    protocol-specific policy after importing the route into the
+    protocol for distribution (again via routing policy).";
+
+  oc-ext:openconfig-version "2.0.1";
+
+  revision "2022-11-01" {
+    description
+      "Update static route nexthop index description.";
+    reference "2.0.1";
+  }
+
+  revision "2022-05-10" {
+    description
+      "Removal of top-level /local-routes, description update to
+      static route metric, addition of static/aggregate route
+      preference, addition of aggregate route metric.";
+    reference "2.0.0";
+  }
+
+  revision "2020-03-24" {
+    description
+      "Add bfd support without augmentation.";
+    reference "1.2.0";
+  }
+
+  revision "2020-03-24" {
+    description
+      "Add a description statement to static routes.";
+    reference "1.1.0";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "1.0.2";
+  }
+
+  revision "2017-05-15" {
+    description
+      "Update to resolve style guide non-compliance.";
+    reference "1.0.1";
+  }
+
+  revision "2016-05-11" {
+    description
+      "OpenConfig public release";
+    reference "1.0.0";
+  }
+
+  // OpenConfig specific extensions for module metadata.
+  oc-ext:regexp-posix;
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  // identity statements
+
+  identity LOCAL_DEFINED_NEXT_HOP {
+    description
+      "A base identity type of local defined next-hops";
+  }
+
+  identity DROP {
+    base LOCAL_DEFINED_NEXT_HOP;
+    description
+      "Discard traffic for the corresponding destination";
+  }
+
+  identity LOCAL_LINK {
+    base LOCAL_DEFINED_NEXT_HOP;
+    description
+      "Treat traffic towards addresses within the specified
+      next-hop prefix as though they are connected to a local
+      link. When the LOCAL_LINK next-hop type is specified,
+      an interface must also be specified such that
+      the local system can determine which link to trigger
+      link-layer address discovery against";
+  }
+
+  // typedef statements
+
+  typedef local-defined-next-hop {
+    type identityref {
+      base LOCAL_DEFINED_NEXT_HOP;
+    }
+    description
+      "Pre-defined next-hop designation for locally generated
+      routes";
+  }
+
+  // grouping statements
+
+  grouping local-generic-settings {
+    description
+      "Generic options that can be set on local routes when
+      they are defined";
+
+    leaf set-tag {
+      type oc-pt:tag-type;
+      description
+        "Set a generic tag value on the route. This tag can be
+        used for filtering routes that are distributed to other
+        routing protocols.";
+    }
+
+    leaf description {
+      type string;
+      description
+        "An optional textual description for the route.";
+    }
+  }
+
+  grouping local-common-route-attributes {
+    description
+      "Common route attributes that can be set on static route next-hops
+      as well as aggregate routes.";
+
+    leaf metric {
+      type uint32;
+      description
+        "A metric (or cost) which is utilized to specify the order of
+        selection of the next-hop entry.  The lower the metric, the more
+        preferable the prefix entry is.  When this value is not
+        specified, the metric is inherited from the default metric of
+        the implementation for static route entries.  When multiple
+        next-hops are specified for a static route, the metric is
+        utilized to determine which of the next-hops to be installed in
+        the RIB.  When multiple next-hops have the same metric (be it
+        specified, or simply the default) then these next-hops should
+        all be installed in the RIB.";
+    }
+
+    leaf preference {
+      type uint32;
+      description
+        "Administrative Distance (preference) of the entry.  The
+        preference defines the order of selection when multiple
+        sources (protocols, static, etc.) contribute to the same
+        prefix entry.  The lower the preference, the more preferable the
+        prefix is.  When this value is not specified, the preference is
+        inherited from the default preference of the implementation for
+        static routes.";
+    }
+  }
+
+  grouping local-static-config {
+    description
+      "Configuration data for static routes.";
+
+    leaf prefix {
+      type inet:ip-prefix;
+      description
+        "Destination prefix for the static route, either IPv4 or
+        IPv6.";
+    }
+
+    uses local-generic-settings;
+  }
+
+  grouping local-static-state {
+    description
+      "Operational state data for static routes";
+  }
+
+
+  grouping local-static-nexthop-config {
+    description
+      "Configuration parameters related to each next-hop entry
+      specified for a static route";
+
+    leaf index {
+      type string;
+      description
+        "An user-specified identifier utilised to uniquely reference
+        the next-hop entry in the next-hop list. The value of this
+        index has no semantic meaning other than for referencing
+        the entry.  It is observed that implementations typically
+        only support a numeric value for this string. ";
+    }
+
+    leaf next-hop {
+      type union {
+        type inet:ip-address;
+        type local-defined-next-hop;
+      }
+      description
+        "The next-hop that is to be used for the static route
+        - this may be specified as an IP address, an interface
+        or a pre-defined next-hop type - for instance, DROP or
+        LOCAL_LINK. When this leaf is not set, and the interface-ref
+        value is specified for the next-hop, then the system should
+        treat the prefix as though it is directly connected to the
+        interface.";
+    }
+
+    leaf recurse {
+      type boolean;
+      default false;
+      description
+        "Determines whether the next-hop should be allowed to
+        be looked up recursively - i.e., via a RIB entry which has
+        been installed by a routing protocol, or another static route
+        - rather than needing to be connected directly to an
+        interface of the local system within the current network
+        instance. When the interface reference specified within the
+        next-hop entry is set (i.e., is not null) then forwarding is
+        restricted to being via the interface specified - and
+        recursion is hence disabled.";
+    }
+
+    uses local-common-route-attributes;
+  }
+
+  grouping local-static-nexthop-state {
+    description
+      "Operational state parameters relating to a next-hop entry
+      for a static route";
+  }
+
+
+  grouping local-static-top {
+    description
+      "Top-level grouping for the list of static route definitions";
+
+    container static-routes {
+      description
+        "Enclosing container for the list of static routes";
+
+      list static {
+        key "prefix";
+        description
+          "List of locally configured static routes";
+
+        leaf prefix {
+          type leafref {
+            path "../config/prefix";
+          }
+          description
+            "Reference to the destination prefix list key.";
+        }
+
+        container config {
+          description
+            "Configuration data for static routes";
+
+          uses local-static-config;
+        }
+
+        container state {
+
+          config false;
+
+          description
+            "Operational state data for static routes";
+
+          uses local-static-config;
+          uses local-static-state;
+        }
+
+        container next-hops {
+          description
+            "Configuration and state parameters relating to the
+            next-hops that are to be utilised for the static
+            route being specified";
+
+          list next-hop {
+            key "index";
+
+            description
+              "A list of next-hops to be utilised for the static
+              route being specified.";
+
+            leaf index {
+              type leafref {
+                path "../config/index";
+              }
+              description
+                "A reference to the index of the current next-hop.
+                The index is intended to be a user-specified value
+                which can be used to reference the next-hop in
+                question, without any other semantics being
+                assigned to it.";
+            }
+
+            container config {
+              description
+                "Configuration parameters relating to the next-hop
+                entry";
+
+              uses local-static-nexthop-config;
+            }
+
+            container state {
+              config false;
+              description
+                "Operational state parameters relating to the
+                next-hop entry";
+
+              uses local-static-nexthop-config;
+              uses local-static-nexthop-state;
+            }
+
+            uses oc-bfd:bfd-enable;
+            uses oc-if:interface-ref;
+          }
+        }
+      }
+    }
+  }
+
+  grouping local-aggregate-config {
+    description
+      "Configuration data for aggregate routes";
+
+    leaf prefix {
+      type inet:ip-prefix;
+      description
+        "Aggregate prefix to be advertised";
+    }
+
+    leaf discard {
+      type boolean;
+      default false;
+      description
+        "When true, install the aggregate route with a discard
+        next-hop -- traffic destined to the aggregate will be
+        discarded with no ICMP message generated.  When false,
+        traffic destined to an aggregate address when no
+        constituent routes are present will generate an ICMP
+        unreachable message.";
+    }
+
+    uses local-generic-settings;
+    uses local-common-route-attributes;
+  }
+
+  grouping local-aggregate-state {
+    description
+      "Operational state data for local aggregate advertisement
+      definitions";
+  }
+
+  grouping local-aggregate-top {
+    description
+      "Top-level grouping for local aggregates";
+
+    container local-aggregates {
+      description
+        "Enclosing container for locally-defined aggregate
+        routes";
+
+      list aggregate {
+        key "prefix";
+        description
+          "List of aggregates";
+
+        leaf prefix {
+          type leafref {
+            path "../config/prefix";
+          }
+          description
+            "Reference to the configured prefix for this aggregate";
+        }
+
+        container config {
+          description
+            "Configuration data for aggregate advertisements";
+
+          uses local-aggregate-config;
+        }
+
+        container state {
+
+          config false;
+
+          description
+            "Operational state data for aggregate
+            advertisements";
+
+          uses local-aggregate-config;
+          uses local-aggregate-state;
+        }
+      }
+    }
+  }
+
+}

--- a/models/yang/common/openconfig-messages.yang
+++ b/models/yang/common/openconfig-messages.yang
@@ -32,12 +32,18 @@ module openconfig-messages {
     /yang/system/openconfig-system.yang model, rather it provies the
     Operator with an alternative method of consuming messages.";
 
-  oc-ext:openconfig-version "0.0.1";
+  oc-ext:openconfig-version "0.1.0";
+
+  revision 2024-07-15 {
+    description
+      "Remove unused top-level messages container.";
+    reference "0.1.0";
+  }
 
   revision "2018-08-13" {
-      description
-        "Initial draft.";
-      reference "0.0.1";
+    description
+      "Initial draft.";
+    reference "0.0.1";
   }
 
   // identity statements
@@ -217,5 +223,4 @@ module openconfig-messages {
     uses debug-messages-top;
     }
   }
-  uses messages-top;
 }

--- a/models/yang/common/openconfig-mpls-igp.yang
+++ b/models/yang/common/openconfig-mpls-igp.yang
@@ -1,0 +1,186 @@
+submodule openconfig-mpls-igp {
+
+  yang-version "1";
+
+  belongs-to "openconfig-mpls" {
+    prefix "oc-mpls";
+  }
+
+  // import some basic types
+  import openconfig-mpls-ldp { prefix oc-ldp; }
+  import openconfig-extensions { prefix oc-ext; }
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    netopenconfig@googlegroups.com";
+
+  description
+    "Configuration generic configuration parameters for IGP-congruent
+    LSPs";
+
+  oc-ext:openconfig-version "3.5.0";
+
+  revision "2023-12-14" {
+    description
+      "Added additional attributes oc-if:interface-ref
+      and metric attributes to static lsp";
+    reference "3.5.0";
+  }
+
+  revision "2023-07-25" {
+    description
+      "Added record-route-enabled to MPLS p2p tunnel config";
+    reference "3.4.0";
+  }
+
+  revision "2023-04-28" {
+    description
+      "Fixed typo in cspf-tiebreaker leaf description";
+    reference "3.3.2";
+  }
+
+  revision "2023-02-03" {
+    description
+      "Clarify usage of interface-ref.";
+    reference "3.3.1";
+  }
+
+  revision "2022-02-11" {
+    description
+      "Add lsp-path PCE control mode";
+    reference "3.3.0";
+  }
+
+  revision "2021-07-28" {
+    description
+      "Add prefix to qualify when statements.";
+    reference "3.2.2";
+  }
+
+  revision "2021-06-16" {
+    description
+      "Remove trailing whitespace";
+    reference "3.2.1";
+  }
+
+  revision "2021-03-24" {
+    description
+      "Add Metric bounds constraints for LSPs.";
+    reference "3.2.0";
+  }
+
+  revision "2019-03-26" {
+    description
+      "Add Pseudowire encapsulation.";
+    reference "3.1.0";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "3.0.1";
+  }
+
+  revision "2018-07-02" {
+    description
+      "Add new RSVP-TE statistics, remove associated-rsvp-session
+      leaf. Remove use of date-and-time.";
+    reference "3.0.0";
+  }
+
+  revision "2018-06-16" {
+    description
+      "Included attributes for base LDP configuration.";
+     reference "2.6.0";
+  }
+
+  revision "2018-06-13" {
+    description
+      "Add ttl-propagation to global MPLS config";
+    reference "2.5.0";
+  }
+
+  revision "2018-06-05" {
+    description
+      "Fixed bugs in when statements on RSVP-TE attributes";
+    reference "2.4.2";
+  }
+
+  revision "2017-08-24" {
+    description
+      "Minor formatting fixes.";
+    reference "2.4.1";
+  }
+
+  revision "2017-06-21" {
+    description
+      "Add TC bits typedef.";
+    reference "2.4.0";
+  }
+
+  revision "2017-03-22" {
+    description
+      "Add RSVP calculated-absolute-subscription-bw";
+    reference "2.3.0";
+  }
+
+  revision "2017-01-26" {
+    description
+      "Add RSVP Tspec, clarify units for RSVP, remove unused LDP";
+    reference "2.2.0";
+  }
+
+  revision "2016-12-15" {
+    description
+      "Add additional MPLS parameters";
+    reference "2.1.0";
+  }
+
+  revision "2016-09-01" {
+    description
+      "Revisions based on implementation feedback";
+    reference "2.0.0";
+  }
+
+  revision "2016-08-08" {
+    description
+      "Public release of MPLS models";
+    reference "1.0.1";
+  }
+
+  // grouping statements
+
+  grouping igp-lsp-common {
+    description
+      "common definitions for IGP-congruent LSPs";
+
+  }
+
+
+  grouping igp-lsp-setup {
+    description
+      "signaling protocol definitions for IGP-based LSPs";
+
+    container path-setup-protocol {
+      description
+        "select and configure the signaling method for
+          the LSP";
+
+      // uses path-setup-common;
+      uses oc-ldp:igp-lsp-ldp-setup;
+    }
+  }
+
+
+  // data definition statements
+
+  // augment statements
+
+  // rpc statements
+
+  // notification statements
+
+}

--- a/models/yang/common/openconfig-mpls-ldp.yang
+++ b/models/yang/common/openconfig-mpls-ldp.yang
@@ -1,0 +1,985 @@
+module openconfig-mpls-ldp {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/ldp";
+
+  prefix "oc-ldp";
+
+  // import some basic types
+  import openconfig-extensions { prefix oc-ext; }
+  import openconfig-inet-types { prefix oc-inet; }
+  import openconfig-interfaces { prefix oc-if; }
+  import openconfig-yang-types { prefix oc-yang; }
+  import openconfig-types { prefix oc-types; }
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    netopenconfig@googlegroups.com";
+
+  description
+    "Configuration of Label Distribution Protocol global and LSP-
+    specific parameters for IGP-congruent LSPs.
+
+    This model reuses data items defined in the IETF YANG model for
+    LDP described by draft-ietf-mpls-ldp-yang-04, YANG Data Model for
+    MPLS LDP, following an alternate structure.
+
+    Portions of this code were derived from draft-ietf-mpls-ldp-yang-04.
+    Please reproduce this note if possible.
+
+    IETF code is subject to the following copyright and license:
+    Copyright (c) IETF Trust and the persons identified as authors of
+    the code.
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, is permitted pursuant to, and subject to the license
+    terms contained in, the Simplified BSD License set forth in
+    Section 4.c of the IETF Trust's Legal Provisions Relating
+    to IETF Documents (http://trustee.ietf.org/license-info).";
+
+  oc-ext:openconfig-version "3.2.1";
+
+  revision "2023-02-06" {
+    description
+      "Add clarification of use of interface-ref.";
+    reference "3.2.1";
+  }
+
+  revision "2022-02-21" {
+    description
+      "Added downstream-on-demand support";
+    reference "3.2.0";
+  }
+
+  revision "2020-01-09" {
+    description
+      "Added session-state leaf";
+    reference "3.1.0";
+  }
+
+  revision "2019-07-09" {
+    description
+      "Remove units for timeticks64 leaves, since the type
+      specifies the units.";
+    reference "3.0.2";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "3.0.1";
+  }
+
+  revision "2018-07-02" {
+    description
+      "Add new RSVP-TE statistics, remove associated-rsvp-session
+      leaf. Remove use of date-and-time.";
+    reference "3.0.0";
+  }
+
+  revision "2018-06-16" {
+    description
+      "Included attributes for base LDP configuration.";
+     reference "2.6.0";
+  }
+
+  revision "2018-06-13" {
+    description
+      "Add ttl-propagation to global MPLS config";
+    reference "2.5.0";
+  }
+
+  revision "2018-06-05" {
+    description
+      "Fixed bugs in when statements on RSVP-TE attributes";
+    reference "2.4.2";
+  }
+
+  revision "2017-08-24" {
+    description
+      "Minor formatting fixes.";
+    reference "2.4.1";
+  }
+
+  revision "2017-06-21" {
+    description
+      "Add TC bits typedef.";
+    reference "2.4.0";
+  }
+
+  revision "2017-03-22" {
+    description
+      "Add RSVP calculated-absolute-subscription-bw";
+    reference "2.3.0";
+  }
+
+  revision "2017-01-26" {
+    description
+      "Add RSVP Tspec, clarify units for RSVP, remove unused LDP";
+    reference "2.2.0";
+  }
+
+  revision "2016-12-15" {
+    description
+      "Add additional MPLS parameters";
+    reference "2.1.0";
+  }
+
+  revision "2016-09-01" {
+    description
+      "Revisions based on implementation feedback";
+    reference "2.0.0";
+  }
+
+  revision "2016-08-08" {
+    description
+      "Public release of MPLS models";
+    reference "1.0.1";
+  }
+
+  // OpenConfig specific extensions for module metadata.
+  oc-ext:regexp-posix;
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  // typedef statements
+
+  typedef mpls-ldp-adjacency-type {
+    type enumeration {
+      enum LINK {
+        description
+          "Link LDP adjacency";
+      }
+      enum TARGETED {
+        description
+          "Targeted LDP adjacency";
+      }
+    }
+    description
+     "enumerated type for specifying LDP adjacencies";
+  }
+
+  typedef mpls-ldp-afi {
+    type enumeration {
+      enum IPV4 {
+        description
+          "IPv4 AFI for LDP adjancencies";
+      }
+      enum IPV6 {
+        description
+          "IPv6 AFI for LDP adjancencies";
+      }
+    }
+    description
+     "enumerated type for specifying LDP AFIs";
+  }
+
+  typedef label-advertisement-mode {
+    type enumeration {
+      enum DOWNSTREAM_UNSOLICITED {
+        description
+          "Downstream Unsolicited.";
+      }
+      enum DOWNSTREAM_ON_DEMAND {
+        description
+          "Downstream on Demand.";
+      }
+    }
+    description
+      "Label Advertisement Mode.";
+  }
+
+  // grouping statements
+
+   grouping ldp-global {
+    description
+      "Global LDP signaling configuration";
+
+    container ldp {
+      description
+        "LDP global signaling configuration";
+
+      container global {
+        description
+          "Platform wide LDP configuration and state";
+
+        uses mpls-ldp-global;
+        uses mpls-ldp-graceful-restart;
+        uses mpls-ldp-authentication-top;
+      }
+
+      uses mpls-ldp-interface-attributes-top;
+      uses mpls-ldp-targeted-top;
+      uses mpls-ldp-neighbors-top;
+
+    }
+  }
+
+  grouping mpls-ldp-authentication-top {
+    description
+    "Grouping containing LDP authentication attributes";
+
+    container authentication {
+      description
+        "Global LDP authentication";
+
+      container config {
+          description
+            "Configuration of LDP authentication attributes";
+          uses mpls-ldp-authentication-config;
+      }
+
+      container state {
+        config false;
+        description
+          "LDP authentication state.";
+        uses mpls-ldp-authentication-config;
+      }
+    }
+  }
+
+  grouping mpls-ldp-neighbors-top {
+    description
+      "Global LDP neighbor attributes";
+
+    container neighbors {
+      description
+        "State and configuration LDP neighbors attributes";
+
+      list neighbor {
+        key "lsr-id label-space-id";
+
+        description
+          "List of LDP neighbors and their attributes.";
+
+        leaf lsr-id {
+          type leafref {
+            path "../config/lsr-id";
+          }
+          description
+            "Neighbor label switch router identifier.";
+        }
+
+        leaf label-space-id {
+          type leafref {
+            path "../config/label-space-id";
+          }
+          description
+            "Label space ID of the neighbor.";
+        }
+
+        container config {
+          description
+            "Neighbor configuration attributes.";
+          uses mpls-ldp-neighbor-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Neighbor state attributes.";
+          uses mpls-ldp-neighbor-config;
+          uses mpls-ldp-neighbor-state;
+        }
+
+        container hello-adjacencies {
+          config false;
+          description "Top container for hello adjacencies
+            for a given LDP neighbor.";
+
+          list hello-adjacency {
+            key "remote-address local-address";
+            config false;
+            description
+              "List of hello adjacencies for a given LDP
+              neighbor.";
+
+            leaf remote-address {
+              config false;
+              description
+                "Within the LDP adjacency, this attribute
+                shows the neighbor address.";
+              type leafref {
+                path "../state/remote-address";
+              }
+            }
+
+            leaf local-address {
+              config false;
+              description
+                "Within the LDP adjacency, this attribute
+                shows the local address.";
+              type leafref {
+                path "../state/local-address";
+              }
+            }
+
+            container state {
+              description
+                "State information for a particular LDP
+                hello adjacency.";
+              uses mpls-ldp-adjacency-state;
+            }
+
+            uses oc-if:interface-ref-state;
+
+            container hello-holdtime {
+
+              description
+                "Specifies the time the sending LSR will
+                maintain its record of Hellos from the
+                receiving LSR";
+
+              container state {
+                description
+                  "State attributes related to the
+                  hello-holdtime.";
+                config false;
+                uses mpls-ldp-hello-holdtime-state;
+              }
+            }
+
+          }
+        }
+
+        uses mpls-ldp-authentication-top;
+
+      }
+    }
+  }
+
+  grouping mpls-ldp-neighbor-config {
+    description
+      "Global configuration for LDP neighbors.";
+
+    leaf lsr-id {
+      type oc-inet:ip-address;
+      description
+        "Neighbor label switch router identifier.";
+    }
+
+    leaf label-space-id {
+      type uint16;
+      description
+        "Label space ID of the neighbor.";
+    }
+
+    leaf enable-downstream-on-demand {
+      type boolean;
+      default "false";
+      description
+        "If this leaf is set to true, LDP downstream on demand is enabled in
+        the LDP session and the router advertises DoD to the peer. If the peer
+        also adverstises DoD, then downstream on demand is used in the session,
+        otherwise downstream unsolicited is used.";
+    }
+
+  }
+
+  grouping mpls-ldp-neighbor-state {
+    description
+      "Grouping containing operational attributes for LDP neighbors.";
+
+    leaf session-state {
+      type enumeration {
+        enum NON_EXISTENT {
+          description "LDP session state: NON EXISTENT.";
+        }
+        enum INITIALIZED {
+          description "LDP session state: INITIALIZED.";
+        }
+        enum OPENREC {
+          description "LDP session state: OPENREC.";
+        }
+        enum OPENSENT {
+          description "LDP session state: OPENSENT.";
+        }
+        enum OPERATIONAL {
+          description "LDP session state: OPERATIONAL.";
+        }
+      }
+      description
+        "Operational status of the LDP session,
+        based on the state machine for session
+        negotiation behavior.";
+      reference
+       "RFC5036, Sec. 2.5.4.";
+    }
+
+    leaf peer-label-advertisement-mode {
+      type label-advertisement-mode;
+      description
+        "This leaf shows the Label Advertisement Mode which is advertised by the peer.";
+    }
+
+    leaf negotiated-label-advertisement-mode {
+      type label-advertisement-mode;
+      description
+        "This leaf shows the Label Advertisement Mode negotiated based on local
+        and remote preferences. If DoD is enabled and the peer also adverstises DoD,
+        then downstream is negotiated. Otherwise, downstream unsolicited is used.";
+    }
+
+  }
+
+  grouping mpls-ldp-adjacency-state {
+
+    description
+      "Set of LDP neighbor related state attributes.";
+
+    leaf remote-address {
+      description
+        "Within the LDP adjacency, this attribute
+        shows the neighbor address.";
+      type oc-inet:ip-address;
+    }
+
+    leaf local-address {
+      description
+        "Within the LDP adjacency, this attribute
+        shows the local address.";
+      type oc-inet:ip-address;
+    }
+
+    leaf adjacency-type {
+      description
+        "This attributes defines if the LDP
+        adjacency is from a direct link or from
+        targeted discovery.";
+      type oc-ldp:mpls-ldp-adjacency-type;
+    }
+
+    leaf last-clear {
+      type oc-types:timeticks64;
+      description
+        "Timestamp of the last time the interface counters
+        were cleared expressed relative to the Unix Epoch
+        (January 1, 1970 00:00:00 UTC).";
+    }
+
+    leaf hello-received {
+      type oc-yang:counter64;
+      description
+        "Number of Hello messaged received by the device";
+    }
+
+    leaf hello-dropped {
+      type oc-yang:counter64;
+      description
+        "Number of Hello messaged dropped by the device";
+    }
+
+  }
+
+  grouping mpls-ldp-hello-holdtime-state {
+    description
+      "Grouping containing the state attributes
+      for hello holdtime.";
+
+    leaf adjacent {
+      description
+        "Hello holdtime attribute learned from the
+        LDP neighbor";
+      type uint16;
+    }
+
+    leaf negotiated {
+      description
+        "Hello holdtime attribute negotiated between
+        the LDP neighbor and the local router.";
+      type uint16;
+    }
+
+    leaf hello-expiration {
+      description
+        "Expiration time for the hello holdtime.";
+      type oc-types:timeticks64;
+    }
+
+    leaf next-hello {
+      description
+        "Time when the next LDP hello will be sent to
+        the adjacent neighbor.";
+      type oc-types:timeticks64;
+    }
+
+  }
+
+  grouping mpls-ldp-global {
+    description
+      "Global LDP attributes";
+
+    container config {
+      description
+        "Global LDP configuration attributes.";
+      uses mpls-ldp-global-config;
+    }
+
+    container state {
+      config false;
+      description
+        "Global LDP state information.";
+      uses mpls-ldp-global-config;
+    }
+  }
+
+  grouping mpls-ldp-global-config {
+    description
+      "Grouping containing platform wide LDP information";
+
+    leaf lsr-id {
+      type oc-inet:ip-address;
+      description
+        "Global label switch router identifier
+        configuration.";
+      reference "RFC5036 LDP Specification";
+    }
+
+  }
+
+  grouping mpls-ldp-interface-attributes-top {
+    description
+      "Top-level structure grouping for interface
+      attributes";
+
+    container interface-attributes {
+      description
+        "Container including attributes for LDP-enabled
+        interfaces";
+
+      container config {
+        description
+          "Configuration of per-interface LDP parameters";
+        uses mpls-ldp-hello-timers-top-config;
+      }
+
+      container state {
+        config false;
+        description
+          "Per-interface LDP protocol and state information";
+        uses mpls-ldp-hello-timers-top-config;
+      }
+
+      container interfaces {
+        description
+          "Container aggregating all interfaces and their
+          LDP-specific attributes.";
+
+        list interface {
+          key "interface-id";
+          description
+            "List of per-interface LDP configurations.
+
+             The interface referenced is based on the interface and
+             subinterface leaves within the interface-ref container -
+             which reference an entry in the /interfaces/interface list -
+             and should not rely on the value of the list key.";
+
+          leaf interface-id {
+            type leafref {
+              path "../config/interface-id";
+            }
+            description
+              "reference to the interface-id data";
+          }
+
+          container config {
+            description
+              "Configuration of per-interface LDP parameters";
+            uses mpls-ldp-interfaces-config;
+            uses mpls-ldp-hello-timers-top-config;
+          }
+
+          container state {
+            config false;
+            description
+              "Per-interface LDP protocol and state information";
+
+            uses mpls-ldp-interfaces-config;
+            uses mpls-ldp-hello-timers-top-config;
+
+            container counters {
+              config false;
+              description
+                "Interface specific LDP statistics and counters";
+            }
+          }
+
+          uses oc-if:interface-ref;
+          uses mpls-ldp-address-families-ldp-top;
+
+        }
+      }
+    }
+  }
+
+  grouping mpls-ldp-address-families-ldp-top {
+    description
+      "Grouping containing the state and configuration
+      attributes for adress families.";
+
+    container address-families {
+      description
+        "Top container comprising the adress families
+        attributes";
+      list address-family {
+        key "afi-name";
+        description
+          "List for attributes related to address-families for LDP.";
+
+        leaf afi-name {
+          type leafref {
+                path "../config/afi-name";
+              }
+              description
+                "Adress-family name atttibute (IPv4, IPv6).";
+        }
+
+        container config {
+          description
+            "Configuration attributes related to address-families
+            for LDP.";
+          uses mpls-ldp-address-family-config;
+          uses admin-config;
+        }
+
+        container state {
+          description
+            "State attributes related to address-families for LDP.";
+          config false;
+          uses mpls-ldp-address-family-config;
+          uses admin-config;
+        }
+      }
+    }
+  }
+
+  grouping mpls-ldp-hello-timers-top-config {
+
+    description
+      "Grouping containing interface-related attributes
+      that can be configured for LDP.";
+
+    leaf hello-holdtime {
+      type uint16;
+      description
+        "Defines the time for which a neighbor adjacency will
+        be kept by the router while it waits for a new link
+        Hello message.";
+      reference "RFC5036 LDP Specification";
+    }
+
+    leaf hello-interval {
+      type uint16;
+      description
+        "Defines the interval for sending Hello messages on
+        each link LDP adjacency.";
+    }
+
+  }
+
+  grouping mpls-ldp-targeted-top {
+
+    description
+      "Grouping containing attributes for targeted LDP";
+
+    container targeted {
+      description
+        "Top container for targeted LDP state and configuration
+        attributes.";
+
+      container config {
+        description
+          "Configuration attributes related to targeted LDP.";
+        uses mpls-ldp-targeted-attributes-top-config;
+      }
+
+      container state {
+        config false;
+        description
+          "State attributes related to targeted LDP.";
+        uses mpls-ldp-targeted-attributes-top-config;
+      }
+
+      uses mpls-ldp-address-targeted-ldp-top;
+    }
+  }
+
+  grouping mpls-ldp-address-targeted-ldp-top {
+    description
+      "Grouping containing address attributes for targeted LDP.";
+
+    container address-families {
+      description
+        "Global container for IPv4 and IPv6 attributes for LDP.";
+
+      list address-family {
+        key "afi-name";
+        description
+          "List of address families for targeted LDP
+          configuration";
+
+        leaf afi-name {
+          type leafref {
+                path "../config/afi-name";
+              }
+              description
+                "Adress-family name atttibute (IPv4, IPv6).";
+        }
+
+        container config {
+          description
+            "Address-family configuration for targeted LDP";
+          uses mpls-ldp-address-family-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Address-family state for targeted LDP";
+          uses mpls-ldp-address-family-config;
+        }
+
+        container targets {
+          description
+            "Container aggregating all targeted sessions and
+            their LDP-specific attributes.";
+
+          list target {
+            key "remote-address";
+
+            description
+              "List of LDP targets configuration";
+
+            leaf remote-address {
+              type leafref {
+                path "../config/remote-address";
+              }
+              description
+                "Neighbor address of the targeted LDP session";
+            }
+
+            container config {
+
+              description
+                "Configuration parameters of a targeted LDP
+                adjacency";
+
+              leaf remote-address {
+                type oc-inet:ip-address;
+                description
+                  "Configuration of neighbor address of the
+                  targeted LDP adjacency";
+              }
+
+              leaf local-address {
+                type oc-inet:ip-address;
+                description
+                  "Local IP address of the LDP adjacency";
+              }
+
+              uses admin-config;
+              uses mpls-ldp-hello-timers-top-config;
+            }
+
+            container state {
+              config false;
+              description
+                "State attributes of a targeted LDP adjacency";
+
+              leaf remote-address {
+                config false;
+                type oc-inet:ip-address;
+                description
+                  "Neighbor address of the targeted LDP adjacency";
+              }
+
+              leaf local-address {
+                config false;
+                type oc-inet:ip-address;
+                description
+                  "Local IP address of the LDP adjacency";
+              }
+
+              uses admin-config;
+              uses mpls-ldp-hello-timers-top-config;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  grouping mpls-ldp-address-family-config {
+    description
+      "Grouping containing adress-family name atttibute";
+
+    leaf afi-name {
+      description
+        "Adress-family name atttibute (IPv4, IPv6).";
+      type oc-ldp:mpls-ldp-afi;
+    }
+
+  }
+
+  grouping mpls-ldp-targeted-attributes-top-config {
+
+    description
+      "Grouping containing targeted LDP configuration
+      attributes.";
+
+    uses mpls-ldp-hello-timers-top-config;
+
+    leaf hello-accept {
+      type boolean;
+      description
+        "Enables or disables the acceptance of targeted LDP
+        hello messages.";
+      reference "RFC5036 LDP Specification";
+    }
+
+  }
+
+  grouping mpls-ldp-interfaces-config {
+    description
+      "LDP configuration information relevant to an interface";
+
+    leaf interface-id {
+      type oc-if:interface-id;
+      description
+        "Identifier for the interface";
+    }
+  }
+
+  grouping mpls-ldp-graceful-restart {
+    description
+      "Attributes relating to LDP Graceful-Restart";
+
+    container graceful-restart {
+      description
+        "Top container for LDP graceful-restart attributes";
+
+      container config {
+        description
+          "LDP graceful-restart configuration attributes.";
+        uses mpls-ldp-graceful-restart-config;
+      }
+
+      container state {
+        config false;
+        description
+          "LDP graceful-restart state attributes.";
+        uses mpls-ldp-graceful-restart-config;
+      }
+    }
+  }
+
+  grouping mpls-ldp-graceful-restart-config {
+    description
+      "Configuration parameters relating to LDP Graceful-Restart";
+
+    uses admin-config;
+
+    leaf reconnect-time {
+      type uint16;
+      description
+        "Interval for which the remote LDP peers
+        will wait for the local node to reconnect after a
+        failure";
+      reference "RFC3478 Graceful Restart Mechanism for Label
+        Distribution Protocol";
+    }
+
+    leaf recovery-time {
+      type uint16;
+      description
+        "Interval used to specify the time for the remote
+        peer to maintain the MPLS forwarding state after
+        the local node has succesfully reconnected";
+      reference "RFC3478 Graceful Restart Mechanism for Label
+        Distribution Protocol";
+    }
+
+    leaf forwarding-holdtime {
+      type uint16;
+      description
+        "Time that defines the interval for keeping the
+        node in recovery mode.";
+      reference "RFC3478 Graceful Restart Mechanism for Label
+        Distribution Protocol";
+    }
+
+    leaf helper-enable {
+      type boolean;
+      description
+        "Enables the graceful restart helper for LDP.";
+    }
+  }
+
+  grouping igp-tunnel-ldp {
+    description
+      "common defintiions for LDP-signaled LSP tunnel
+      types";
+  }
+
+  grouping igp-lsp-ldp-setup {
+    description
+      "grouping for LDP setup attributes";
+
+    container ldp {
+      description
+        "LDP signaling setup for IGP-congruent LSPs";
+      uses igp-tunnel-ldp;
+    }
+  }
+
+  grouping mpls-ldp-authentication-config {
+    description
+      "LDP authentication parameters container.";
+
+    leaf enable {
+      type boolean;
+      default false;
+      description
+        "Enables LDP authentication on the node.";
+    }
+
+    leaf authentication-key {
+      type oc-types:routing-password;
+      description
+        "authenticate LDP signaling
+         messages";
+      reference
+        "RFC1321 The MD5 Message-Digest Algorithm
+        RFC5036 LDP Specification";
+    }
+  }
+
+  grouping admin-config {
+    description
+      "Re-usable grouping to enable or disable a particular LDP feature.";
+
+    leaf enabled {
+      type boolean;
+      default false;
+      description
+        "When set to true, the functionality within which this leaf is
+        defined is enabled, when set to false it is explicitly disabled.";
+    }
+  }
+
+  // data definition statements
+
+  // augment statements
+
+  // rpc statements
+
+  // notification statements
+
+}

--- a/models/yang/common/openconfig-mpls-rsvp.yang
+++ b/models/yang/common/openconfig-mpls-rsvp.yang
@@ -1,0 +1,1482 @@
+module openconfig-mpls-rsvp {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/rsvp";
+
+  prefix "oc-rsvp";
+
+  // import some basic types
+  import openconfig-inet-types { prefix inet; }
+  import openconfig-mpls-types { prefix oc-mplst; }
+  import openconfig-yang-types { prefix yang; }
+  import openconfig-types { prefix oc-types; }
+  import openconfig-extensions { prefix oc-ext; }
+  import openconfig-interfaces { prefix oc-if; }
+
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+     netopenconfig@googlegroups.com";
+
+  description
+    "Configuration for RSVP-TE signaling, including global protocol
+     parameters and LSP-specific configuration for constrained-path
+     LSPs";
+
+  oc-ext:openconfig-version "4.0.1";
+
+  revision "2023-02-06" {
+    description
+      "Clarify use of interface-ref.";
+    reference "4.0.1";
+  }
+
+  revision "2022-03-27" {
+    description
+      "Change authentication-key to routing-password type, Add new
+      authentication-type to indicate hashing algorithm.";
+    reference "4.0.0";
+  }
+
+  revision "2021-07-28" {
+    description
+      "Add prefix to qualify when statements.";
+    reference "3.0.3";
+  }
+
+  revision "2020-02-04" {
+    description
+      "Changed peak-data-rate leaf type to ieeefloat32 only.";
+    reference "3.0.2";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "3.0.1";
+  }
+
+  revision "2018-07-02" {
+    description
+      "Add new RSVP-TE statistics, remove associated-rsvp-session
+      leaf. Remove use of date-and-time.";
+    reference "3.0.0";
+  }
+
+  revision "2018-06-16" {
+    description
+      "Included attributes for base LDP configuration.";
+     reference "2.6.0";
+  }
+
+  revision "2018-06-13" {
+    description
+      "Add ttl-propagation to global MPLS config";
+    reference "2.5.0";
+  }
+
+  revision "2018-06-05" {
+    description
+      "Fixed bugs in when statements on RSVP-TE attributes";
+    reference "2.4.2";
+  }
+
+  revision "2017-08-24" {
+    description
+      "Minor formatting fixes.";
+    reference "2.4.1";
+  }
+
+  revision "2017-06-21" {
+    description
+      "Add TC bits typedef.";
+    reference "2.4.0";
+  }
+
+  revision "2017-03-22" {
+    description
+      "Add RSVP calculated-absolute-subscription-bw";
+    reference "2.3.0";
+  }
+
+  revision "2017-01-26" {
+    description
+      "Add RSVP Tspec, clarify units for RSVP, remove unused LDP";
+    reference "2.2.0";
+  }
+
+  revision "2016-12-15" {
+    description
+      "Add additional MPLS parameters";
+    reference "2.1.0";
+  }
+
+  revision "2016-09-01" {
+    description
+      "Revisions based on implementation feedback";
+    reference "2.0.0";
+  }
+
+  revision "2016-08-08" {
+    description
+      "Public release of MPLS models";
+    reference "1.0.1";
+  }
+
+  // OpenConfig specific extensions for module metadata.
+  oc-ext:regexp-posix;
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  // grouping statements
+
+  grouping mpls-rsvp-soft-preemption-config {
+    description
+      "Configuration for MPLS soft preemption";
+    leaf enable {
+      type boolean;
+      default false;
+      description
+        "Enables soft preemption on a node.";
+    }
+
+    leaf soft-preemption-timeout {
+      type uint16 {
+        range 0..max;
+      }
+      default 30;
+      description
+        "Timeout value for soft preemption to revert
+         to hard preemption. The default timeout for
+         soft-preemption is 30 seconds - after which
+         the local system reverts to hard pre-emption.";
+      reference "RFC5712 MPLS-TE soft preemption";
+    }
+  }
+
+  grouping mpls-rsvp-soft-preemption {
+    description
+      "Top level group for MPLS soft preemption";
+    container soft-preemption {
+      description
+        "Protocol options relating to RSVP
+         soft preemption";
+      container config {
+        description
+          "Configuration parameters relating to RSVP
+           soft preemption support";
+        uses mpls-rsvp-soft-preemption-config;
+      }
+      container state {
+        config false;
+        description
+          "State parameters relating to RSVP
+           soft preemption support";
+        uses mpls-rsvp-soft-preemption-config;
+      }
+    }
+  }
+
+  grouping mpls-rsvp-hellos-config {
+    description
+      "RSVP protocol options configuration.";
+
+    leaf hello-interval {
+      type uint16 {
+        range 1000..60000;
+      }
+      units milliseconds;
+      default 9000;
+      description
+        "set the interval in ms between RSVP hello
+         messages";
+      reference
+        "RFC 3209: RSVP-TE: Extensions to RSVP for
+         LSP Tunnels.
+         RFC 5495: Description of the Resource
+         Reservation Protocol - Traffic-Engineered
+         (RSVP-TE) Graceful Restart Procedures";
+    }
+
+    leaf refresh-reduction {
+      type boolean;
+      default true;
+      description
+        "enables all RSVP refresh reduction message
+         bundling, RSVP message ID, reliable message delivery
+         and summary refresh";
+      reference
+        "RFC 2961 RSVP Refresh Overhead Reduction
+         Extensions";
+    }
+  }
+
+  grouping mpls-rsvp-hellos {
+    description
+      "Top level grouping for RSVP hellos parameters";
+    // TODO: confirm that the described semantics are supported
+    // on various implementations. Finer grain configuration
+    // will be vendor-specific
+
+    container hellos {
+      description
+        "Top level container for RSVP hello parameters";
+
+      container config {
+        description
+          "Configuration parameters relating to RSVP
+           hellos";
+        uses mpls-rsvp-hellos-config;
+      }
+      container state {
+        config false;
+        description
+          "State information associated with RSVP hellos";
+        uses mpls-rsvp-hellos-config;
+      }
+    }
+  }
+
+  grouping mpls-rsvp-subscription-config {
+    description
+      "RSVP subscription configuration";
+
+    leaf subscription {
+      type oc-types:percentage;
+      description
+        "percentage of the interface bandwidth that
+         RSVP can reserve";
+    }
+  }
+
+  grouping mpls-rsvp-subscription-state {
+    description
+      "Operational state parameters relating to the
+      bandwidth subscription on an interface";
+
+    leaf calculated-absolute-subscription-bw {
+      type uint64;
+      units "kbps";
+      description
+        "The calculated absolute value of the bandwidth
+        which is reservable to RSVP-TE on the interface
+        prior to any adjustments that may be made from
+        external sources.";
+    }
+  }
+
+  grouping mpls-rsvp-subscription {
+    description
+      "Top level group for RSVP subscription options";
+
+    container subscription {
+      description
+        "Bandwidth percentage reservable by RSVP
+         on an interface";
+
+      container config {
+        description
+          "Configuration parameters relating to RSVP
+          subscription options";
+        uses mpls-rsvp-subscription-config;
+      }
+
+      container state {
+        config false;
+        description
+          "State parameters relating to RSVP
+          subscription options";
+        uses mpls-rsvp-subscription-config;
+        uses mpls-rsvp-subscription-state;
+      }
+    }
+  }
+
+  grouping mpls-rsvp-graceful-restart-config {
+    description
+      "Configuration parameters relating to RSVP Graceful-Restart";
+
+    leaf enable {
+      type boolean;
+      default false;
+      description
+        "Enables graceful restart on the node.";
+    }
+
+    leaf restart-time {
+      type uint32;
+      description
+        "Graceful restart time (seconds).";
+      reference
+        "RFC 5495: Description of the Resource
+         Reservation Protocol - Traffic-Engineered
+         (RSVP-TE) Graceful Restart Procedures";
+    }
+    leaf recovery-time {
+      type uint32;
+      description
+        "RSVP state recovery time";
+    }
+  }
+
+  grouping mpls-rsvp-graceful-restart {
+    description
+      "Top level group for RSVP graceful-restart
+       parameters";
+
+    container graceful-restart {
+      description
+        "Operational state and configuration parameters relating to
+        graceful-restart for RSVP";
+
+      container config {
+        description
+          "Configuration parameters relating to
+           graceful-restart";
+        uses mpls-rsvp-graceful-restart-config;
+      }
+
+      container state {
+        config false;
+        description
+          "State information associated with
+           RSVP graceful-restart";
+        uses mpls-rsvp-graceful-restart-config;
+      }
+    }
+  }
+
+  grouping mpls-rsvp-authentication-config {
+    description
+      "RSVP authentication parameters container.";
+
+    leaf enable {
+      type boolean;
+      default false;
+      description
+        "Enables RSVP authentication on the node.";
+    }
+
+    leaf authentication-type {
+      type identityref {
+        base oc-mplst:RSVP_AUTH_TYPE;
+      }
+      description
+        "RSVP message authentication algorithm type";
+    }
+
+    leaf authentication-key {
+      type oc-types:routing-password;
+      description
+        "Authenticate RSVP signaling messages";
+      reference
+        "RFC 2747: RSVP Cryptographic Authentication";
+    }
+  }
+
+  grouping mpls-rsvp-authentication {
+    description
+      "Top level group for RSVP authentication,
+       as per RFC2747";
+
+    container authentication {
+      description
+        "Configuration and state parameters relating to RSVP
+        authentication as per RFC2747";
+
+      container config {
+        description
+          "Configuration parameters relating
+           to authentication";
+        uses mpls-rsvp-authentication-config;
+      }
+
+      container state {
+        config false;
+        description
+          "State information associated
+           with authentication";
+        uses mpls-rsvp-authentication-config;
+      }
+    }
+  }
+
+  grouping mpls-rsvp-protection-config {
+    description
+      "RSVP facility (link/node) protection configuration";
+
+    leaf link-protection-style-requested {
+      type identityref {
+        base oc-mplst:PROTECTION_TYPE;
+      }
+      default oc-mplst:LINK_NODE_PROTECTION_REQUESTED;
+      description
+        "Style of mpls frr protection desired:
+        link, link-node, or unprotected";
+    }
+
+    leaf bypass-optimize-interval {
+      type uint16;
+      units seconds;
+      description
+        "interval between periodic optimization
+        of the bypass LSPs";
+      // note: this is interface specific on juniper
+      // on iox, this is global. need to resolve.
+    }
+    // to be completed, things like enabling link protection,
+    // optimization times, etc.
+  }
+
+  grouping mpls-rsvp-link-protection {
+    description
+      "Top level group for RSVP protection";
+    container protection {
+      description
+        "link-protection (NHOP) related configuration";
+
+      container config {
+        description
+          "Configuration for link-protection";
+        uses mpls-rsvp-protection-config;
+      }
+
+      container state {
+        config false;
+        description
+          "State for link-protection";
+        uses mpls-rsvp-protection-config;
+      }
+    }
+  }
+
+  grouping mpls-rsvp-statistics {
+    description
+      "Top level grouping for RSVP protocol state";
+
+    uses mpls-rsvp-protocol-state;
+  }
+
+  grouping rsvp-global {
+    description
+      "Global RSVP protocol configuration";
+    container rsvp-te {
+      description
+        "RSVP-TE global signaling protocol configuration";
+
+      uses mpls-rsvp-session-state;
+
+      container neighbors {
+        description
+          "Configuration and state for RSVP neighbors connecting
+          to the device";
+
+        list neighbor {
+          key "address";
+
+          config false;
+
+          description
+            "List of RSVP neighbors of the local system";
+
+          leaf address {
+            type leafref {
+              path "../state/address";
+            }
+            description
+              "Reference to the address of the RSVP neighbor";
+          }
+
+          container state {
+            config false;
+            description
+              "Operational state parameters relating to the
+              RSVP neighbor";
+            uses mpls-rsvp-neighbor-state;
+          }
+        }
+      }
+
+      container global {
+        description
+          "Platform wide RSVP configuration and state";
+        uses mpls-rsvp-graceful-restart;
+        uses mpls-rsvp-soft-preemption;
+        uses mpls-rsvp-hellos;
+
+        container state {
+          config false;
+          description
+            "Platform wide RSVP state, including counters";
+          // TODO - reconcile global and per-interface
+          // protocol-related statistics
+
+          container counters {
+            config false;
+            description
+              "Platform wide RSVP statistics and counters";
+            uses mpls-rsvp-global-protocol-state;
+            uses mpls-rsvp-statistics;
+
+            container errors {
+              description
+                "Error counters associated with the global RSVP-TE
+                instance.";
+              uses mpls-rsvp-error-counters;
+            }
+          }
+        }
+      }
+
+      container interface-attributes {
+        description
+          "Attributes relating to RSVP-TE enabled interfaces";
+
+        list interface {
+          key "interface-id";
+          description
+            "List of per-interface RSVP configurations.
+
+             The interface referenced is based on the interface and
+             subinterface leaves within the interface-ref container -
+             which reference an entry in the /interfaces/interface list -
+             and should not rely on the value of the list key.";
+
+          leaf interface-id {
+            type leafref {
+              path "../config/interface-id";
+            }
+            description
+              "reference to the interface-id data";
+          }
+
+
+          container config {
+            description
+              "Configuration of per-interface RSVP parameters";
+            uses mpls-rsvp-interfaces-config;
+          }
+
+          container state {
+            config false;
+            description
+              "Per-interface RSVP protocol and state information";
+
+            uses mpls-rsvp-interfaces-state;
+            uses mpls-rsvp-interfaces-config;
+
+            container counters {
+              config false;
+              description
+                "Interface specific RSVP statistics and counters";
+              uses mpls-rsvp-protocol-state;
+              uses mpls-rsvp-rate-limited-messages-state;
+
+              container errors {
+                description
+                  "Interface specific RSVP error counters";
+                uses mpls-rsvp-error-counters;
+              }
+            }
+          }
+
+          uses oc-if:interface-ref;
+          uses mpls-rsvp-interface-reservations;
+          uses mpls-rsvp-hellos;
+          uses mpls-rsvp-authentication;
+          uses mpls-rsvp-subscription;
+          uses mpls-rsvp-link-protection;
+        }
+      }
+    }
+  }
+
+  grouping rsvp-p2p-tunnel-attributes-config {
+    description
+      "properties of RSVP point-to-point paths";
+
+    leaf source {
+      when "../signaling-protocol = 'oc-mplst:PATH_SETUP_RSVP'" {
+        description
+          "When the signaling protocol is RSVP-TE ";
+      }
+      type inet:ip-address;
+      description
+        "RSVP-TE tunnel source address";
+    }
+
+    leaf soft-preemption {
+      when "../signaling-protocol = 'oc-mplst:PATH_SETUP_RSVP'" {
+        description
+          "When the signaling protocol is RSVP-TE ";
+      }
+      type boolean;
+      default false;
+      description
+        "Enables RSVP soft-preemption on this LSP";
+    }
+
+    uses rsvp-priorities-tunnel-config;
+  }
+
+  grouping rsvp-priorities-tunnel-config {
+    description
+      "Configuration paramters related to RSVP-TE priorities for
+      an LSP tunnel";
+
+    leaf setup-priority {
+      when "../signaling-protocol = 'oc-mplst:PATH_SETUP_RSVP'" {
+        description
+          "When the signaling protocol is RSVP-TE ";
+      }
+      type uint8 {
+        range 0..7;
+      }
+      default 7;
+      description
+        "RSVP-TE preemption priority during LSP setup, lower is
+         higher priority; default 7 indicates that LSP will not
+         preempt established LSPs during setup";
+      reference "RFC 3209 - RSVP-TE: Extensions to RSVP for
+         LSP Tunnels";
+    }
+
+    leaf hold-priority {
+      when "../signaling-protocol = 'oc-mplst:PATH_SETUP_RSVP'" {
+        description
+           "When the signaling protocol is RSVP-TE ";
+      }
+      type uint8 {
+        range 0..7;
+      }
+      default 0;
+      description
+        "preemption priority once the LSP is established,
+         lower is higher priority; default 0 indicates other LSPs
+         will not preempt the LSPs once established";
+      reference "RFC 3209 - RSVP-TE: Extensions to RSVP for
+        LSP Tunnels";
+    }
+  }
+
+  grouping rsvp-priorities-path-config {
+    description
+      "Configuration paramters related to RSVP-TE priorities on
+      a primary/secondary path associated with an LSP.";
+
+    leaf setup-priority {
+      when "../../../../../" +
+        "config/signaling-protocol = 'oc-mplst:PATH_SETUP_RSVP'" {
+        description
+          "When the signaling protocol is RSVP-TE ";
+      }
+      type uint8 {
+        range 0..7;
+      }
+      default 7;
+      description
+        "RSVP-TE preemption priority during LSP setup, lower is
+         higher priority; default 7 indicates that LSP will not
+         preempt established LSPs during setup";
+      reference "RFC 3209 - RSVP-TE: Extensions to RSVP for
+         LSP Tunnels";
+    }
+
+    leaf hold-priority {
+      when "../../../../../" +
+        "config/signaling-protocol = 'oc-mplst:PATH_SETUP_RSVP'" {
+        description
+           "When the signaling protocol is RSVP-TE ";
+      }
+      type uint8 {
+        range 0..7;
+      }
+      default 0;
+      description
+        "preemption priority once the LSP is established,
+         lower is higher priority; default 0 indicates other LSPs
+         will not preempt the LSPs once established";
+      reference "RFC 3209 - RSVP-TE: Extensions to RSVP for
+        LSP Tunnels";
+    }
+  }
+
+  grouping rsvp-p2p-path-attributes-config {
+    description
+      "properties of RSPP point-to-point paths";
+
+    uses rsvp-priorities-path-config;
+
+    leaf retry-timer {
+      when "../../../../../" +
+        "config/signaling-protocol = 'oc-mplst:PATH_SETUP_RSVP'" {
+        description
+        "When the signaling protocol is RSVP-TE ";
+      }
+      type uint16 {
+        range 1..600;
+      }
+      units seconds;
+      description
+        "sets the time between attempts to establish the
+         LSP";
+    }
+  }
+
+  grouping mpls-rsvp-neighbor-state {
+    description
+      "State information for RSVP neighbors";
+
+    leaf address {
+      type inet:ip-address;
+      description
+        "Address of RSVP neighbor";
+    }
+
+    leaf detected-interface {
+      type string;
+      description
+        "Interface where RSVP neighbor was detected";
+    }
+
+    leaf neighbor-status {
+      type enumeration {
+        enum UP {
+          description
+            "RSVP hello messages are detected from the neighbor";
+        }
+        enum DOWN {
+          description
+            "RSVP neighbor not detected as up, due to a
+             communication failure or IGP notification
+             the neighbor is unavailable";
+        }
+      }
+      description
+        "Enumuration of possible RSVP neighbor states";
+    }
+
+    leaf refresh-reduction {
+      type boolean;
+      description
+        "Suppport of neighbor for RSVP refresh reduction";
+      reference
+        "RFC 2961 RSVP Refresh Overhead Reduction
+         Extensions";
+    }
+
+  }
+
+  grouping mpls-rsvp-session-state {
+    description
+      "State information for RSVP TE sessions";
+
+    container sessions {
+      description
+        "Enclosing container for sessions";
+
+      list session {
+        key "local-index";
+        config false;
+
+        description
+          "List of RSVP sessions";
+
+        leaf local-index {
+          type leafref {
+            path "../state/local-index";
+          }
+          description
+            "Reference to the local index for the RSVP
+            session";
+        }
+
+        uses mpls-rsvp-record-route-object-top;
+        uses mpls-rsvp-explicit-route-object-top;
+
+        container state {
+          description
+            "Operational state parameters relating to the
+            RSVP session";
+
+          leaf local-index {
+            type uint64;
+            description
+              "The index used to identify the RSVP session
+               on the local network element. This index is
+               generated by the device and is unique only
+               to the local network element.";
+          }
+
+          leaf source-address {
+            type inet:ip-address;
+            description
+              "Origin address of RSVP session";
+          }
+
+          leaf destination-address {
+            type inet:ip-address;
+            description
+              "Destination address of RSVP session";
+          }
+
+          leaf tunnel-id {
+            type uint16;
+            description
+              "The tunnel ID is an identifier used in the
+               RSVP session, which remains constant over
+               the life of the tunnel.";
+            reference "RFC 3209";
+          }
+
+          leaf lsp-id {
+            type uint16;
+            description
+              "The LSP ID distinguishes between two LSPs
+               originated from the same headend, and is
+               commonly used to distinguish RSVP sessions
+               during make before break operations.";
+            reference "RFC 3209";
+          }
+
+          leaf session-name {
+            type string;
+            description
+              "The signaled name of this RSVP session.";
+          }
+
+          leaf status {
+            type enumeration {
+              enum UP {
+                description
+                  "RSVP session is up";
+              }
+              enum DOWN {
+                description
+                  "RSVP session is down";
+              }
+            }
+            description
+              "Enumeration of RSVP session states";
+          }
+
+          leaf type {
+            type identityref {
+              base oc-mplst:LSP_ROLE;
+            }
+            description
+              "The type/role of the RSVP session, signifing
+              the session's role on the current device, such as
+              a transit session vs. an ingress session.";
+          }
+
+          leaf protection-requested {
+            type identityref {
+              base oc-mplst:PROTECTION_TYPE;
+            }
+            description
+              "The type of protection requested for the RSVP session";
+          }
+
+          leaf label-in {
+            type oc-mplst:mpls-label;
+            description
+              "Incoming MPLS label associated with this RSVP session";
+          }
+
+          leaf label-out {
+            type oc-mplst:mpls-label;
+            description
+              "Outgoing MPLS label associated with this RSVP session";
+          }
+
+          container sender-tspec {
+            description
+              "Operational state statistics relating to the SENDER_TSPEC
+              received for the RSVP session";
+
+            leaf rate {
+              type oc-types:ieeefloat32;
+              units "Bps";
+              description
+                "The rate at which the head-end device generates traffic,
+                expressed in bytes per second.";
+              reference
+                "RFC2210: RSVP with INTSERV";
+            }
+
+            leaf size {
+              type oc-types:ieeefloat32;
+              units "bytes per second";
+              description
+                "The size of the token bucket that is used to determine
+                the rate at which the head-end device generates traffic,
+                expressed in bytes per second.";
+              reference
+                "RFC2210: RSVP with INTSERV";
+            }
+
+            leaf peak-data-rate {
+              type oc-types:ieeefloat32;
+              units "bytes per second";
+              description
+                "The maximum traffic generation rate that the head-end
+                device sends traffic at.";
+              reference
+                "RFC2210: RSVP with INTSERV";
+            }
+          }
+        }
+      }
+    }
+  } //rsvp-session-state
+
+  grouping mpls-rsvp-interfaces-config {
+    description
+      "RSVP configuration information relevant to an interface";
+
+    leaf interface-id {
+      type oc-if:interface-id;
+      description
+        "Identifier for the interface";
+    }
+  }
+
+  grouping mpls-rsvp-interfaces-state {
+    description
+      "RSVP state information relevant to an interface";
+
+    leaf max-link-bandwidth {
+      type oc-mplst:bandwidth-kbps;
+      description
+        "The maximum link bandwidth expressed in kilobits
+        per second. This value should be the same (other than
+        the units) as the value that is advertised into the
+        IGP traffic engineering database.";
+    }
+  }
+
+  grouping mpls-rsvp-interface-reservations {
+    description
+      "Operational state related to interface bandwidth
+      reservations";
+
+    container bandwidth-reservations {
+      description
+        "Enclosing container for bandwidth reservation";
+      list bandwidth-reservation {
+        key "priority";
+        config false;
+        description
+          "Available and reserved bandwidth by priority on
+           the interface.";
+
+        leaf priority {
+          type leafref {
+            path "../state/priority";
+          }
+          description "Reference to the RSVP priority level";
+        }
+
+        container state {
+          description
+            "Operational state parameters relating to a
+            bandwidth reservation at a certain priority";
+
+          leaf priority {
+            type union {
+              type uint8 {
+                range 0..7;
+              }
+              type enumeration {
+                enum ALL {
+                  description
+                    "The ALL keyword represents the overall
+                    state of the interface - i.e., the union
+                    of all of the priority levels";
+                }
+              }
+            }
+            description
+              "RSVP priority level for LSPs traversing the interface";
+          }
+
+          leaf available-bandwidth {
+            type oc-mplst:bandwidth-mbps;
+            description
+              "Bandwidth currently available with the priority level,
+              or for the entire interface when the priority is set to
+              ALL";
+          }
+
+          leaf reserved-bandwidth {
+            type oc-mplst:bandwidth-mbps;
+            description
+              "Bandwidth currently reserved within the priority level,
+              or the sum of all priority levels when the keyword is set
+              to ALL";
+          }
+
+          leaf active-reservations-count {
+            type yang:gauge64;
+            description
+              "Number of active RSVP reservations in the associated
+              priority, or the sum of all reservations when the priority
+              level is set to ALL";
+          }
+
+          leaf highwater-mark {
+            type oc-mplst:bandwidth-mbps;
+            description
+              "Maximum bandwidth reserved on the interface within the
+              priority, or across all priorities in the case that the
+              priority level is set to ALL";
+          }
+        }
+      }
+    }
+  }
+
+  grouping mpls-rsvp-global-protocol-state {
+    description
+      "RSVP protocol statistics which may not apply
+      on an interface, but are significant globally.";
+
+    leaf path-timeouts {
+      type yang:counter64;
+      description
+        "The number of Path State Blocks (PSBs) that
+        have been timed out by the local system.";
+    }
+
+    leaf reservation-timeouts {
+      type yang:counter64;
+      description
+        "The number of Reservation State Blocks (RSBs) that
+        have been timed out by the local system.";
+    }
+
+    uses mpls-rsvp-rate-limited-messages-state;
+  }
+
+  grouping mpls-rsvp-rate-limited-messages-state {
+    description
+      "Common grouping for rate limit messages";
+
+    leaf rate-limited-messages {
+      type yang:counter64;
+      description
+        "RSVP messages dropped due to rate limiting";
+    }
+  }
+
+  grouping mpls-rsvp-protocol-state {
+    description
+      "RSVP protocol statistics and message counters";
+
+    leaf in-path-messages {
+      type yang:counter64;
+      description
+        "Number of received RSVP Path messages";
+    }
+
+    leaf in-path-error-messages {
+      type yang:counter64;
+      description
+        "Number of received RSVP Path Error messages";
+    }
+
+    leaf in-path-tear-messages {
+      type yang:counter64;
+      description
+        "Number of received RSVP Path Tear messages";
+    }
+
+    leaf in-reservation-messages {
+      type yang:counter64;
+      description
+        "Number of received RSVP Resv messages";
+    }
+
+    leaf in-reservation-error-messages {
+      type yang:counter64;
+      description
+        "Number of received RSVP Resv Error messages";
+    }
+
+    leaf in-reservation-tear-messages {
+      type yang:counter64;
+      description
+        "Number of received RSVP Resv Tear messages";
+    }
+
+    leaf in-hello-messages {
+      type yang:counter64;
+      description
+        "Number of received RSVP hello messages";
+    }
+
+    leaf in-srefresh-messages {
+      type yang:counter64;
+      description
+        "Number of received RSVP summary refresh messages";
+    }
+
+    leaf in-ack-messages {
+      type yang:counter64;
+      description
+        "Number of received RSVP refresh reduction ack
+         messages";
+    }
+
+    leaf out-path-messages {
+      type yang:counter64;
+      description
+        "Number of sent RSVP PATH messages";
+    }
+
+    leaf out-path-error-messages {
+      type yang:counter64;
+      description
+        "Number of sent RSVP Path Error messages";
+    }
+
+    leaf out-path-tear-messages {
+      type yang:counter64;
+      description
+        "Number of sent RSVP Path Tear messages";
+    }
+
+    leaf out-reservation-messages {
+      type yang:counter64;
+      description
+        "Number of sent RSVP Resv messages";
+    }
+
+    leaf out-reservation-error-messages {
+      type yang:counter64;
+      description
+        "Number of sent RSVP Resv Error messages";
+    }
+
+    leaf out-reservation-tear-messages {
+      type yang:counter64;
+      description
+        "Number of sent RSVP Resv Tear messages";
+    }
+
+    leaf out-hello-messages {
+      type yang:counter64;
+      description
+        "Number of sent RSVP hello messages";
+    }
+
+    leaf out-srefresh-messages {
+      type yang:counter64;
+      description
+        "Number of sent RSVP summary refresh messages";
+    }
+
+    leaf out-ack-messages {
+      type yang:counter64;
+      description
+        "Number of sent RSVP refresh reduction ack messages";
+    }
+  }
+
+  grouping mpls-rsvp-record-route-object-top {
+    description
+      "Top-level structure grouping for list of record route
+      objects.";
+
+    container record-route-objects {
+      description
+        "Enclosing container for MPLS RRO objects associated with the
+        traffic engineered tunnel.";
+
+      list record-route-object {
+        key "index";
+        config false;
+
+        description
+        "Read-only list of record route objects associated with the
+        traffic engineered tunnel. Each entry in the list
+        may contain a hop IP address, MPLS label allocated
+        at the hop, and the flags associated with the entry.";
+
+        leaf index {
+          type leafref {
+            path "../state/index";
+          }
+          description
+            "Reference to the index of the record route object.
+            The index is used to indicate the ordering of hops in
+            the path.";
+        }
+
+        container state {
+          config false;
+
+          description
+            "Information related to RRO objects. The hop, label, and
+            optional flags are present for each entry in the list.";
+
+          uses mpls-rsvp-record-route-object-state;
+        }
+      }
+    }
+  }
+
+  grouping mpls-rsvp-record-route-object-state {
+    description
+      "Grouping to hold information relating to record route
+       objects relevant to a traffic engineering LSP.";
+
+    leaf index {
+      type uint8;
+      description
+        "Index of object in the list. Used for ordering.";
+    }
+
+    leaf address {
+      type inet:ip-address;
+      description
+        "IP router hop for RRO entry";
+    }
+
+    leaf reported-label {
+      type oc-mplst:mpls-label;
+      description
+        "Label reported for RRO hop";
+    }
+
+    leaf reported-flags {
+      type uint8;
+      description
+        "Subobject flags for MPLS label";
+    }
+  }
+
+  grouping mpls-rsvp-explicit-route-object-top {
+    description
+      "Top-level structure for explicit-route objects.";
+
+    container explicit-route-objects {
+      description
+        "Enclosing container for MPLS ERO objects associated
+        with the traffic engineered tunnel.";
+
+      list explicit-route-object {
+        key "index";
+
+        config false;
+
+        description
+          "Read-only list of explicit route objects associated with the
+          traffic-engineered tunnel. Each entry in the list contains
+          a hop IP address, and the MPLS label allocated at the hop.";
+
+        leaf index {
+          type leafref {
+            path "../state/index";
+          }
+          description
+            "Reference to the index of the entry in the explicit route
+            object. The index is used to indicate the ordering of hops
+            in the path.";
+        }
+
+        container state {
+          config false;
+          description
+            "Information related to the ERO index.";
+          uses mpls-rsvp-explicit-route-object-state;
+        }
+      }
+    }
+  }
+
+  grouping mpls-rsvp-explicit-route-object-state {
+    description
+      "Grouping defining information related to an individual hop
+      of an ERO.";
+
+    leaf index {
+      type uint64;
+      description
+        "Index of the entry in the ERO. Entries are ordered in
+        ascending order from the source to destination of the
+        LSP.";
+    }
+
+    leaf loose {
+      type boolean;
+      description
+        "When set to true, indicates that the hop of the ERO is
+        a loose hop within the explicit route. If unset, indicates
+        that the hop must explicitly traverse the entity specified
+        in the ERO hop as the next-entity.";
+    }
+
+    leaf type {
+      type enumeration {
+        enum IPV4 {
+          description
+            "The hop represents an IPv4 prefix.";
+          reference "RFC3209";
+        }
+        enum IPV6 {
+          description
+            "The hop represents an IPv6 prefix.";
+          reference "RFC3209";
+        }
+        enum ASN {
+          description
+            "The hop represents an autonomous system number.";
+          reference "RFC3209";
+        }
+        enum ASN4 {
+          description
+            "The hop represents a 4-byte autonomous system number.";
+        }
+        enum LABEL {
+          description
+            "The hop represents an MPLS label.";
+          reference "RFC3473";
+        }
+        enum UNNUMBERED_INTERFACE {
+          description
+            "The hop represents an unnumbered interface.";
+          reference "RFC3477";
+        }
+      }
+      description
+        "The type of hop indicated by the ERO entry.";
+    }
+
+    leaf ip-prefix {
+      type inet:ip-prefix;
+      description
+        "The IPv4 or IPv6 prefix indicated by the ERO. Specified
+        only when the ERO hop is an IPv4 or IPv6 prefix.";
+    }
+
+    leaf asn {
+      type inet:as-number;
+      description
+        "The autonomous system number indicated by the ERO. Specified
+        only when the ERO hop is an 2 or 4-byte AS number.";
+    }
+
+    leaf label {
+      type oc-mplst:mpls-label;
+      description
+        "The MPLS label specified in the ERO hop. Specified only when
+        the hop is an MPLS label.";
+    }
+
+    leaf interface-id {
+      type uint32;
+      description
+        "The interface ID for an unnumbered interface. Specified only
+        when the ERO hop is a unnumbered interface.";
+    }
+    reference
+      "RFC3477 - Signalling Unnumbered Links in Resource
+       ReSerVation Protocol - Traffic Engineering (RSVP-TE)";
+
+  }
+
+  grouping mpls-rsvp-error-counters {
+    description
+      "Grouping containing definitions of leaves relating to
+      errors in RSVP-TE. This grouping can be used in different
+      contexts - e.g., per-RSVP-TE protocol instance, or per-
+      interface such that the errors represented should
+      correspond to the number of errors that have occurred for
+      the context in which the grouping is used.";
+
+    leaf authentication-fail {
+      type yang:counter64;
+      description
+        "The number of packets received that have failed RSVP-TE
+        authentication checks in the specified context.";
+    }
+
+    leaf bad-checksum {
+      type yang:counter64;
+      description
+        "The number of packets received that have an incorrect RSVP-TE
+        checksum in the context.";
+    }
+
+    leaf bad-packet-format {
+      type yang:counter64;
+      description
+        "The number of packets received that were dropped due to being
+        badly formed in the context.";
+    }
+
+    leaf bad-packet-length {
+      type yang:counter64;
+      description
+        "The number of packets received that were dropped due to having
+        an invalid length specified in the context.";
+    }
+
+    leaf out-of-order {
+      type yang:counter64;
+      description
+        "The number of messages received out of order in the context.";
+    }
+
+    leaf received-nack {
+      type yang:counter64;
+      description
+        "The number of NACK RESV messages received in the context.";
+    }
+
+    leaf transmit-failure {
+      type yang:counter64;
+      description
+        "The total number of packets dropped on transmit in the context.";
+    }
+
+    leaf transmit-queue-full {
+      type yang:counter64;
+      description
+        "The number of packets dropped due to the transmit queue being
+        full in the context.";
+    }
+
+    leaf unknown-ack {
+      type yang:counter64;
+      description
+        "The number of packets received containing an ACK for an unknown
+        message ID in the context.";
+    }
+
+    leaf unknown-nack {
+      type yang:counter64;
+      description
+        "The number of packets received containing a NACK for an unknown
+        message ID in the context.";
+    }
+  }
+
+
+
+  // data definition statements
+
+  // augment statements
+
+  // rpc statements
+
+  // notification statements
+
+}

--- a/models/yang/common/openconfig-mpls-sr.yang
+++ b/models/yang/common/openconfig-mpls-sr.yang
@@ -1,0 +1,149 @@
+module openconfig-mpls-sr {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/mpls-sr";
+
+  prefix "oc-mpls-sr";
+
+
+  // import some basic types
+  import openconfig-extensions { prefix oc-ext; }
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    netopenconfig@googlegroups.com";
+
+  description
+    "Configuration for MPLS with segment routing-based LSPs,
+    including global parameters, and LSP-specific configuration for
+    both constrained-path and IGP-congruent LSPs";
+
+  oc-ext:openconfig-version "3.0.1";
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "3.0.1";
+  }
+
+  revision "2018-07-02" {
+    description
+      "Add new RSVP-TE statistics, remove associated-rsvp-session
+      leaf. Remove use of date-and-time.";
+    reference "3.0.0";
+  }
+
+  revision "2018-06-16" {
+    description
+      "Included attributes for base LDP configuration.";
+     reference "2.6.0";
+  }
+
+  revision "2018-06-13" {
+    description
+      "Add ttl-propagation to global MPLS config";
+    reference "2.5.0";
+  }
+
+  revision "2018-06-05" {
+    description
+      "Fixed bugs in when statements on RSVP-TE attributes";
+    reference "2.4.2";
+  }
+
+  revision "2017-08-24" {
+    description
+      "Minor formatting fixes.";
+    reference "2.4.1";
+  }
+
+  revision "2017-06-21" {
+    description
+      "Add TC bits typedef.";
+    reference "2.4.0";
+  }
+
+  revision "2017-03-22" {
+    description
+      "Add RSVP calculated-absolute-subscription-bw";
+    reference "2.3.0";
+  }
+
+  revision "2017-01-26" {
+    description
+      "Add RSVP Tspec, clarify units for RSVP, remove unused LDP";
+    reference "2.2.0";
+  }
+
+  revision "2016-12-15" {
+    description
+      "Add additional MPLS parameters";
+    reference "2.1.0";
+  }
+
+  revision "2016-09-01" {
+    description
+      "Revisions based on implementation feedback";
+    reference "2.0.0";
+  }
+
+  revision "2016-08-08" {
+    description
+      "Public release of MPLS models";
+    reference "1.0.1";
+  }
+
+  // OpenConfig specific extensions for module metadata.
+  oc-ext:regexp-posix;
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  grouping sr-path-attributes-config {
+    description
+      "Configuration parameters relating to SR-TE LSPs";
+
+    leaf sid-selection-mode {
+      type enumeration {
+        enum ADJ_SID_ONLY {
+          description
+            "The SR-TE tunnel should only use adjacency SIDs
+            to build the SID stack to be pushed for the LSP";
+        }
+        enum MIXED_MODE {
+          description
+            "The SR-TE tunnel can use a mix of adjacency
+            and prefix SIDs to build the SID stack to be pushed
+            to the LSP";
+        }
+      }
+      default MIXED_MODE;
+      description
+        "The restrictions placed on the SIDs to be selected by the
+        calculation method for the explicit path when it is
+        instantiated for a SR-TE LSP";
+    }
+
+    leaf sid-protection-required {
+      type boolean;
+      default "false";
+      description
+        "When this value is set to true, only SIDs that are
+        protected are to be selected by the calculating method
+        when the explicit path is instantiated by a SR-TE LSP.";
+    }
+  }
+
+  // data definition statements
+
+  // augment statements
+
+  // rpc statements
+
+  // notification statements
+
+}

--- a/models/yang/common/openconfig-mpls-static.yang
+++ b/models/yang/common/openconfig-mpls-static.yang
@@ -1,0 +1,383 @@
+submodule openconfig-mpls-static {
+
+  yang-version "1";
+
+  belongs-to "openconfig-mpls" {
+    prefix "mpls";
+  }
+
+  // import some basic types
+  import openconfig-mpls-types {prefix oc-mplst; }
+  import openconfig-inet-types { prefix inet; }
+  import openconfig-extensions { prefix oc-ext; }
+  import openconfig-interfaces { prefix oc-if; }
+
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    netopenconfig@googlegroups.com";
+
+  description
+    "Defines static LSP configuration";
+
+
+  oc-ext:openconfig-version "3.5.0";
+
+  revision "2023-12-14" {
+    description
+      "Added additional attributes oc-if:interface-ref
+      and metric attributes to static lsp";
+    reference "3.5.0";
+  }
+
+  revision "2023-07-25" {
+    description
+      "Added record-route-enabled to MPLS p2p tunnel config";
+    reference "3.4.0";
+  }
+
+  revision "2023-04-28" {
+    description
+      "Fixed typo in cspf-tiebreaker leaf description";
+    reference "3.3.2";
+  }
+
+  revision "2023-02-03" {
+    description
+      "Clarify usage of interface-ref.";
+    reference "3.3.1";
+  }
+
+  revision "2022-02-11" {
+    description
+      "Add lsp-path PCE control mode";
+    reference "3.3.0";
+  }
+
+  revision "2021-07-28" {
+    description
+      "Add prefix to qualify when statements.";
+    reference "3.2.2";
+  }
+
+  revision "2021-06-16" {
+    description
+      "Remove trailing whitespace";
+    reference "3.2.1";
+  }
+
+  revision "2021-03-24" {
+    description
+      "Add Metric bounds constraints for LSPs.";
+    reference "3.2.0";
+  }
+
+  revision "2019-03-26" {
+    description
+      "Add Pseudowire encapsulation.";
+    reference "3.1.0";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "3.0.1";
+  }
+
+  revision "2018-07-02" {
+    description
+      "Add new RSVP-TE statistics, remove associated-rsvp-session
+      leaf. Remove use of date-and-time.";
+    reference "3.0.0";
+  }
+
+  revision "2018-06-16" {
+    description
+      "Included attributes for base LDP configuration.";
+     reference "2.6.0";
+  }
+
+  revision "2018-06-13" {
+    description
+      "Add ttl-propagation to global MPLS config";
+    reference "2.5.0";
+  }
+
+  revision "2018-06-05" {
+    description
+      "Fixed bugs in when statements on RSVP-TE attributes";
+    reference "2.4.2";
+  }
+
+  revision "2017-08-24" {
+    description
+      "Minor formatting fixes.";
+    reference "2.4.1";
+  }
+
+  revision "2017-06-21" {
+    description
+      "Add TC bits typedef.";
+    reference "2.4.0";
+  }
+
+  revision "2017-03-22" {
+    description
+      "Add RSVP calculated-absolute-subscription-bw";
+    reference "2.3.0";
+  }
+
+  revision "2017-01-26" {
+    description
+      "Add RSVP Tspec, clarify units for RSVP, remove unused LDP";
+    reference "2.2.0";
+  }
+
+  revision "2016-12-15" {
+    description
+      "Add additional MPLS parameters";
+    reference "2.1.0";
+  }
+
+  revision "2016-09-01" {
+    description
+      "Revisions based on implementation feedback";
+    reference "2.0.0";
+  }
+
+  revision "2016-08-08" {
+    description
+      "Public release of MPLS models";
+    reference "1.0.1";
+  }
+
+  // grouping statements
+
+  grouping static-lsp-common-config {
+    description
+      "common definitions for static LSPs";
+
+    leaf next-hop {
+      type inet:ip-address;
+      description
+        "next hop IP address for the LSP";
+    }
+
+    leaf incoming-label {
+      type oc-mplst:mpls-label;
+      description
+        "label value on the incoming packet";
+    }
+
+    leaf push-label {
+      type oc-mplst:mpls-label;
+      description
+        "label value to push at the current hop for the
+        LSP";
+    }
+
+    // interface-ref
+    uses oc-if:interface-ref-common;
+
+    leaf metric {
+      type uint8;
+      description
+        "Specifies metric value used for the MPLS route";
+    }
+  }
+
+  grouping static-lsp-ingress-config {
+    description
+      "Configuration data for ingress LSPs";
+
+    uses static-lsp-common-config;
+  }
+
+  grouping static-lsp-ingress-state {
+    description
+      "Operational state data for ingress LSPs";
+  }
+
+  grouping static-lsp-ingress-top {
+    description
+      "Top-level grouping for ingress LSP data";
+
+    container ingress {
+      description
+        "Static LSPs for which the router is an
+          ingress node";
+
+      container config {
+        description
+          "Configuration data for ingress LSPs";
+
+        uses static-lsp-ingress-config;
+      }
+
+      container state {
+
+        config false;
+
+        description
+          "Operational state data for ingress LSPs";
+
+        uses static-lsp-ingress-config;
+        uses static-lsp-ingress-state;
+      }
+    }
+  }
+
+  grouping static-lsp-transit-config {
+    description
+      "Configuration data for transit LSPs";
+
+    uses static-lsp-common-config;
+  }
+
+  grouping static-lsp-transit-state {
+    description
+      "Operational state data for transit LSPs";
+  }
+
+  grouping static-lsp-transit-top {
+    description
+      "Top-level grouping for transit LSP data";
+
+    container transit {
+      description
+        "Static LSPs for which the router is an
+          transit node";
+
+      container config {
+        description
+          "Configuration data for transit LSPs";
+
+        uses static-lsp-transit-config;
+      }
+
+      container state {
+
+        config false;
+
+        description
+          "Operational state data for transit LSPs";
+
+        uses static-lsp-transit-config;
+        uses static-lsp-transit-state;
+      }
+    }
+  }
+
+  grouping static-lsp-egress-config {
+    description
+      "Configuration data for egress LSPs";
+
+    uses static-lsp-common-config;
+  }
+
+  grouping static-lsp-egress-state {
+    description
+      "Operational state data for egress LSPs";
+  }
+
+  grouping static-lsp-egress-top {
+    description
+      "Top-level grouping for egress LSP data";
+
+    container egress {
+      description
+        "Static LSPs for which the router is an
+          egress node";
+
+      container config {
+        description
+          "Configuration data for egress LSPs";
+
+        uses static-lsp-egress-config;
+      }
+
+      container state {
+
+        config false;
+
+        description
+          "Operational state data for egress LSPs";
+
+        uses static-lsp-egress-config;
+        uses static-lsp-egress-state;
+      }
+    }
+  }
+
+  grouping static-lsp-config {
+    description
+      "Configuration data for static LSPs";
+
+    leaf name {
+      type string;
+      description
+        "name to identify the LSP";
+    }
+  }
+
+  grouping static-lsp-state {
+    description
+      "Operational state data for static LSPs";
+
+  }
+
+  grouping static-lsp-top {
+    description
+      "grouping for top level list of static LSPs";
+
+
+    list static-lsp {
+      key "name";
+      description
+        "list of defined static LSPs";
+
+      leaf name {
+        type leafref {
+          path "../config/name";
+        }
+        description
+          "Reference the name list key";
+      }
+
+      container config {
+        description
+          "Configuration data for the static lsp";
+
+        uses static-lsp-config;
+      }
+
+      container state {
+        config false;
+
+        description
+          "Operational state data for the static lsp";
+
+        uses static-lsp-config;
+        uses static-lsp-state;
+
+      }
+
+      // TODO: separation into ingress, transit, egress may help
+      // to figure out what exactly is configured, but need to
+      // consider whether implementations can support the
+      // separation
+      uses static-lsp-ingress-top;
+      uses static-lsp-transit-top;
+      uses static-lsp-egress-top;
+    }
+  }
+
+  // data definition statements
+
+  // augment statements
+
+
+}

--- a/models/yang/common/openconfig-mpls-te.yang
+++ b/models/yang/common/openconfig-mpls-te.yang
@@ -1,0 +1,1516 @@
+submodule openconfig-mpls-te {
+
+  yang-version "1";
+
+  belongs-to "openconfig-mpls" {
+    prefix "oc-mpls";
+  }
+
+
+  // import some basic types
+  import openconfig-inet-types { prefix inet; }
+  import openconfig-mpls-rsvp { prefix oc-rsvp; }
+  import openconfig-mpls-sr { prefix oc-sr; }
+  import openconfig-mpls-types {prefix oc-mplst; }
+  import openconfig-types { prefix oc-types; }
+  import openconfig-yang-types { prefix yang; }
+  import openconfig-extensions { prefix oc-ext; }
+  import openconfig-pcep { prefix oc-pcep; }
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    netopenconfig@googlegroups.com";
+
+  description
+    "Configuration related to constrained-path LSPs and traffic
+    engineering.  These definitions are not specific to a particular
+    signaling protocol or mechanism (see related submodules for
+    signaling protocol-specific configuration).";
+
+  oc-ext:openconfig-version "3.5.0";
+
+  revision "2023-12-14" {
+    description
+      "Added additional attributes oc-if:interface-ref
+      and metric attributes to static lsp";
+    reference "3.5.0";
+  }
+
+  revision "2023-07-25" {
+    description
+      "Added record-route-enabled to MPLS p2p tunnel config";
+    reference "3.4.0";
+  }
+
+  revision "2023-04-28" {
+    description
+      "Fixed typo in cspf-tiebreaker leaf description";
+    reference "3.3.2";
+  }
+
+  revision "2023-04-25" {
+    description
+      "Add clarifying comments on use of interface-ref.";
+    reference "3.3.1";
+  }
+
+  revision "2022-02-11" {
+    description
+      "Add lsp-path PCE control mode";
+    reference "3.3.0";
+  }
+
+  revision "2021-07-28" {
+    description
+      "Add prefix to qualify when statements.";
+    reference "3.2.2";
+  }
+
+  revision "2021-06-16" {
+    description
+      "Remove trailing whitespace.";
+    reference "3.1.1";
+  }
+
+  revision "2021-03-24" {
+    description
+      "Add Metric bounds constraints for LSPs.";
+    reference "3.1.0";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "3.0.1";
+  }
+
+  revision "2018-07-02" {
+    description
+      "Add new RSVP-TE statistics, remove associated-rsvp-session
+      leaf. Remove use of date-and-time.";
+    reference "3.0.0";
+  }
+
+  revision "2018-06-16" {
+    description
+      "Included attributes for base LDP configuration.";
+     reference "2.6.0";
+  }
+
+  revision "2018-06-13" {
+    description
+      "Add ttl-propagation to global MPLS config";
+    reference "2.5.0";
+  }
+
+  revision "2018-06-05" {
+    description
+      "Fixed bugs in when statements on RSVP-TE attributes";
+    reference "2.4.2";
+  }
+
+  revision "2017-08-24" {
+    description
+      "Minor formatting fixes.";
+    reference "2.4.1";
+  }
+
+  revision "2017-06-21" {
+    description
+      "Add TC bits typedef.";
+    reference "2.4.0";
+  }
+
+  revision "2017-03-22" {
+    description
+      "Add RSVP calculated-absolute-subscription-bw";
+    reference "2.3.0";
+  }
+
+  revision "2017-01-26" {
+    description
+      "Add RSVP Tspec, clarify units for RSVP, remove unused LDP";
+    reference "2.2.0";
+  }
+
+  revision "2016-12-15" {
+    description
+      "Add additional MPLS parameters";
+    reference "2.1.0";
+  }
+
+  revision "2016-09-01" {
+    description
+      "Revisions based on implementation feedback";
+    reference "2.0.0";
+  }
+
+  revision "2016-08-08" {
+    description
+      "Public release of MPLS models";
+    reference "1.0.1";
+  }
+
+  // typedef statements
+
+ typedef te-bandwidth-type {
+    type enumeration {
+      enum SPECIFIED {
+        description
+          "Bandwidth is explicitly specified";
+      }
+      enum AUTO {
+        description
+          "Bandwidth is automatically computed";
+      }
+    }
+    description
+      "enumerated type for specifying whether bandwidth is
+       explicitly specified or automatically computed";
+  }
+
+  typedef mpls-srlg-flooding-type {
+    type enumeration {
+      enum FLOODED_SRLG {
+        description
+          "SRLG is flooded in the IGP";
+      }
+      enum STATIC_SRLG {
+        description
+          "SRLG is not flooded, the members are
+           statically configured";
+      }
+    }
+    description
+      "Enumerated bype for specifying how the SRLG is flooded";
+  }
+
+  typedef mpls-hop-type {
+    type enumeration {
+      enum LOOSE {
+        description
+          "loose hop in an explicit path";
+      }
+      enum STRICT {
+        description
+          "strict hop in an explicit path";
+      }
+    }
+    description
+     "enumerated type for specifying loose or strict
+      paths";
+  }
+
+  typedef te-metric-type {
+    type union {
+      type enumeration {
+        enum IGP {
+          description
+           "set the LSP metric to track the underlying
+            IGP metric";
+        }
+      }
+      type uint32;
+    }
+    description
+     "union type for setting the LSP TE metric to a
+      static value, or to track the IGP metric";
+  }
+
+  typedef cspf-tie-breaking {
+    type enumeration {
+      enum RANDOM {
+        description
+         "CSPF calculation selects a random path among
+          multiple equal-cost paths to the destination";
+      }
+      enum LEAST_FILL {
+        description
+         "CSPF calculation selects the path with greatest
+          available bandwidth";
+      }
+      enum MOST_FILL {
+        description
+          "CSPF calculation selects the path with the least
+          available bandwidth";
+      }
+    }
+    default RANDOM;
+    description
+     "type to indicate the CSPF selection policy when
+      multiple equal cost paths are available";
+  }
+
+
+  // grouping statements
+
+  grouping te-tunnel-reoptimize-config {
+    description
+      "Definition for reoptimize timer configuration";
+
+    leaf reoptimize-timer {
+      type uint16;
+      units seconds;
+      description
+       "frequency of reoptimization of
+        a traffic engineered LSP";
+    }
+  }
+
+  grouping te-lsp-auto-bandwidth-config {
+    description
+      "Configuration parameters related to autobandwidth";
+
+    leaf enabled {
+      type boolean;
+      default false;
+      description
+        "enables mpls auto-bandwidth on the
+         lsp";
+    }
+
+    leaf min-bw {
+      type oc-mplst:bandwidth-kbps;
+      description
+        "set the minimum bandwidth in Kbps for an
+         auto-bandwidth LSP";
+    }
+
+    leaf max-bw {
+      type oc-mplst:bandwidth-kbps;
+      description
+        "set the maximum bandwidth in Kbps for an
+         auto-bandwidth LSP";
+    }
+
+    leaf adjust-interval {
+      type uint32;
+      description
+        "time in seconds between adjustments to
+         LSP bandwidth";
+    }
+
+    leaf adjust-threshold {
+      type oc-types:percentage;
+      description
+        "percentage difference between the LSP's
+         specified bandwidth and its current bandwidth
+         allocation -- if the difference is greater than the
+         specified percentage, auto-bandwidth adjustment is
+         triggered";
+    }
+  }
+
+  grouping te-lsp-auto-bandwidth-state {
+    description
+      "Operational state parameters relating to auto-bandwidth";
+
+    leaf interval-high-bw {
+      type oc-mplst:bandwidth-kbps;
+      description
+        "The maximum measured bandwidth during the current
+        auto-bandwidth adjust interval expressed in kilobits
+        per second.";
+    }
+  }
+
+  grouping te-lsp-overflow-config {
+    description
+     "configuration for mpls lsp bandwidth
+      overflow adjustment";
+
+    leaf enabled {
+      type boolean;
+      default false;
+      description
+       "enables mpls lsp bandwidth overflow
+        adjustment on the lsp";
+    }
+
+    leaf overflow-threshold {
+      type oc-types:percentage;
+      description
+       "bandwidth percentage change to trigger
+        an overflow event";
+
+    }
+
+    leaf trigger-event-count {
+      type uint16;
+      description
+       "number of consecutive overflow sample
+        events needed to trigger an overflow adjustment";
+    }
+  }
+
+  grouping te-lsp-underflow-config {
+    description
+      "configuration for mpls lsp bandwidth
+      underflow adjustment";
+
+    leaf enabled {
+      type boolean;
+      default false;
+      description
+       "enables bandwidth underflow
+        adjustment on the lsp";
+    }
+
+    leaf underflow-threshold {
+      type oc-types:percentage;
+      description
+       "bandwidth percentage change to trigger
+        and underflow event";
+    }
+
+    leaf trigger-event-count {
+      type uint16;
+      description
+       "number of consecutive underflow sample
+        events needed to trigger an underflow adjustment";
+    }
+  }
+
+  grouping te-path-placement-constraints-config {
+    description
+      "Configuration data for link affinities";
+
+    leaf-list exclude-group {
+      type leafref {
+        path "../../../../../../../../../../te-global-attributes" +
+          "/mpls-admin-groups/admin-group/admin-group-name";
+      }
+      description
+        "list of references to named admin-groups to exclude in
+        path calculation.";
+    }
+
+    leaf-list include-all-group {
+      type leafref {
+        path "../../../../../../../../../../te-global-attributes" +
+          "/mpls-admin-groups/admin-group/admin-group-name";
+      }
+      description
+        "list of references to named admin-groups of which all must
+        be included";
+    }
+
+    leaf-list include-any-group {
+      type leafref {
+        path "../../../../../../../../../../te-global-attributes" +
+          "/mpls-admin-groups/admin-group/admin-group-name";
+      }
+      description
+        "list of references to named admin-groups of which one must
+        be included";
+    }
+  }
+
+  grouping te-path-placement-constraints-state {
+    description
+      "Operational state data for link affinities";
+    //TODO: currently a placeholder
+  }
+
+  grouping te-path-placement-constraints-top {
+    description
+      "Top-level grouping ";
+
+    container admin-groups {
+      description
+        "Top-level container for include/exclude constraints for
+        link affinities";
+
+      container config {
+        description
+          "Configuration data ";
+
+        uses te-path-placement-constraints-config;
+      }
+
+      container state {
+        config false;
+
+        description
+          "Operational state data ";
+
+        uses te-path-placement-constraints-config;
+        uses te-path-placement-constraints-state;
+      }
+    }
+  }
+
+  grouping te-tunnel-protection-config {
+    description
+     "Configuration parameters related to LSP
+      protection";
+    leaf protection-style-requested {
+      type identityref {
+        base oc-mplst:PROTECTION_TYPE;
+      }
+      default oc-mplst:UNPROTECTED;
+      description
+        "style of mpls frr protection desired: can be
+        link, link-node or unprotected.";
+    }
+  }
+
+  grouping explicit-route-subobject-config {
+    description
+      "The explicit route subobject grouping";
+
+    leaf address {
+     type inet:ip-address;
+     description
+      "router hop for the LSP path";
+    }
+
+    leaf hop-type {
+      type mpls-hop-type;
+      description
+        "strict or loose hop";
+    }
+
+    leaf index {
+      type uint8 {
+        range "0..255";
+      }
+      description
+        "Index of this explicit route object to express
+        the order of hops in the path";
+    }
+
+  }
+
+  grouping named-explicit-path-config {
+    description
+      "Configuration parameters relating to a named
+       explicit path";
+
+    leaf name {
+      type string;
+      description
+        "A string name that uniquely identifies an explicit
+         path";
+    }
+  }
+
+  // Explicit paths config somewhat following the IETF model
+  grouping explicit-paths-top {
+    description
+      "Top level global explicit path configuration
+      grouping";
+
+    container named-explicit-paths {
+      description
+        "Enclosing container for the named explicit paths";
+      list named-explicit-path {
+        key "name";
+        description
+          "A list of explicit paths";
+
+        leaf name {
+          type leafref {
+            path "../config/name";
+          }
+          description
+            "A string name that uniquely identifies
+            an explicit path";
+        }
+
+        container config {
+          description
+            "Configuration parameters relating to named explicit
+            paths";
+          uses named-explicit-path-config;
+          uses oc-sr:sr-path-attributes-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state parameters relating to the named
+            explicit paths";
+          uses named-explicit-path-config;
+          uses oc-sr:sr-path-attributes-config;
+        }
+
+        container explicit-route-objects {
+          description
+            "Enclosing container for EROs";
+
+          list explicit-route-object {
+            key "index";
+            description
+              "List of explicit route objects";
+
+            leaf index {
+              type leafref {
+                path "../config/index";
+              }
+
+              description
+                "Index of this explicit route object,
+                 to express the order of hops in path";
+            }
+
+            container config {
+              description
+                "Configuration parameters relating to an explicit
+                route";
+              uses explicit-route-subobject-config;
+            }
+
+
+            container state {
+              config false;
+              description
+                "State parameters relating to an explicit route";
+              uses explicit-route-subobject-config;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  grouping mpls-te-srlg-config {
+    description
+      "Configuration of various attributes associated
+      with the SRLG";
+
+    leaf name {
+      type string;
+      description
+        "SRLG group identifier";
+    }
+
+    leaf value {
+      type uint32;
+      description
+        "group ID for the SRLG";
+    }
+
+    leaf cost {
+      type uint32;
+      description
+        "The cost of the SRLG to the computation
+        algorithm";
+    }
+
+    leaf flooding-type {
+      type mpls-srlg-flooding-type;
+      default FLOODED_SRLG;
+      description
+        "The type of SRLG, either flooded in the IGP or
+         statically configured";
+    }
+  }
+
+  grouping mpls-te-srlg-members-config {
+    description
+      "Configuration of the membership of the SRLG";
+
+    leaf from-address {
+      type inet:ip-address;
+      description
+        "IP address of the a-side of the SRLG link";
+    }
+
+    leaf to-address {
+      type inet:ip-address;
+      description
+        "IP address of the z-side of the SRLG link";
+    }
+  }
+
+  grouping mpls-te-srlg-top {
+    description
+      "Top level grouping for MPLS shared
+      risk link groups.";
+
+    container srlgs {
+      description
+        "Shared risk link groups attributes";
+      list srlg {
+        key "name";
+        description
+          "List of shared risk link groups";
+
+        leaf name {
+          type leafref {
+            path "../config/name";
+            // Requires YANG 1.1
+            //require-instance true;
+          }
+          description
+            "The SRLG group identifier";
+        }
+
+        container config {
+          description
+            "Configuration parameters related to the SRLG";
+          uses mpls-te-srlg-config;
+        }
+
+        container state {
+          config false;
+          description
+            "State parameters related to the SRLG";
+          uses mpls-te-srlg-config;
+        }
+
+        container static-srlg-members {
+          when "../config/flooding-type = 'STATIC_SRLG'" {
+            description
+              "Include this container for static
+              SRLG specific configuration";
+          }
+          description
+            "SRLG members for static (not flooded) SRLGs ";
+
+          list members-list {
+            key "from-address";
+            description
+             "List of SRLG members, which are expressed
+              as IP address endpoints of links contained in the
+              SRLG";
+
+            leaf from-address {
+              type leafref {
+                path "../config/from-address";
+                // Requires YANG 1.1
+                //require-instance true;
+              }
+              description
+                "The from address of the link in the SRLG";
+            }
+
+            container config {
+              description
+                "Configuration parameters relating to the
+                SRLG members";
+              uses mpls-te-srlg-members-config;
+            }
+
+            container state {
+              config false;
+              description
+                "State parameters relating to the SRLG
+                members";
+              uses mpls-te-srlg-members-config;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  grouping te-global-tunnel-config {
+    description
+      "Configuration parameters relevant to a single
+       traffic engineered tunnel.";
+
+    leaf name {
+      type string;
+      description
+        "The tunnel name";
+    }
+
+    leaf type {
+      type identityref {
+        base oc-mplst:TUNNEL_TYPE;
+      }
+      description
+        "Tunnel type, p2p or p2mp";
+    }
+
+    leaf signaling-protocol {
+      type identityref {
+        base oc-mplst:PATH_SETUP_PROTOCOL;
+      }
+      description
+        "Signaling protocol used to set up this tunnel";
+    }
+
+    leaf description {
+      type string;
+      description
+        "optional text description for the tunnel";
+    }
+
+    leaf admin-status {
+      type identityref {
+        base oc-mplst:TUNNEL_ADMIN_STATUS;
+      }
+      default oc-mplst:ADMIN_UP;
+      description
+        "TE tunnel administrative state.";
+    }
+
+    leaf preference {
+      type uint8 {
+        range "1..255";
+      }
+      description
+        "Specifies a preference for this tunnel.
+        A lower number signifies a better preference";
+    }
+
+    leaf metric-type {
+      type identityref {
+        base oc-mplst:LSP_METRIC_TYPE;
+      }
+      default oc-mplst:LSP_METRIC_INHERITED;
+      description
+        "The type of metric specification that should be used to set
+        the LSP(s) metric";
+    }
+
+    leaf metric {
+      type int32;
+      description
+        "The value of the metric that should be specified. The value
+        supplied in this leaf is used in conjunction with the metric
+        type to determine the value of the metric used by the system.
+        Where the metric-type is set to LSP_METRIC_ABSOLUTE - the
+        value of this leaf is used directly; where it is set to
+        LSP_METRIC_RELATIVE, the relevant (positive or negative)
+        offset is used to formulate the metric; where metric-type
+        is LSP_METRIC_INHERITED, the value of this leaf is not
+        utilised";
+    }
+
+    leaf shortcut-eligible {
+      type boolean;
+      default "true";
+      description
+        "Whether this LSP is considered to be eligible for us as a
+        shortcut in the IGP. In the case that this leaf is set to
+        true, the IGP SPF calculation uses the metric specified to
+        determine whether traffic should be carried over this LSP";
+    }
+
+    leaf protection-style-requested {
+      type identityref {
+        base oc-mplst:PROTECTION_TYPE;
+      }
+      default oc-mplst:UNPROTECTED;
+      description
+        "style of mpls frr protection desired: can be
+        link, link-node or unprotected.";
+    }
+
+    uses te-tunnel-reoptimize-config;
+    uses oc-rsvp:rsvp-p2p-tunnel-attributes-config;
+
+  }
+
+  grouping tunnel-p2p-attributes-config {
+    description
+      "Configuration related to p2p LSPs";
+    leaf destination {
+      type inet:ip-address;
+      description
+        "P2P tunnel destination address";
+    }
+    leaf record-route-enabled {
+      type boolean;
+      description
+        "Enables recording a path on an LSP using the record route object (RRO)";
+    }
+  }
+
+  grouping p2p-path-state {
+    description
+      "Operational state parameters for p2p paths";
+
+    leaf-list associated-rsvp-sessions {
+      type leafref {
+        path "../../../../../../../../../signaling-protocols/" +
+             "rsvp-te/sessions/session/local-index";
+      }
+      description
+        "If the signalling protocol specified for this path is
+        RSVP-TE, this leaf-list provides a reference to the associated
+        sessions within the RSVP-TE protocol sessions list, such
+        that details of the signaling can be retrieved. More than
+        one session may exist during re-signalling such as
+        make-before-break.";
+    }
+
+    leaf spf-metric {
+      type uint64;
+      description
+        "The IGP metric of the shortest path to the LSP destination.
+        This value is used to compare the current metric of the
+        constrained path to the shortest path that is available in
+        the network topology.";
+    }
+
+    leaf cspf-metric {
+      type uint64;
+      description
+        "The IGP metric of the path currently used by the LSP.
+        This value is used to represent the metric of the path
+        used by the LSP following the execution of the CSPF
+        algorithm and signalling of the LSP.";
+    }
+  }
+
+  grouping p2p-path-config {
+    description
+      "Configuration parameters for p2p paths";
+
+    leaf name {
+      type string;
+      description
+        "Path name";
+    }
+
+    leaf path-computation-method {
+      type identityref {
+        base oc-mplst:PATH_COMPUTATION_METHOD;
+      }
+      default oc-mplst:LOCALLY_COMPUTED;
+      description
+        "The method used for computing the path, either
+        locally computed, queried from a server or not
+        computed at all (explicitly configured).";
+    }
+
+    leaf use-cspf {
+      when "../path-computation-method = 'oc-mplst:LOCALLY_COMPUTED'" {
+        description
+          "The use of cspf when the path-computation method is
+           local computation";
+      }
+      type boolean;
+      description
+        "Flag to enable CSPF for locally computed LSPs";
+    }
+
+    leaf cspf-tiebreaker {
+      when "../path-computation-method = 'oc-mplst:LOCALLY_COMPUTED'" {
+        description
+          "The cspf tiebreaking method when the path is
+           locally computed";
+      }
+      type cspf-tie-breaking;
+      description
+        "Determine the tie-breaking method to choose between
+        equally desirable paths during CSPF computation";
+    }
+
+    leaf path-computation-server {
+      when "../path-computation-method = 'oc-mplst:EXTERNALLY_QUERIED'" {
+        description
+          "The path-computation server when the path is
+           externally queried";
+      }
+      type leafref {
+        path "../../../../../../../../../../protocols/protocol/pcep/path-computation-servers/" +
+             "path-computation-server/pce-server-address";
+      }
+      description
+        "Reference to the address of a previously configured
+        external path computation server.";
+    }
+
+    leaf path-control {
+      type oc-pcep:lsp-control-type;
+      description
+        "Set the LSP path control mode as PCE_DELEGATED
+        PCC_CONTROLLED or PCC_REPORT_ONLY information
+        state to the PCE.";
+    }
+
+    leaf explicit-path-name {
+      when "../path-computation-method = 'oc-mplst:EXPLICITLY_DEFINED'" {
+        description
+          "The name of the explicitly defined path used";
+      }
+
+      type leafref {
+        path "../../../../../../../"
+             + "named-explicit-paths/named-explicit-path/"
+             + "config/name";
+        // Requires YANG 1.1
+        //require-instance true;
+      }
+      description
+        "reference to a defined path";
+    }
+
+    leaf preference {
+      type uint8 {
+        range "1..255";
+      }
+      description
+        "Specifies a preference for this path. The lower the
+        number higher the preference";
+    }
+
+    uses oc-rsvp:rsvp-p2p-path-attributes-config;
+  }
+
+
+  grouping te-tunnel-p2p-top {
+    description
+      "Top level grouping for p2p configuration";
+
+    container p2p-tunnel-attributes {
+      when "../config/type = 'oc-mplst:P2P'" {
+        description
+         "Include this container for LSPs of type P2P";
+      }
+      description
+        "Parameters related to LSPs of type P2P";
+
+      container config {
+       description
+         "Configuration parameters for P2P LSPs";
+       uses tunnel-p2p-attributes-config;
+      }
+
+      container state {
+       config false;
+       description
+         "State parameters for P2P LSPs";
+       uses tunnel-p2p-attributes-config;
+      }
+
+      uses p2p-primary-paths-top;
+      uses p2p-secondary-paths-top;
+    }
+  }
+
+
+  grouping te-tunnel-state {
+    description
+      "Counters and statistical data relevent to a single
+       tunnel.";
+
+    leaf oper-status {
+      type identityref {
+        base oc-mplst:LSP_OPER_STATUS;
+      }
+      description
+       "The operational status of the TE tunnel";
+    }
+
+    leaf role {
+      type identityref {
+        base oc-mplst:LSP_ROLE;
+      }
+      description
+       "The lsp role at the current node, whether it is headend,
+        transit or tailend.";
+    }
+
+    leaf auto-generated {
+      type boolean;
+      description
+        "If the LSP was auto-generated by the system this leaf
+        should be set to true. Examples of auto-generated LSPs
+        are dynamically created backup LSPs to meet a FRR
+        policy.";
+    }
+
+    container counters {
+      description
+        "State data for MPLS label switched paths. This state
+        data is specific to a single label switched path.";
+
+      leaf bytes {
+        type yang:counter64;
+        description
+          "Number of bytes that have been forwarded over the
+           label switched path.";
+      }
+
+      leaf packets {
+        type yang:counter64;
+        description
+          "Number of pacets that have been forwarded over the
+           label switched path.";
+      }
+
+      leaf path-changes {
+        type yang:counter64;
+        description
+          "Number of path changes for the label switched path";
+      }
+
+      leaf state-changes {
+        type yang:counter64;
+        description
+          "Number of state changes for the label switched path";
+      }
+
+      leaf online-time {
+        type oc-types:timeticks64;
+        description
+          "Indication of the time the label switched path
+           transitioned to an Oper Up or in-service state.
+
+           The value is the timestamp in nanoseconds relative to
+           the Unix Epoch (Jan 1, 1970 00:00:00 UTC).";
+      }
+
+      leaf current-path-time {
+        type oc-types:timeticks64;
+        description
+          "Indicates the time the LSP switched onto its
+           current path. The value is reset upon a LSP path
+           change.
+
+           The value is the timestamp in nanoseconds relative to
+           the Unix Epoch (Jan 1, 1970 00:00:00 UTC).";
+
+      }
+
+      leaf next-reoptimization-time {
+        type oc-types:timeticks64;
+        description
+          "Indicates the next scheduled time the LSP
+           will be reoptimized.
+
+           The value is the timestamp in nanoseconds relative to
+           the Unix Epoch (Jan 1, 1970 00:00:00 UTC).";
+
+      }
+    }
+  }
+
+  grouping te-tunnel-bandwidth-config {
+    description
+      "Configuration parameters related to bandwidth for a tunnel";
+
+    leaf specification-type {
+      type te-bandwidth-type;
+      default SPECIFIED;
+      description
+        "The method used for settign the bandwidth, either explicitly
+        specified or configured";
+    }
+
+    leaf set-bandwidth {
+      when "../specification-type = 'SPECIFIED'" {
+       description
+         "The bandwidth value when bandwidth is explicitly
+          specified";
+      }
+      type oc-mplst:bandwidth-kbps;
+      description
+       "set bandwidth explicitly, e.g., using
+        offline calculation";
+    }
+  }
+
+  grouping te-tunnel-bandwidth-state {
+    description
+      "Operational state parameters relating to bandwidth for a tunnel";
+
+    leaf signaled-bandwidth {
+      type oc-mplst:bandwidth-kbps;
+      description
+        "The currently signaled bandwidth of the LSP. In the case where
+        the bandwidth is specified explicitly, then this will match the
+        value of the set-bandwidth leaf; in cases where the bandwidth is
+        dynamically computed by the system, the current value of the
+        bandwidth should be reflected.";
+    }
+  }
+
+  grouping te-tunnel-bandwidth-top {
+    description
+      "Top level grouping for specifying bandwidth for a tunnel";
+
+    container bandwidth {
+      description
+        "Bandwidth configuration for TE LSPs";
+
+      container config {
+        description
+          "Configuration parameters related to bandwidth on TE
+          tunnels:";
+        uses te-tunnel-bandwidth-config;
+      }
+
+      container state {
+        config false;
+        description
+          "State parameters related to bandwidth
+          configuration of TE tunnels";
+        uses te-tunnel-bandwidth-config;
+        uses te-tunnel-bandwidth-state;
+      }
+
+      container auto-bandwidth {
+        when "../config/specification-type = 'AUTO'" {
+          description
+            "Include this container for auto bandwidth
+            specific configuration";
+        }
+        description
+          "Parameters related to auto-bandwidth";
+
+        container config {
+          description
+            "Configuration parameters relating to MPLS
+            auto-bandwidth on the tunnel.";
+          uses te-lsp-auto-bandwidth-config;
+        }
+
+        container state {
+          config false;
+          description
+            "State parameters relating to MPLS
+            auto-bandwidth on the tunnel.";
+          uses te-lsp-auto-bandwidth-config;
+          uses te-lsp-auto-bandwidth-state;
+        }
+
+        container overflow {
+          description
+            "configuration of MPLS overflow bandwidth
+            adjustement for the LSP";
+
+          container config {
+            description
+              "Config information for MPLS overflow bandwidth
+              adjustment";
+            uses te-lsp-overflow-config;
+          }
+
+          container state {
+            config false;
+            description
+              "Config information for MPLS overflow bandwidth
+              adjustment";
+            uses te-lsp-overflow-config;
+          }
+        }
+
+        container underflow {
+          description
+            "configuration of MPLS underflow bandwidth
+            adjustement for the LSP";
+
+          container config {
+            description
+              "Config information for MPLS underflow bandwidth
+              adjustment";
+            uses te-lsp-underflow-config;
+          }
+
+          container state {
+            config false;
+            description
+              "State information for MPLS underflow bandwidth
+              adjustment";
+            uses te-lsp-underflow-config;
+          }
+        }
+      }
+    }
+  }
+
+  grouping p2p-path-candidate-secondary-path-config {
+    description
+      "Configuration parameters relating to a secondary path which
+      is a candidate for a particular primary path";
+
+    leaf secondary-path {
+      type leafref {
+        path "../../../../../../p2p-secondary-paths/" +
+             "p2p-secondary-path/config/name";
+      }
+      description
+        "A reference to the secondary path that should be utilised
+        when the containing primary path option is in use";
+    }
+
+    leaf priority {
+      type uint16;
+      description
+        "The priority of the specified secondary path option. Higher
+        priority options are less preferable - such that a secondary
+        path reference with a priority of 0 is the most preferred";
+    }
+  }
+
+  grouping p2p-path-candidate-secondary-path-state {
+    description
+      "Operational state parameters relating to a secondary path
+      which is a candidate for a particular primary path";
+
+    leaf active {
+      type boolean;
+      description
+        "Indicates the current active path option that has
+        been selected of the candidate secondary paths";
+    }
+  }
+
+  grouping path-constraints-config {
+    description "Configuration parameters related to path metric bound constraints.";
+
+    leaf type {
+      type identityref {
+        base oc-mplst:PATH_METRIC_TYPE;
+      }
+      description
+        "Identifies an entry in the list of metric-types
+        bound for the TE path.";
+    }
+
+    leaf metric-upper-bound {
+      type uint64;
+      default 0;
+      description
+        "Upper bound on end-to-end path metric. A zero indicate
+        an unbounded upper limit for the specific metric-type.";
+    }
+  }
+
+  grouping path-constraints-top {
+    description
+      "Top-level path-constraints grouping.";
+
+    container path-metric-bound-constraints {
+      description
+        "Enclosing container for the path metric bound constraints.";
+
+      list path-metric-bound-constraint {
+        key "type";
+        description
+          "A list of metric bounds that are applied as constraints to the LSP.
+          It act as a logical AND, hence all of them must be satisfied.
+          If not, it will return an error.
+          Constraints within this list may be applicable to either
+          the local CSPF process (where data is available to the local device)
+          or be communicated to a PCE for calculation.";
+
+        leaf type {
+          type leafref {
+            path "../config/type";
+          }
+          description
+            "Identifies an entry in the list of metric-types
+            bound for the TE path.";
+        }
+
+        container config {
+          description
+          "Configuration parameters relating to path metric bound constraints.";
+          uses path-constraints-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state parameters relating to path metric bound constraints.";
+          uses path-constraints-config;
+        }
+      }
+    }
+  }
+
+  grouping p2p-primary-paths-top {
+    description
+      "Top level grouping for p2p primary paths";
+
+    container p2p-primary-path {
+      description
+        "Primary paths associated with the LSP";
+
+      list p2p-primary-path {
+        key "name";
+        description
+         "List of p2p primary paths for a tunnel";
+
+        leaf name {
+         type leafref {
+           path "../config/name";
+           // Requires YANG 1.1
+           //require-instance true;
+         }
+         description
+          "Path name";
+        }
+
+        container config {
+         description
+          "Configuration parameters related to paths";
+         uses p2p-path-config;
+        }
+
+        container state {
+          config false;
+          description
+            "State parameters related to paths";
+          uses p2p-path-config;
+          uses p2p-path-state;
+        }
+
+        uses path-constraints-top;
+
+        container candidate-secondary-paths {
+          description
+            "The set of candidate secondary paths which may be used
+            for this primary path. When secondary paths are specified
+            in the list the path of the secondary LSP in use must be
+            restricted to those path options referenced. The
+            priority of the secondary paths is specified within the
+            list. Higher priority values are less preferred - that is
+            to say that a path with priority 0 is the most preferred
+            path. In the case that the list is empty, any secondary
+            path option may be utilised when the current primary path
+            is in use.";
+
+          list candidate-secondary-path {
+            key "secondary-path";
+
+            description
+              "List of secondary paths which may be utilised when the
+              current primary path is in use";
+
+            leaf secondary-path {
+              type leafref {
+                path "../config/secondary-path";
+              }
+              description
+                "A reference to the secondary path option reference
+                which acts as the key of the candidate-secondary-path
+                list";
+            }
+
+            container config {
+              description
+                "Configuration parameters relating to the candidate
+                secondary path";
+
+              uses p2p-path-candidate-secondary-path-config;
+            }
+
+            container state {
+              config false;
+              description
+                "Operational state parameters relating to the candidate
+                secondary path";
+
+              uses p2p-path-candidate-secondary-path-config;
+              uses p2p-path-candidate-secondary-path-state;
+            }
+          }
+        }
+        uses te-path-placement-constraints-top;
+
+      }
+    }
+  }
+
+  grouping p2p-secondary-paths-top {
+    description
+      "Top level grouping for p2p secondary paths";
+
+    container p2p-secondary-paths {
+      description
+        "Secondary paths for the LSP";
+
+      list p2p-secondary-path {
+        key "name";
+        description
+          "List of p2p primary paths for a tunnel";
+
+        leaf name {
+          type leafref {
+            path "../config/name";
+            // Requires YANG 1.1
+            //require-instance true;
+          }
+          description
+            "Path name";
+        }
+
+        container config {
+          description
+            "Configuration parameters related to paths";
+          uses p2p-path-config;
+        }
+
+        container state {
+          config false;
+          description
+            "State parameters related to paths";
+          uses p2p-path-config;
+          uses p2p-path-state;
+        }
+        uses path-constraints-top;
+        uses te-path-placement-constraints-top;
+      }
+    }
+  }
+
+  grouping te-tunnels-top {
+    description
+      "Top level grouping for TE tunnels";
+
+    container tunnels {
+      description
+        "Enclosing container for tunnels";
+      list tunnel {
+        key "name";
+        description
+          "List of TE tunnels. This list contains only the LSPs that the
+          current device originates (i.e., for which it is the head-end).
+          Where the signaling protocol utilised for an LSP allows a mid-point
+          or tail device to be aware of the LSP (e.g., RSVP-TE), then the
+          associated sessions are maintained per protocol";
+
+        leaf name {
+          type leafref {
+            path "../config/name";
+            // Requires YANG 1.1
+            //require-instance true;
+          }
+          description
+            "The tunnel name";
+        }
+
+        container config {
+          description
+            "Configuration parameters related to TE tunnels:";
+          uses te-global-tunnel-config;
+        }
+
+        container state {
+          config false;
+          description
+            "State parameters related to TE tunnels";
+          uses te-global-tunnel-config;
+          uses te-tunnel-state;
+
+        }
+
+        uses te-tunnel-bandwidth-top;
+        uses te-tunnel-p2p-top;
+        // TODO - add the p2mp configuration
+      }
+    }
+  }
+
+// data definition statements
+
+// augment statements
+
+// rpc statements
+
+// notification statements
+
+}

--- a/models/yang/common/openconfig-mpls-types.yang
+++ b/models/yang/common/openconfig-mpls-types.yang
@@ -1,0 +1,548 @@
+module openconfig-mpls-types {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/mpls-types";
+
+  prefix "oc-mplst";
+
+  import openconfig-extensions { prefix oc-ext; }
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    netopenconfig@googlegroups.com";
+
+  description
+    "General types for MPLS / TE data model";
+
+  oc-ext:openconfig-version "3.5.0";
+
+  revision "2023-12-14" {
+    description
+      "Added additional attributes oc-if:interface-ref
+      and metric attributes to static lsp";
+    reference "3.5.0";
+  }
+
+  revision "2021-12-01" {
+    description
+      "Add new identity for RSVP authentication types";
+    reference "3.4.0";
+  }
+
+  revision "2021-06-16" {
+    description
+      "Remove trailing whitespace";
+    reference "3.3.1";
+  }
+
+  revision "2021-03-23" {
+    description
+      "Add new identity for path metric types.";
+    reference "3.3.0";
+  }
+
+  revision "2020-02-04" {
+    description
+      "Consistent prefix for openconfig-mpls-types.";
+    reference "3.2.0";
+  }
+
+  revision "2019-03-26" {
+    description
+      "Add Pseudowire encapsulation.";
+    reference "3.1.0";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "3.0.1";
+  }
+
+  revision "2018-07-02" {
+    description
+      "Add new RSVP-TE statistics, remove associated-rsvp-session
+      leaf. Remove use of date-and-time.";
+    reference "3.0.0";
+  }
+
+  revision "2018-06-16" {
+    description
+      "Included attributes for base LDP configuration.";
+     reference "2.6.0";
+  }
+
+  revision "2018-06-13" {
+    description
+      "Add ttl-propagation to global MPLS config";
+    reference "2.5.0";
+  }
+
+  revision "2018-06-05" {
+    description
+      "Fixed bugs in when statements on RSVP-TE attributes";
+    reference "2.4.2";
+  }
+
+  revision "2017-08-24" {
+    description
+      "Minor formatting fixes.";
+    reference "2.4.1";
+  }
+
+  revision "2017-06-21" {
+    description
+      "Add TC bits typedef.";
+    reference "2.4.0";
+  }
+
+  revision "2017-03-22" {
+    description
+      "Add RSVP calculated-absolute-subscription-bw";
+    reference "2.3.0";
+  }
+
+  revision "2017-01-26" {
+    description
+      "Add RSVP Tspec, clarify units for RSVP, remove unused LDP";
+    reference "2.2.0";
+  }
+
+  revision "2016-12-15" {
+    description
+      "Add additional MPLS parameters";
+    reference "2.1.0";
+  }
+
+  revision "2016-09-01" {
+    description
+      "Revisions based on implementation feedback";
+    reference "2.0.0";
+  }
+
+  revision "2016-08-08" {
+    description
+      "Public release of MPLS models";
+    reference "1.0.1";
+  }
+
+  // identity statements
+
+  identity PATH_COMPUTATION_METHOD {
+    description
+     "base identity for supported path computation
+      mechanisms";
+  }
+
+  identity LOCALLY_COMPUTED {
+    base PATH_COMPUTATION_METHOD;
+    description
+      "indicates a constrained-path LSP in which the
+      path is computed by the local LER";
+  }
+
+  identity EXTERNALLY_QUERIED {
+    base PATH_COMPUTATION_METHOD;
+    description
+     "Constrained-path LSP in which the path is
+      obtained by querying an external source, such as a PCE server.
+      In the case that an LSP is defined to be externally queried, it may
+      also have associated explicit definitions (which are provided to the
+      external source to aid computation); and the path that is returned by
+      the external source is not required to provide a wholly resolved
+      path back to the originating system - that is to say, some local
+      computation may also be required";
+  }
+
+  identity EXPLICITLY_DEFINED {
+    base PATH_COMPUTATION_METHOD;
+    description
+     "constrained-path LSP in which the path is
+      explicitly specified as a collection of strict or/and loose
+      hops";
+  }
+
+
+  // using identities rather than enum types to simplify adding new
+  // signaling protocols as they are introduced and supported
+  identity PATH_SETUP_PROTOCOL {
+    description
+      "base identity for supported MPLS signaling
+      protocols";
+  }
+
+  identity PATH_SETUP_RSVP {
+    base PATH_SETUP_PROTOCOL;
+    description
+      "RSVP-TE signaling protocol";
+  }
+
+  identity PATH_SETUP_SR {
+    base PATH_SETUP_PROTOCOL;
+    description
+      "Segment routing";
+  }
+
+  identity PATH_SETUP_LDP {
+    base PATH_SETUP_PROTOCOL;
+    description
+      "LDP - RFC 5036";
+  }
+
+
+  identity PROTECTION_TYPE {
+    description
+      "base identity for protection type";
+  }
+
+  identity UNPROTECTED {
+    base PROTECTION_TYPE;
+    description
+      "no protection is desired";
+  }
+
+  identity LINK_PROTECTION_REQUIRED {
+    base PROTECTION_TYPE;
+    description
+      "link protection is desired";
+  }
+
+  identity LINK_NODE_PROTECTION_REQUESTED {
+    base PROTECTION_TYPE;
+    description
+      "node and link protection are both desired";
+  }
+
+  identity LSP_ROLE {
+    description
+      "Base identity for describing the role of
+       label switched path at the current node";
+  }
+
+  identity INGRESS {
+    base LSP_ROLE;
+    description
+      "Label switched path is an ingress (headend)
+       LSP";
+  }
+
+  identity EGRESS {
+    base LSP_ROLE;
+    description
+      "Label switched path is an egress (tailend)
+       LSP";
+  }
+
+  identity TRANSIT {
+    base LSP_ROLE;
+    description
+      "Label switched path is a transit LSP";
+  }
+
+
+  identity TUNNEL_TYPE {
+    description
+      "Base identity from which specific tunnel types are
+      derived.";
+  }
+
+  identity P2P {
+    base TUNNEL_TYPE;
+    description
+      "TE point-to-point tunnel type.";
+  }
+
+  identity P2MP {
+    base TUNNEL_TYPE;
+    description
+      "TE point-to-multipoint tunnel type.";
+  }
+
+
+  identity LSP_OPER_STATUS {
+    description
+      "Base identity for LSP operational status";
+  }
+
+  identity DOWN {
+    base LSP_OPER_STATUS;
+    description
+      "LSP is operationally down or out of service";
+  }
+
+  identity UP {
+    base LSP_OPER_STATUS;
+    description
+      "LSP is operationally active and available
+       for traffic.";
+  }
+
+  identity TUNNEL_ADMIN_STATUS {
+    description
+      "Base identity for tunnel administrative status";
+  }
+
+  identity ADMIN_DOWN {
+    base TUNNEL_ADMIN_STATUS;
+    description
+      "LSP is administratively down";
+  }
+
+  identity ADMIN_UP {
+    base TUNNEL_ADMIN_STATUS;
+    description
+      "LSP is administratively up";
+  }
+
+  identity NULL_LABEL_TYPE {
+    description
+      "Base identity from which specific null-label types are
+      derived.";
+  }
+
+  identity EXPLICIT {
+    base NULL_LABEL_TYPE;
+    description
+      "Explicit null label is used.";
+  }
+
+  identity IMPLICIT {
+    base NULL_LABEL_TYPE;
+    description
+      "Implicit null label is used.";
+  }
+
+  identity LSP_METRIC_TYPE {
+    description
+      "Base identity for types of LSP metric specification";
+  }
+
+  identity LSP_METRIC_RELATIVE {
+    base LSP_METRIC_TYPE;
+    description
+      "The metric specified for the LSPs to which this identity refers
+      is specified as a relative value to the IGP metric cost to the
+      LSP's tail-end.";
+  }
+
+  identity LSP_METRIC_ABSOLUTE {
+    base LSP_METRIC_TYPE;
+    description
+      "The metric specified for the LSPs to which this identity refers
+      is specified as an absolute value";
+  }
+
+  identity LSP_METRIC_INHERITED {
+    base LSP_METRIC_TYPE;
+    description
+      "The metric for for the LSPs to which this identity refers is
+      not specified explicitly - but rather inherited from the IGP
+      cost directly";
+  }
+
+  // Note: The IANA PWE3 Types Registry has several more values than these
+  identity PSEUDOWIRE_ENCAPSULATION {
+    description
+      "Sets the PDU type of the PSEUDOWIRE Example in RFC4448. This value
+      should be enumerated from the IANA Pseudowire types registry";
+  }
+
+  identity PWE_ETHERNET_TAGGED_MODE {
+    base PSEUDOWIRE_ENCAPSULATION;
+    description
+      "Ethernet Tagged Mode RFC4448";
+    reference "IANA PWE3 0x0004";
+  }
+
+  identity PWE_ETHERNET_RAW_MODE {
+    base PSEUDOWIRE_ENCAPSULATION;
+    description
+      "Ethernet Raw Mode RFC4448";
+    reference "IANA PWE3 0x0005";
+  }
+
+  identity PATH_METRIC_TYPE {
+    description
+      "Base identity for path metric type.";
+  }
+
+  identity TE_METRIC {
+    base PATH_METRIC_TYPE;
+    description
+      "TE path metric.";
+    reference
+      "RFC3785: Use of Interior Gateway Protocol (IGP) Metric as a
+      second MPLS Traffic Engineering (TE) Metric.
+      RFC5440: Path Computation Element (PCE) Communication Protocol (PCEP).";
+  }
+
+  identity IGP_METRIC {
+    base PATH_METRIC_TYPE;
+    description
+      "IGP path metric.";
+    reference
+      "RFC5440: Path Computation Element (PCE) Communication Protocol (PCEP).";
+  }
+
+  identity HOP_COUNT {
+    base PATH_METRIC_TYPE;
+    description
+      "Hop count path metric.";
+    reference
+      "RFC5440: Path Computation Element (PCE) Communication Protocol (PCEP).";
+  }
+
+  identity PATH_DELAY {
+    base PATH_METRIC_TYPE;
+    description
+      "Unidirectional average link delay.
+      It represents the sum of the Link Delay metric
+      of all links along a P2P path.";
+    reference
+      "RFC8570 IS-IS Traffic Engineering (TE) Metric Extensions.
+      RFC7471 OSPF Traffic Engineering (TE) Metric Extensions.
+      RFC 8233: Extensions to the Path Computation Element Communication Protocol (PCEP)
+      to Compute Service-Aware Label Switched Paths (LSPs) Path Computation Element (PCE)
+      Communication Protocol (PCEP).";
+  }
+
+  identity RSVP_AUTH_TYPE {
+    description
+      "Base identity for RSVP message authentication types";
+    reference
+      "RFC2747: RSVP Cryptographic Authentication";
+  }
+
+  identity RSVP_AUTH_MD5 {
+    base RSVP_AUTH_TYPE;
+    description
+      "HMAC-MD5 message authentication";
+  }
+
+  // typedef statements
+  typedef mpls-label {
+    type union {
+      type uint32 {
+        range 16..1048575;
+      }
+      type enumeration {
+        enum IPV4_EXPLICIT_NULL {
+          value 0;
+          description
+            "valid at the bottom of the label stack,
+            indicates that stack must be popped and packet forwarded
+            based on IPv4 header";
+        }
+        enum ROUTER_ALERT {
+          value 1;
+          description
+            "allowed anywhere in the label stack except
+            the bottom, local router delivers packet to the local CPU
+            when this label is at the top of the stack";
+        }
+        enum IPV6_EXPLICIT_NULL {
+          value 2;
+          description
+            "valid at the bottom of the label stack,
+            indicates that stack must be popped and packet forwarded
+            based on IPv6 header";
+        }
+        enum IMPLICIT_NULL {
+          value 3;
+          description
+            "assigned by local LSR but not carried in
+            packets";
+        }
+        enum ENTROPY_LABEL_INDICATOR {
+          value 7;
+          description
+            "Entropy label indicator, to allow an LSR
+            to distinguish between entropy label and applicaiton
+            labels RFC 6790";
+        }
+        enum NO_LABEL {
+          description
+            "This value is utilised to indicate that the packet that
+            is forwarded by the local system does not have an MPLS
+            header applied to it. Typically, this is used at the
+            egress of an LSP";
+        }
+      }
+    }
+    description
+      "type for MPLS label value encoding";
+    reference "RFC 3032 - MPLS Label Stack Encoding";
+  }
+
+  typedef tunnel-type {
+    type enumeration {
+      enum P2P {
+        description
+          "point-to-point label-switched-path";
+      }
+      enum P2MP {
+        description
+          "point-to-multipoint label-switched-path";
+      }
+      enum MP2MP {
+        description
+          "multipoint-to-multipoint label-switched-path";
+      }
+    }
+    description
+      "defines the tunnel type for the LSP";
+    reference
+      "RFC 6388 - Label Distribution Protocol Extensions for
+      Point-to-Multipoint and Multipoint-to-Multipoint Label Switched
+      Paths
+      RFC 4875 - Extensions to  Resource Reservation Protocol
+      - Traffic Engineering (RSVP-TE) for Point-to-Multipoint TE
+      Label Switched Paths (LSPs)";
+  }
+
+  typedef bandwidth-kbps {
+    type uint64;
+    units "Kbps";
+    description
+      "Bandwidth values expressed in kilobits per second";
+  }
+
+  typedef bandwidth-mbps {
+    type uint64;
+    units "Mbps";
+    description
+      "Bandwidth values expressed in megabits per second";
+  }
+
+  typedef bandwidth-gbps {
+    type uint64;
+    units "Gbps";
+    description
+      "Bandwidth values expressed in gigabits per second";
+  }
+
+  typedef mpls-tc {
+    type uint8 {
+      range "0..7";
+    }
+    description
+      "Values of the MPLS Traffic Class (formerly known as
+      Experimental, EXP) bits";
+  }
+
+  // grouping statements
+
+  // data definition statements
+
+  // augment statements
+
+  // rpc statements
+
+  // notification statements
+
+}

--- a/models/yang/common/openconfig-mpls.yang
+++ b/models/yang/common/openconfig-mpls.yang
@@ -1,0 +1,829 @@
+module openconfig-mpls {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/mpls";
+
+  prefix "oc-mpls";
+
+
+  // import some basic types
+  import openconfig-mpls-types { prefix oc-mplst; }
+  import openconfig-mpls-rsvp { prefix oc-rsvp; }
+  import openconfig-mpls-ldp { prefix oc-ldp; }
+  import openconfig-types { prefix oc-types; }
+  import openconfig-interfaces { prefix oc-if; }
+  import openconfig-extensions { prefix oc-ext; }
+  import openconfig-segment-routing { prefix oc-sr; }
+
+  // include submodules
+  include openconfig-mpls-te;
+  include openconfig-mpls-igp;
+  include openconfig-mpls-static;
+
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    netopenconfig@googlegroups.com";
+
+  description
+    "This module provides data definitions for configuration of
+    Multiprotocol Label Switching (MPLS) and associated protocols for
+    signaling and traffic engineering.
+
+    RFC 3031: Multiprotocol Label Switching Architecture
+
+    The MPLS / TE data model consists of several modules and
+    submodules as shown below.  The top-level MPLS module describes
+    the overall framework.  Three types of LSPs are supported:
+
+    i) traffic-engineered (or constrained-path)
+
+    ii) IGP-congruent (LSPs that follow the IGP path)
+
+    iii) static LSPs which are not signaled
+
+    The structure of each of these LSP configurations is defined in
+    corresponding submodules.  Companion modules define the relevant
+    configuration and operational data specific to key signaling
+    protocols used in operational practice.
+
+
+                              +-------+
+            +---------------->| MPLS  |<--------------+
+            |                 +-------+               |
+            |                     ^                   |
+            |                     |                   |
+       +----+-----+      +--------+-------+     +-----+-----+
+       | TE LSPs  |      | IGP-based LSPs |     |static LSPs|
+       |          |      |                |     |           |
+       +----------+      +----------------+     +-----------+
+           ^  ^                    ^  ^
+           |  +----------------+   |  +--------+
+           |                   |   |           |
+           |   +------+      +-+---+-+      +--+--+
+           +---+ RSVP |      |SEGMENT|      | LDP |
+               +------+      |ROUTING|      +-----+
+                             +-------+
+    ";
+  oc-ext:openconfig-version "3.5.0";
+
+  revision "2023-12-14" {
+    description
+      "Added additional attributes oc-if:interface-ref
+      and metric attributes to static lsp";
+    reference "3.5.0";
+  }
+
+  revision "2023-07-25" {
+    description
+      "Added record-route-enabled to MPLS p2p tunnel config";
+    reference "3.4.0";
+  }
+
+  revision "2023-04-28" {
+    description
+      "Fixed typo in cspf-tiebreaker leaf description";
+    reference "3.3.2";
+  }
+
+  revision "2023-04-25" {
+    description
+      "Clarify usage of interface-ref.";
+    reference "3.3.1";
+  }
+
+  revision "2022-02-11" {
+    description
+      "Add lsp-path PCE control mode";
+    reference "3.3.0";
+  }
+
+  revision "2021-07-28" {
+    description
+      "Add prefix to qualify when statements.";
+    reference "3.2.2";
+  }
+
+  revision "2021-06-16" {
+    description
+      "Remove trailing whitespace";
+    reference "3.2.1";
+  }
+
+  revision "2021-03-24" {
+    description
+      "Add Metric bounds constraints for LSPs.";
+    reference "3.2.0";
+  }
+
+  revision "2019-03-26" {
+    description
+      "Add Pseudowire encapsulation.";
+    reference "3.1.0";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "3.0.1";
+  }
+
+  revision "2018-07-02" {
+    description
+      "Add new RSVP-TE statistics, remove associated-rsvp-session
+      leaf. Remove use of date-and-time.";
+    reference "3.0.0";
+  }
+
+  revision "2018-06-16" {
+    description
+      "Included attributes for base LDP configuration.";
+     reference "2.6.0";
+  }
+
+  revision "2018-06-13" {
+    description
+      "Add ttl-propagation to global MPLS config";
+    reference "2.5.0";
+  }
+
+  revision "2018-06-05" {
+    description
+      "Fixed bugs in when statements on RSVP-TE attributes";
+    reference "2.4.2";
+  }
+
+  revision "2017-08-24" {
+    description
+      "Minor formatting fixes.";
+    reference "2.4.1";
+  }
+
+  revision "2017-06-21" {
+    description
+      "Add TC bits typedef.";
+    reference "2.4.0";
+  }
+
+  revision "2017-03-22" {
+    description
+      "Add RSVP calculated-absolute-subscription-bw";
+    reference "2.3.0";
+  }
+
+  revision "2017-01-26" {
+    description
+      "Add RSVP Tspec, clarify units for RSVP, remove unused LDP";
+    reference "2.2.0";
+  }
+
+  revision "2016-12-15" {
+    description
+      "Add additional MPLS parameters";
+    reference "2.1.0";
+  }
+
+  revision "2016-09-01" {
+    description
+      "Revisions based on implementation feedback";
+    reference "2.0.0";
+  }
+
+  revision "2016-08-08" {
+    description
+      "Public release of MPLS models";
+    reference "1.0.1";
+  }
+
+  // OpenConfig specific extensions for module metadata.
+  oc-ext:regexp-posix;
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  // grouping statements
+
+  grouping mpls-admin-group-config {
+    description
+      "configuration data for MPLS link admin groups";
+
+      leaf admin-group-name {
+        type string;
+        description
+          "name for mpls admin-group";
+      }
+
+      leaf bit-position {
+        type uint32;
+        description
+          "bit-position value for mpls admin-group. The value
+           for the admin group is an integer that represents one
+           of the bit positions in the admin-group bitmask. Values
+           between 0 and 31 are interpreted as the original limit
+           of 32 admin groups. Values >=32 are interpreted as
+           extended admin group values as per RFC7308.";
+      }
+
+  }
+
+  grouping mpls-admin-groups-top {
+
+    description
+      "top-level mpls admin-groups config
+      and state containers";
+
+    container mpls-admin-groups {
+      description
+        "Top-level container for admin-groups configuration
+        and state";
+
+      list admin-group {
+        key "admin-group-name";
+        description
+          "configuration of value to name mapping
+          for mpls affinities/admin-groups";
+
+        leaf admin-group-name {
+          type leafref {
+            path "../config/admin-group-name";
+          }
+          description
+            "name for mpls admin-group";
+        }
+        container config {
+          description
+            "Configurable items for admin-groups";
+          uses mpls-admin-group-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state for admin-groups";
+          uses mpls-admin-group-config;
+        }
+      }
+    }
+  }
+
+  grouping mpls-te-igp-flooding-bandwidth-config {
+    description
+      "Configurable items for igp flooding bandwidth
+      threshold configuration.";
+    leaf threshold-type {
+      type enumeration {
+        enum DELTA {
+          description
+            "DELTA indicates that the local
+            system should flood IGP updates when a
+            change in reserved bandwidth >= the specified
+            delta occurs on the interface.";
+        }
+        enum THRESHOLD_CROSSED {
+          description
+            "THRESHOLD-CROSSED indicates that
+            the local system should trigger an update (and
+            hence flood) the reserved bandwidth when the
+            reserved bandwidth changes such that it crosses,
+            or becomes equal to one of the threshold values.";
+        }
+      }
+      description
+        "The type of threshold that should be used to specify the
+        values at which bandwidth is flooded. DELTA indicates that
+        the local system should flood IGP updates when a change in
+        reserved bandwidth >= the specified delta occurs on the
+        interface. Where THRESHOLD_CROSSED is specified, the local
+        system should trigger an update (and hence flood) the
+        reserved bandwidth when the reserved bandwidth changes such
+        that it crosses, or becomes equal to one of the threshold
+        values";
+    }
+
+    leaf delta-percentage {
+      when "../threshold-type = 'DELTA'" {
+        description
+          "The percentage delta can only be specified when the
+          threshold type is specified to be a percentage delta of
+          the reserved bandwidth";
+      }
+      type oc-types:percentage;
+      description
+        "The percentage of the maximum-reservable-bandwidth
+        considered as the delta that results in an IGP update
+        being flooded";
+    }
+
+    leaf threshold-specification {
+      when "../threshold-type = 'THRESHOLD_CROSSED'" {
+        description
+          "The selection of whether mirrored or separate threshold
+          values are to be used requires user specified thresholds to
+          be set";
+      }
+      type enumeration {
+        enum MIRRORED_UP_DOWN {
+          description
+            "MIRRORED_UP_DOWN indicates that a single set of
+            threshold values should be used for both increasing
+            and decreasing bandwidth when determining whether
+            to trigger updated bandwidth values to be flooded
+            in the IGP TE extensions.";
+        }
+        enum SEPARATE_UP_DOWN {
+          description
+            "SEPARATE_UP_DOWN indicates that a separate
+            threshold values should be used for the increasing
+            and decreasing bandwidth when determining whether
+            to trigger updated bandwidth values to be flooded
+            in the IGP TE extensions.";
+        }
+      }
+      description
+        "This value specifies whether a single set of threshold
+        values should be used for both increasing and decreasing
+        bandwidth when determining whether to trigger updated
+        bandwidth values to be flooded in the IGP TE extensions.
+        MIRRORED-UP-DOWN indicates that a single value (or set of
+        values) should be used for both increasing and decreasing
+        values, where SEPARATE-UP-DOWN specifies that the increasing
+        and decreasing values will be separately specified";
+    }
+
+    leaf-list up-thresholds {
+      when "../threshold-type = 'THRESHOLD_CROSSED'" +
+        "and ../threshold-specification = 'SEPARATE_UP_DOWN'" {
+          description
+            "A list of up-thresholds can only be specified when the
+            bandwidth update is triggered based on crossing a
+            threshold and separate up and down thresholds are
+            required";
+        }
+      type oc-types:percentage;
+      description
+        "The thresholds (expressed as a percentage of the maximum
+        reservable bandwidth) at which bandwidth updates are to be
+        triggered when the bandwidth is increasing.";
+    }
+
+    leaf-list down-thresholds {
+      when "../threshold-type = 'THRESHOLD_CROSSED'" +
+        "and ../threshold-specification = 'SEPARATE_UP_DOWN'" {
+          description
+            "A list of down-thresholds can only be specified when the
+            bandwidth update is triggered based on crossing a
+            threshold and separate up and down thresholds are
+            required";
+        }
+      type oc-types:percentage;
+      description
+        "The thresholds (expressed as a percentage of the maximum
+        reservable bandwidth) at which bandwidth updates are to be
+        triggered when the bandwidth is decreasing.";
+    }
+
+    leaf-list up-down-thresholds {
+      when "../threshold-type = 'THRESHOLD_CROSSED'" +
+        "and ../threshold-specification = 'MIRRORED_UP_DOWN'" {
+          description
+            "A list of thresholds corresponding to both increasing
+            and decreasing bandwidths can be specified only when an
+            update is triggered based on crossing a threshold, and
+            the same up and down thresholds are required.";
+        }
+      type oc-types:percentage;
+      description
+        "The thresholds (expressed as a percentage of the maximum
+        reservable bandwidth of the interface) at which bandwidth
+        updates are flooded - used both when the bandwidth is
+        increasing and decreasing";
+    }
+  }
+
+
+  grouping  mpls-te-igp-flooding-bandwidth {
+    description
+      "Top level group for traffic engineering
+      database flooding options";
+    container igp-flooding-bandwidth {
+      description
+        "Interface bandwidth change percentages
+        that trigger update events into the IGP traffic
+        engineering database (TED)";
+      container config {
+        description
+          "Configuration parameters for TED
+          update threshold ";
+        uses  mpls-te-igp-flooding-bandwidth-config;
+      }
+      container state {
+        config false;
+        description
+          "State parameters for TED update threshold ";
+        uses  mpls-te-igp-flooding-bandwidth-config;
+      }
+    }
+  }
+
+
+  grouping te-lsp-delay-config {
+    description
+      "Group for the timers goerning the delay
+      in installation and cleanup of TE LSPs";
+
+    leaf install-delay {
+      type uint16 {
+        range 0..3600;
+      }
+      units seconds;
+      description
+        "delay the use of newly installed te lsp for a
+        specified amount of time.";
+    }
+
+    leaf cleanup-delay {
+      type uint16;
+      units seconds;
+      description
+        "delay the removal of old te lsp for a specified
+        amount of time";
+    }
+  }
+
+  grouping te-interface-attributes-top {
+    description
+      "Top level grouping for attributes
+      for TE interfaces.";
+
+    list interface {
+      key "interface-id";
+      description
+        "List of TE interfaces.
+
+         The interface referenced is based on the interface and
+         subinterface leaves within the interface-ref container -
+         which reference an entry in the /interfaces/interface list -
+         and should not rely on the value of the list key.";
+
+      leaf interface-id {
+        type leafref {
+          path "../config/interface-id";
+        }
+        description
+          "Reference to the interface id list key";
+      }
+
+      container config {
+        description
+          "Configuration parameters related to TE interfaces:";
+        uses te-interface-attributes-config;
+      }
+
+      container state {
+        config false;
+        description
+          "State parameters related to TE interfaces";
+        uses te-interface-attributes-config;
+      }
+
+      uses oc-if:interface-ref;
+
+      uses  mpls-te-igp-flooding-bandwidth;
+    }
+  }
+
+  grouping te-interface-attributes-config {
+    description
+      "global level definitions for interfaces
+      on which TE is run";
+
+    leaf interface-id {
+      type oc-if:interface-id;
+      description
+        "Id of the interface";
+    }
+
+    leaf te-metric {
+      type uint32;
+      description
+        "TE specific metric for the link";
+    }
+
+    leaf-list srlg-membership {
+      type leafref {
+          path "../../../../te-global-attributes/srlgs/srlg/name";
+      }
+      description
+        "list of references to named shared risk link groups that the
+        interface belongs to.";
+    }
+
+    leaf-list admin-group {
+      type string;
+      description
+        "list of admin groups (by name) on the interface";
+    }
+  }
+
+  grouping mpls-te-lsp-timers {
+    description
+      "Grouping for traffic engineering timers";
+    container te-lsp-timers {
+      description
+        "Definition for delays associated with setup
+        and cleanup of TE LSPs";
+
+      container config {
+        description
+          "Configuration parameters related
+          to timers for TE LSPs";
+
+        uses te-lsp-delay-config;
+        uses te-tunnel-reoptimize-config;
+      }
+
+      container state {
+        config false;
+        description
+          "State related to timers for TE LSPs";
+
+        uses te-lsp-delay-config;
+        uses te-tunnel-reoptimize-config;
+      }
+    }
+  }
+
+  grouping mpls-global-config {
+    description
+      "Definition of global MPLS configuration parameters";
+
+    leaf null-label {
+      type identityref {
+        base oc-mplst:NULL_LABEL_TYPE;
+      }
+      default oc-mplst:IMPLICIT;
+      description
+        "The null-label type used, implicit or explicit";
+    }
+
+    leaf ttl-propagation {
+      type boolean;
+      default true;
+      description
+        "Enables TTL propagation across the MPLS domain.
+        When ttl-propagation is set to true, the IP TTL
+        is copied into the MPLS header TTL when pushing
+        a label to an IP packet. If false, the IP TTL is
+        not copied into the MPLS header TTL and, therefore,
+        the IP TTL is not updated in the MPLS domain.";
+    }
+
+    leaf pw-encapsulation {
+      type identityref {
+        base oc-mplst:PSEUDOWIRE_ENCAPSULATION;
+      }
+      description
+        "The PDU type to use with pseudowires.";
+    }
+
+  }
+
+ grouping mpls-global-top {
+    description
+      "Top level grouping for global MPLS configuration ";
+
+      container config {
+        description
+          "Top level global MPLS configuration";
+        uses mpls-global-config;
+      }
+
+      container state {
+        config false;
+        description
+          "Top level global MPLS state";
+        uses mpls-global-config;
+      }
+ }
+
+ grouping mpls-interfaces-top {
+    description
+      "Top level grouping for attributes
+      for MPLS-enabled interfaces.";
+
+    container interface-attributes {
+      description
+        "Parameters related to MPLS interfaces";
+
+      list interface {
+        key "interface-id";
+        description
+          "List of MPLS-enabled interfaces.
+
+           The interface referenced is based on the interface and
+           subinterface leaves within the interface-ref container -
+           which reference an entry in the /interfaces/interface list -
+           and should not rely on the value of the list key.";
+
+        leaf interface-id {
+          type leafref {
+            path "../config/interface-id";
+          }
+          description
+            "Reference to the interface id list key";
+        }
+
+        container config {
+          description
+            "Configuration parameters related to MPLS interfaces:";
+          uses mpls-interface-attributes-config;
+        }
+
+        container state {
+          config false;
+          description
+            "State parameters related to TE interfaces";
+          uses mpls-interface-attributes-config;
+        }
+
+        uses oc-if:interface-ref;
+      }
+    }
+  }
+
+  grouping mpls-interface-attributes-config {
+    description
+      "global level definitions for interfaces
+      on which MPLS is run";
+
+    leaf interface-id {
+      type oc-if:interface-id;
+      description
+        "Indentifier for the MPLS interface";
+    }
+
+    leaf mpls-enabled {
+      type boolean;
+      default false;
+      description
+        "Enable MPLS forwarding on this interface";
+    }
+  }
+
+  grouping mpls-label-block-config {
+    description
+      "Configuration parameters relating to an MPLS label block.";
+
+    leaf local-id {
+      type string;
+      description
+        "A local identifier for the global label block allocation.";
+    }
+
+    leaf lower-bound {
+      type oc-mplst:mpls-label;
+      description
+        "Lower bound of the global label block. The block is defined to include
+        this label.";
+    }
+
+    leaf upper-bound {
+      type oc-mplst:mpls-label;
+      description
+        "Upper bound for the global label block. The block is defined to include
+        this label.";
+    }
+  }
+
+  grouping mpls-label-blocks-top {
+    description
+      "Top-level configuration and operational state parameters corresponding
+      to reserved label blocks.";
+
+    container reserved-label-blocks {
+      description
+        "A range of labels starting with the start-label and up-to and including
+        the end label that should be allocated as reserved. These labels should
+        not be utilised by any dynamic label allocation on the local system unless
+        the allocating protocol is explicitly configured to specify that
+        allocation of labels should be out of the label block specified.";
+
+      list reserved-label-block {
+        key "local-id";
+
+        description
+          "A range of labels starting with the start-label up to and including
+          the end label that should be allocated for use by a specific protocol.";
+
+        leaf local-id {
+          type leafref {
+            path "../config/local-id";
+          }
+          description
+            "A reference to a unique local identifier for this label block.";
+        }
+
+        container config {
+          description
+            "Configuration parameters relating to the label block.";
+
+          uses mpls-label-block-config;
+        }
+
+        container state {
+          config false;
+          description
+            "State parameters relating to the label block.";
+
+          uses mpls-label-block-config;
+        }
+      }
+    }
+  }
+
+  grouping mpls-top {
+    description
+      "Top level grouping for MPLS configuration and state";
+
+    container mpls {
+      description
+        "Anchor point for mpls configuration and operational
+        data";
+
+      container global {
+        // entropy label support, label ranges will be added here.
+       description
+        "general mpls configuration applicable to any
+        type of LSP and signaling protocol - label ranges,
+        entropy label supportmay be added here";
+       uses mpls-global-top;
+       uses mpls-interfaces-top;
+       uses mpls-label-blocks-top;
+      }
+
+      container te-global-attributes {
+        description
+          "traffic-engineering global attributes";
+        uses mpls-te-srlg-top;
+        uses mpls-admin-groups-top;
+        uses mpls-te-lsp-timers;
+      }
+
+      container te-interface-attributes {
+        description
+          "traffic engineering attributes specific
+          for interfaces";
+        uses te-interface-attributes-top;
+      }
+
+      container signaling-protocols {
+        description
+          "top-level signaling protocol configuration";
+
+        uses oc-rsvp:rsvp-global;
+        uses oc-ldp:ldp-global;
+        uses oc-sr:sr-mpls-top;
+      }
+
+      container lsps {
+        description
+          "LSP definitions and configuration";
+
+        container constrained-path {
+          description
+            "traffic-engineered LSPs supporting different
+            path computation and signaling methods";
+          uses explicit-paths-top;
+          uses te-tunnels-top;
+        }
+
+        container unconstrained-path {
+          description
+            "LSPs that use the IGP-determined path, i.e., non
+            traffic-engineered, or non constrained-path";
+
+          uses igp-lsp-common;
+          uses igp-lsp-setup;
+        }
+
+        container static-lsps {
+          description
+            "statically configured LSPs, without dynamic
+            signaling";
+
+          uses static-lsp-top;
+        }
+      }
+    }
+  }
+
+  // augment statements
+
+  // rpc statements
+
+  // notification statements
+}

--- a/models/yang/common/openconfig-network-instance-l2.yang
+++ b/models/yang/common/openconfig-network-instance-l2.yang
@@ -1,0 +1,934 @@
+submodule openconfig-network-instance-l2 {
+
+  belongs-to openconfig-network-instance {
+    prefix "oc-netinst";
+  }
+
+  // import some basic types
+  import openconfig-extensions { prefix "oc-ext"; }
+  import openconfig-interfaces { prefix "oc-if"; }
+  import openconfig-yang-types { prefix "oc-yang"; }
+  import openconfig-inet-types { prefix "oc-inet"; }
+  import openconfig-evpn-types { prefix oc-evpn-types; }
+  import openconfig-evpn { prefix "oc-evpn"; }
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This module contains groupings which specifically relate to
+    Layer 2 network instance configuration and operational state
+    parameters.";
+
+  oc-ext:openconfig-version "4.4.1";
+
+  revision "2024-02-27" {
+    description
+      "Clarify that tables are created only by the system and not
+      users.";
+    reference "4.4.1";
+  }
+
+  revision "2024-02-27" {
+    description
+      "Clarify metric to be used for route redistribution when
+      disable-metric-propagation is set to true.";
+    reference "4.4.0";
+  }
+
+  revision "2023-12-13" {
+    description
+      "Expand when statement for connection-points endpoints";
+    reference "4.3.0";
+  }
+
+  revision "2023-11-03" {
+    description
+      "Add reference URL for Route Redistribution rules";
+    reference "4.2.2";
+  }
+
+  revision "2023-11-01" {
+    description
+      "Refactor apply policy to separate default policy in it's own common
+      set of groupings";
+    reference "4.2.1";
+  }
+
+  revision "2023-09-07" {
+    description
+      "Add L2RIB Per Producer Next-Hop Capability";
+    reference "4.2.0";
+  }
+
+  revision "2023-08-09" {
+    description
+      "Update interface key to use interface-id type";
+    reference "4.1.1";
+  }
+
+  revision "2023-07-12" {
+    description
+      "Moved ethernet-segments to top level
+      container.";
+    reference "4.1.0";
+  }
+
+  revision "2023-04-25" {
+    description
+      "Clarify use of interface-ref.";
+    reference "4.0.3";
+  }
+
+  revision "2023-03-15" {
+    description
+      "Clarify that tables are to be deleted by the
+      network operating system";
+    reference "4.0.2";
+  }
+
+  revision "2023-02-07" {
+    description
+      "Add prefixes to identity values in when statements";
+    reference "4.0.1";
+  }
+
+  revision "2022-12-21" {
+    description
+      "Removal of global per network-instance MTU";
+    reference "4.0.0";
+  }
+
+  revision "2022-12-21" {
+    description
+      "Removal of interface list unique statement";
+    reference "3.1.0";
+  }
+
+  revision "2022-12-20" {
+    description
+      "Removal of top-level enabled-address-families leaf-list";
+    reference "3.0.0";
+  }
+
+  revision "2022-11-18" {
+    description
+      "Enforce network-instance type as mandatory, removal of top-level
+      enabled leaf, migrate IETF types to OpenConfig types";
+    reference "2.0.0";
+  }
+
+  revision "2022-09-15" {
+    description
+      "Add fallback-vrf option.";
+    reference "1.4.0";
+  }
+
+  revision "2022-07-04" {
+    description
+      "Add pcep protocol to network-instance";
+    reference "1.3.0";
+  }
+
+  revision "2022-06-21" {
+    description
+      "Add prefix to qualification netinst-ref.";
+    reference "1.2.0";
+  }
+
+  revision "2022-04-20" {
+    description
+      "Add support for l2rib state data";
+    reference "1.1.0";
+  }
+
+  revision "2022-04-19" {
+    description
+      "Description updates for DEFAULT_INSTANCE implementation
+      guidance and default value/guidance for protocol instances";
+    reference "1.0.0";
+  }
+
+  revision "2022-04-19" {
+    description
+      "Fix some broken xpath references in when statements.";
+    reference "0.16.3";
+
+  }
+
+  revision "2021-11-17" {
+    description
+      "Add prefix to qualification prefix to when statements
+      at identifier level.";
+    reference "0.16.2";
+  }
+
+  revision "2021-07-22" {
+    description
+      "Remove unused imported models.";
+    reference "0.16.1";
+  }
+
+  revision "2021-06-11" {
+    description
+      "Structural update for arp-proxy and
+      proxy-nd.";
+    reference "0.16.0";
+  }
+
+  revision "2021-01-25" {
+    description
+      "Add support for evpn";
+    reference "0.15.0";
+  }
+
+  revision "2020-06-20" {
+    description
+      "Add support for toggling metric propagation
+      when using table-connections.";
+    reference "0.14.0";
+  }
+
+  revision "2019-11-28" {
+    description
+      "Revert fixes for paths in when statements";
+    reference "0.13.2";
+  }
+
+  revision "2019-04-16" {
+    description
+      "Move BGP RIB into the protocol/bgp container.";
+    reference "0.12.0";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "0.11.1";
+  }
+
+  revision "2018-08-11" {
+    description
+      "Add vlan id as additional key in MAC table";
+    reference "0.11.0";
+  }
+
+  revision "2018-06-22" {
+    description
+      "Fix typo in OSPF when statement";
+    reference "0.10.2";
+  }
+
+  revision "2018-06-05" {
+    description
+      "Fix bugs in when statements";
+    reference "0.10.1";
+  }
+
+  revision "2018-02-19" {
+    description
+      "Add PIM and IGMP to network instance";
+    reference "0.10.0";
+  }
+
+  revision "2017-12-13" {
+    description
+      "Fix incorrect constraint on SR and MPLS containers";
+    reference "0.9.0";
+  }
+
+  revision "2017-08-24" {
+    description
+      "Minor formatting fixes";
+    reference "0.8.1";
+  }
+
+  revision "2017-02-28" {
+    description
+      "Add OSPFv2 to network instance";
+    reference "0.8.0";
+  }
+
+  revision "2017-01-26" {
+    description
+      "Add policy forwarding to network instance";
+    reference "0.7.0";
+  }
+
+  revision "2017-01-13" {
+    description
+      "Add AFT to the network instance";
+    reference "0.6.0";
+  }
+
+  revision "2016-12-15" {
+    description
+      "Add segment routing to network instance";
+    reference "0.5.0";
+  }
+
+  revision "2016-11-10" {
+    description
+      "Update model to include IS-IS.";
+    reference "0.4.1";
+  }
+
+  revision "2016-10-12" {
+    description
+      "Update table connections";
+    reference "0.4.0";
+  }
+
+  revision "2016-09-28" {
+    description
+      "Change L2 instance to submodule; add MAC table";
+    reference "0.3.0";
+  }
+
+  revision "2016-08-11" {
+    description
+      "Resolve repeated container names in routing protocols";
+    reference "0.2.3";
+  }
+
+  revision "2016-07-08" {
+    description
+      "Updated with refactored routing protocol models";
+    reference "0.2.1";
+  }
+
+  revision "2016-03-29" {
+    description
+      "Initial revision";
+    reference "0.2.0";
+  }
+
+  revision "2015-11-20" {
+    description
+      "Initial revision";
+    reference "0.1.0";
+  }
+
+  grouping l2ni-instance {
+    description
+      "Configuration and operational state parameters relating
+      to a Layer 2 network instance";
+
+    container fdb {
+      description
+        "Operational state and configuration parameters relating to
+        the forwarding database of the network instance";
+
+      container config {
+        description
+          "Configuration parameters relating to the FDB";
+        uses l2ni-fdb-mac-config;
+      }
+      container state {
+        config false;
+        description
+          "Operational state parameters relating to the FDB";
+        uses l2ni-fdb-mac-config;
+      }
+
+       uses l2ni-mac-table-top;
+       uses oc-evpn:evpn-mac-mobility-top;
+       uses oc-evpn:evpn-arp-proxy-top;
+       uses oc-evpn:evpn-nd-proxy-top;
+       uses l2ni-l2rib-top;
+    }
+  }
+
+  grouping l2ni-fdb-mac-config {
+    description
+      "Parameters relating to FDB behaviour relating to MAC
+      addresses";
+
+    leaf mac-learning {
+      type boolean;
+      description
+        "When this leaf is set to true, MAC learning is enabled for
+        the network instance, such that MAC addresses are learned
+        from ingress frames and added to the FDB.";
+    }
+
+    leaf mac-aging-time {
+      // Cisco supports one aging time for local and remote, but
+      // can specify this time is absolute or against inactivity.
+      // ALU SROS supports different aging times for local and remote
+      // but does not allow absolute/inactivity specification.
+      // JNPR supports only a single aging time, and no specification
+      // of whether inactivity/absolute is used.
+      // It is easy to augment new options in here for local remote
+      // and an extra leaf to allow specification of the type of aging
+      // so this is left as a single value.
+      type uint16;
+      units seconds;
+      description
+        "The number of seconds of inactivity after which the entry
+        in the local FDB is timed out.";
+    }
+
+    leaf maximum-entries {
+      type uint16;
+      description
+        "The maximum number of MAC address entries that should be
+        accepted into the FDB";
+    }
+
+    uses oc-evpn:evpn-mac-vrf-config;
+  }
+
+  grouping l2ni-encapsulation-config {
+    description
+      "Encapsulation related configuration parameters for a L2
+      network instance";
+
+    leaf control-word {
+      type boolean;
+      description
+        "Whether the control-word should be used for the network
+        instance";
+      reference "RFC3985";
+    }
+  }
+
+  grouping l2ni-mac-table-config {
+    description
+      "Configuration data for MAC table entries";
+
+    leaf mac-address {
+      type oc-yang:mac-address;
+      description
+        "MAC address for the dynamic or static MAC table
+        entry";
+    }
+
+    leaf vlan {
+      //TODO(aashaikh): Consider whether this should just reflect the
+      //VLAN id or be a union type to also support displaying/setting
+      //the VLAN by name (i.e., global VLAN configured in the VLAN
+      // model).
+      type leafref {
+        path "../../../../../../vlans/vlan/config/vlan-id";
+      }
+      description
+        "VLAN on which the MAC address is present. The same MAC
+        address may be seen on multiple VLANs in some cases.";
+    }
+  }
+
+  grouping l2ni-mac-table-state {
+    description
+      "Operational state data for MAC table entries";
+
+    leaf age {
+      type uint64;
+      units seconds;
+      description
+        "The time in seconds since the MAC address has been in the
+        table";
+    }
+
+    leaf entry-type {
+      type enumeration {
+        enum STATIC {
+          description
+            "Statically programmed MAC table entry";
+        }
+        enum DYNAMIC {
+          description
+            "Dynamically learned MAC table entry";
+        }
+      }
+      description
+        "Indicates whether the entry was statically configured, or
+        dynamically learned.";
+    }
+
+    leaf evi {
+      type oc-evpn-types:vni-id;
+      description "EVPN EVI to associate with the BD/VLAN";
+    }
+  }
+
+  grouping l2ni-mac-table-top {
+    description
+      "Top-level grouping for MAC table list";
+
+
+    container mac-table {
+      description
+        "Table of learned or statically configured MAC addresses and
+        corresponding VLANs in the bridge domain";
+
+      container entries {
+        description
+          "Enclosing container for list of MAC table entries";
+
+        list entry {
+          key "mac-address vlan";
+          description
+            "List of learned MAC addresses";
+
+          leaf mac-address {
+            type leafref {
+              path "../config/mac-address";
+            }
+            description
+              "Reference to mac-address list key";
+          }
+
+          leaf vlan {
+            type leafref {
+              path "../config/vlan";
+            }
+            description
+              "Reference to vlan list key";
+          }
+
+          container config {
+            description
+              "Configuration data for MAC table entries";
+
+            uses l2ni-mac-table-config;
+          }
+
+          container state {
+
+            config false;
+
+            description
+              "Operational state data for MAC table entries";
+
+            uses l2ni-mac-table-config;
+            uses l2ni-mac-table-state;
+          }
+
+          container interface {
+            description
+              "Reference to the base and/or subinterface for the
+              MAC table entry";
+
+            uses oc-if:interface-ref;
+          }
+        }
+      }
+    }
+  }
+
+  grouping l2ni-l2rib-top {
+    description
+      "Top-level grouping for l2rib MAC and MAC-IP table list";
+
+    container l2rib {
+      config false;
+      description
+        "Operational state container for MAC address and MAC-IP address
+         information that is learned and installed into the MAC VRF Layer 2
+         Routing Information Base (L2RIB)";
+
+      container mac-table {
+        description
+          "Operational state container for MAC address information installed
+           into the MAC VRF of the L2RIB";
+
+        container entries {
+          description
+            "Enclosing container for list of MAC address entries";
+
+          list entry {
+            key "mac-address";
+            description "List of learned MAC addresses";
+
+            leaf mac-address {
+              type leafref {
+                path "../state/mac-address";
+              }
+              description "Leafref of MAC address object";
+            }
+
+            container state {
+              config false;
+              description
+                "Operational state data for L2RIB MAC table object entry";
+              uses l2ni-l2rib-mac-table-state;
+            }
+
+            container producers {
+              description "Source producers for each MAC Table entry";
+              list producer {
+                key "producer";
+                description
+                  "List of producers for each MAC table entry";
+
+                leaf producer {
+                  type leafref {
+                    path "../state/producer";
+                  }
+                  description
+                    "Reference to producer list key";
+                }
+
+                container state {
+                  config false;
+                  description "State container for L2RIB MAC Table Entries";
+                  uses l2ni-l2rib-common-producer-state;
+                  uses l2ni-l2rib-mac-table-producer-state;
+                }
+              }
+            }
+          }
+        }
+        uses l2ni-l2rib-common-next-hop-group-state;
+        uses l2ni-l2rib-common-next-hop-state;
+      }
+
+      container mac-ip-table {
+        description
+          "Operational state container for MAC-IP address information installed
+           into the MAC VRF of the L2RIB";
+
+        container entries {
+          description
+            "Enclosing container for list of MAC-IP address entries";
+
+          list entry {
+            key "mac-address host-ip";
+            description "List of learned MAC-IP addresses";
+
+            leaf mac-address {
+              type leafref {
+                path "../state/mac-address";
+              }
+              description "Leafref of MAC-IP address object";
+            }
+
+            leaf host-ip {
+              type leafref {
+                path "../state/host-ip";
+              }
+              description "IP address of the Customer Edge device";
+            }
+
+            container state {
+              config false;
+              description
+                "Operational state data for L2RIB MAC-IP table object entry";
+              uses l2ni-l2rib-mac-ip-table-state;
+            }
+
+            container producers {
+              description "Source producers for each MAC-IP Table entry";
+              list producer {
+                key "producer";
+                description
+                  "List of producers for each MAC-IP table entry";
+
+                leaf producer {
+                  type leafref {
+                    path "../state/producer";
+                  }
+                  description
+                    "Reference to producer list key";
+                }
+
+                container state {
+                  config false;
+                  description "State container for L2RIB MAC Table Entries";
+                  uses l2ni-l2rib-common-producer-state;
+                }
+              }
+            }
+          }
+        }
+        uses l2ni-l2rib-common-next-hop-group-state;
+        uses l2ni-l2rib-common-next-hop-state;
+      }
+    }
+  }
+
+  grouping l2ni-l2rib-mac-table-state {
+    description "L2RIB MAC Table Operational State Grouping";
+    uses l2ni-l2rib-common-state;
+  }
+
+  grouping l2ni-l2rib-mac-ip-table-state {
+    description "L2RIB Mac-IP Table Operational State Grouping";
+    uses l2ni-l2rib-common-state;
+
+    leaf host-ip {
+      type oc-inet:ip-address;
+      description
+        "Host IP address of the CE device for the L2RIB MAC-IP entry";
+      reference "RFC7432: BGP MPLS-Based Ethernet VPN";
+    }
+
+    leaf l3-vni {
+      type oc-evpn-types:evi-id;
+      description
+        "Symmetric IRB uses the same forwarding semantics when routing
+         between IP subnets with VRF Lite or MPLS L3VPNs. With symmetric IRB,
+         all traffic egressing and returning from a VTEP uses the same VNI.
+         Specifically, the same Layer 3 VNI (L3VNI) associated with the VRF
+         is used for all routed traffic. Layer3 VNI used for inter-subnet
+         routing";
+    }
+  }
+
+  grouping l2ni-l2rib-common-state {
+    description "L2RIB Common Property Operational State Data Grouping";
+
+    leaf mac-address {
+        type oc-yang:mac-address;
+        description "MAC address of the L2RIB MAC or MAC-IP entry";
+    }
+    leaf vlan {
+      type leafref {
+        path "../../../../../../../vlans/vlan/config/vlan-id";
+      }
+      description
+        "VLAN on which the MAC or MAC-IP address is present.";
+    }
+    leaf evi {
+      type oc-evpn-types:evi-id;
+      description "EVPN Instance Identifier for the MAC or MAC-IP";
+    }
+    leaf l2-vni {
+      type oc-evpn-types:evi-id;
+      description "Layer2 VNI segment mapped to given vlan-id";
+    }
+  }
+
+  grouping l2ni-l2rib-common-producer-state {
+    description "L2RIB Common Producer Attributes Operational State Data Grouping";
+
+    leaf producer {
+      type enumeration {
+        enum LOCAL {
+          description "local producer source";
+        }
+        enum STATIC {
+          description "static producer source";
+        }
+        enum BGP {
+          description "bgp producer source";
+        }
+      }
+      description "Source of the learned L2RIB route";
+    }
+
+    leaf seq-number {
+      type uint32;
+      description
+        "The sequence number is used to ensure that PEs retain the correct
+         MAC/IP Advertisement route when multiple updates occur for the same
+         MAC address";
+      reference "RFC7432: BGP MPLS-Based Ethernet VPN";
+    }
+
+    leaf mobility-state {
+      type enumeration {
+        enum FROZEN {
+          description
+            "Permanently frozen mac-address";
+        }
+        enum DUPLICATE {
+          description
+            "Duplicate mac-address";
+        }
+      }
+      description
+        "Indicates if learned MAC address is duplicate or frozen";
+      reference "draft-ietf-bess-evpn-irb-extended-mobility-05";
+    }
+
+    leaf esi {
+      type oc-evpn-types:esi;
+      description
+        "Ethernet Segment Identifier (ESI) for local and remote routes.
+         ESI is used to resolve the next-hop-group. All mac-addresses
+         learned with the same ESI should point to the same next-hop-group";
+    }
+
+    leaf sticky {
+      type boolean;
+      description "MAC address is sticky and not subjected to MAC moves";
+      reference "RFC7432: BGP MPLS-Based Ethernet VPN";
+    }
+
+    leaf next-hop {
+      type leafref {
+        path "../../../../../../next-hops/next-hop/index";
+      }
+      status deprecated;
+      description "Leafref next-hop for the MAC-IP table entry";
+    }
+
+    leaf-list next-hop-group {
+      type leafref {
+        path "../../../../../../next-hop-groups/next-hop-group/id";
+      }
+      description "Leafref next-hop-group for the MAC-IP table entry";
+    }
+  }
+
+  grouping l2ni-l2rib-common-next-hop-state {
+    description "L2RIB Common Next Hop Attributes Operational State Data Grouping";
+
+    container next-hops {
+      description "A next-hop associated with the MAC or MAC-IP entry";
+      list next-hop {
+        key "index";
+        description "List of next hop attributes for each MAC or MAC-IP";
+
+        leaf index {
+          type leafref {
+            path "../state/index";
+          }
+          description
+            "A unique index identifying the next-hop entry for the
+             MAC or MAC-IP entry";
+        }
+        container state {
+          description "State container for common next-hop attributes";
+          config false;
+          leaf index {
+            type uint64;
+            description "A unique entry for the next-hop.";
+          }
+          leaf peer-ip {
+            type oc-inet:ip-address;
+            description "Next hop peer address";
+          }
+          leaf label {
+            type oc-evpn-types:evi-id;
+            description "Next hop label representing the l2vni for the route";
+          }
+          leaf esi {
+            type oc-evpn-types:esi;
+            description "Ethernet Segment Identifier (ESI)";
+            reference "RFC7432: BGP MPLS-Based Ethernet VPN";
+          }
+          leaf resolved {
+            type boolean;
+            description
+              "Indicates if the path is eligible for forwarding as per evpn mass
+               withdraw procedures as defined in RFC 7432";
+          }
+          uses oc-if:interface-ref-common;
+        }
+      }
+    }
+  }
+
+  grouping l2ni-l2rib-common-next-hop-group-state {
+    description "L2RIB Common Next Hop Group Attributes Operational State Data Grouping";
+
+    container next-hop-groups {
+      description "Surrounding container for groups of L2RIB next-hops.";
+      list next-hop-group {
+        key "id";
+        description
+          "An individual set of next-hops grouped into a common group.
+           Each entry within an L2RIB can optionally point to a
+           next-hop-group.";
+
+        leaf id {
+          type leafref {
+            path "../state/id";
+          }
+          description
+            "A reference to a unique identifier for the next-hop-group.";
+        }
+        container state {
+          description "State container for common next-hop-group attributes";
+          config false;
+          leaf id {
+            type uint64;
+            description
+              "A unique identifier for the next-hop-group. This index is not
+               expected to be consistent across reboots, or reprogramming of
+               the next-hop-group. When updating a next-hop-group, if the group
+               is removed by the system or assigned an alternate identifier, the
+               system should send telemetry notifications deleting the previous
+               identifier. If the identifier of the next-hop-group is changed,
+               all L2RIB entries that reference it must also be updated.";
+          }
+          leaf esi {
+            type oc-evpn-types:esi;
+            description "Ethernet Segment Identifier (ESI)";
+            reference "RFC7432: BGP MPLS-Based Ethernet VPN";
+          }
+          leaf type {
+            type enumeration {
+              enum ESI {
+                description
+                  "Per ESI pathlist next-hop-group used for evpn mass withdraw procedures as defined in RFC 7432";
+              }
+              enum ESI_EVI {
+                description
+                  "Per ESI,EVI pathlist next-hop-group used for evpn aliasing procedures as defined in RFC 7432";
+              }
+              enum BASE_ECMP {
+                description
+                  "Base ECMP next-hop-group used in absence of evpn aliasing";
+              }
+            }
+            description "Type of next-hop-group";
+          }
+        }
+        container next-hops {
+          description
+            "Surrounding container for the list of next-hops within the next-hop-group.";
+          list next-hop {
+            key "index";
+            description
+              "An individual next-hop within the next-hop-group. Each next-hop is a
+               reference to an entry within the next-hop list.";
+
+            leaf index {
+              type leafref {
+                path "../state/index";
+              }
+              description
+                "A reference to the index for the next-hop within the the next-hop-group.";
+            }
+            container state {
+              description
+                "Operational state parameters related to a next-hop within the next-hop-group.";
+              config false;
+              leaf index {
+                type leafref {
+                  path "../../../../../../next-hops/next-hop/index";
+                }
+                description
+                  "A reference to the identifier for the next-hop to which the entry in the
+                   next-hop group corresponds.";
+              }
+            }
+          }
+        }
+
+      }
+    }
+  }
+
+  grouping l2ni-l2rib-mac-table-producer-state {
+    description "L2RIB MAC Table Operational State Data Grouping";
+
+    leaf derived-from-mac-ip {
+      type boolean;
+      description "Derived from BGP MAC-IP route-type 2";
+    }
+
+    leaf directly-received {
+      type boolean;
+      description "BGP learned MAC route-type 2";
+    }
+  }
+}

--- a/models/yang/common/openconfig-network-instance-l3.yang
+++ b/models/yang/common/openconfig-network-instance-l3.yang
@@ -1,0 +1,242 @@
+module openconfig-network-instance-l3 {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/network-instance-l3";
+
+  prefix "oc-ni-l3";
+
+  // import some basic types
+  import openconfig-extensions { prefix "oc-ext"; }
+  import openconfig-types { prefix "octypes"; }
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This module contains groupings which specifically relate to
+    Layer 3 network instance configuration and operational state
+    parameters.";
+
+  oc-ext:openconfig-version "2.0.0";
+
+  revision "2022-11-08" {
+    description
+      "Removal of top-level enabled-address-families leaf-list";
+    reference "2.0.0";
+  }
+
+  revision "2022-09-15" {
+    description
+      "Reflect implementation status by releasing 1.0.0.";
+    reference "1.0.0";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "0.11.1";
+  }
+
+  revision "2018-08-17" {
+    description
+      "Add a route limit for L3 network instances.";
+    reference "0.11.0";
+  }
+
+  revision "2017-12-13" {
+    description
+      "Fix incorrect constraint on SR and MPLS containers";
+    reference "0.9.0";
+  }
+
+  revision "2017-08-24" {
+    description
+      "Minor formatting fixes";
+    reference "0.8.1";
+  }
+
+  revision "2017-02-28" {
+    description
+      "Add OSPFv2 to network instance";
+    reference "0.8.0";
+  }
+
+  revision "2017-01-26" {
+    description
+      "Add policy forwarding to network instance";
+    reference "0.7.0";
+  }
+
+  revision "2017-01-13" {
+    description
+      "Add AFT to the network instance";
+    reference "0.6.0";
+  }
+
+  revision "2016-12-15" {
+    description
+      "Add segment routing to network instance";
+    reference "0.5.0";
+  }
+
+  revision "2016-11-10" {
+    description
+      "Update model to include IS-IS.";
+    reference "0.4.1";
+  }
+
+  revision "2016-09-28" {
+    description
+      "Change L2 instance to submodule; add MAC table";
+    reference "0.3.0";
+  }
+
+  revision "2016-08-11" {
+    description
+      "Resolve repeated container names in routing protocols";
+    reference "0.2.3";
+  }
+
+  revision "2016-07-08" {
+    description
+      "Updated with refactored routing protocol models";
+    reference "0.2.1";
+  }
+
+  revision "2016-03-29" {
+    description
+      "Initial revision";
+    reference "0.2.0";
+  }
+
+  revision "2016-03-14" {
+    description
+      "Initial revision";
+    reference "0.1.0";
+  }
+
+  // OpenConfig specific extensions for module metadata.
+  oc-ext:regexp-posix;
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  grouping l3ni-instance {
+    description
+      "Configuration and operational state parameters relevant
+      to network instances that include a Layer 3 type";
+
+  }
+
+  grouping l3ni-route-limit-structural {
+    description
+      "Configuration and state for the maximum number of routes
+      that should be used by routing instance.";
+
+    container route-limits {
+      description
+        "Configuration and operational state relating to the
+        maximum number of routes for the address family that
+        should be allowed within the Layer 3 network instance.
+
+        When the specified value is reached, no further prefixes
+        should be installed into the system's RIB from this network
+        instance unless the warning only leaf is set. In this case,
+        new routes should still be installed. If a alarm threshold
+        is specified, then this should be used to generate
+        alarms via telemetry for the network instance.";
+
+      list route-limit {
+        key "afi";
+
+        description
+          "A route limit applying to a particular address family.";
+
+        leaf afi {
+          type leafref {
+            path "../config/afi";
+          }
+          description
+            "Reference to the address family for which the route
+            limit is being applied.";
+        }
+
+        container config {
+          description
+            "Configuration options relating to the route limit.";
+          uses l3ni-route-limit-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state parameters relating to the route limit.";
+          uses l3ni-route-limit-config;
+          uses l3ni-route-limit-state;
+        }
+      }
+    }
+  }
+
+  grouping l3ni-route-limit-config {
+    description
+      "Configuration options relating to the route limit for a network
+      instance.";
+
+    leaf afi {
+      type identityref {
+        base octypes:ADDRESS_FAMILY;
+      }
+      description
+        "The address family for which the route limit applies.";
+    }
+
+    leaf maximum {
+      type uint32;
+      description
+        "The maximum number of routes for the address family. The
+        system should not install more than maximum number of
+        prefixes into the RIB unless the warning-only leaf is specified.";
+    }
+
+    leaf warning-only {
+      type boolean;
+      default false;
+      description
+        "When specified, the route limit specified is considered only as
+        a warning - and routes should continue to be installed into the
+        RIB over the limit specified in the maximum leaf.";
+    }
+
+    leaf alarm-threshold {
+      type uint32;
+      description
+        "When specified, an alarm should be generated when the threshold
+        number of installed routes is reached.";
+    }
+  }
+
+  grouping l3ni-route-limit-state {
+    description
+      "Operational state relating to the route limit for a network
+      instance.";
+
+    leaf threshold-exceeded {
+      type boolean;
+      description
+        "This leaf should be set to true in the case that the threshold
+        number of routes has been exceeded.";
+    }
+
+    leaf installed-routes {
+      type uint32;
+      description
+        "The current number of routes installed for the address family.";
+    }
+  }
+}

--- a/models/yang/common/openconfig-network-instance-types.yang
+++ b/models/yang/common/openconfig-network-instance-types.yang
@@ -1,0 +1,329 @@
+module openconfig-network-instance-types {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/network-instance-types";
+
+  prefix "oc-ni-types";
+
+  import openconfig-extensions { prefix "oc-ext"; }
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "Types associated with a network instance";
+
+  oc-ext:openconfig-version "0.9.3";
+
+  revision "2021-07-14" {
+    description
+      "Use auto-generated regex for route-distinguisher pattern statements";
+    reference "0.9.3";
+  }
+
+  revision "2021-06-16" {
+    description
+      "Remove trailing whitespace";
+    reference "0.9.2";
+  }
+
+  revision "2021-05-21" {
+    description
+      "Add support for evpn";
+    reference "0.9.1";
+  }
+
+  revision "2021-03-03" {
+    description
+      "Fix route-distinguisher's pattern statement, and remove the regexp-posix
+      extension, which makes pattern statements conform to the YANG standard.";
+    reference "0.9.0";
+  }
+
+  revision "2020-06-30" {
+    description
+      "Add OpenConfig POSIX pattern extensions.";
+    reference "0.8.3";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "0.8.2";
+  }
+
+  revision "2017-08-24" {
+    description
+      "Minor formatting fixes";
+    reference "0.8.1";
+  }
+
+  revision "2017-02-28" {
+    description
+      "Add OSPFv2 to network instance";
+    reference "0.8.0";
+  }
+
+  revision "2017-01-26" {
+    description
+      "Add policy forwarding to network instance";
+    reference "0.7.0";
+  }
+
+  revision "2017-01-13" {
+    description
+      "Add AFT to the network instance";
+    reference "0.6.0";
+  }
+
+  revision "2016-12-15" {
+    description
+      "Add segment routing to network instance";
+    reference "0.5.0";
+  }
+
+  revision "2016-11-10" {
+    description
+      "Update model to include IS-IS.";
+    reference "0.4.1";
+  }
+
+  revision "2016-10-12" {
+    description
+      "Update table connections";
+    reference "0.4.0";
+  }
+
+  revision "2016-09-28" {
+    description
+      "Change L2 instance to submodule; add MAC table";
+    reference "0.3.0";
+  }
+
+  revision "2016-08-11" {
+    description
+      "Resolve repeated container names in routing protocols";
+    reference "0.2.3";
+  }
+
+  revision "2016-07-08" {
+    description
+      "Updated with refactored routing protocol models";
+    reference "0.2.1";
+  }
+
+  revision "2016-03-29" {
+    description
+      "Initial revision";
+    reference "0.2.0";
+  }
+
+  revision "2015-10-18" {
+    description
+      "Initial revision";
+    reference "0.1.0";
+  }
+
+  // OpenConfig specific extensions for module metadata.
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  // identity statements
+  identity NETWORK_INSTANCE_TYPE {
+  	description
+  	 "A base identity which can be extended to indicate different
+     types of network instance supported by a device.";
+  }
+
+  identity DEFAULT_INSTANCE {
+    base NETWORK_INSTANCE_TYPE;
+    description
+      "A special routing instance which acts as the 'default' or
+      'global' routing instance for a network device.";
+  }
+
+  identity L3VRF {
+    base NETWORK_INSTANCE_TYPE;
+    description
+      "A private Layer 3 only routing instance which is formed of
+      one or more RIBs";
+  }
+
+  identity L2VSI {
+    base NETWORK_INSTANCE_TYPE;
+    description
+      "A private Layer 2 only switch instance which is formed of
+      one or more L2 forwarding tables";
+  }
+
+  identity L2P2P {
+    base NETWORK_INSTANCE_TYPE;
+    description
+      "A private Layer 2 only forwarding instance which acts as
+      a point to point connection between two endpoints";
+  }
+
+  identity L2L3 {
+    base NETWORK_INSTANCE_TYPE;
+    description
+      "A private Layer 2 and Layer 3 forwarding instance";
+  }
+
+  identity ENDPOINT_TYPE {
+    description
+      "Specification of the type of endpoint that is being associated
+      with a network instance";
+  }
+
+  identity LOCAL {
+    base ENDPOINT_TYPE;
+    description
+      "A local interface which is being associated with the endpoint.
+      In addition, the LOCAL endpoint can be used with the VXLAN
+      attributes to define a VXLAN tunnel end-point interface.";
+  }
+
+  identity REMOTE {
+    base ENDPOINT_TYPE;
+    description
+      "A remote interface which is being associated with the
+      endpoint";
+  }
+
+  identity LABEL_ALLOCATION_MODE {
+    description
+      "Base identity to be used to express types of label allocation
+      strategies to be used within a network instance";
+  }
+
+  identity PER_PREFIX {
+    base LABEL_ALLOCATION_MODE;
+    description
+      "A label is to be allocated per prefix entry in the RIB for the
+      network instance";
+  }
+
+  identity PER_NEXTHOP {
+    base LABEL_ALLOCATION_MODE;
+    description
+      "A label is to be allocated per nexthop entry in the RIB for
+      the network instance";
+  }
+
+  identity INSTANCE_LABEL {
+    base LABEL_ALLOCATION_MODE;
+    description
+      "A single label is to be used for the instance";
+  }
+
+  identity ENCAPSULATION {
+    description
+      "On the wire encapsulations that can be used when
+      differentiating network instances";
+  }
+
+  identity MPLS {
+    base ENCAPSULATION;
+    description
+      "Use MPLS labels to distinguish network instances on the wire";
+  }
+
+  identity VXLAN {
+    base ENCAPSULATION;
+    description
+      "Use VXLAN (RFC7348) VNIs to distinguish network instances on
+      the wire";
+  }
+
+  identity SIGNALLING_PROTOCOL {
+    description
+      "The signalling protocol that should be used to diseminate
+      entries within a forwarding instance";
+  }
+
+  identity LDP {
+    base SIGNALLING_PROTOCOL;
+    description
+      "Use LDP-based setup for signalling. Where the instance is
+      a point-to-point service this refers to RFC4447 ('Martini')
+      setup. Where the service is an L2VSI, or L2L3 instance it
+      refers to RFC4762 LDP-signalled VPLS instances";
+  }
+
+  identity BGP_VPLS {
+    base SIGNALLING_PROTOCOL;
+    description
+      "Use BGP-based signalling and autodiscovery for VPLS instances
+      as per RFC4761";
+  }
+
+  identity BGP_EVPN {
+    base SIGNALLING_PROTOCOL;
+    description
+      "Use BGP-based Ethernet VPN (RFC7432) based signalling for
+      the network instance";
+  }
+
+  // rjs note:
+  // this should move to openconfig-types when merged
+  typedef route-distinguisher {
+    type union {
+      // type 0: <2-byte administrator>:<4-byte assigned number>
+      //         <0-65535>:<0-4294967295>
+      type string {
+        pattern
+          '([0-9]|[1-9][0-9]{1,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|'
+          + '65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5]):([0-9]|[1-9][0-9]{1,8}|'
+          + '[1-3][0-9]{9}|4[01][0-9]{8}|42[0-8][0-9]{7}|429[0-3][0-9]{6}|'
+          + '4294[0-8][0-9]{5}|42949[0-5][0-9]{4}|429496[0-6][0-9]{3}|'
+          + '4294967[01][0-9]{2}|42949672[0-8][0-9]|429496729[0-5])';
+        oc-ext:posix-pattern
+          '^(([0-9]|[1-9][0-9]{1,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|'
+          + '65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5]):([0-9]|[1-9][0-9]{1,8}|'
+          + '[1-3][0-9]{9}|4[01][0-9]{8}|42[0-8][0-9]{7}|429[0-3][0-9]{6}|'
+          + '4294[0-8][0-9]{5}|42949[0-5][0-9]{4}|429496[0-6][0-9]{3}|'
+          + '4294967[01][0-9]{2}|42949672[0-8][0-9]|429496729[0-5]))$';
+      }
+      // type 1: <ip-address>:<2-byte assigned number>
+      //         <ipv4>:<0-65535>
+      type string {
+        pattern
+          '([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\.([0-9]|'
+          + '[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])){3}:([0-9]|'
+          + '[1-9][0-9]{1,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|'
+          + '655[0-2][0-9]|6553[0-5])';
+        oc-ext:posix-pattern
+          '^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\.([0-9]|'
+          + '[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])){3}:([0-9]|'
+          + '[1-9][0-9]{1,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|'
+          + '655[0-2][0-9]|6553[0-5]))$';
+      }
+      // type 2: <4-byte as-number>:<2-byte assigned number>
+      //         <0-4294967295>:<0-65535>
+      type string {
+        pattern
+          '([0-9]|[1-9][0-9]{1,8}|[1-3][0-9]{9}|4[01][0-9]{8}|'
+          + '42[0-8][0-9]{7}|429[0-3][0-9]{6}|4294[0-8][0-9]{5}|'
+          + '42949[0-5][0-9]{4}|429496[0-6][0-9]{3}|4294967[01][0-9]{2}|'
+          + '42949672[0-8][0-9]|429496729[0-5]):([0-9]|[1-9][0-9]{1,3}|'
+          + '[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|'
+          + '6553[0-5])';
+        oc-ext:posix-pattern
+          '^(([0-9]|[1-9][0-9]{1,8}|[1-3][0-9]{9}|4[01][0-9]{8}|'
+          + '42[0-8][0-9]{7}|429[0-3][0-9]{6}|4294[0-8][0-9]{5}|'
+          + '42949[0-5][0-9]{4}|429496[0-6][0-9]{3}|4294967[01][0-9]{2}|'
+          + '42949672[0-8][0-9]|429496729[0-5]):([0-9]|[1-9][0-9]{1,3}|'
+          + '[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|'
+          + '6553[0-5]))$';
+      }
+    }
+    description "A route distinguisher value";
+    reference "RFC4364";
+  }
+}

--- a/models/yang/common/openconfig-network-instance.yang
+++ b/models/yang/common/openconfig-network-instance.yang
@@ -1,0 +1,1433 @@
+module openconfig-network-instance {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/network-instance";
+
+  prefix "oc-netinst";
+
+  // import some basic types
+  import openconfig-yang-types { prefix "oc-yang"; }
+  import openconfig-inet-types { prefix "oc-inet"; }
+  import openconfig-network-instance-types { prefix "oc-ni-types"; }
+  import openconfig-policy-types { prefix "oc-pol-types"; }
+  import openconfig-routing-policy { prefix "oc-rpol"; }
+  import openconfig-local-routing { prefix "oc-loc-rt"; }
+  import openconfig-interfaces { prefix "oc-if"; }
+  import openconfig-extensions { prefix "oc-ext"; }
+  import openconfig-network-instance-l3 { prefix "oc-ni-l3"; }
+  import openconfig-types { prefix "oc-types"; }
+  import openconfig-bgp { prefix "oc-bgp"; }
+  import openconfig-mpls { prefix "oc-mpls"; }
+  import openconfig-vlan { prefix "oc-vlan"; }
+  import openconfig-ospfv2 { prefix "oc-ospfv2"; }
+  import openconfig-policy-forwarding { prefix "oc-pf"; }
+  import openconfig-segment-routing { prefix "oc-sr"; }
+  import openconfig-isis { prefix "oc-isis"; }
+  import openconfig-aft { prefix "oc-aft"; }
+  import openconfig-pim { prefix "oc-pim"; }
+  import openconfig-igmp { prefix "oc-igmp"; }
+  import openconfig-evpn { prefix "oc-evpn"; }
+  import openconfig-pcep { prefix "oc-pcep"; }
+
+  // include submodules
+  include openconfig-network-instance-l2;
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "An OpenConfig description of a network-instance. This may be
+    a Layer 3 forwarding construct such as a virtual routing and
+    forwarding (VRF) instance, or a Layer 2 instance such as a
+    virtual switch instance (VSI). Mixed Layer 2 and Layer 3
+    instances are also supported.";
+
+  oc-ext:openconfig-version "4.4.1";
+
+  revision "2024-02-27" {
+    description
+      "Clarify that tables are created only by the system and not
+      users.";
+    reference "4.4.1";
+  }
+
+  revision "2024-02-27" {
+    description
+      "Clarify metric to be used for route redistribution when
+      disable-metric-propagation is set to true.";
+    reference "4.4.0";
+  }
+
+  revision "2023-12-13" {
+    description
+      "Expand when statement for connection-points endpoints";
+    reference "4.3.0";
+  }
+
+  revision "2023-11-03" {
+    description
+      "Add reference URL for Route Redistribution rules";
+    reference "4.2.2";
+  }
+
+  revision "2023-11-01" {
+    description
+      "Refactor apply policy to separate default policy in it's own common
+      set of groupings";
+    reference "4.2.1";
+  }
+
+  revision "2023-09-07" {
+    description
+      "Add L2RIB Per Producer Next-Hop Capability";
+    reference "4.2.0";
+  }
+
+  revision "2023-08-09" {
+    description
+      "Update interface key to use interface-id type";
+    reference "4.1.1";
+  }
+
+  revision "2023-07-12" {
+    description
+      "Moved ethernet-segments to top-level
+      container.";
+    reference "4.1.0";
+  }
+
+  revision "2023-04-25" {
+    description
+      "Clarify use of interface-ref.";
+    reference "4.0.3";
+  }
+
+  revision "2023-03-15" {
+    description
+      "Clarify that tables are to be deleted by the
+      network operating system";
+    reference "4.0.2";
+  }
+
+  revision "2023-02-07" {
+    description
+      "Add prefixes to identity values in when statements";
+    reference "4.0.1";
+  }
+
+  revision "2022-12-21" {
+    description
+      "Removal of global per network-instance MTU";
+    reference "4.0.0";
+  }
+
+  revision "2022-12-21" {
+    description
+      "Removal of interface list unique statement";
+    reference "3.1.0";
+  }
+
+  revision "2022-12-20" {
+    description
+      "Removal of top-level enabled-address-families leaf-list";
+    reference "3.0.0";
+  }
+
+  revision "2022-11-18" {
+    description
+      "Enforce network-instance type as mandatory, removal of top-level
+      enabled leaf, migrate IETF types to OpenConfig types";
+    reference "2.0.0";
+  }
+
+  revision "2022-09-15" {
+    description
+      "Add fallback-vrf option.";
+    reference "1.4.0";
+  }
+
+  revision "2022-07-04" {
+    description
+      "Add PCEP protocol to network-instance";
+    reference "1.3.0";
+  }
+
+  revision "2022-06-21" {
+    description
+      "Add prefix to qualification netinst-ref.";
+    reference "1.2.0";
+  }
+
+  revision "2022-04-20" {
+    description
+      "Add support for l2rib state data";
+    reference "1.1.0";
+  }
+
+  revision "2022-04-19" {
+    description
+      "Description updates for DEFAULT_INSTANCE implementation
+      guidance and default value/guidance for protocol instances";
+    reference "1.0.0";
+  }
+
+  revision "2022-04-19" {
+    description
+      "Fix some broken xpath references in when statements.";
+    reference "0.16.3";
+  }
+
+  revision "2021-11-17" {
+    description
+      "Add prefix to qualification prefix to when statements
+      at identifier level.";
+    reference "0.16.2";
+  }
+
+  revision "2021-07-22" {
+    description
+      "Add prefix to qualify when statements";
+    reference "0.16.1";
+  }
+
+  revision "2021-06-11" {
+    description
+      "Structural update for arp-proxy and
+      proxy-nd.";
+    reference "0.16.0";
+  }
+
+  revision "2021-01-25" {
+    description
+      "Add support for evpn";
+    reference "0.15.0";
+  }
+
+  revision "2020-06-20" {
+    description
+      "Add support for toggling metric propagation
+      when using table-connections.";
+    reference "0.14.0";
+  }
+
+  revision "2019-11-28" {
+    description
+      "Revert fixes for paths in when statements";
+    reference "0.13.2";
+  }
+
+  revision "2019-06-11" {
+    description
+      "Fixed paths in when statements";
+    reference "0.13.1";
+  }
+
+  revision "2019-05-14" {
+    description
+      "Added support for BGP signalled VPWS and VPLS.";
+    reference "0.13.0";
+  }
+
+  revision "2019-04-16" {
+    description
+      "Move BGP RIB into the protocol/bgp container.";
+    reference "0.12.0";
+  }
+
+  revision "2019-02-03" {
+    description
+      "Extend netinst type description to link it to, for example, MPLS
+      service types.";
+    reference "0.11.2";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "0.11.1";
+  }
+
+  revision "2018-08-11" {
+    description
+      "Add vlan id as additional key in MAC table";
+    reference "0.11.0";
+  }
+
+  revision "2018-06-22" {
+    description
+      "Fix typo in OSPF when statement";
+    reference "0.10.2";
+  }
+
+  revision "2018-06-05" {
+    description
+      "Fix bugs in when statements";
+    reference "0.10.1";
+  }
+
+  revision "2018-02-19" {
+    description
+      "Add PIM and IGMP to network instance";
+    reference "0.10.0";
+  }
+
+  revision "2017-12-13" {
+    description
+      "Fix incorrect constraint on SR and MPLS containers";
+    reference "0.9.0";
+  }
+
+  revision "2017-08-24" {
+    description
+      "Minor formatting fixes";
+    reference "0.8.1";
+  }
+
+  revision "2017-02-28" {
+    description
+      "Add OSPFv2 to network instance";
+    reference "0.8.0";
+  }
+
+  revision "2017-01-26" {
+    description
+      "Add policy forwarding to network instance";
+    reference "0.7.0";
+  }
+
+  revision "2017-01-13" {
+    description
+      "Add AFT to the network instance";
+    reference "0.6.0";
+  }
+
+  revision "2016-12-15" {
+    description
+      "Add segment routing to network instance";
+    reference "0.5.0";
+  }
+
+  revision "2016-11-10" {
+    description
+      "Add IS-IS to OpenConfig network instance";
+    reference "0.4.1";
+  }
+
+  revision "2016-10-12" {
+    description
+      "Update table connections";
+    reference "0.4.0";
+  }
+
+  revision "2016-09-28" {
+    description
+      "Change L2 instance to submodule; add MAC table";
+    reference "0.3.0";
+  }
+
+  revision "2016-08-11" {
+    description
+      "Resolve repeated container names in routing protocols";
+    reference "0.2.3";
+  }
+
+  revision "2016-07-08" {
+    description
+      "Updated with refactored routing protocol models";
+    reference "0.2.1";
+  }
+
+  revision "2016-03-29" {
+    description
+      "Initial revision";
+    reference "0.2.0";
+  }
+
+  revision "2015-10-18" {
+    description
+      "Initial revision";
+    reference "0.1.0";
+  }
+
+  // OpenConfig specific extensions for module metadata.
+  oc-ext:regexp-posix;
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  typedef network-instance-ref {
+    type leafref {
+      path "/oc-netinst:network-instances/oc-netinst:network-instance/" +
+           "oc-netinst:config/oc-netinst:name";
+    }
+    description
+      "A re-usable type that can be referenced within other
+       modules that references a network instance.";
+  }
+
+  grouping network-instance-top {
+    description
+      "Top-level grouping containing a list of network instances.";
+
+    container network-instances {
+      description
+        "The L2, L3, or L2+L3 forwarding instances that are
+        configured on the local system";
+
+      list network-instance {
+        key "name";
+
+        description
+          "Network instances configured on the local system
+
+          IPv4 and IPv6 forwarding are enabled by default within an L3
+          network-instance and subsequently, routes can be populated
+          into the network-instance using protocols that enable IPv4 and
+          IPv6 configuration without explicitly enabling these.";
+
+        leaf name {
+          type leafref {
+            path "../config/name";
+          }
+          description
+            "A unique name identifying the network instance";
+        }
+
+        container config {
+          description
+            "Configuration parameters relating to a network
+            instance";
+          uses network-instance-config;
+        }
+
+
+        container state {
+          config false;
+          description
+            "Operational state parameters relating to a network
+            instance";
+          uses network-instance-config;
+          uses network-instance-state;
+        }
+
+        uses l2ni-instance {
+            when "./config/type = 'oc-ni-types:L2VSI'
+                  or ./config/type = 'oc-ni-types:L2P2P'
+                  or ./config/type = 'oc-ni-types:L2L3'
+                  or ./config/type = 'oc-ni-types:DEFAULT_INSTANCE'" {
+                  description
+                    "Layer 2 configuration parameters included when
+                    a network instance is a Layer 2 instance or a
+                    combined L2L3 instance";
+            }
+        }
+
+        container evpn {
+          when "../config/type = 'oc-ni-types:L2VSI'
+                or ../config/type = 'oc-ni-types:L3VRF'" {
+           description
+             "EVPN container should be included for L2 and L3 NIs";
+         }
+         description
+           "Configuration of parameters for EVPN related bridge domains
+           (MAC VRFs) and layer3 VRFs (IP VRFs)";
+          uses oc-evpn:evpn-config-top;
+        }
+
+        container encapsulation {
+          when "../config/type != 'oc-ni-types:DEFAULT_INSTANCE'" {
+            description
+              "Only allow the encapsulation of the instance to be
+              set when the instance is not the default instance";
+          }
+          description
+            "Configuration parameters relating to the encapsulation
+            used for the network instance";
+
+          container config {
+            description
+              "Configuration parameters relating to the encapsulation
+              of the network instance";
+
+            uses encapsulation-config;
+
+            uses l2ni-encapsulation-config {
+              when "../../config/type = 'oc-ni-types:L2VSI' or ../../config/type = 'oc-ni-types:L2P2P'
+                      or ../../config/type = 'oc-ni-types:L2L3'" {
+                        description
+                          "Only allow L2 encapsulations to be set
+                          when the instance is of a type that supports
+                          L2";
+              }
+            }
+          }
+
+          container state {
+            config false;
+            description
+              "State parameters relating to the encapsulation of
+              the network instance";
+            uses encapsulation-config;
+
+            uses l2ni-encapsulation-config {
+              when "../../config/type = 'oc-ni-types:L2VSI' or ../../config/type = 'oc-ni-types:L2P2P'
+                      or ../../config/type = 'oc-ni-types:L2L3'" {
+                        description
+                          "Only allow L2 encapsulations to be set
+                          when the instance is of a type that supports
+                          L2";
+              }
+            }
+          }
+        }
+
+        container inter-instance-policies {
+          description
+            "Policies dictating how RIB or FIB entries are imported
+            to and exported from this instance";
+
+          uses oc-rpol:apply-policy-group;
+          uses oc-evpn:evpn-import-export-policy-top;
+        }
+
+        container table-connections {
+          description
+            "Policies dictating how RIB or FIB entries are propagated
+            between tables";
+
+          list table-connection {
+            key "src-protocol dst-protocol address-family";
+
+            description
+              "A list of connections between pairs of routing or
+              forwarding tables, the leaking of entries between
+              which is specified by the import policy.
+
+              A connection connecting a source table to a destination
+              table implies that routes that match the policy specified
+              for the connection are available for the destination
+              protocol to advertise, or match within its policies.";
+
+            reference
+              "Route Redistribution in OpenConfig Network Instance:
+              https://github.com/openconfig/public/blob/master/doc/network_instance_redistribution.md#interconnection-of-protocol-ribs";
+
+            leaf src-protocol {
+              type leafref {
+                path "../config/src-protocol";
+              }
+              description
+                "The name of the protocol associated with the table
+                which should be utilised as the source of forwarding
+                or routing information";
+            }
+
+            leaf dst-protocol {
+              type leafref {
+                path "../config/dst-protocol";
+              }
+              description
+                "The table to which routing entries should be
+                exported";
+            }
+
+            leaf address-family {
+              type leafref {
+                path "../config/address-family";
+              }
+              description
+                "The address family associated with the connection";
+            }
+
+            container config {
+              description
+                "Configuration parameters relating to the connection
+                between tables";
+              uses inter-table-policies-config;
+            }
+            container state {
+              config false;
+              description
+                "State parameters relating to the connection between
+                tables";
+              uses inter-table-policies-config;
+            }
+          }
+        }
+
+        container interfaces {
+          description
+            "The interfaces that are associated with this network
+            instance";
+
+          list interface {
+            key "id";
+
+            description
+              "An interface associated with the network instance.
+
+               The interface referenced is based on the interface and
+               subinterface leaves within the interface-ref container -
+               which reference an entry in the /interfaces/interface list -
+               and should not rely on the value of the list key.";
+
+            leaf id {
+              type leafref {
+                path "../config/id";
+              }
+              description
+                "A reference to an identifier for this interface which
+                acts as a key for this list";
+            }
+
+            container config {
+              description
+                "Configuration parameters relating to the associated
+                interface";
+              uses instance-interfaces-config;
+            }
+
+            container state {
+              config false;
+              description
+                "Operational state parameters relating to the
+                associated interface";
+
+              uses instance-interfaces-config;
+              uses instance-interfaces-state;
+            }
+          }
+        }
+
+        uses oc-ni-l3:l3ni-route-limit-structural {
+          when "./config/type = 'oc-ni-types:L3VRF' or ./config/type = 'oc-ni-types:L2L3'" {
+            description
+              "Layer 3 VRF or L2/L3 instances can have route limits
+              applied. This is not supported for the default instance.";
+          }
+        }
+
+        container tables {
+          description
+            "The routing tables that are managed by this network
+            instance.  Tables are created and removed by the system.
+            Users do not create tables.";
+
+          list table {
+            key "protocol address-family";
+
+            description
+              "A network instance manages one or more forwarding or
+              routing tables. These may reflect a Layer 2 forwarding
+              information base, a Layer 3 routing table, or an MPLS
+              LFIB.
+
+              The table populated by a protocol within an instance is
+              identified by the protocol identifier (e.g., BGP, IS-IS)
+              and the address family (e.g., IPv4, IPv6) supported by
+              that protocol. Multiple instances of the same protocol
+              populate a single table -- such that
+              a single IS-IS or OSPF IPv4 table exists per network
+              instance.
+
+              An implementation is expected to create entries within
+              this list when the relevant protocol context is enabled.
+              i.e., when a BGP instance is created with IPv4 and IPv6
+              address families enabled, the protocol=BGP,
+              address-family=IPv4 table is created by the system. The
+	            removal of the table should not require additional or
+	            explicit configurations.
+
+              Users cannot create or delete tables.  Instead a user may
+              configure table-connections which reference these tables.";
+
+            leaf protocol {
+              type leafref {
+                path "../config/protocol";
+              }
+              description
+                "A reference to the protocol that populates
+                the table";
+            }
+
+            leaf address-family {
+              type leafref {
+                path "../config/address-family";
+              }
+              description
+                "A reference to the address-family that the
+                table represents";
+            }
+
+            container config {
+              description
+                "Configuration parameters relating to the
+                table";
+              uses table-config;
+            }
+
+            container state {
+              config false;
+              description
+                "State parameters related to the table";
+              uses table-config;
+            }
+          }
+        }
+
+        container connection-points {
+          description
+            "The set of connection points within a forwarding
+            instance";
+
+          list connection-point {
+            key "connection-point-id";
+
+            description
+              "A connection point within a Layer 2 network instance.
+              Each connection-point consists of a set of interfaces
+              only one of which is active at any one time. Other than
+              the specification of whether an interface is local
+              (i.e., exists within this network-instance), or remote,
+              all configuration and state parameters are common";
+
+            leaf connection-point-id {
+              type leafref {
+                path "../config/connection-point-id";
+              }
+              description
+                "A locally significant reference for the
+                connection-point";
+            }
+
+            container config {
+              description
+                "Configuration parameters relating to a Layer 2
+                network instance connection point";
+              uses instance-connection-point-config;
+            }
+            container state {
+              config false;
+              description
+                "Operational state parameters relating to a Layer 2
+                network instance connection point";
+
+              uses instance-connection-point-config;
+              uses instance-connection-point-state;
+            }
+
+            container endpoints {
+              when "../../../config/type = 'oc-ni-types:L2P2P' " +
+                 "or ../../../config/type = 'oc-ni-types:L2VSI'" +
+                 "or ../../../config/type = 'oc-ni-types:DEFAULT_INSTANCE'" {
+                description
+                  "Configuration parameters to associate interfaces
+                   into a common group for use in Layer 2 network
+                   instances";
+              }
+
+              description
+                "The set of endpoints which are grouped within the
+                connection point";
+
+              list endpoint {
+                key "endpoint-id";
+
+                description
+                  "A list of the endpoints (interfaces or remote
+                  connection points that can be used for this
+                  connection point). The active endpoint is selected
+                  based on the precedence that it is configured
+                  with.";
+
+                leaf endpoint-id {
+                  type leafref {
+                    path "../config/endpoint-id";
+                  }
+                  description
+                    "A pointer to the configured identifier for the
+                    endpoint";
+                }
+
+                container config {
+                  description
+                    "Configuration parameters relating to the
+                    endpoint";
+                  uses instance-endpoint-config;
+                }
+
+                container state {
+                  config false;
+                  description
+                    "Operational state parameters relating to the
+                    endpoint";
+                  uses instance-endpoint-config;
+                  uses instance-endpoint-state;
+                }
+
+                container local {
+                  when "../config/type = 'oc-ni-types:LOCAL'" {
+                    description
+                      "Only include the local configuration when
+                      the endpoint is specified to be local to
+                      the network element";
+                  }
+
+                  description
+                    "Configuration and operational state parameters
+                    relating to a local interface";
+
+                  container config {
+                    description
+                      "Configuration parameters relating to a local
+                      endpoint";
+                    uses instance-endpoint-local-config;
+                  }
+
+                  container state {
+                    config false;
+                    description
+                      "Operational state parameters relating to a
+                      local endpoint";
+                    uses instance-endpoint-local-config;
+                  }
+                }
+
+                container remote {
+                  when "../config/type = 'oc-ni-types:REMOTE'" {
+                    description
+                      "Only include the remote configuration when
+                      the endpoint is specified to be remote to
+                      the network element";
+                  }
+
+                  description
+                    "Configuration and operational state parameters
+                    relating to a remote interface";
+
+                  container config {
+                    description
+                      "Configuration parameters relating to a remote
+                      endpoint";
+                    uses instance-endpoint-remote-config;
+                  }
+
+                  container state {
+                    config false;
+                    description
+                      "Operational state parameters relating to
+                      a remote endpoint";
+                    uses instance-endpoint-remote-config;
+                  }
+                }
+                container vxlan {
+                  description
+                    "Configuration and operational state parameters
+                    relating to a VXLAN tunnel end-point interface";
+                  uses oc-evpn:evpn-overlays-grp-top;
+                }
+              }
+            }
+          }
+        }
+
+        uses oc-mpls:mpls-top {
+          when "./config/type = 'oc-ni-types:DEFAULT_INSTANCE'" {
+            description
+              "MPLS configuration is only valid within the default
+              network instance.";
+          }
+        }
+
+        uses oc-sr:sr-top {
+          when "./config/type = 'oc-ni-types:DEFAULT_INSTANCE'" {
+            description
+              "Segment routing configuration is only valid with the default
+              network instance.";
+          }
+        }
+
+        uses oc-vlan:vlan-top;
+
+        uses oc-pf:policy-forwarding-top;
+
+        uses oc-aft:aft-top;
+
+        container protocols {
+          description
+            "The routing protocols that are enabled for this
+            network-instance.";
+
+          list protocol {
+            key "identifier name";
+
+            description
+              "A process (instance) of a routing protocol. Some
+              systems may not support more than one instance of
+              a particular routing protocol";
+
+            leaf identifier {
+              type leafref {
+                path "../config/identifier";
+              }
+              description
+                "The protocol name for the routing or forwarding
+                protocol to be instantiated";
+            }
+
+            leaf name {
+              type leafref {
+                path "../config/name";
+              }
+              description
+                "An operator-assigned identifier for the routing
+                or forwarding protocol. For some processes this
+                leaf may be system defined.";
+            }
+
+            container config {
+              description
+                "Configuration parameters relating to the routing
+                protocol instance";
+
+              uses protocols-config;
+            }
+
+            container state {
+              config false;
+              description
+                "State parameters relating to the routing protocol
+                instance";
+
+              uses protocols-config;
+              uses protocols-state;
+            }
+
+            uses oc-loc-rt:local-static-top {
+              when "./config/identifier = 'oc-pol-types:STATIC'" {
+                description
+                  "Include static route parameters only when the
+                  protocol is set to static";
+              }
+              description
+                "Configuration and state parameters relating to
+                static routes";
+            }
+
+            uses oc-loc-rt:local-aggregate-top {
+              when "./config/identifier = 'oc-pol-types:LOCAL_AGGREGATE'" {
+                description
+                  "Include aggregate route parameters only when the
+                  protocol is set to aggregate";
+              }
+              description
+                "Configuration and state parameters relating to
+                locally generated aggregate routes";
+            }
+
+            uses oc-bgp:bgp-top {
+              when "./config/identifier = 'oc-pol-types:BGP'" {
+                description
+                  "Include BGP parameters only when the protocol
+                  is of type BGP";
+              }
+              description
+                "Configuration and state parameters relating to
+                Border Gateway Protocol (BGP)";
+            }
+
+            uses oc-ospfv2:ospfv2-top {
+              when "./config/identifier = 'oc-pol-types:OSPF'" {
+                description
+                  "Include OSPFv2 parameters only when the protocol
+                  is of type OSPFv2";
+              }
+            }
+
+            uses oc-isis:isis-top {
+              when "./config/identifier = 'oc-pol-types:ISIS'" {
+                description
+                  "Include IS-IS configuration when the protocol is of type
+                  IS-IS";
+              }
+              description
+                "Configuration and state parameters relating to Intermediate
+                System to Intermediate System (IS-IS).";
+            }
+
+            uses oc-pim:pim-top {
+              when "./config/identifier = 'oc-pol-types:PIM'" {
+                description
+                  "Include PIM configuration when the protocol is of type
+                  PIM";
+              }
+              description
+                "Configuration and state parameters relating to Protocol
+                Indepdendent Multicast (PIM).";
+            }
+
+            uses oc-igmp:igmp-top {
+              when "./config/identifier = 'oc-pol-types:IGMP'" {
+                description
+                  "Include IGMP configuration when the protocol is of type
+                  IGMP";
+              }
+              description
+                "Configuration and state parameters relating to the Internet
+                Group Management Protocol (IGMP).";
+            }
+
+			uses oc-pcep:pcep-top {
+              when "./config/identifier = 'oc-pol-types:PCEP'" {
+                description
+                  "Include PCEP configuration when the protocol is of type
+                  PCEP";
+              }
+              description
+                "Configuration and state parameters relating to the Path
+                Computation Element Protocol (PCEP).";
+            }
+          }
+        }
+      }
+    }
+  }
+
+  grouping instance-endpoint-config {
+    description
+      "Configuration data relating to an forwarding-instance
+      endpoint";
+
+    leaf endpoint-id {
+      type string;
+      description
+        "An identifier for the endpoint";
+    }
+
+    leaf precedence {
+      type uint16;
+      description
+        "The precedence of the endpoint - the lowest precendence
+        viable endpoint will be utilised as the active endpoint
+        within a connection";
+    }
+
+    leaf type {
+      type identityref {
+        base "oc-ni-types:ENDPOINT_TYPE";
+      }
+      description
+        "The type of endpoint that is referred to by the current
+        endpoint";
+    }
+
+  }
+
+  grouping instance-endpoint-local-config {
+    description
+      "Configuration parameters relating to an endpoint that is local
+      to the current system";
+
+    uses oc-if:interface-ref-common;
+
+    leaf site-id {
+      type uint16;
+      description
+        "The VE ID as defined in RFC4761 (VPLS) or CE ID as defined in
+        RFC6624 (l2vpn) to uniquely identify this endpoint (site) as part
+        of the BGP discovery of remote endpoints for layer 2 services.";
+      reference "RFC6624 Section 2.2.1, RFC4761 Section 3.2.2";
+    }
+
+    // TODO not seen this in configuration yet; is it managed by the
+    // PE router code?
+    leaf site-label-block-offset {
+      type uint16;
+      description
+        "The VPLS label block offset that is signaled with the 'site-id'.";
+      reference "RFC4761 Section 3.2.1 'VBO'";
+    }
+
+    leaf site-label-block-size {
+      type uint16;
+      description
+        "The VPLS label block size that is signaled with the 'site-id'.";
+      reference "RFC4761 Section 3.2.1 'VBS'";
+    }
+  }
+
+  grouping instance-endpoint-remote-config {
+    description
+      "Configuration parameters relating to an endpoint that is
+      remote from the local system";
+    leaf remote-system {
+      type oc-inet:ip-address;
+      description
+        "The IP address of the device which hosts the
+        remote end-point";
+    }
+
+    leaf virtual-circuit-identifier {
+      type uint32;
+      description
+        "The virtual-circuit identifier that identifies the
+        connection at the remote end-point";
+    }
+
+    leaf site-id {
+      type uint16;
+      description
+        "Identifies remote sites. When BGP discovery is used this
+        is the customer edge identifier";
+      reference "RFC6624 Section 2.2.1";
+    }
+  }
+
+  grouping instance-endpoint-state {
+    description
+      "Operational state data relating to a forwarding-instance
+      endpoint";
+    leaf active {
+      type boolean;
+      description
+        "When the backup endpoint is active, the value of this
+        parameter is set to true";
+    }
+  }
+
+  grouping instance-connection-point-config {
+    description
+      "Configuration data relating to a forwarding-instance
+      connection point";
+
+    leaf connection-point-id {
+      type string;
+      description
+        "An identifier for a connection point";
+    }
+  }
+
+  grouping instance-connection-point-state {
+    description
+      "Operational state data relating to a forwarding-instance
+      connection point";
+  }
+
+  grouping table-config {
+    description
+      "Config parameters relating to an L2/L2.5/L3 table that exists
+      within a network instance";
+
+    leaf protocol {
+      type leafref {
+        path "../../../../protocols/protocol/config/identifier";
+      }
+      description
+        "Reference to the protocol that the table is associated with.";
+    }
+
+    leaf address-family {
+      type identityref {
+        base oc-types:ADDRESS_FAMILY;
+      }
+      description
+        "The address family (IPv4, IPv6) of the table's entries";
+    }
+  }
+
+  grouping instance-interfaces-config {
+    description
+      "Configuration parameters related to an interface associated
+      with the network instance";
+
+    leaf id {
+      type oc-if:interface-id;
+      description
+        "A unique identifier for this interface - this is expressed
+        as a free-text string";
+    }
+
+    uses oc-if:interface-ref-common;
+
+    leaf-list associated-address-families {
+      type identityref {
+        base oc-types:ADDRESS_FAMILY;
+      }
+      description
+        "The address families on the subinterface which are to be
+        associated with this network instance. When this leaf-list
+        is empty and the network instance requires Layer 3 information
+        the address families for which the network instance is
+        enabled should be imported. If the value of this leaf-list
+        is specified then the association MUST only be made for
+        those address families that are included in the list.";
+    }
+
+    leaf mac-pinning {
+      type boolean;
+      description
+        "Enable (TRUE) or disable (FALSE). There are scenarios in which
+        it is desired to configure some MAC addresses as static so
+        that they are not subjected to MAC moves. If you enable MAC pinning
+        on a CE interface, that MAC address cannot be moved to any
+        other CE interface";
+      reference
+        "RFC 7432: BGP MPLS-Based Ethernet VPN";
+    }
+
+    leaf irb-anycast-gateway {
+      type enumeration {
+        enum DISTRIBUTED_SYMETRIC {
+          description "Distributed anycast gateway";
+        }
+        enum DISTRIBUTED_ASYMETRIC {
+          description "Distributed asymetric anycast gateway";
+        }
+        enum HYBRID {
+          description "Hybrid anycast gateway";
+        }
+        enum CENTRALIZED {
+          description "Centralized anycast gateway";
+        }
+      }
+      description
+        "Associate VLAN SVI with anycast Gateway.
+        The SVI is the layer3 interface for the mac-vrf
+        when the SVI is being used as the first hop default gw.";
+    }
+  }
+
+  grouping instance-interfaces-state {
+    description
+      "Operational state parameters relating to an interface
+      associated with this network instance";
+  }
+
+  grouping inter-table-policies-config {
+    description
+      "Configuration entries that relate to how RIB or FIB entries
+      are propagated between tables within the same network
+      instance";
+
+    leaf src-protocol {
+      type leafref {
+        // we are at table-connections/table-connection/config/.
+        path "../../../../tables/table/config/protocol";
+      }
+      description
+        "The source protocol for the table connection";
+    }
+
+    leaf address-family {
+      type leafref {
+        // we are at table-connections/table-connection/config/.
+        path "../../../../tables/" +
+          "table[protocol=current()/../src-protocol]/" +
+          "config/address-family";
+      }
+      description
+        "The address family associated with the connection. This
+        must be defined for the source protocol. The target
+        address family is implicitly defined by the address family
+        specified for the source protocol.";
+    }
+
+    leaf dst-protocol {
+      type leafref {
+        path "../../../../tables/table/config/protocol";
+      }
+      description
+        "The destination protocol for the table connection";
+    }
+
+    leaf disable-metric-propagation {
+      type boolean;
+      default false;
+      description
+        "By default a system may reflect the metric specified in
+        the destination protocol according to that which is set in
+        the source protocol. For example:
+         - IS-IS metric may be reflected in BGP MED (and vice versa)
+         - OSPF metric may be reflected in the BGP MED (and vice versa)
+        When this leaf is set to true, this reflection behaviour MUST be
+        disabled, and rather the metric must be set to '0' or explicitly
+        set by policy.";
+    }
+
+    uses oc-rpol:apply-policy-import-config;
+    uses oc-rpol:default-policy-import-config;
+  }
+
+  grouping network-instance-config {
+    description
+      "Configuration parameters relating to a top-level network
+      instance";
+
+    leaf name {
+      type string;
+      description
+        "An operator-assigned unique name for the network instance.
+        If the operator does not designate a name for the instance of
+        type 'DEFAULT_INSTANCE' (e.g. config), the implementation
+        should use the name of 'DEFAULT' (e.g. state).";
+    }
+
+    leaf type {
+      type identityref {
+        base "oc-ni-types:NETWORK_INSTANCE_TYPE";
+      }
+      mandatory true;
+      description
+        "The type of network instance. The value of this leaf
+        indicates the type of forwarding entries that should be
+        supported by this network instance. Signalling protocols also
+        use the network instance type to infer the type of service
+        they advertise; for example MPLS signalling for an L2VSI
+        network instance would infer a VPLS service whereas a type of
+        L2PTP would infer a VPWS (pseudo-wire) service.
+
+        An implementation must support only a single network-instance
+        of type 'DEFAULT_INSTANCE'.";
+    }
+
+    leaf description {
+      type string;
+      description
+        "A free-form string to be used by the network operator to
+        describe the function of this network instance";
+    }
+
+    leaf router-id {
+      type oc-yang:dotted-quad;
+      description
+        "A identifier for the local network instance - typically
+        used within associated routing protocols or signalling
+        routing information in another network instance";
+    }
+
+    leaf route-distinguisher {
+      type oc-ni-types:route-distinguisher;
+      description
+        "The route distinguisher that should be used for the local
+        VRF or VSI instance when it is signalled via BGP.";
+    }
+
+    leaf fallback-network-instance {
+      type network-instance-ref;
+      description
+        "When this leaf is populated, the specified network instance
+        should be used as a fallback instance when a route cannot
+        be resolved in the local network-instance.
+        This configuration is only valid when specified in a non-default
+        instance which must be a L3 capable VRF (i.e., L2L3, or L3VRF).";
+      when "../type = 'oc-ni-types:L3VRF'";
+    }
+  }
+
+  grouping network-instance-state {
+    description
+      "Operational state parameters relating to a network instance";
+  }
+
+  grouping protocols-config {
+    description
+      "Configuration parameters relating to a generic protocol
+      instance within a network instance";
+
+    leaf identifier {
+      type identityref {
+        base "oc-pol-types:INSTALL_PROTOCOL_TYPE";
+      }
+      description
+        "The protocol identifier for the instance";
+    }
+
+    leaf name {
+      type string;
+      default "DEFAULT";
+      description
+        "A unique name for the protocol instance.
+
+        If the operator does not designate a name for the protocol
+        instance (e.g. config), the implementation should use the
+        name of 'DEFAULT' (e.g. state).  In addition, for
+        implementations that support single protocol instances, the
+        default value is recommended for consistency and uniqueness
+        per protocol instance.";
+    }
+
+    leaf enabled {
+      type boolean;
+      description
+        "A boolean value indicating whether the local protocol
+        instance is enabled.";
+    }
+
+    leaf default-metric {
+      type uint32;
+      description
+        "The default metric within the RIB for entries that are
+        installed by this protocol instance. This value may
+        be overridden by protocol specific configuration options.
+        The lower the metric specified the more preferable the RIB
+        entry is to be selected for use within the network instance.
+        Where multiple entries have the same metric value then these
+        equal cost paths should be treated according to the specified
+        ECMP path selection behaviour for the instance";
+    }
+  }
+
+  grouping protocols-state {
+    description
+      "Operational state parameters relating to a protocol instance";
+  }
+
+  grouping instance-interface-association-config {
+    description
+      "Grouping containing leaves that are to be augmented into an
+      interface or subinterface to include mapping to a network
+      instance";
+
+    leaf network-instance {
+      type leafref {
+        path "/network-instances/network-instance/name";
+      }
+      description
+        "The network instance that this interface is associated
+        with";
+    }
+  }
+
+  grouping encapsulation-config {
+    description
+      "Type agnostic configuration parameters relating to the
+      encapsulation of the network instance";
+
+    leaf encapsulation-type {
+      type identityref {
+        base oc-ni-types:ENCAPSULATION;
+      }
+      description
+        "The on-the-wire encapsulation that should be used when
+        sending traffic from this network instance";
+    }
+
+    // rjs: This is left here as I suspect that this can
+    // be used in EVPN. Need to validate implementations, otherwise
+    // move to L3. (TODO)
+    leaf label-allocation-mode {
+      type identityref {
+        base oc-ni-types:LABEL_ALLOCATION_MODE;
+      }
+      description
+        "The label allocation mode to be used for L3 entries
+        in the network instance";
+    }
+  }
+  uses network-instance-top;
+}

--- a/models/yang/common/openconfig-ospf-policy.yang
+++ b/models/yang/common/openconfig-ospf-policy.yang
@@ -1,0 +1,199 @@
+module openconfig-ospf-policy {
+  yang-version "1";
+
+  namespace "http://openconfig.net/yang/ospf-policy";
+
+  prefix "oc-ospf-pol";
+
+  import openconfig-routing-policy { prefix "oc-rpol"; }
+  import openconfig-extensions { prefix "oc-ext"; }
+  import openconfig-ospf-types { prefix "oc-ospf-types"; }
+
+  organization
+    "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This module defines extensions to the OpenConfig policy
+    model to add extensions for OSPF. This module is intended
+    to be generic for both OSPFv2 and OSPFv3.";
+
+  oc-ext:openconfig-version "0.1.3";
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "0.1.3";
+  }
+
+  revision "2018-06-05" {
+    description
+      "Bug fixes in when statements in lsdb";
+    reference "0.1.2";
+  }
+
+  revision "2017-08-24" {
+    description
+      "Minor formatting fixes.";
+    reference "0.1.1";
+  }
+
+  revision "2016-08-22" {
+    description
+      "Initial revision";
+    reference "0.0.1";
+  }
+
+  // OpenConfig specific extensions for module metadata.
+  oc-ext:regexp-posix;
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  grouping ospf-match-config {
+    description
+      "Configuration parameters for OSPF match conditions";
+
+    leaf area-eq {
+      type oc-ospf-types:ospf-area-identifier;
+      description
+        "Match prefixes which are within a particular OSPF area";
+    }
+  }
+
+  grouping ospf-match-conditions {
+    description
+      "Match conditions that are added by OSPF";
+
+    container ospf-conditions {
+      description
+        "Match conditions specific to OSPF";
+
+      container config {
+        description
+          "Configuration parameters relating to OSPF match conditions";
+
+        uses ospf-match-config;
+      }
+
+      container state {
+        config false;
+        description
+          "Operational state parameters relating to OSPF match conditions";
+
+        uses ospf-match-config;
+      }
+    }
+  }
+
+  grouping ospf-actions-config {
+    description
+      "Configuration parameters for OSPF policy actions";
+
+    leaf set-area {
+      type oc-ospf-types:ospf-area-identifier;
+      description
+        "Set the area for the matched route. This action is typically
+        used when importing prefixes into OSPF, such that a route can
+        be imported into a specific area within the instance.";
+    }
+  }
+
+  grouping ospf-actions-set-metric-config {
+    description
+      "Configuration parameters relating to setting the OSPF metric";
+
+    leaf metric-type {
+      type enumeration {
+        enum EXTERNAL_TYPE_1 {
+          description
+            "Set the external type 1 metric";
+        }
+        enum EXTERNAL_TYPE_2 {
+          description
+            "Set the external type 2 metric";
+        }
+      }
+      default "EXTERNAL_TYPE_2";
+      description
+        "Specify the type of metric which is to be set by the policy";
+    }
+
+    leaf metric {
+      type oc-ospf-types:ospf-metric;
+      description
+        "Set the metric of the routes matching the policy to the value
+        specified by this leaf.";
+    }
+  }
+
+  grouping ospf-actions {
+    description
+      "Actions that are added by OSPF to the action framework";
+
+    container ospf-actions {
+      description
+        "Actions specific to OSPF";
+
+      container config {
+        description
+          "Configuration parameters for OSPF actions";
+
+        uses ospf-actions-config;
+      }
+
+      container state {
+        config false;
+        description
+          "Operational state parameters for OSPF actions";
+
+        uses ospf-actions-config;
+      }
+
+      container set-metric {
+        description
+          "Configuration and state parameters relating to manipulating
+          the OSPF metric";
+
+        container config {
+          description
+            "Configuration parameters relating to setting the OSPF metric";
+          uses ospf-actions-set-metric-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state parameters relating to setting the OSPF
+            metric";
+
+          uses ospf-actions-set-metric-config;
+        }
+      }
+    }
+  }
+
+  // augment the groupings into the routing policy model
+
+  // TODO: discuss whether igp-actions should be used or whether this should
+  // be removed.
+
+  augment "/oc-rpol:routing-policy/oc-rpol:policy-definitions/" +
+            "oc-rpol:policy-definition/oc-rpol:statements/oc-rpol:statement/" +
+            "oc-rpol:conditions" {
+    description
+      "Add OSPF specific match conditions to the routing policy model";
+    uses ospf-match-conditions;
+  }
+
+  augment "/oc-rpol:routing-policy/oc-rpol:policy-definitions/" +
+            "oc-rpol:policy-definition/oc-rpol:statements/oc-rpol:statement/" +
+            "oc-rpol:actions" {
+    description
+      "Add OSPF specific actions to the routing policy model";
+    uses ospf-actions;
+  }
+
+}

--- a/models/yang/common/openconfig-ospf-types.yang
+++ b/models/yang/common/openconfig-ospf-types.yang
@@ -1,0 +1,795 @@
+module openconfig-ospf-types {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/ospf-types";
+
+  prefix "oc-ospf-types";
+
+  // import some basic types
+  import ietf-yang-types { prefix "yang"; }
+  import openconfig-extensions { prefix "oc-ext"; }
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "Type definitions for OSPF";
+
+  oc-ext:openconfig-version "0.1.3";
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "0.1.3";
+  }
+
+  revision "2018-06-05" {
+    description
+      "Bug fixes in when statements in lsdb";
+    reference "0.1.2";
+  }
+
+  revision "2017-08-24" {
+    description
+      "Minor formatting fixes.";
+    reference "0.1.1";
+  }
+
+  revision "2017-02-28"{
+    description
+      "Initial public release of OSPFv2";
+    reference "0.1.0";
+  }
+
+  revision "2016-06-24" {
+    description
+      "Initial revision";
+    reference "0.0.1";
+  }
+
+  // OpenConfig specific extensions for module metadata.
+  oc-ext:regexp-posix;
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  // typedefs
+  typedef ospf-area-identifier {
+    type union {
+      type uint32;
+      type yang:dotted-quad;
+    }
+    description
+      "An identifier for an area with OSPF version 2 or 3. This value
+      is expressed as either a dotted-quad, or a unsigned 32-bit
+      number";
+  }
+
+  typedef ospf-metric {
+    type uint16;
+    description
+      "A common type that can be utilised to express an OSPF metric";
+  }
+
+  typedef sr-sid-type {
+    type enumeration {
+      enum LABEL {
+        description
+          "When the length of the SR/Label Sub-TLV is specified to be 3, then
+          the right-most 20-bits represent a label value within the SR/Label
+          Sub-TLV. When this leaf is set to a value of Label the first-entry
+          leaf should be interpreted to be an MPLS label.";
+      }
+      enum SID {
+        description
+          "When the length of the SR/Label Sub-TLV is specified to be 4, then
+          the value specified in the first-entry leaf should be specified to
+          be a segment identifier.";
+      }
+    }
+    description
+      "A common type used to express the type of segment identifier that is
+      used in LSDB entries relating to segment routing";
+  }
+
+  // identities
+  identity OSPF_LSA_TYPE {
+    description
+      "Base identity for an OSPF LSA type. This identity is intended
+      to be used across both OSPFv2 and OSPFv3. Identity values that
+      correspond to only one OSPF version are marked as such.";
+  }
+
+  identity ROUTER_LSA {
+    base "OSPF_LSA_TYPE";
+    description
+      "Type 1 - ROUTER_LSA. An LSA originated by each router within
+      the area describing the state and cost of the router's links
+      in the area.";
+    reference "RFC2328";
+  }
+
+  identity NETWORK_LSA {
+    base "OSPF_LSA_TYPE";
+    description
+      "Type 2 - NETWORK_LSA. An LSA originated for each broadcast and
+      non-broadcast multiple access (NBMA) in the area. This LSA is
+      originated by the designated router.";
+    reference "RFC2328";
+  }
+
+  identity SUMMARY_IP_NETWORK_LSA {
+    base "OSPF_LSA_TYPE";
+    description
+      "Type 3 - SUMMARY_IP_NETWORK_LSA. An LSA originated by area
+      border routers describing inter-area destinations. This LSA type
+      is used when the destination is an IP network";
+    reference "RFC2328";
+  }
+
+  identity SUMMARY_ASBR_LSA {
+    base "OSPF_LSA_TYPE";
+    description
+      "Type 4 - SUMMARY_ASBR_LSA. An LSA originated by an area border
+      router describing inter-area destinations. This LSA type is used
+      when the destination is an AS boundary router.";
+    reference "RFC2328";
+  }
+
+  identity AS_EXTERNAL_LSA {
+    base "OSPF_LSA_TYPE";
+    description
+      "Type 5 - AS_EXTERNAL_LSA. This LSA type is used to describe
+      destinations external to the autonomous system, and is
+      originated by an AS boundary router (ASBR).";
+    reference "RFC2328";
+  }
+
+  identity NSSA_AS_EXTERNAL_LSA {
+    base "OSPF_LSA_TYPE";
+    description
+      "Type 7 - NSSA_AS_EXTERNAL_LSA. This LSA type is used by
+      systems within a not-so-stubby-area (NSSA) to inject external
+      prefixes into the LSDB. They are translated to Type 5 LSAs
+      at an ABR device.";
+    reference "RFC3101";
+  }
+
+  identity OSPFV2_LINK_SCOPE_OPAQUE_LSA {
+    base "OSPF_LSA_TYPE";
+    description
+      "Type 9 - OSPFV2_LINK_SCOPE_OPAQUE_LSA. This LSA type is used
+      in OSPFv2 to distribute arbitrary information via the OSPF
+      protocol. The contents is specific to the application defining
+      the Opaque Type specified within the LSDB. LSAs with Type 9 have
+      a scope of the link that they are being transmitted on (and the
+      associated network or subnetwork).";
+    reference "RFC5250";
+  }
+
+  identity OSPFV2_AREA_SCOPE_OPAQUE_LSA {
+    base "OSPF_LSA_TYPE";
+    description
+      "Type 10 - OSPFV2_AREA_SCOPE_OPAQUE_LSA. This LSA type is used
+      in OSPFv2 to distribute arbitrary information via the OSPF
+      protocol. The contents is specific to the application defining
+      the Opaque Type specified within the LSDB. LSAs with Type 10 have
+      a scope of the area that they are transmitted within.";
+    reference "RFC5250";
+  }
+
+  identity OSPFV2_AS_SCOPE_OPAQUE_LSA {
+    base "OSPF_LSA_TYPE";
+    description
+      "Type 11 - OSPFV2_AS_SCOPE_OPAQUE_LSA. This LSA type is used
+      in OSPFv2 to distribute arbitrary information via the OSPF
+      protocol. The contents is specific to the application defining
+      the Opaque Type specified within the LSDB. LSAs with Type 11
+      have a scope of the autonomous system that they are transmitted
+      within.";
+    reference "RFC5250";
+  }
+
+  identity ROUTER_LSA_TYPES {
+    description
+      "Sub-types of the router LSA";
+  }
+
+  identity ROUTER_LSA_P2P {
+    base "ROUTER_LSA_TYPES";
+    description
+      "The LSA represents a point-to-point connection to another
+      router";
+  }
+
+  identity ROUTER_LSA_TRANSIT_NETWORK {
+    base "ROUTER_LSA_TYPES";
+    description
+      "The LSA represents a connection to a transit network";
+  }
+
+  identity ROUTER_LSA_STUB_NETWORK {
+    base "ROUTER_LSA_TYPES";
+    description
+      "The LSA represents a connection to a stub network";
+  }
+
+  identity ROUTER_LSA_VIRTUAL_LINK {
+    base "ROUTER_LSA_TYPES";
+    description
+      "The LSA represents a virtual link connection";
+  }
+
+  identity OSPF_NEIGHBOR_STATE {
+    description
+      "The state of an adjacency between the local system and a remote
+      device";
+  }
+
+  identity DOWN {
+    base "OSPF_NEIGHBOR_STATE";
+    description
+      "The initial state of a neighbor, indicating that no recent
+      information has been received from the neighbor.";
+    reference "RFC2328";
+  }
+
+  identity ATTEMPT {
+    base "OSPF_NEIGHBOR_STATE";
+    description
+      "Utilised for neighbors that are attached to NBMA networks, it
+      indicates that no information has been recently received from
+      the neighbor but that Hello packets should be directly sent
+      to that neighbor.";
+    reference "RFC2328";
+  }
+
+  identity INIT {
+    base "OSPF_NEIGHBOR_STATE";
+    description
+      "Indicates that a Hello packet has been received from the
+      neighbor but bi-directional communication has not yet been
+      established. That is to say that the local Router ID does
+      not appear in the list of neighbors in the remote system's
+      Hello packet.";
+    reference "RFC2328";
+  }
+
+  identity TWO_WAY {
+    base "OSPF_NEIGHBOR_STATE";
+    description
+      "Communication between the local and remote system is
+      bi-directional such that the local system's Router ID is listed
+      in the received remote system's Hello packet.";
+    reference "RFC2328";
+  }
+
+  identity EXSTART {
+    base "OSPF_NEIGHBOR_STATE";
+    description
+      "An adjacency with the remote system is being formed. The local
+      system is currently transmitting empty database description
+      packets in order to establish the master/slave relationship for
+      the adjacency.";
+    reference "RFC2328";
+  }
+
+  identity EXCHANGE {
+    base "OSPF_NEIGHBOR_STATE";
+    description
+      "The local and remote systems are currently exchanging database
+      description packets in order to determine which elements of
+      their local LSDBs are out of date.";
+    reference "RFC2328";
+  }
+
+  identity LOADING {
+    base "OSPF_NEIGHBOR_STATE";
+    description
+      "The local system is sending Link State Request packets to the
+      remote system in order to receive the more recently LSAs that
+      were discovered during the Exchange phase of the procedure
+      establishing the adjacency.";
+    reference "RFC2328";
+  }
+
+  identity FULL {
+    base "OSPF_NEIGHBOR_STATE";
+    description
+      "The neighboring routers are fully adjacent such that both
+      LSDBs are synchronized. The adjacency will appear in Router and
+      Network LSAs";
+    reference "RFC2328";
+  }
+
+  identity OSPF_NETWORK_TYPE {
+    description
+      "Types of network that OSPF should consider attached to an
+      interface";
+  }
+
+  identity POINT_TO_POINT_NETWORK {
+    base "OSPF_NETWORK_TYPE";
+    description
+      "A interface that connects two routers.";
+    reference "RFC2328";
+  }
+
+  identity BROADCAST_NETWORK {
+    base "OSPF_NETWORK_TYPE";
+    description
+      "An interface that supports >2 attached routers which has the
+      ability to address all connected systems via a single
+      (broadcast) address.";
+  }
+
+  identity NON_BROADCAST_NETWORK {
+    base "OSPF_NETWORK_TYPE";
+    description
+      "An interface that supports >2 attached rotuers which does not
+      have the ability to address all connected systems with a
+      broadcast address.";
+  }
+
+  // rjs TODO: Maybe need p2mp here.
+
+
+  identity OSPF_OPAQUE_LSA_TYPE {
+    description
+      "This identity is the base used for opaque LSA types. The values
+      that extend this base are those that are described in the IANA
+      OSPF Opaque Link-State Advertisements (LSA) Option Types registry";
+  }
+
+  identity TRAFFIC_ENGINEERING {
+    base "OSPF_OPAQUE_LSA_TYPE";
+    description
+      "The Traffic Engineering LSA. This type is used only with area-scope
+      Opaque LSAs - and is used to describe routers, point-to-point links
+      and connections to multi-access networks for traffic engineering
+      purposes.";
+    reference "RFC3630";
+  }
+
+  identity GRACE_LSA {
+    base "OSPF_OPAQUE_LSA_TYPE";
+    description
+      "Grace LSAs are announced by a system undergoing graceful-restart.
+      A system that is attempting an OSPF graceful restart announces
+      Grace-LSAs with a specified grace period, indicating the intention
+      to have completed an restart within the specified period.";
+    reference "RFC3623";
+  }
+
+  identity ROUTER_INFORMATION {
+    base "OSPF_OPAQUE_LSA_TYPE";
+    description
+      "The Router Information LSA is used by an OSPFv2 system to announce
+      optional capabilities of the local system, over and above those that
+      are included within the OSPF hello message field.  The flooding scope
+      of the LSA can be link-, area-, or AS-wide (i.e., the LSA type can
+      be 9, 10 or 11).";
+    reference "RFC7770";
+  }
+
+  identity OSPFV2_EXTENDED_PREFIX {
+    base "OSPF_OPAQUE_LSA_TYPE";
+    description
+      "The Extended Prefix LSA is used in OSPFv2 to carry a set of attributes
+      that are to be associated with a prefix that is advertised in OSPF. The
+      attributes are carried as one or more TLV tuples. The flooding scope
+      of the LSA can be link-, area-, or AS-wide as specified by the
+      advertising system. The flooding scope of the LSA may exceed the scope
+      of the corresponding prefix.";
+    reference "RFC7684";
+  }
+
+  identity OSPFV2_EXTENDED_LINK {
+    base "OSPF_OPAQUE_LSA_TYPE";
+    description
+      "The Extended Link LSA is used in OSPFv2 to carry a set of attributes
+      that are to be associated with a link that is advertised in OSPF. The
+      link attributes are carried as one or more TLV tuples. The flooding
+      scope of the link LSA is area-local - i.e., it is carried in a Type 10
+      opaque LSA.";
+    reference "RFC7684";
+  }
+
+  identity OSPF_TE_LSA_TLV_TYPE {
+    description
+      "This identity is the base used for the type field of TLVs that are
+      included within the Traffic Engineering Opaque LSA.";
+  }
+
+  identity TE_ROUTER_ADDRESS {
+    base "OSPF_TE_LSA_TLV_TYPE";
+    description
+      "A stable IP address of the advertising router that is always reachable
+      if the node has connectivity.";
+  }
+
+  identity TE_LINK {
+    base "OSPF_TE_LSA_TLV_TYPE";
+    description
+      "A single link within a traffic engineering topology. A set of sub-TLVs
+      are carried within this attribute to indicate traffic engineering
+      characteristics of the link.";
+  }
+
+  identity TE_ROUTER_IPV6_ADDRESS {
+    base "OSPF_TE_LSA_TLV_TYPE";
+    description
+      "A stable IPv6 address of the advertising router that is always
+      reachable if the node has connectivity. This TLV is used only with
+      OSPFv3";
+    reference "RFC5329";
+  }
+
+  identity TE_LINK_LOCAL {
+    base "OSPF_TE_LSA_TLV_TYPE";
+    description
+      "Attributes associated with the local link by the system.";
+    reference "RFC4203";
+  }
+
+  identity TE_NODE_ATTRIBUTE {
+    base "OSPF_TE_LSA_TLV_TYPE";
+    description
+      "Attributes associted with the local system";
+    reference "RFC5786";
+  }
+
+  identity TE_OPTICAL_NODE_PROPERTY {
+    base "OSPF_TE_LSA_TLV_TYPE";
+    description
+      "Attributes associated with the local optical node. A set of sub-TLVs
+      are carried within this TLV which are used within the GMPLS control
+      plane when using OSPF";
+  }
+
+  identity OSPF_TE_LINK_TLV_TYPE {
+    description
+      "This identity is the based used for the type field for sub-TLVs of the
+      Link TLV of the OSPF Traffic Engineering Opaque LSA";
+  }
+
+  identity TE_LINK_TYPE {
+    base "OSPF_TE_LINK_TLV_TYPE";
+    description
+      "The OSPF-TE Link Type sub-TLV appears exactly once per OSPF-TE Link
+      and describes the type of the link";
+  }
+
+  identity TE_LINK_ID {
+    base "OSPF_TE_LINK_TLV_TYPE";
+    description
+      "The OSPF-TE Link ID sub-TLV appears exactly once per OSPF-TE link and
+      identifies the remote end of the link.";
+  }
+
+  identity TE_LINK_LOCAL_IP {
+    base "OSPF_TE_LINK_TLV_TYPE";
+    description
+      "The OSPF-TE Local IP specifies a list of the interface addresses of the
+      local system corresponding to the traffic engineering link.";
+  }
+
+  identity TE_LINK_REMOTE_IP {
+    base "OSPF_TE_LINK_TLV_TYPE";
+    description
+      "The OSPF-TE Remote IP specifies a list of IP addresses of the remote
+      neighbors associated with the traffic engineering link.";
+  }
+
+  identity TE_LINK_METRIC {
+    base "OSPF_TE_LINK_TLV_TYPE";
+    description
+      "The OSPF-TE Metric specifies the link metric for traffic engineering
+      purposes";
+  }
+
+  identity TE_LINK_MAXIMUM_BANDWIDTH {
+    base "OSPF_TE_LINK_TLV_TYPE";
+    description
+      "The OSPF-TE Maximum Bandwidth specifies the maximum bandwidth of the
+      link that it is associated with.";
+  }
+
+  identity TE_LINK_MAXIMUM_RESERVABLE_BANDWIDTH {
+    base "OSPF_TE_LINK_TLV_TYPE";
+    description
+      "The OSPF-TE Maximum Reservable Bandwidth specifies the maximum
+      bandwidth that may be reserved on the link in bytes per second";
+  }
+
+  identity TE_LINK_UNRESERVED_BANDWIDTH {
+    base "OSPF_TE_LINK_TLV_TYPE";
+    description
+      "The OSPF-TE unreserved bandwidth indicates the amount of bandwidth
+      at each priority level that is currently not reserved";
+  }
+
+  identity TE_LINK_ADMIN_GROUP {
+    base "OSPF_TE_LINK_TLV_TYPE";
+    description
+      "The OSPF-TE administrative group indicates the administrative group
+      that the is assigned to the interface";
+  }
+
+  identity TE_NODE_ATTRIBUTE_TLV_TYPE {
+    description
+      "This identity forms the base for sub-TLVs of the Node Attribute TLV
+      of the Traffic Engineering LSA";
+  }
+
+  identity NODE_IPV4_LOCAL_ADDRESS {
+    base "TE_NODE_ATTRIBUTE_TLV_TYPE";
+    description
+      "The Node Attribute Sub-TLV contains a list of the IPv4 addresses of
+      the local system";
+  }
+
+  identity NODE_IPV6_LOCAL_ADDRESS {
+    base "TE_NODE_ATTRIBUTE_TLV_TYPE";
+    description
+      "The Node Attribute Sub-TLV contains a list of the IPv6 addresses of
+      the local system";
+  }
+
+  identity GRACE_LSA_TLV_TYPES {
+    description
+      "This identity is used as the base for TLVs within the Grace LSA";
+  }
+
+  identity GRACE_PERIOD {
+    base "GRACE_LSA_TLV_TYPES";
+    description
+      "This sub-TLV describes the period for which adjacencies should be
+      maintained with the restarting system";
+  }
+
+  identity GRACE_RESTART_REASON {
+    base "GRACE_LSA_TLV_TYPES";
+    description
+      "This sub-TLV describes the reason for the OSPF restart of the system
+      that is restarting";
+  }
+
+  identity GRACE_IP_INTERFACE_ADDRESS {
+    base "GRACE_LSA_TLV_TYPES";
+    description
+      "This sub-TLV specifies the restarting system's IP address on the
+      interface via which it is advertising the Grace LSA";
+  }
+
+  identity RI_LSA_TLV_TYPES {
+    description
+      "This identity is used as the base for the TLVs within the Router
+      Information LSA";
+    reference "RFC7770";
+  }
+
+  identity RI_INFORMATIONAL_CAPABILITIES {
+    base "RI_LSA_TLV_TYPES";
+    description
+      "Informational capabilities of the advertising system";
+    reference "RFC7770";
+  }
+
+  identity RI_FUNCTIONAL_CAPABILITIES {
+    base "RI_LSA_TLV_TYPES";
+    description
+      "Functional capabilities of the advertising system";
+    reference "RFC7770";
+  }
+
+  identity RI_NODE_ADMIN_TAG {
+    base "RI_LSA_TLV_TYPES";
+    description
+      "Operator-defined administrative tags associated with the advertising
+      system";
+    reference "RFC7777";
+  }
+
+  identity RI_SR_SID_LABEL_RANGE {
+    base "RI_LSA_TLV_TYPES";
+    description
+      "SID or Label ranges for use with segment routing when forwarding to
+      the advertising system";
+    reference "draft-ietf-ospf-segment-routing-extensions";
+  }
+
+  identity RI_SR_ALGORITHM {
+    base "RI_LSA_TLV_TYPES";
+    description
+      "The algorithms that are supported for segment routing by the
+      advertising system";
+    reference "draft-ietf-ospf-segment-routing-extensions";
+  }
+
+  // will be shared with IS-IS
+  identity SR_ALGORITHM {
+    description
+      "This identity is used as a base for the algorithms that can be
+      supported for segment routing and are advertised by a system in the RI
+      LSA";
+  }
+
+  identity SPF {
+    base "SR_ALGORITHM";
+    description
+      "The standard shortest path algorithm based on link metric,
+      as used by the OSPF protocol";
+  }
+
+  identity STRICT_SPF {
+    base "SR_ALGORITHM";
+    description
+      "The standard shortest path algorithm based on link metric, with the
+      requirement that all nodes along the path honor the SPF decision. That
+      is to say that the SPF decision cannot be altered by local policy at
+      the node";
+  }
+
+  identity OSPF_RI_SR_SID_LABEL_TLV_TYPES {
+    description
+      "This identity is used as a base for the sub-TLVs of the Segment
+      Routing SID/Label Range TLV";
+  }
+
+  identity SR_SID_LABEL_TLV {
+    base "OSPF_RI_SR_SID_LABEL_TLV_TYPES";
+    description
+      "A range of SID/Label values used by the local system";
+    reference "draft-ietf-ospf-segment-routing-extensions";
+  }
+
+  identity OSPFV2_ROUTER_LINK_TYPE {
+    description
+      "OSPFv2 Router Link Types as per the IANA registry defined in
+      RFC2740";
+  }
+
+  identity POINT_TO_POINT_LINK {
+    base "OSPFV2_ROUTER_LINK_TYPE";
+    description
+      "The link is a point-to-point connection to another router";
+  }
+
+  identity TRANSIT_NETWORK_LINK {
+    base "OSPFV2_ROUTER_LINK_TYPE";
+    description
+      "The link is a connection to a transit network";
+  }
+
+  identity STUB_NETWORK_LINK {
+    base "OSPFV2_ROUTER_LINK_TYPE";
+    description
+      "The link is a connection to a stub network";
+  }
+
+  identity VIRTUAL_LINK {
+    base "OSPFV2_ROUTER_LINK_TYPE";
+    description
+      "The link is a virtual connection to another router";
+  }
+
+  identity OSPFV2_EXTENDED_PREFIX_SUBTLV_TYPE {
+    description
+      "Sub-TLVs of the OSPFv2 Extended Prefix LSA as defined by
+      RFC7684";
+  }
+
+  identity EXTENDED_PREFIX_RANGE {
+    base "OSPFV2_EXTENDED_PREFIX_SUBTLV_TYPE";
+    description
+      "The attributes being described relate to a range of prefixes";
+  }
+
+  identity PREFIX_SID {
+    base "OSPFV2_EXTENDED_PREFIX_SUBTLV_TYPE";
+    description
+      "The TLV describes a Segment Routing Prefix Segment Identifier
+      associated with a prefix";
+  }
+
+  identity SID_LABEL_BINDING {
+    base "OSPFV2_EXTENDED_PREFIX_SUBTLV_TYPE";
+    description
+      "The TLV describes a binding of a SID to a path to the prefix,
+      which may have associated path characteristics";
+  }
+
+  identity OSPFV2_EXTENDED_PREFIX_SID_LABEL_BINDING_SUBTLV_TYPE {
+    description
+      "Sub-TLV types carried in the SID/Label Binding Sub-TLV of
+      the Extended Prefix Sub-TLV";
+  }
+
+  identity SID_MPLS_LABEL_BINDING {
+    base "OSPFV2_EXTENDED_PREFIX_SID_LABEL_BINDING_SUBTLV_TYPE";
+    description
+      "This sub-TLV indicates a binding between an SR SID and an
+      MPLS label and must be present in the sub-TLV";
+  }
+
+  identity ERO_METRIC {
+    base "OSPFV2_EXTENDED_PREFIX_SID_LABEL_BINDING_SUBTLV_TYPE";
+    description
+      "This sub-TLV indicates the cost of the ERO path being
+      advertised in the SID/Label TLV";
+  }
+
+  identity ERO_PATH {
+    base "OSPFV2_EXTENDED_PREFIX_SID_LABEL_BINDING_SUBTLV_TYPE";
+    description
+      "This sub-TLV indicates the path associated with an ERO
+      being advertised in the SID/Label TLV";
+  }
+
+  identity OSPFV2_EXTPREFIX_BINDING_ERO_PATH_SEGMENT_TYPE {
+    description
+      "The types of segment included within an ERO Path described
+      within the SID/Label binding sub-TLV";
+  }
+
+  identity IPV4_SEGMENT {
+    base "OSPFV2_EXTPREFIX_BINDING_ERO_PATH_SEGMENT_TYPE";
+    description
+      "The segment is specified as an IPv4 address";
+  }
+
+  identity UNNUMBERED_INTERFACE_SEGMENT {
+    base "OSPFV2_EXTPREFIX_BINDING_ERO_PATH_SEGMENT_TYPE";
+    description
+      "The segment is specified as an unnumbered interface of
+      a remote system";
+  }
+
+  identity OSPFV2_EXTENDED_LINK_SUBTLV_TYPE {
+    description
+      "Sub-TLVs of the Extended Link TLV for OSPFv2";
+  }
+
+  identity ADJACENCY_SID {
+    base "OSPFV2_EXTENDED_LINK_SUBTLV_TYPE";
+    description
+      "The extended link sub-TLV indicates an Adjacency SID";
+  }
+
+  identity MAX_METRIC_TRIGGER {
+    description
+      "Triggers which cause the maximum metric to be set for
+      entities advertised in OSPF";
+  }
+
+  identity MAX_METRIC_ON_SYSTEM_BOOT {
+    base "MAX_METRIC_TRIGGER";
+    description
+      "Set the maximum metric when the system boots.";
+  }
+
+  identity MAX_METRIC_INCLUDE {
+    description
+      "Entities that may optionally be included when advertising
+      the maximum metric.";
+  }
+
+  identity MAX_METRIC_INCLUDE_STUB {
+    base "MAX_METRIC_INCLUDE";
+    description
+      "Include stub networks when advertising the maximum metric.";
+  }
+
+  identity MAX_METRIC_INCLUDE_TYPE2_EXTERNAL {
+    base "MAX_METRIC_INCLUDE";
+    description
+      "Include OSPF Type 2 external routes when advertising
+      the maximum metric.";
+  }
+}

--- a/models/yang/common/openconfig-ospfv2-area-interface.yang
+++ b/models/yang/common/openconfig-ospfv2-area-interface.yang
@@ -1,0 +1,546 @@
+submodule openconfig-ospfv2-area-interface {
+
+  belongs-to openconfig-ospfv2 {
+    prefix "oc-ospfv2";
+  }
+
+  import ietf-yang-types { prefix "yang"; }
+  import openconfig-extensions { prefix "oc-ext"; }
+  import openconfig-types { prefix "oc-types"; }
+  import openconfig-interfaces { prefix "oc-if"; }
+  import openconfig-ospf-types { prefix "oc-ospf-types"; }
+  import openconfig-bfd { prefix "oc-bfd"; }
+
+  // include common submodule
+  include openconfig-ospfv2-common;
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This submodule provides OSPFv2 configuration and operational
+    state parameters that are specific to the area context";
+
+  oc-ext:openconfig-version "0.5.1";
+
+  revision "2023-11-01" {
+    description
+      "Refactor apply policy to separate default policy in it's own common
+      set of groupings";
+    reference "0.5.1";
+  }
+
+  revision "2023-08-25" {
+    description
+      "Add leaf metric to lsdb-summary-lsa-state.";
+    reference "0.5.0";
+  }
+
+  revision "2023-08-09" {
+    description
+      "Update interface key to use interface-id type";
+    reference "0.4.3";
+  }
+
+  revision "2023-07-05" {
+    description
+      "Fix typo in experimental-te leaf description.";
+    reference "0.4.2";
+  }
+
+  revision "2023-03-06" {
+    description
+      "Clarify use of interface-ref.";
+    reference "0.4.1";
+  }
+
+  revision "2022-02-10" {
+    description
+      "Fix spelling error in retransmission-queue-length leaf.";
+    reference "0.4.0";
+  }
+
+  revision "2021-07-28" {
+    description
+      "Add prefix to qualify when statements.";
+    reference "0.3.1";
+  }
+
+  revision "2021-03-17" {
+    description
+      "Add bfd support without augmentation.";
+    reference "0.3.0";
+  }
+
+  revision "2019-11-28" {
+    description
+      "Revert path changes in when statements in LSDB model";
+    reference "0.2.2";
+  }
+
+  revision "2019-11-05" {
+    description
+      "Fix paths in when statements in LSDB model";
+    reference "0.2.1";
+  }
+
+  revision "2019-07-09" {
+    description
+      "Normalise all timeticks64 to be expressed in nanoseconds.";
+    reference "0.2.0";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "0.1.3";
+  }
+
+  revision "2018-06-05" {
+    description
+      "Bug fixes in when statements in lsdb";
+    reference "0.1.2";
+  }
+
+  revision "2017-08-24" {
+    description
+      "Minor formatting fixes.";
+    reference "0.1.1";
+  }
+
+  revision "2017-02-28"{
+    description
+      "Initial public release of OSPFv2";
+    reference "0.1.0";
+  }
+
+  revision "2016-06-24" {
+    description
+      "Initial revision";
+    reference "0.0.1";
+  }
+
+  grouping ospfv2-area-interface-config {
+    description
+      "Configuration parameters for an OSPF interface";
+
+    leaf id {
+      type oc-if:interface-id;
+      description
+        "An operator-specified string utilised to uniquely
+        reference this interface";
+    }
+
+    leaf network-type {
+      type identityref {
+        base "oc-ospf-types:OSPF_NETWORK_TYPE";
+      }
+      description
+        "The type of network that OSPFv2 should use for the specified
+        interface.";
+    }
+
+    leaf priority {
+      type uint8;
+      description
+        "The local system's priority to become the designated
+        router";
+    }
+
+    leaf multi-area-adjacency-primary {
+      type boolean;
+      default true;
+      description
+        "When the specified interface is included in more than one
+        area's configuration, this leaf marks whether the area should
+        be considered the primary (when the value is true). In the
+        case that this value is false, the area is considered a
+        secondary area.";
+    }
+
+    leaf authentication-type {
+      type string;
+      // rjs TODO: discuss with bogdanov@ what the approach for auth
+      // links should be.
+      description
+        "The type of authentication that should be used on this
+        interface";
+    }
+
+    leaf metric {
+      type oc-ospf-types:ospf-metric;
+      description
+        "The metric for the interface";
+    }
+
+    leaf passive {
+      type boolean;
+      description
+        "When this leaf is set to true, the interface should be
+        advertised within the OSPF area but OSPF adjacencies should
+        not be established over the interface";
+    }
+
+    leaf hide-network {
+      type boolean;
+      description
+        "When this leaf is set to true, the network connected to
+        the interface should be hidden from OSPFv2 advertisements
+        per the procedure described in RFC6860.";
+      reference
+        "RFC6860 - Hiding Transit-Only Networks in OSFF";
+    }
+  }
+
+  grouping ospfv2-area-interface-timers-config {
+    description
+      "Configuration parameters relating to per-interface OSPFv2
+      timers";
+
+    leaf dead-interval {
+      type uint32;
+      units seconds;
+      description
+        "The number of seconds that the local system should let
+        elapse before declaring a silent router down";
+      reference "RFC2328";
+    }
+
+    leaf hello-interval {
+      type uint32;
+      units seconds;
+      description
+        "The number of seconds the local system waits between the
+        transmission of subsequent Hello packets";
+    }
+
+    leaf retransmission-interval {
+      type uint32;
+      units seconds;
+      description
+        "The number of seconds that the local system waits before
+        retransmitting an unacknowledged LSA.";
+    }
+  }
+
+  grouping ospfv2-area-interface-mpls-config {
+    description
+      "Configuration parameters relating to MPLS extensions for OSPF";
+
+    leaf traffic-engineering-metric {
+      type uint32;
+      description
+        "A link metric that should only be considered for traffic
+        engineering purposes.";
+      reference "RFC3630, §2.5.5";
+    }
+  }
+
+  grouping ospfv2-area-interface-neighbor-config {
+    description
+      "Configuration parameters relating to an individual neighbor
+      system on an interface within an OSPF area";
+
+    leaf router-id {
+      type yang:dotted-quad;
+      description
+        "The router ID of the remote system.";
+    }
+
+    leaf metric {
+      type oc-ospf-types:ospf-metric;
+      description
+        "The metric that should be considered to the remote neighbor
+        over this interface. This configuration is only applicable
+        for multiple-access networks";
+    }
+  }
+
+  grouping ospfv2-area-interface-neighbor-state {
+    description
+      "Operational state parameters relating an individual neighbor
+      system on an interface within an OSPF area";
+
+    leaf priority {
+      type uint8;
+      description
+        "The remote system's priority to become the designated
+        router";
+    }
+
+    leaf dead-time {
+      type oc-types:timeticks64;
+      description
+        "The time at which this neighbor's adjacency will be
+        considered dead. The value is expressed relative to
+        the Unix Epoch (Jan 1, 1970 00:00:00 UTC).";
+    }
+
+    leaf designated-router {
+      type yang:dotted-quad;
+      description
+        "The designated router for the adjacency. This device
+        advertises the Network LSA for broadcast and NBMA networks.";
+    }
+
+    leaf backup-designated-router {
+      type yang:dotted-quad;
+      description
+        "The backup designated router for the adjacency.";
+    }
+
+    leaf optional-capabilities {
+      // rjs TODO: should this be anything more than the hex-string
+      // this is currently what is shown in IOS/JUNOS
+      type yang:hex-string;
+      description
+        "The optional capabilities field received in the Hello
+        message from the neighbor";
+    }
+
+    leaf last-established-time {
+      type oc-types:timeticks64;
+      // rjs TODO: check implementations - is FULL considered 'up'
+      // since the adjacency is probably up since ExStart
+      description
+        "The time at which the adjacency was last established with
+        the neighbor. That is to say the time at which the
+        adjacency last transitioned into the FULL state. The
+        value is expressed relative to the Unix Epoch (Jan 1 1970
+        00:00:00 UTC).";
+    }
+
+    leaf adjacency-state {
+      type identityref {
+        base "oc-ospf-types:OSPF_NEIGHBOR_STATE";
+      }
+      description
+        "The state of the adjacency with the neighbor.";
+    }
+
+    leaf state-changes {
+      type uint32;
+      description
+        "The number of transitions out of the FULL state that this
+        neighbor has been through";
+    }
+
+    leaf retransmission-queue-length {
+      type uint32;
+      description
+        "The number of LSAs that are currently in the queue to be
+        retransmitted to the neighbor";
+    }
+  }
+
+  grouping ospfv2-area-interface-lsa-filter-config {
+    description
+      "Configuration options relating to filtering LSAs
+      on an interface.";
+
+    leaf all {
+      type boolean;
+      description
+        "When this leaf is set to true, all LSAs should be
+        filtered to the neighbours with whom adjacencies are
+        formed on the interface.";
+    }
+
+    // NB: this container can be augmented to add additional
+    // filtering options which exist in some implementations.
+  }
+
+  grouping ospfv2-area-interface-mpls-igp-ldp-sync-state {
+    description
+      "Operational state parameters relating to MPLS LDP/IGP
+      synchronization on a per-neighbor basis";
+
+    leaf synchronized {
+      type boolean;
+      description
+        "When the value of this leaf is set to true, the
+        LDP neighbors reachable via this interface are considered
+        to be synchronized, and hence the link is considered
+        usable by the IGP.";
+    }
+  }
+
+  grouping ospfv2-area-interfaces-structure {
+    description
+      "Structural grouping for configuration and operational state
+      parameters that relate to an interface";
+
+    container interfaces {
+      description
+        "Enclosing container for a list of interfaces enabled within
+        this area";
+
+      list interface {
+        key "id";
+
+        description
+          "List of interfaces which are enabled within this area.
+
+           The interface referenced is based on the interface and
+           subinterface leaves within the interface-ref container -
+           which reference an entry in the /interfaces/interface list -
+           and should not rely on the value of the list key.";
+
+        leaf id {
+          type leafref {
+            path "../config/id";
+          }
+          description
+            "A pointer to the identifier for the interface.";
+        }
+
+        container config {
+          description
+            "Configuration parameters for the interface on which
+            OSPFv2 is enabled";
+
+          uses ospfv2-area-interface-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state parameters for the interface on which
+            OSPFv2 is enabled";
+          uses ospfv2-area-interface-config;
+        }
+
+        uses oc-if:interface-ref;
+
+        container timers {
+          description
+            "Timers relating to OSPFv2 on the interface";
+
+          container config {
+            description
+              "Configuration parameters for OSPFv2 timers on the
+              interface";
+            uses ospfv2-area-interface-timers-config;
+          }
+
+          container state {
+            config false;
+            description
+              "Operational state parameters for OSPFv2 timers on
+              the interface";
+
+            uses ospfv2-area-interface-timers-config;
+          }
+        }
+
+        container mpls {
+          description
+            "Configuration and operational state parameters for
+            OSPFv2 extensions related to MPLS on the interface.";
+
+          container config {
+            description
+              "Configuration parameters for OSPFv2 extensions relating
+              to MPLS for the interface";
+            uses ospfv2-area-interface-mpls-config;
+          }
+
+          container state {
+            config false;
+            description
+              "Operational state for OSPFv2 extensions relating to
+              MPLS for the interface";
+            uses ospfv2-area-interface-mpls-config;
+          }
+
+          container igp-ldp-sync {
+            description
+              "OSPFv2 parameters relating to LDP/IGP synchronization";
+
+            container config {
+              description
+                "Configuration parameters relating to LDP/IG
+                synchronization.";
+              uses ospfv2-common-mpls-igp-ldp-sync-config;
+            }
+
+            container state {
+              config false;
+              description
+                "Operational state variables relating to LDP/IGP
+                synchronization";
+              uses ospfv2-common-mpls-igp-ldp-sync-config;
+              uses ospfv2-area-interface-mpls-igp-ldp-sync-state;
+            }
+          }
+        }
+
+        container lsa-filter {
+          description
+            "OSPFv2 parameters relating to filtering of LSAs to
+            neighbors the specified interface.";
+
+          container config {
+            description
+              "Configuration parameters relating to filtering LSAs
+              on the specified interface.";
+            uses ospfv2-area-interface-lsa-filter-config;
+          }
+
+          container state {
+            config false;
+            description
+              "Operational state parameters relating to filtering
+              LSAs on the specified interface";
+            uses ospfv2-area-interface-lsa-filter-config;
+          }
+        }
+
+        container neighbors {
+          description
+            "Enclosing container for the list of neighbors that
+            an adjacency has been established with on the interface";
+
+          list neighbor {
+            key "router-id";
+
+            description
+              "A neighbor with which an OSPFv2 adjacency has been
+              established within this area";
+
+            leaf router-id {
+              type leafref {
+                path "../config/router-id";
+              }
+              description
+                "Reference to the router ID of the adjacent system";
+            }
+
+            container config {
+              description
+                "Configuration parameters relating to the adjacent
+                system";
+              uses ospfv2-area-interface-neighbor-config;
+            }
+
+            container state {
+              config false;
+              description
+                "Operational state parameters relating to the adjacent
+                system";
+              uses ospfv2-area-interface-neighbor-config;
+              uses ospfv2-area-interface-neighbor-state;
+            }
+          }
+        }
+
+        uses oc-bfd:bfd-enable;
+      }
+    }
+  }
+
+}

--- a/models/yang/common/openconfig-ospfv2-area.yang
+++ b/models/yang/common/openconfig-ospfv2-area.yang
@@ -1,0 +1,242 @@
+submodule openconfig-ospfv2-area {
+
+  belongs-to openconfig-ospfv2 {
+    prefix "oc-ospfv2";
+  }
+
+  import openconfig-extensions { prefix "oc-ext"; }
+  import openconfig-ospf-types { prefix "oc-ospf-types"; }
+  import ietf-inet-types { prefix "inet"; }
+
+  // include other required submodules
+  include openconfig-ospfv2-area-interface;
+  include openconfig-ospfv2-lsdb;
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This submodule provides OSPFv2 configuration and operational
+    state parameters that are specific to the area context";
+
+  oc-ext:openconfig-version "0.5.1";
+
+  revision "2023-11-01" {
+    description
+      "Refactor apply policy to separate default policy in it's own common
+      set of groupings";
+    reference "0.5.1";
+  }
+
+  revision "2023-08-25" {
+    description
+      "Add leaf metric to lsdb-summary-lsa-state.";
+    reference "0.5.0";
+}
+
+  revision "2023-08-09" {
+    description
+      "Update interface key to use interface-id type";
+    reference "0.4.3";
+  }
+
+  revision "2023-07-05" {
+    description
+      "Fix typo in experimental-te leaf description.";
+    reference "0.4.2";
+  }
+
+  revision "2023-03-06" {
+    description
+      "Clarify use of interface-ref.";
+    reference "0.4.1";
+  }
+
+  revision "2022-02-10" {
+    description
+      "Fix spelling error in retransmission-queue-length leaf.";
+    reference "0.4.0";
+  }
+
+  revision "2021-07-28" {
+    description
+      "Add prefix to qualify when statements.";
+    reference "0.3.1";
+  }
+
+  revision "2021-03-17" {
+    description
+      "Add bfd support without augmentation.";
+    reference "0.3.0";
+  }
+
+  revision "2019-11-28" {
+    description
+      "Revert path changes in when statements in LSDB model";
+    reference "0.2.2";
+  }
+
+  revision "2019-11-05" {
+    description
+      "Fix paths in when statements in LSDB model";
+    reference "0.2.1";
+  }
+
+  revision "2019-07-09" {
+    description
+      "Normalise all timeticks64 to be expressed in nanoseconds.";
+    reference "0.2.0";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "0.1.3";
+  }
+
+  revision "2018-06-05" {
+    description
+      "Bug fixes in when statements in lsdb";
+    reference "0.1.2";
+  }
+
+  revision "2017-08-24" {
+    description
+      "Minor formatting fixes.";
+    reference "0.1.1";
+  }
+
+  revision "2017-02-28"{
+    description
+      "Initial public release of OSPFv2";
+    reference "0.1.0";
+  }
+
+  revision "2016-06-24" {
+    description
+      "Initial revision";
+    reference "0.0.1";
+  }
+
+  grouping ospfv2-area-config {
+    description
+      "Configuration parameters relating to an OSPF area";
+
+    leaf identifier {
+      type oc-ospf-types:ospf-area-identifier;
+      description
+        "An identifier for the OSPFv2 area - described as either a
+        32-bit unsigned integer, or a dotted-quad";
+    }
+  }
+
+  grouping ospfv2-area-mpls-config {
+    description
+      "Configuration parameters relating to OSPFv2 extensions for
+      MPLS";
+
+    leaf traffic-engineering-enabled {
+      type boolean;
+      description
+        "Specifies whether traffic engineering extensions should be
+        advertised within the area";
+    }
+  }
+
+  grouping ospfv2-area-virtual-link-config {
+    description
+      "Configuration parameters relating to a virtual-link within
+      the OSPF area";
+
+    leaf remote-router-id {
+      type inet:ipv4-address-no-zone;
+      description
+        "The router ID of the device which terminates the remote end
+        of the virtual link";
+    }
+  }
+
+  grouping ospfv2-area-structure {
+    description
+      "Structural grouping for configuration and operational state
+      parameters that relate to an individual area";
+
+    container config {
+      description
+        "Configuration parameters relating to an OSPFv2 area";
+
+      uses ospfv2-area-config;
+    }
+
+    container state {
+      config false;
+      description
+        "Operational state parameters relating to an OSPFv2 area";
+      uses ospfv2-area-config;
+    }
+
+    container mpls {
+      description
+        "Configuration and operational state parameters for OSPFv2
+        extensions relating to MPLS";
+
+      container config {
+        description
+          "Configuration parameters relating to MPLS extensions for
+          OSPFv2";
+        uses ospfv2-area-mpls-config;
+      }
+
+      container state {
+        config false;
+        description
+          "Operational state parameters relating to MPLS extensions
+          for OSPFv2";
+        uses ospfv2-area-mpls-config;
+      }
+    }
+
+    uses ospfv2-lsdb-structure;
+    uses ospfv2-area-interfaces-structure;
+
+    container virtual-links {
+      description
+        "Configuration and state parameters relating to virtual
+        links from the source area to a remote router";
+
+      list virtual-link {
+        key "remote-router-id";
+
+        description
+          "Configuration and state parameters relating to a
+          virtual link";
+
+        leaf remote-router-id {
+          type leafref {
+            path "../config/remote-router-id";
+          }
+          description
+            "Reference to the remote router ID";
+        }
+
+        container config {
+          description
+            "Configuration parameters relating to the OSPF virtual link";
+          uses ospfv2-area-virtual-link-config;
+        }
+
+        container state {
+          config false;
+          description
+            "State parameters relating to the OSPF virtual link";
+          uses ospfv2-area-virtual-link-config;
+          uses ospfv2-area-interface-neighbor-state;
+        }
+      }
+    }
+  }
+}

--- a/models/yang/common/openconfig-ospfv2-common.yang
+++ b/models/yang/common/openconfig-ospfv2-common.yang
@@ -1,0 +1,164 @@
+submodule openconfig-ospfv2-common {
+
+  belongs-to openconfig-ospfv2 {
+    prefix "oc-ospfv2";
+  }
+
+  import openconfig-extensions { prefix "oc-ext"; }
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This submodule provides OSPFv2 configuration and operational
+    state parameters that are shared across multiple contexts";
+
+  oc-ext:openconfig-version "0.5.1";
+
+  revision "2023-11-01" {
+    description
+      "Refactor apply policy to separate default policy in it's own common
+      set of groupings";
+    reference "0.5.1";
+  }
+
+  revision "2023-08-25" {
+    description
+      "Add leaf metric to lsdb-summary-lsa-state.";
+    reference "0.5.0";
+}
+
+  revision "2023-08-09" {
+    description
+      "Update interface key to use interface-id type";
+    reference "0.4.3";
+  }
+
+  revision "2023-07-05" {
+    description
+      "Fix typo in experimental-te leaf description.";
+    reference "0.4.2";
+  }
+
+  revision "2023-03-06" {
+    description
+      "Clarify use of interface-ref.";
+    reference "0.4.1";
+  }
+
+  revision "2022-02-10" {
+    description
+      "Fix spelling error in retransmission-queue-length leaf.";
+    reference "0.4.0";
+  }
+
+  revision "2021-07-28" {
+    description
+      "Add prefix to qualify when statements.";
+    reference "0.3.1";
+  }
+
+  revision "2021-03-17" {
+    description
+      "Add bfd support without augmentation.";
+    reference "0.3.0";
+  }
+
+  revision "2019-11-28" {
+    description
+      "Revert path changes in when statements in LSDB model";
+    reference "0.2.2";
+  }
+
+  revision "2019-11-05" {
+    description
+      "Fix paths in when statements in LSDB model";
+    reference "0.2.1";
+  }
+
+  revision "2019-07-09" {
+    description
+      "Normalise all timeticks64 to be expressed in nanoseconds.";
+    reference "0.2.0";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "0.1.3";
+  }
+
+  revision "2018-06-05" {
+    description
+      "Bug fixes in when statements in lsdb";
+    reference "0.1.2";
+  }
+
+  revision "2017-08-24" {
+    description
+      "Minor formatting fixes.";
+    reference "0.1.1";
+  }
+
+  revision "2017-02-28"{
+    description
+      "Initial public release of OSPFv2";
+    reference "0.1.0";
+  }
+
+  revision "2016-06-24" {
+    description
+      "Initial revision";
+    reference "0.0.1";
+  }
+
+  grouping ospfv2-common-mpls-igp-ldp-sync-config {
+    description
+      "Configuration parameters used for OSPFv2 MPLS/IGP
+      synchronization";
+
+    leaf enabled {
+      type boolean;
+      description
+        "When this leaf is set to true, do not utilise this link for
+        forwarding via the IGP until such time as LDP adjacencies to
+        the neighbor(s) over the link are established.";
+    }
+
+    leaf post-session-up-delay {
+      type uint32;
+      units milliseconds;
+      description
+        "This leaf specifies a delay, expressed in units of milliseconds,
+        between the LDP session to the IGP neighbor being established, and
+        it being considered synchronized by the IGP.";
+    }
+  }
+
+  grouping ospfv2-common-timers {
+    description
+      "Common definition of the type of timers that the OSPFv2 implementation
+      uses";
+
+    leaf timer-type {
+      type enumeration {
+        enum LINEAR_BACKOFF {
+          description
+            "The backoff used by the OSPFv2 implementation is linear, such that
+            a common delay is added following each event.";
+        }
+        enum EXPONENTIAL_BACKOFF {
+          description
+            "The backoff used by the OSPFv2 implementation is exponential, such
+            that the delay added following each event increases.";
+        }
+      }
+      description
+        "The timer mode that is utilised by the implementation.";
+    }
+  }
+}

--- a/models/yang/common/openconfig-ospfv2-global.yang
+++ b/models/yang/common/openconfig-ospfv2-global.yang
@@ -1,0 +1,583 @@
+submodule openconfig-ospfv2-global {
+
+  belongs-to openconfig-ospfv2 {
+    prefix "oc-ospfv2";
+  }
+
+  import ietf-yang-types { prefix "yang"; }
+  import openconfig-extensions { prefix "oc-ext"; }
+  import openconfig-routing-policy { prefix "oc-rpol"; }
+  import openconfig-ospf-types { prefix "oc-ospft"; }
+
+  // Include common submodule
+  include openconfig-ospfv2-common;
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This submodule provides OSPFv2 configuration and operational
+    state parameters that are global to a particular OSPF instance";
+
+  oc-ext:openconfig-version "0.5.1";
+
+  revision "2023-11-01" {
+    description
+      "Refactor apply policy to separate default policy in it's own common
+      set of groupings";
+    reference "0.5.1";
+  }
+
+  revision "2023-08-25" {
+    description
+      "Add leaf metric to lsdb-summary-lsa-state.";
+    reference "0.5.0";
+  }
+
+  revision "2023-08-09" {
+    description
+      "Update interface key to use interface-id type";
+    reference "0.4.3";
+  }
+
+  revision "2023-07-05" {
+    description
+      "Fix typo in experimental-te leaf description.";
+    reference "0.4.2";
+  }
+
+  revision "2023-03-06" {
+    description
+      "Clarify use of interface-ref.";
+    reference "0.4.1";
+  }
+
+  revision "2022-02-10" {
+    description
+      "Fix spelling error in retransmission-queue-length leaf.";
+    reference "0.4.0";
+  }
+
+  revision "2021-07-28" {
+    description
+      "Add prefix to qualify when statements.";
+    reference "0.3.1";
+  }
+
+  revision "2021-03-17" {
+    description
+      "Add bfd support without augmentation.";
+    reference "0.3.0";
+  }
+
+  revision "2019-11-28" {
+    description
+      "Revert path changes in when statements in LSDB model";
+    reference "0.2.2";
+  }
+
+  revision "2019-11-05" {
+    description
+      "Fix paths in when statements in LSDB model";
+    reference "0.2.1";
+  }
+
+  revision "2019-07-09" {
+    description
+      "Normalise all timeticks64 to be expressed in nanoseconds.";
+    reference "0.2.0";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "0.1.3";
+  }
+
+  revision "2018-06-05" {
+    description
+      "Bug fixes in when statements in lsdb";
+    reference "0.1.2";
+  }
+
+  revision "2017-08-24" {
+    description
+      "Minor formatting fixes.";
+    reference "0.1.1";
+  }
+
+  revision "2017-02-28"{
+    description
+      "Initial public release of OSPFv2";
+    reference "0.1.0";
+  }
+
+  revision "2016-06-24" {
+    description
+      "Initial revision";
+    reference "0.0.1";
+  }
+
+  grouping ospfv2-global-config {
+    description
+      "Global configuration for OSPFv2";
+
+    leaf router-id {
+      type yang:dotted-quad;
+      description
+        "A 32-bit number represented as a dotted quad assigned to
+        each router running the OSPFv2 protocol. This number should
+        be unique within the autonomous system";
+      reference "rfc2828";
+    }
+
+    leaf summary-route-cost-mode {
+      type enumeration {
+        enum RFC1583_COMPATIBLE {
+          description
+            "Specify that summary routes should assume the cost of
+            the lowest-cost more-specific route as per the behaviour
+            specified in RFC1583";
+        }
+        enum RFC2328_COMPATIBLE {
+          description
+            "Specify that summary routes should assume the cost of the
+            highest-cost more-specific route as per the revised
+            behaviour specified in RFC2328";
+        }
+      }
+      default "RFC2328_COMPATIBLE";
+      description
+        "Specify how costs for the summary routes should be specified
+        as per the behaviour in the original OSPF specification
+        RFC1583, or alternatively whether the revised behaviour
+        described in RFC2328 should be utilised";
+    }
+
+    leaf igp-shortcuts {
+      type boolean;
+      description
+        "When this leaf is set to true, OSPFv2 will route traffic to
+        a remote system via any LSP to the system that is marked as
+        shortcut eligible.";
+    }
+
+    leaf log-adjacency-changes {
+      type boolean;
+      description
+        "When this leaf is set to true, a log message will be
+        generated when the state of an OSPFv2 neighbour changes.";
+    }
+
+    leaf hide-transit-only-networks {
+      type boolean;
+      description
+        "When this leaf is set to true, do not advertise prefixes
+        into OSPFv2 that correspond to transit interfaces, as per
+        the behaviour discussed in RFC6860.";
+      reference
+        "RFC6860 - Hiding Transit-Only Networks in OSPF";
+    }
+  }
+
+  grouping ospfv2-global-spf-timers-config {
+    description
+      "Configuration parameters relating to global SPF timer
+      parameters for OSPFv2";
+
+    leaf initial-delay {
+      // rjs TODO: IS-IS model has this as decimal64 - should it be
+      // that or uint32 msec?
+      type uint32;
+      units msec;
+      description
+        "The value of this leaf specifies the time between a change
+        in topology being detected and the first run of the SPF
+        algorithm.";
+    }
+
+    leaf maximum-delay {
+      // rjs TODO: same question as above
+      type uint32;
+      units msec;
+      description
+        "The value of this leaf specifies the maximum delay between
+        a topology change being detected and the SPF algorithm
+        running. This value is used for implementations that support
+        increasing the wait time between SPF runs.";
+    }
+
+    // rjs TODO: some questions here around what we should specify:
+    // JUNOS has rapid-runs and holddown
+    // Cisco has maximum time between runs, and then a doubling of
+    // the wait interval up to that maximum.
+    // ALU has first-wait, second-wait, max-wait
+  }
+
+  grouping ospfv2-global-lsa-generation-timers-config {
+    description
+      "Configuration parameters relating to global LSA generation
+      parameters for OSPFv2";
+
+    leaf initial-delay {
+      type uint32;
+      units msec;
+      description
+        "The value of this leaf specifies the time between the first
+        time an LSA is generated and advertised and the subsequent
+        generation of that LSA.";
+    }
+
+    leaf maximum-delay {
+      type uint32;
+      units msec;
+      description
+        "The value of this leaf specifies the maximum time between the
+        generation of an LSA and the subsequent re-generation of that
+        LSA. This value is used in implementations that support
+        increasing delay between generation of an LSA";
+    }
+  }
+
+  grouping ospfv2-global-spf-timers-state {
+    description
+      "Operational state parameters relating to OSPFv2 global
+      timers";
+
+    uses ospfv2-common-timers;
+  }
+
+  grouping ospfv2-global-lsa-generation-timers-state {
+    description
+      "Operational state parameters relating to OSPFv2 global
+      timers";
+
+    uses ospfv2-common-timers;
+  }
+
+  grouping ospfv2-global-graceful-restart-config {
+    description
+      "Configuration parameters relating to graceful restart for
+      OSPFv2";
+
+    leaf enabled {
+      type boolean;
+      description
+        "When the value of this leaf is set to true, graceful restart
+        is enabled on the local system. In this case, the system will
+        use Grace-LSAs to signal that it is restarting to its
+        neighbors.";
+    }
+
+    leaf helper-only {
+      type boolean;
+      description
+        "Operate graceful-restart only in helper mode. When this leaf
+        is set to true, the local system does not use Grace-LSAs to
+        indicate that it is restarting, but will accept Grace-LSAs
+        from remote systems, and suppress withdrawl of adjacencies
+        of the system for the grace period specified";
+    }
+  }
+
+  grouping ospfv2-global-mpls-config {
+    description
+      "Configuration parameters for OSPFv2 options which
+      relate to MPLS";
+
+    leaf traffic-engineering-extensions {
+      type boolean;
+      description
+        "When this leaf is set to true, use traffic engineering
+        extensions for OSPF to advertise TE parameters via type 10
+        Opaque LSAs";
+    }
+  }
+
+  grouping ospfv2-global-inter-areapp-config {
+    description
+      "Configuration parameters for OSPFv2 policies which propagate
+      prefixes between areas";
+
+    leaf src-area {
+      type leafref {
+        // we are at ospf/global/inter-area-propagation-policies/...
+        // inter-area-propagation-policy/config/src-area
+        path "../../../../../areas/area/identifier";
+      }
+      description
+        "The area from which prefixes are to be exported.";
+    }
+
+    leaf dst-area {
+      type leafref {
+        // we are at ospf/global/inter-area-propagation-policies/...
+        // inter-area-propagation-policy/config/src-area
+        path "../../../../../areas/area/identifier";
+      }
+      description
+        "The destination area to which prefixes are to be imported";
+    }
+
+    uses oc-rpol:apply-policy-import-config;
+    uses oc-rpol:default-policy-import-config;
+  }
+
+  grouping ospfv2-global-max-metric-config {
+    description
+      "Configuration paramters relating to setting the OSPFv2
+      maximum metric.";
+
+    leaf set {
+      type boolean;
+      description
+        "When this leaf is set to true, all non-stub interfaces of
+        the local system are advertised with the maximum metric,
+        such that the router does not act as a transit system,
+        (similarly to the IS-IS overload functionality).";
+      reference
+        "RFC3137 - OSPF Stub Router Advertisement";
+    }
+
+    leaf timeout {
+      type uint64;
+      units "seconds";
+      description
+        "The delay, in seconds, after which the advertisement of
+        entities with the maximum metric should be cleared, and
+        the system reverts to the default, or configured, metrics.";
+    }
+
+    leaf-list include {
+      type identityref {
+        base "oc-ospft:MAX_METRIC_INCLUDE";
+      }
+      description
+        "By default, the maximum metric is advertised for all
+        non-stub interfaces of a device. When identities are
+        specified within this leaf-list, additional entities
+        are also advertised with the maximum metric according
+        to the values within the list.";
+    }
+
+    leaf-list trigger {
+      type identityref {
+        base "oc-ospft:MAX_METRIC_TRIGGER";
+      }
+      description
+        "By default, the maximum metric is only advertised
+        when the max-metric/set leaf is specified as true.
+        In the case that identities are specified within this
+        list, they provide additional triggers (e.g., system
+        boot) that may cause the max-metric to be set. In this
+        case, the system should still honour the timeout specified
+        by the max-metric/timeout leaf, and clear the max-metric
+        advertisements after the expiration of this timer.";
+    }
+  }
+
+  grouping ospfv2-global-structural {
+    description
+      "Top level structural grouping for OSPFv2 global parameters";
+
+    container global {
+      description
+        "Configuration and operational state parameters for settings
+        that are global to the OSPFv2 instance";
+
+      container config {
+        description
+          "Global configuration parameters for OSPFv2";
+        uses ospfv2-global-config;
+      }
+
+      container state {
+        config false;
+        description
+          "Operational state parameters for OSPFv2";
+        uses ospfv2-global-config;
+      }
+
+      container timers {
+        description
+          "Configuration and operational state parameters for OSPFv2
+          timers";
+
+        container spf {
+          description
+            "Configuration and operational state parameters relating
+            to timers governing the operation of SPF runs";
+
+          container config {
+            description
+              "Configuration parameters relating to global OSPFv2
+              SPF timers";
+            uses ospfv2-global-spf-timers-config;
+          }
+
+          container state {
+            config false;
+            description
+              "Operational state parameters relating to the global
+              OSPFv2 SPF timers";
+            uses ospfv2-global-spf-timers-config;
+            uses ospfv2-global-spf-timers-state;
+          }
+        }
+
+        container max-metric {
+          description
+            "Configuration and operational state parameters relating
+            to setting the OSPFv2 maximum metric.";
+
+          container config {
+            description
+              "Configuration parameters relating to setting the OSPFv2
+              maximum metric for a set of advertised entities.";
+            uses ospfv2-global-max-metric-config;
+          }
+
+          container state {
+            config false;
+            description
+              "Operational state parameters relating to setting the
+              OSPFv2 maximum metric for a set of advertised entities.";
+            uses ospfv2-global-max-metric-config;
+          }
+        }
+
+        container lsa-generation {
+          description
+            "Configuration and operational state parameters relating
+            to timers governing the generation of LSAs by the local
+            system";
+
+          container config {
+            description
+              "Configuration parameters relating to the generation of
+              LSAs by the local system";
+            uses ospfv2-global-lsa-generation-timers-config;
+          }
+
+          container state {
+            config false;
+            description
+              "Operational state parameters relating to the generation
+              of LSAs by the local system";
+            uses ospfv2-global-lsa-generation-timers-config;
+            uses ospfv2-global-lsa-generation-timers-state;
+          }
+        }
+      }
+
+      container graceful-restart {
+        description
+          "Configuration and operational state parameters for OSPFv2
+          graceful restart";
+
+        container config {
+          description
+            "Configuration parameters relating to OSPFv2 graceful
+            restart";
+          uses ospfv2-global-graceful-restart-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state parameters relating to OSPFv2 graceful
+            restart";
+          uses ospfv2-global-graceful-restart-config;
+        }
+      }
+
+      container mpls {
+        description
+          "OSPFv2 parameters relating to MPLS";
+
+        container config {
+          description
+            "Configuration parameters relating to MPLS for OSPFv2";
+          uses ospfv2-global-mpls-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state parameters relating to MPLS for
+            OSPFv2";
+          uses ospfv2-global-mpls-config;
+        }
+
+        container igp-ldp-sync {
+          description
+            "OSPFv2 parameters relating to LDP/IGP synchronization";
+
+          container config {
+            description
+              "Configuration parameters relating to LDP/IG
+              synchronization.";
+            uses ospfv2-common-mpls-igp-ldp-sync-config;
+          }
+
+          container state {
+            config false;
+            description
+              "Operational state variables relating to LDP/IGP
+              synchronization";
+            uses ospfv2-common-mpls-igp-ldp-sync-config;
+          }
+        }
+      }
+
+      container inter-area-propagation-policies {
+        description
+          "Policies defining how inter-area propagation should be performed
+          by the OSPF instance";
+
+        list inter-area-propagation-policy {
+          key "src-area dst-area";
+          description
+            "A list of connections between pairs of areas - routes are
+            propagated from the source (src) area to the destination (dst)
+            area according to the policy specified";
+
+          leaf src-area {
+            type leafref {
+              path "../config/src-area";
+            }
+            description
+              "Reference to the source area";
+          }
+
+          leaf dst-area {
+            type leafref {
+              path "../config/dst-area";
+            }
+            description
+              "Reference to the destination area";
+          }
+
+          container config {
+            description
+              "Configuration parameters relating to the inter-area
+              propagation policy";
+            uses ospfv2-global-inter-areapp-config;
+          }
+
+          container state {
+            config false;
+            description
+              "Operational state parameters relating to the inter-area
+              propagation policy";
+            uses ospfv2-global-inter-areapp-config;
+          }
+        }
+      }
+    }
+  }
+}

--- a/models/yang/common/openconfig-ospfv2-lsdb.yang
+++ b/models/yang/common/openconfig-ospfv2-lsdb.yang
@@ -1,0 +1,2434 @@
+submodule openconfig-ospfv2-lsdb {
+
+  belongs-to openconfig-ospfv2 {
+    prefix "oc-ospfv2";
+  }
+
+  // import some basic types
+  import ietf-yang-types { prefix "yang"; }
+  import ietf-inet-types { prefix "inet"; }
+  import openconfig-types { prefix "oc-types"; }
+  import openconfig-extensions { prefix "oc-ext"; }
+  import openconfig-ospf-types { prefix "oc-ospf-types"; }
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "An OpenConfig model for the Open Shortest Path First (OSPF)
+    version 2 link-state database (LSDB)";
+
+  oc-ext:openconfig-version "0.5.1";
+
+  revision "2023-11-01" {
+    description
+      "Refactor apply policy to separate default policy in it's own common
+      set of groupings";
+    reference "0.5.1";
+  }
+
+  revision "2023-08-25" {
+    description
+      "Add leaf metric to lsdb-summary-lsa-state.";
+    reference "0.5.0";
+}
+  revision "2023-08-09" {
+    description
+      "Update interface key to use interface-id type";
+    reference "0.4.3";
+  }
+
+  revision "2023-07-05" {
+    description
+      "Fix typo in experimental-te leaf description.";
+    reference "0.4.2";
+  }
+
+  revision "2023-03-06" {
+    description
+      "Clarify use of interface-ref.";
+    reference "0.4.1";
+  }
+
+  revision "2022-02-10" {
+    description
+      "Fix spelling error in retransmission-queue-length leaf.";
+    reference "0.4.0";
+  }
+
+  revision "2021-07-28" {
+    description
+      "Add prefix to qualify when statements.";
+    reference "0.3.1";
+  }
+
+  revision "2021-03-17" {
+    description
+      "Add bfd support without augmentation.";
+    reference "0.3.0";
+  }
+
+  revision "2019-11-28" {
+    description
+      "Revert path changes in when statements in LSDB model";
+    reference "0.2.2";
+  }
+
+  revision "2019-11-05" {
+    description
+      "Fix paths in when statements in LSDB model";
+    reference "0.2.1";
+  }
+
+  revision "2019-07-09" {
+    description
+      "Normalise all timeticks64 to be expressed in nanoseconds.";
+    reference "0.2.0";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "0.1.3";
+  }
+
+  revision "2018-06-05" {
+    description
+      "Bug fixes in when statements in lsdb";
+    reference "0.1.2";
+  }
+
+  revision "2017-08-24" {
+    description
+      "Minor formatting fixes.";
+    reference "0.1.1";
+  }
+
+  revision "2017-02-28"{
+    description
+      "Initial public release of OSPFv2";
+    reference "0.1.0";
+  }
+
+  revision "2016-06-24" {
+    description
+      "Initial revision";
+    reference "0.0.1";
+  }
+
+  grouping ospfv2-lsdb-common-prefix-properties {
+    description
+      "Common properties used in the LSDB that relate to IPv4 prefixes";
+
+    leaf prefix-length {
+      type uint8 {
+        range "0..32";
+      }
+      description
+        "The length of the IPv4 prefix contained in the Extended Prefix LSA";
+    }
+
+    leaf address-family {
+      // TODO: should this be an identity?
+      type enumeration {
+        enum IPV4_UNICAST {
+          value 0;
+          description
+            "The prefix contained within the Extended Prefix LSA is an IPv4
+            unicast prefix";
+        }
+      }
+      description
+        "The address family of the prefix contained in the Extended Prefix
+        LSA";
+    }
+  }
+
+  grouping ospfv2-lsdb-common-link-specification {
+    description
+      "Generic attributes used to identify links within OSPFv2";
+
+    leaf link-id {
+      type yang:dotted-quad;
+      description
+        "The identifier for the link specified. The value of the link
+        identifier is dependent upon the type of the LSA. The value is
+        specified to be, per sub-type:
+          1) Neighbouring router's router ID.
+          2) IP address of DR.
+          3) IP network address.
+          4) Neighbouring router router's ID.";
+    }
+
+    leaf link-data {
+      type union {
+        type yang:dotted-quad;
+        type uint32;
+      }
+      description
+        "The data associated with the link type. The value is
+        dependent upon the subtype of the LSA. When the connection is
+        to a stub network it represents the mask; for p2p connections
+        that are unnumbered it represents the ifIndex value of the
+        router's interface; for all other connections it represents
+        the local system's IP address";
+    }
+
+  }
+
+  grouping ospfv2-lsdb-common-unknown-tlv {
+    description
+      "A generic specification of a TLV to be used when the
+      value cannot be decoded by the local system";
+
+    leaf type {
+      type uint16;
+      description
+        "The type value of the unknown TLV";
+    }
+
+    leaf length {
+      type uint16;
+      description
+        "The length value of the unknown TLV";
+    }
+
+    leaf value {
+      type binary;
+      description
+        "The value portion of the unknwon TLV";
+    }
+  }
+
+  grouping ospfv2-lsdb-common-unknown-tlv-structure {
+    description
+      "A generic specification of an unknown TLV";
+
+    container unknown-tlv {
+      description
+        "An unknown TLV within the context. Unknown TLVs are
+        defined to be the set of TLVs that are not modelled
+        within the OpenConfig model, or are unknown to the
+        local system such that it cannot decode their value.";
+
+      container state {
+        description
+          "Contents of an unknown TLV within the LSA";
+        uses ospfv2-lsdb-common-unknown-tlv;
+      }
+    }
+  }
+
+  grouping ospfv2-lsdb-common-unknown-subtlv-structure {
+    description
+      "A generic specification of an unknown TLV";
+
+    container unknown-subtlv {
+      description
+        "An unknown SubTLV within the context. Unknown Sub-TLV
+        are defined to be the set of SubTLVs that are not modelled
+        by the OpenConfig schema, or are unknown to the local system
+        such that it cannot decode their value.";
+
+      container state {
+        description
+          "Contents of an unknown TLV within the LSA";
+        uses ospfv2-lsdb-common-unknown-tlv;
+      }
+    }
+  }
+
+  grouping ospfv2-lsdb-common-tos-metric {
+    description
+      "Common LSDB LSA parameters for type of service and metric";
+
+    leaf tos {
+      type uint8;
+      description
+        "OSPF encoding of the type of service referred to by this
+        LSA. Encoding for OSPF TOS are described in RFC2328.";
+    }
+
+    leaf metric {
+      type oc-ospf-types:ospf-metric;
+      description
+        "The metric value to be used for the TOS specified. This value
+        represents the cost of use of the link for the specific type
+        of service.";
+    }
+  }
+
+  grouping ospfv2-lsdb-common-sr-sid-spec {
+    description
+      "Re-usable specification of a segment routing SID";
+
+    leaf sid-type {
+      type oc-ospf-types:sr-sid-type;
+      description
+        "The type of the value contained within the sub-TLV";
+    }
+
+    leaf sid-value {
+      type uint32;
+      description
+        "The value of the binding included within the sub-TLV. The type of
+        this binding is indicated by the type leaf.";
+    }
+  }
+
+  grouping ospfv2-lsdb-area-state {
+    description
+      "Per-area operational state parameters for an OSPFv2 area";
+
+    leaf identifier {
+      type oc-ospf-types:ospf-area-identifier;
+      description
+        "An identifier for the area, expressed as a dotted quad or
+        an unsigned 32-bit integer";
+    }
+  }
+
+  grouping ospfv2-lsdb-area-lsa-type-state {
+    description
+      "Per-LSA type operational state parameters for an OSPFv2 area";
+
+    leaf type {
+      type identityref {
+        base "oc-ospf-types:OSPF_LSA_TYPE";
+      }
+      description
+        "The type of LSA being described. The type of the LSA is
+        expressed as a canonical name.";
+    }
+  }
+
+  grouping ospfv2-lsdb-area-lsa-state {
+    description
+      "Generic parameters of an OSPFv2 LSA";
+
+    leaf link-state-id {
+      type yang:dotted-quad;
+      description
+        "The Link State ID for the specified LSA type. The exact
+        defined value of the Link State ID is dependent on the LSA
+        type.";
+    }
+
+    leaf advertising-router {
+      type yang:dotted-quad;
+      description
+        "The router ID of the router that originated the LSA";
+    }
+
+    leaf sequence-number {
+      type int32;
+      description
+        "A signed 32-bit integer used to detect old and duplicate
+        LSAs. The greater the sequence number the more recent the
+        LSA.";
+    }
+
+    leaf checksum {
+      type uint16;
+      description
+        "The checksum of the complete contents of the LSA excluding
+        the age field.";
+    }
+
+    leaf age {
+      type uint16;
+      units seconds;
+      description
+        "The time since the LSA's generation in seconds";
+    }
+  }
+
+  grouping ospfv2-lsdb-router-lsa-structure {
+    description
+      "Structural grouping for Router LSA contents within the LSDB";
+
+    container router-lsa {
+      description
+        "Contents of the router LSA";
+
+      container state {
+        description
+          "State parameters of the router LSA";
+        uses ospfv2-lsdb-router-lsa-state;
+      }
+
+      uses ospfv2-lsdb-generic-lsa-tos-metric-structure;
+    }
+  }
+
+  grouping ospfv2-lsdb-generic-lsa-tos-metric-structure {
+    description
+      "Grouping including a generic TOS/metric structure for an
+      LSA";
+
+    container types-of-service {
+      description
+        "Breakdown of LSA contents specifying multiple
+        TOS values";
+
+      list type-of-service {
+        key "tos";
+        description
+          "Per-type of service parameters for the LSA";
+
+        leaf tos {
+          type leafref {
+            path "../state/tos";
+          }
+          description
+            "Reference to the type of service identifier which is
+            specified in the LSA";
+        }
+
+        container state {
+          description
+            "Per-TOS parameters for the LSA";
+
+          uses ospfv2-lsdb-generic-lsa-tos-metric-state;
+        }
+      }
+    }
+  }
+
+  grouping ospfv2-lsdb-network-lsa-structure {
+    description
+      "Structural grouping for Network LSA contents within the LSDB";
+
+    container network-lsa {
+      description
+        "Contents of the network LSA";
+
+      container state {
+        description
+          "State parameters of the network LSA";
+        uses ospfv2-lsdb-network-lsa-state;
+      }
+    }
+  }
+
+  grouping ospfv2-lsdb-summary-lsa-structure {
+    description
+      "Structural grouping for the Summary LSA contents within the
+      LSDB";
+
+    container summary-lsa {
+      description
+        "Contents of the summary LSA";
+
+      container state {
+        description
+          "State parameters of the summary LSA";
+        uses ospfv2-lsdb-summary-lsa-state;
+      }
+
+      uses ospfv2-lsdb-generic-lsa-tos-metric-structure;
+    }
+  }
+
+  grouping ospfv2-lsdb-asexternal-lsa-structure {
+    description
+      "Structural grouping for the AS External LSA contents within
+      the LSDB";
+
+    container as-external-lsa {
+      description
+        "Contents of the AS External LSA";
+
+      container state {
+        description
+          "State parameters for the AS external LSA";
+        uses ospfv2-lsdb-asexternal-lsa-state;
+      }
+
+      container types-of-service {
+        description
+          "Breakdown of External LSA contents specifying multiple
+          TOS values";
+
+        list type-of-service {
+          key "tos";
+          description
+            "Per-type of service parameters for the AS External LSA";
+
+          leaf tos {
+            type leafref {
+              path "../state/tos";
+            }
+            description
+              "Reference to the type of service identifier which is
+              specified in the AS External LSA";
+          }
+
+          container state {
+            description
+              "Per-TOS parameters for the LSA";
+
+            uses ospfv2-lsdb-asexternal-tos-state;
+          }
+        }
+      }
+
+    }
+  }
+
+  grouping ospfv2-lsdb-nssa-external-lsa-structure {
+    description
+      "Structural grouping for the NSSA External LSA contents within
+      the LSDB";
+
+    container nssa-external-lsa {
+      description
+        "Contents of the NSSA External LSA";
+
+      container state {
+        description
+          "State parameters for the AS external LSA";
+        // Type 7 LSAs are are a super-set of Type 5 LSAs so we simply
+        // include the Type 5
+        uses ospfv2-lsdb-asexternal-lsa-state;
+        uses ospfv2-lsdb-nssa-external-lsa-state;
+      }
+
+      container types-of-service {
+        description
+          "Breakdown of the NSSA External LSA contents specifying multiple
+          TOS values";
+
+        list type-of-service {
+          key "tos";
+          description
+            "Per-type of service parameters for the NSSA external LSA";
+
+          leaf tos {
+            type leafref {
+              path "../state/tos";
+            }
+            description
+              "Reference to the type of services identifier which is specified
+              in the NSSA External LSA";
+          }
+
+          container state {
+            description
+              "Per-TOS parameters for the LSA";
+            uses ospfv2-lsdb-asexternal-tos-state;
+          }
+        }
+      }
+    }
+  }
+
+  grouping ospfv2-lsdb-opaque-lsa-structure {
+    description
+      "Structural grouping for Opaque LSA contents within the LSDB";
+
+    container opaque-lsa {
+      description
+        "Contents of the opaque LSA";
+
+      container state {
+        description
+          "State parameters for the opaque LSA";
+        uses ospfv2-lsdb-opaque-lsa-state;
+      }
+
+      container traffic-engineering {
+        when "../state/type = 'oc-ospf-types:TRAFFIC_ENGINEERING'" {
+          description
+            "Include the traffic-engineering information when
+            the Opaque LSA being described is a Traffic Engineering
+            LSA";
+        }
+        description
+          "Contents of the Traffic Engineering Opaque LSA";
+
+        container tlvs {
+          description
+            "The TLVs contained in the TE Opaque LSA";
+          list tlv {
+            // this is an unkeyed list
+            description
+              "The Type-Length-Value tuples included in the TE LSA";
+
+            container state {
+              description
+                "The contents of the TLV tuple within the TE LSA";
+              uses ospfv2-lsdb-opaque-lsa-te-tlv-state;
+            }
+
+            uses ospfv2-lsdb-common-unknown-tlv-structure;
+
+            container router-address {
+              when "../state/type = 'oc-ospf-types:TE_ROUTER_ADDRESS'" {
+                description
+                  "Include the router address container only when the type
+                  of the TLV is Router Address";
+              }
+
+              description
+                "Parameters included in the Router Address TLV";
+
+              container state {
+                description
+                  "State parameters of the router address TLV";
+                uses ospfv2-lsdb-opaque-te-router-address-state;
+              }
+            }
+
+            container link {
+              when "../state/type = 'oc-ospf-types:TE_ROUTER_LINK'" {
+                description
+                  "Include the link container only when the type of the
+                  TLV describes a traffic engineering link";
+              }
+
+              description
+                "Parameters included in the Link TLV";
+              container sub-tlvs {
+                description
+                  "Sub-TLVs included in the Link TLV";
+
+                list sub-tlv {
+                  // unkeyed list
+                  description
+                    "The Sub-TLVs included within the Traffic Engineering
+                    LSA's sub-TLV";
+
+                  container state {
+                    description
+                      "State parameters of the Link Sub-TLV";
+
+                    uses ospfv2-lsdb-opaque-te-link-state;
+                  }
+
+                  uses ospfv2-lsdb-common-unknown-subtlv-structure;
+
+                  container unreserved-bandwidths {
+                    description
+                      "The unreserved link bandwidths for the Traffic
+                      Engineering LSA - utilised when the sub-TLV type
+                      indicates that the sub-TLV describes unreserved
+                      bandwidth";
+
+                    list unreserved-bandwidth {
+                      key "priority";
+
+                      description
+                        "The unreserved bandwidth at each priority level";
+
+                      leaf priority {
+                        type leafref {
+                          path "../state/priority";
+                        }
+                        description
+                          "A reference to the priority level being described";
+                      }
+
+                      container state {
+                        description
+                          "State parameters relating to the unreserved
+                          bandwidth of the link being described";
+                        uses ospfv2-lsdb-opaque-te-link-unreserved-bw-state;
+                      }
+                    }
+                  }
+
+                  container administrative-groups {
+                    description
+                      "The administrative groups that are set for the
+                      Traffic Engineering LSA - utilised when the sub-TLV type
+                      indicates that the sub-TLV describes administrative
+                      groups";
+
+                    list admin-group {
+                      key "bit-index";
+
+                      description
+                        "The administrative group described within the
+                        sub-TLV";
+
+                      leaf bit-index {
+                        type leafref {
+                          path "../state/bit-index";
+                        }
+                        description
+                          "A reference to the bit index being described";
+                      }
+
+                      container state {
+                        description
+                          "State parameters relating to the administrative
+                          groups being described for the link";
+                        uses ospfv2-lsdb-opaque-te-link-admin-group-state;
+                      }
+                    }
+                  }
+                }
+              }
+            }
+
+            container node-attribute {
+              when "../state/type = 'oc-ospf-types:TE_NODE_ATTRIBUTE'" {
+                description
+                  "Include the node-attribute container only when the type of
+                  the TLV describes a node attribute";
+              }
+
+              description
+                "Parameters included in the Node Attribute TLV";
+
+              container sub-tlvs {
+                description
+                  "Sub-TLVs of the Node Attribute TLV of the Traffic
+                  Engineering LSA";
+
+                list sub-tlv {
+                  // unkeyed list
+                  description
+                    "List of the Sub-TLVs contained within the Node Attribute
+                    TLV";
+
+                  container state {
+                    description
+                      "State parameters of the Node Attribute TLV sub-TLV";
+                    uses ospfv2-lsdb-opaque-te-node-attribute-state;
+                  }
+
+                  uses ospfv2-lsdb-common-unknown-subtlv-structure;
+                }
+              }
+            }
+
+            // A set of TLVs are omitted here - based on operational
+            // requirements, these are:
+            // * link-local
+            // * ipv6-address (OSPFv3 only)
+            // * optical-node-property
+          }
+        }
+      } // traffic-engineering
+
+      container grace-lsa {
+        when "../state/type = 'oc-ospf-types:GRACE_LSA'" {
+          description
+            "Include the grace-lsa container when the opaque LSA is specified
+            to be of that type.";
+        }
+
+        description
+          "The Grace LSA is utilised when a remote system is undergoing
+          graceful restart";
+
+        container tlvs {
+          description
+            "TLVs of the Grace LSA";
+
+          list tlv {
+            description
+              "TLV entry in the Grace LSA, advertised by a system undergoing
+              graceful restart";
+
+            // unkeyed list
+            container state {
+              description
+                "Per-TLV state parameters of the Grace LSA";
+              uses ospfv2-lsdb-opaque-grace-state;
+            }
+            uses ospfv2-lsdb-common-unknown-tlv-structure;
+          }
+        }
+      } // grace LSA
+
+      container router-information {
+        when "../state/type = 'oc-ospf-types:ROUTER_INFORMATION_LSA'" {
+          description
+            "Include the router-information container when the opaque LSA
+            type is specified to be an RI LSA";
+        }
+
+        description
+          "The router information LSA is utilised to advertise capabilities
+          of a system to other systems who receive the LSA";
+
+        container tlvs {
+          description
+            "The TLVs included within the Router Information LSA.";
+
+          list tlv {
+            description
+              "TLV entry in the Router Information LSA";
+
+            // unkeyed list
+            container state {
+              description
+                "Per-TLV state parameters of the RI LSA";
+              uses ospfv2-lsdb-opaque-ri-state;
+            }
+
+            uses ospfv2-lsdb-common-unknown-tlv-structure;
+
+            container informational-capabilities {
+              when "../state/type = 'oc-ospf-types:RI_INFORMATIONAL_CAPABILITIES'" {
+                description
+                  "Include the informational capabilities specification when
+                  the TLV of the RI LSA is specified to be of this type";
+              }
+
+              description
+                "Information related to the capabilities of the advertising
+                router within the scope that the opaque RI LSA is being
+                advertised";
+
+              container state {
+                description
+                  "State parameters of the informational capabilitis of the
+                  RI LSA";
+                uses ospfv2-lsdb-opaque-ri-informational-state;
+              }
+            }
+
+            container node-administrative-tags {
+              when "../state/type = 'oc-ospf-types:RI_NODE_ADMIN_TAG'" {
+                description
+                  "Include the node administrative tags specification when
+                  the TLV of the RI LSA is specified to be of this type";
+              }
+
+              description
+                "Per-node administrative tags associated with the local system
+                specified by the operator";
+
+              container state {
+                description
+                  "State parameters of the node administrative tags advertised
+                  in the RI LSA";
+                uses ospfv2-lsdb-opaque-ri-admintag-state;
+              }
+            }
+
+            container segment-routing-algorithm {
+              when "../state/type = 'oc-ospf-types:RI_SR_ALGORITHM'" {
+                description
+                  "Include the segment routing algorithm specific parameters when
+                  the TLV of the RI LSA is specified to be of this type";
+              }
+
+              description
+                "The algorithms supported for Segment Routing by the local system";
+
+              container state {
+                description
+                  "State parameters of the Segment Routing algorithm advertised in
+                  the RI LSA";
+                uses ospfv2-lsdb-opaque-ri-sralgo-state;
+              }
+            }
+
+            container segment-routing-sid-label-range {
+              when "../state/type = 'oc-ospf-types:RI_SR_SID_LABEL_RANGE'" {
+                description
+                  "Include the segment routing SID/Label range TLV specific state when
+                  the TLV of the RI LSA is specified to be of this type";
+              }
+
+              description
+                "The Segment Identifier (SID) or label ranges that are supported by
+                the local system for Segment Routing";
+
+              container tlvs {
+                description
+                  "Sub-TLVs of the SID/Label range TLV of the RI LSA";
+
+                list tlv {
+                  // unkeyed list
+                  description
+                    "Sub-TLVs of the SID/Label range TLV";
+
+                  uses ospfv2-lsdb-common-unknown-tlv-structure;
+
+                  container state {
+                    description
+                      "State parameters of the sub-TLVs of the SR/Label range TLV";
+                    uses ospfv2-lsdb-opaque-ri-srrange-tlv-state;
+                  }
+
+                  container sid-label {
+                    description
+                      "Sub-TLV used to advertise the SID or label associated with the
+                      subset of the SRGB being advertised";
+
+                    container state {
+                      description
+                        "State parameters of the SID/Label sub-TLV of the SR/Label
+                        range TLV of the RI LSA";
+                      uses ospfv2-lsdb-opaque-ri-srrange-sid-label-tlv-state;
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      } // router-information
+
+      container extended-prefix {
+        when "../state/type = 'oc-ospf-types:OSPFV2_EXTENDED_PREFIX'" {
+          description
+            "Include the extended-prefix container when the opaque LSA
+            type is specified to be an extended prefix LSA";
+        }
+
+        description
+          "An OSPFv2 Extended Prefix Opaque LSA, used to encapsulate
+          TLV attributes associated with a prefix advertised in OSPF.";
+
+        reference "RFC7684 - OSPFv2 Prefix/Link Attribute Advertisement";
+
+        container state {
+          description
+            "State parameters of the Extended Prefix LSA";
+          uses ospfv2-lsdb-extended-prefix-state;
+        }
+
+        container tlvs {
+          description
+            "TLVs contained within the Extended Prefix LSA";
+
+          list tlv {
+            // unkeyed list
+            description
+              "A TLV contained within the extended prefix LSA";
+
+            container state {
+              description
+                "State parameters relating to the sub-TLV of the extended
+                prefix LSA";
+              uses ospfv2-lsdb-extended-prefix-tlv-state;
+            }
+
+            container extended-prefix-range {
+              when "../state/type = 'oc-ospf-types:EXTENDED_PREFIX_RANGE'" {
+                description
+                  "Include the prefix range sub-TLV when the type of the
+                  sub-TLV is specified as such";
+              }
+
+              description
+                "State parameters relating to the extended prefix range
+                sub-TLV of the extended prefix LSA";
+
+              container state {
+                description
+                  "State parameters relating to the Extended Prefix Range
+                  sub-TLV of the Extended Prefix LSA";
+                uses ospfv2-lsdb-extended-prefix-range-state;
+              }
+            }
+
+            container prefix-sid {
+              when "../state/type = 'oc-ospf-types:PREFIX_SID'" {
+                description
+                  "Include parameters relating to the Prefix SID when the type
+                  of the sub-TLV is indicated as such";
+              }
+
+              description
+                "State parameters relating to the Prefix SID sub-TLV of the
+                extended prefix LSA";
+
+              container state {
+                description
+                  "State parameters relating to the Prefix SID sub-TLV of the
+                  extended prefix LSA";
+                uses ospfv2-lsdb-extended-prefix-prefix-sid-state;
+              }
+            } // prefix-sid
+
+            container sid-label-binding {
+              when "../state/type = 'oc-ospf-types:SID_LABEL_BINDING'" {
+                description
+                  "Include parameters relating to the SID/Label binding sub-TLV
+                  only when the type is indicated as such";
+              }
+
+              description
+                "State parameters relating to the SID/Label binding sub-TLV
+                of the extended prefix LSA";
+
+              container state {
+                description
+                  "State parameters relating to the SID/Label binding sub-TLV
+                  of the extended prefix LSA";
+                uses ospfv2-lsdb-extended-prefix-sid-label-binding-state;
+              }
+
+              container tlvs {
+                description
+                  "TLVs contained within the SID/Label Binding sub-TLV of the
+                  SID/Label Binding TLV";
+
+                list tlv {
+                  description
+                    "A TLV contained within the SID/Label Binding sub-TLV";
+
+                  container state {
+                    description
+                      "State parameters relating to the SID/Label Binding
+                      sub-TLV";
+                    uses ospfv2-lsdb-extended-prefix-sid-label-binding-tlv-state;
+                  }
+
+                  container sid-label-binding {
+                    when "../state/type = 'oc-ospf-types:SID_LABEL_BINDING'" {
+                      description
+                        "Include the SID/Label Binding sub-TLV parameters only
+                        when the type is indicated as such";
+                    }
+
+                    description
+                      "Parameters for the SID/Label Binding sub-TLV of the
+                      SID/Label binding TLV";
+
+                    container state {
+                      description
+                        "State parameteres relating to the SID/Label Binding
+                        sub-TLV";
+                      uses ospfv2-lsdb-extprefix-sid-label-binding-state;
+                    }
+                  } // sid-label-binding
+
+                  container ero-metric {
+                    when "../state/type = 'oc-ospf-types:ERO_METRIC'" {
+                      description
+                        "Include the ERO Metric sub-TLV parameters only when
+                        the type is indicated as such";
+                    }
+
+                    description
+                      "Parameters for the ERO Metric Sub-TLV of the SID/Label
+                      binding TLV";
+
+                    container state {
+                      description
+                        "State parameters relating to the ERO Metric Sub-TLV of
+                        the SID/Label binding TLV";
+                      uses ospfv2-lsdb-extprefix-sid-label-ero-metric-state;
+                    }
+                  } // ero-metric
+
+                  container ero-path {
+                    when "../state/type = 'oc-ospf-types:ERO_PATH'" {
+                      description
+                        "Include the ERO Path sub-TLV parameters only when the
+                        type is indicated as such";
+                    }
+
+                    description
+                      "Parameters for the ERO Path Sub-TLV of the SID/Label
+                      binding TLV";
+
+                    container segments {
+                      description
+                        "Segments of the path described within the SID/Label
+                        Binding sub-TLV";
+
+                      list segment {
+                        description
+                          "A segment of the path described within the sub-TLV";
+
+                        container state {
+                          description
+                            "State parameters relating to the path segment
+                            contained within the sub-TLV";
+                          uses ospfv2-lsdb-extprefix-sid-lbl-ero-path-seg-state;
+                        }
+
+                        container ipv4-segment {
+                          when "../state/type = 'oc-ospf-types:IPV4_SEGMENT'" {
+                            description
+                              "Include the IPv4 segment only when the type is
+                              indicated as such";
+                          }
+
+                          description
+                            "Details of the IPv4 segment interface of the ERO";
+
+                          container state {
+                            description
+                              "State parameters of the IPv4 segment of the ERO";
+                            uses ospfv2-lsdb-extprefix-sid-lbl-ero-ipv4-state;
+                          }
+                        } // ipv4-segment
+
+                        container unnumbered-hop {
+                          when "../state/type = 'oc-ospf-types:UNNUMBERED_INTERFACE_SEGMENT'" {
+                            description
+                              "Include the unnumbered segment only when the
+                              type is indicated as such";
+                          }
+
+                          description
+                            "Details of the unnumbered interface segment of the
+                            ERO";
+
+                          container state {
+                            description
+                              "State parameters of the unnumbered interface
+                              segment of the ERO";
+                            uses ospfv2-lsdb-extprefix-sid-lbl-ero-unnum-state;
+                          }
+                        } // unnumbered-hop
+                      } // tlv
+                    } // tlvs
+                  }
+                }
+              }
+            } // sid-label-binding
+
+            uses ospfv2-lsdb-common-unknown-tlv-structure;
+          }
+        }
+      } // extended-prefix
+
+      container extended-link {
+        description
+          "The OSPFv2 Extended Link Opaque LSA, used to encapsulate TLV
+          attributes associated with a link advertised in OSPF.";
+
+        reference "RFC7684 - OSPFv2 Prefix/Link Attribute Advertisement";
+
+        container state {
+          description
+            "State parameters of the Extended Link LSA";
+          uses ospfv2-lsdb-extended-link-state;
+        }
+
+        container tlvs {
+          description
+            "TLVs contained within the Extended Link LSA";
+
+          list tlv {
+            description
+              "List of TLVs within the Extended Link LSA";
+
+            container state {
+              description
+                "State parameters relating to the sub-TLV of the extended link
+                LSA";
+              uses ospfv2-lsdb-extended-link-tlv-state;
+            }
+
+            uses ospfv2-lsdb-common-unknown-tlv-structure;
+
+            container adjacency-sid {
+              when "../state/type = 'oc-ospf-types:ADJACENCY_SID'" {
+                description
+                  "Include the Adjacency SID parameters only when the type of
+                  the sub-TLV is indicated as such";
+              }
+
+              description
+                "Parameters relating to an Adjacency SID sub-TLV of the
+                extended link LSA";
+
+              container state {
+                description
+                  "State parameters relating to an Adjacency SID";
+
+                uses ospfv2-lsdb-extended-link-adj-sid-state;
+              }
+            }
+          }
+        }
+
+      } // extended-link
+
+      uses ospfv2-lsdb-common-unknown-tlv-structure;
+    }
+  }
+
+  grouping ospfv2-lsdb-generic-lsa-tos-metric-state {
+    description
+      "Per-TOS state parameters for the Router LSA";
+
+    uses ospfv2-lsdb-common-tos-metric;
+  }
+
+  grouping ospfv2-lsdb-router-lsa-state {
+    description
+      "Parameters of the router LSA";
+
+    leaf type {
+      type identityref {
+        base "oc-ospf-types:ROUTER_LSA_TYPES";
+      }
+      description
+        "The sub-type of the Router LSA.";
+    }
+
+    uses ospfv2-lsdb-common-link-specification;
+
+    leaf metric {
+      type oc-ospf-types:ospf-metric;
+      description
+        "The cost of utilising the link specified independent of TOS";
+    }
+
+    leaf number-links {
+      type uint16;
+      description
+        "The number of links that are described within the LSA";
+    }
+
+    leaf number-tos-metrics {
+      type uint16;
+      description
+        "The number of different TOS metrics given for this link, not
+        including the link metric (which is referred to as TOS 0).";
+    }
+  }
+
+  grouping ospfv2-lsdb-network-lsa-state {
+    description
+      "Parameters of the Network LSA";
+
+    leaf network-mask {
+      type uint8 {
+        range "0..32";
+      }
+      description
+        "The mask of the network described by the Network LSA
+        represented as a CIDR mask.";
+    }
+
+    leaf-list attached-router {
+      type yang:dotted-quad;
+      description
+        "A list of the router ID of the routers that are attached to
+        the network described by the Network LSA";
+    }
+  }
+
+  grouping ospfv2-lsdb-summary-lsa-state {
+    description
+      "Parameters of the Summary LSA";
+
+    leaf network-mask {
+      type uint8 {
+        range "0..32";
+      }
+      description
+        "The mask of the network described by the Summary LSA
+        represented as a CIDR mask.";
+    }
+
+    leaf metric {
+      type oc-ospf-types:ospf-metric;
+      description
+        "The cost of utilising the summary link specified independent of TOS.";
+    }
+
+  }
+
+  grouping ospfv2-lsdb-asexternal-lsa-common-parameters {
+    description
+      "Common parameters that are used for OSPFv2 AS External LSAs";
+
+    leaf forwarding-address {
+      type inet:ipv4-address-no-zone;
+      description
+        "The destination to which traffic for the external prefix
+        should be advertised. When this value is set to 0.0.0.0 then
+        traffic should be forwarded to the LSA's originator";
+    }
+
+    leaf external-route-tag {
+      type uint32;
+      description
+        "An opaque tag that set by the LSA originator to carry
+        information relating to the external route";
+    }
+  }
+
+  grouping ospfv2-lsdb-asexternal-lsa-state {
+    description
+      "Parameters for the AS External LSA";
+
+    leaf mask {
+      type uint8 {
+        range "0..32";
+      }
+      description
+        "The subnet mask for the advertised destination";
+    }
+
+    leaf metric-type {
+      type enumeration {
+        enum "TYPE_1" {
+          description
+            "When the metric of a prefix is specified as Type 1
+            then it is considered to be expressed in the same units as
+            the link-state metrics carried in OSPF. That is to say
+            that the metric advertised is directly compared to the
+            internal cost";
+        }
+        enum "TYPE_2" {
+          description
+            "When the metric of a prefix is specified as Type 2 then
+            it is considered to be expressed as a cost in addition to
+            that of the link-state metric to the advertising router.
+            That is to say that the metric is considered to be the
+            cost to the advertising router plus the advertised metric
+            for the external entity";
+        }
+      }
+      description
+        "The type of metric included within the AS External LSA.";
+    }
+
+    leaf metric {
+      type oc-ospf-types:ospf-metric;
+      description
+        "The cost to reach the external network specified. The exact
+        interpretation of this cost is dependent on the type of
+        metric specified";
+    }
+
+    uses ospfv2-lsdb-asexternal-lsa-common-parameters;
+  }
+
+  grouping ospfv2-lsdb-asexternal-tos-state {
+    description
+      "Per-TOS parameters for the AS External LSA";
+
+    uses ospfv2-lsdb-asexternal-lsa-common-parameters;
+    uses ospfv2-lsdb-common-tos-metric;
+  }
+
+  grouping ospfv2-lsdb-nssa-external-lsa-state {
+    description
+      "Operational state parameters specific to the NSSA External
+      LSA";
+
+    leaf propagate {
+      type boolean;
+      description
+        "When this bit is set to true, an NSSA border router will
+        translate a Type 7 LSA (NSSA External) to a Type 5 LSA
+        (AS External).";
+      reference "RFC3101, Section 2.3";
+    }
+  }
+
+  grouping ospfv2-lsdb-opaque-lsa-state {
+    description
+      "Operational state parameters specific to an Opaque LSA";
+
+    leaf scope {
+      type enumeration {
+        enum LINK {
+          description
+            "The scope of the LSA is the current link. The LSA
+            is not flooded beyond the local network. This
+            enumeration denotes a Type 9 LSA.";
+        }
+        enum AREA {
+          description
+            "The scope of the LSA is the local area. The LSA
+            is not flooded beyond the area of origin. This
+            enumeration denotes a Type 10 LSA.";
+        }
+        enum AS {
+          description
+            "The scope of the LSA is the local autonomous
+            system (AS). The flooding domain is the same
+            as a Type 5 LSA - it is not flooded into
+            stub areas or NSSAs. This enumeration denotes a
+            Type 11 LSA.";
+        }
+      }
+      description
+        "The scope of the opaque LSA. The type of the LSA
+        indicates its scope - the value of this leaf
+        determines both the flooding domain, and the type
+        of the LSA.";
+    }
+
+    leaf type {
+      type identityref {
+        base "oc-ospf-types:OSPF_OPAQUE_LSA_TYPE";
+      }
+      description
+        "The Opaque Type of the LSA. This value is used to
+        indicate the type of data carried by the opaque LSA";
+    }
+  }
+
+  grouping ospfv2-lsdb-opaque-lsa-te-tlv-state {
+    description
+      "The contents of the Traffic Engineering LSA";
+
+    leaf type {
+      type identityref {
+        base "oc-ospf-types:OSPF_TE_LSA_TLV_TYPE";
+      }
+      description
+        "The type of TLV within the Traffic Engineering LSA";
+    }
+  }
+
+  grouping ospfv2-lsdb-opaque-te-unknown-state {
+    description
+      "The contents of the unknown TLV within the Traffic Engineering LSA";
+
+    uses ospfv2-lsdb-common-unknown-tlv;
+  }
+
+  grouping ospfv2-lsdb-opaque-te-link-state {
+    description
+      "The contents of the sub-TLVs of a Traffic Engineering LSA Link TLV";
+
+    leaf type {
+      type union {
+        type identityref {
+          base "oc-ospf-types:OSPF_TE_LINK_TLV_TYPE";
+        }
+        type enumeration {
+          enum UNKNOWN {
+            description
+              "The sub-TLV received in the LSA is unknown to the local
+              system";
+          }
+        }
+      }
+      description
+        "The sub-TLV type specified in the Link TLV. When the value is
+        known by the local system, a canonical name of the sub-TLV is utilised
+        - the special UNKNOWN value indicates that the system did not
+        support the sub-TLV type received in the LSA.";
+    }
+
+    leaf unknown-type {
+      when "../type = 'UNKNOWN'" {
+        description
+          "Include the unknown type field only when the sub-TLV was not
+          known to the local system";
+      }
+
+      type uint16;
+      description
+        "The value of the type field of an unknown sub-TLV";
+    }
+
+    leaf unknown-value {
+      when "../type = 'UNKNOWN'" {
+        description
+          "Include the unknown value field only when the sub-TLV was not
+          known to the local system";
+      }
+
+      type binary;
+      description
+        "The binary contents of the unknown TLV";
+    }
+
+    leaf link-type {
+      when "../type = 'TE_LINK_TYPE'" {
+        description
+          "Include the link-type field only when the sub-TLV type was a TE
+          link type";
+      }
+
+      type enumeration {
+        enum POINT_TO_POINT {
+          description
+            "The link being described by the TE LSA Link sub-TLV is a
+            point-to-point link to exactly one other system";
+        }
+        enum MULTI_ACCESS {
+          description
+            "The link being described by the TE LSA Link sub-TLV is a
+            multi-access link that supports connectivity to multiple remote
+            systems";
+        }
+        enum UNKNOWN {
+          description
+            "The link type received was unknown to the local system";
+        }
+      }
+      description
+        "The type of the link that is being described by the TE LSA Link
+        sub-TLV";
+    }
+
+    leaf link-id {
+      when "../type = 'TE_LINK_ID'" {
+        description
+          "Include the link ID field only when the sub-TLV type was a TE
+          Link identifier";
+      }
+
+      type yang:dotted-quad;
+      description
+        "The ID of the remote system. For point-to-point links, this is the
+        router ID of the neighbor. For multi-access links it is the address
+        of the designated router.";
+    }
+
+    leaf-list local-ip-address {
+      when "../type = 'oc-ospf-types:TE_LINK_LOCAL_IP'" {
+        description
+          "Include the local IP address field only when the sub-TLV type was
+          a local IP address";
+      }
+
+      type inet:ipv4-address-no-zone;
+      description
+        "The IP address(es) of the local system that correspond to the
+        specified TE link";
+    }
+
+    leaf-list remote-ip-address {
+      when "../type = 'oc-ospf-types:TE_LINK_REMOTE_IP'" {
+        description
+          "Include the remote IP address field only when the sub-TLV type was
+          a remote IP address";
+      }
+
+      type inet:ipv4-address-no-zone;
+      description
+        "The IP address(es) of the remote systems that are attached to the
+        specified TE link";
+    }
+
+    leaf metric {
+      when "../type = 'oc-ospf-types:TE_LINK_METRIC'" {
+        description
+          "Include the traffic engineering metric only when the sub-TLV type
+          is a TE metric";
+      }
+
+      type uint32;
+      description
+        "The metric of the link that should be used for traffic engineering
+        purposes. This link may be different than the standard OSPF link
+        metric.";
+    }
+
+    leaf maximum-bandwidth {
+      when "../type = 'oc-ospf-types:TE_LINK_MAXIMUM_BANDWIDTH'" {
+        description
+          "Include the traffic engineering metric only when the sub-TLV type
+          is the maximum bandwidth";
+      }
+
+      type oc-types:ieeefloat32;
+      units "bytes per second";
+      description
+        "The maximum bandwidth of the link. This value reflects the actual
+        bandwidth of the link expressed asn IEEE 32-bit floating point
+        number";
+    }
+
+    leaf maximum-reservable-bandwidth {
+      when "../type = 'oc-ospf-types:TE_LINK_MAXIUMUM_RESERVABLE_BANDWIDTH'" {
+        description
+          "Include the maximum reservable bandwidth field only when the
+          sub-TLV type is the maximum reservable bandwidth";
+      }
+
+      type oc-types:ieeefloat32;
+      units "bytes per second";
+      description
+        "The maximum reservable bandwidth for the link. This value represents
+        the total bandwidth which may be used for traffic engineering
+        purposes. The value may exceed the maximum-bandwidth value
+        in cases where the link is oversubscribed. The value is reflected as
+        a 32-bit IEEE floating-point number";
+    }
+  }
+
+  grouping ospfv2-lsdb-opaque-te-link-unreserved-bw-state {
+    description
+      "The per-priority unreserved bandwidth described within the unreserved
+      bandwidth sub-TLV of the Link TLV of the Traffic Engineering LSA";
+
+    leaf priority {
+      type uint8 {
+        range "0..7";
+      }
+      description
+        "The priority level being described";
+    }
+
+    leaf unreserved-bandwidth {
+      type oc-types:ieeefloat32;
+      description
+        "The unreserved bandwidth for at priority level P, where P is
+        equal to the priority of the current list entry. The reservable
+        bandwidth at priority P is equal to the sum of the reservable
+        bandwidth at all levels 0..P.";
+    }
+  }
+
+  grouping ospfv2-lsdb-opaque-te-link-admin-group-state {
+    description
+      "Per bit administrative group status";
+
+    leaf bit-index {
+      type uint8 {
+        range "0..31";
+      }
+      description
+        "The index of the bit within the 32-bit administrative group field
+        of the Administrative Group sub-TLV of the Traffic Engineering LSA";
+    }
+
+    leaf set {
+      type boolean;
+      default false;
+      description
+        "Whether the bit is set within the administrative group field";
+    }
+  }
+
+  grouping ospfv2-lsdb-opaque-te-node-attribute-state {
+    description
+      "State parameters relating to the Traffic Engineering Node Attribute
+      TLV of the Traffic Engineering LSA";
+
+    leaf type {
+      type union {
+        type identityref {
+          base "oc-ospf-types:TE_NODE_ATTRIBUTE_TLV_TYPE";
+        }
+        type enumeration {
+          enum UNKNOWN {
+            description
+              "The sub-TLV type received within the TE LSA Node Attribute TLV
+              was unknown the the local system";
+          }
+        }
+      }
+      description
+        "The type of the sub-TLV of the Node Attribute TLV contained within
+        the TE LSA. If the local system can interpret the value received the
+        canonical name of the type is utilised, otherwise the special UNKNOWN
+        value is used";
+    }
+
+    leaf-list local-ipv4-addresses {
+      when "../type = 'oc-ospf-types:NODE_IPV4_LOCAL_ADDRESS'" {
+        description
+          "Include the local IPv4 addresses when the type of the sub-TLV
+          indicates that this is the contained data";
+      }
+
+      type inet:ipv4-prefix;
+      description
+        "The local IPv4 addresses of the node expressed in CIDR notation";
+    }
+
+    leaf-list local-ipv6-addresses {
+      when "../type = 'oc-ospf-types:NODE_LOCAL_IPV6_ADDRESS'" {
+        description
+          "Include the local IPv6 addresses when the type of the sub-TLV
+          indicfates that this is the contained data";
+      }
+
+      type inet:ipv6-prefix;
+      description
+        "The local IPv6 addreses of the node";
+    }
+  }
+
+  grouping ospfv2-lsdb-opaque-te-router-address-state {
+    description
+      "The contents of the value field of the Router Address TLV of the
+      Traffic Engineering LSA.";
+
+    leaf address {
+      type inet:ipv4-address-no-zone;
+      description
+        "A stable IP address of the advertising router, that is always
+        reachable when the router is connected to the network. Typically this
+        is a loopback address.";
+    }
+  }
+
+  grouping ospfv2-lsdb-opaque-grace-state {
+    description
+      "State parameters on a per-TLV basis of the Grace LSA";
+
+    leaf type {
+      type identityref {
+        base "oc-ospf-types:GRACE_LSA_TLV_TYPES";
+      }
+      description
+        "The type of the sub-TLV received within the Grace LSA";
+    }
+
+    leaf period {
+      when "../type = 'oc-ospf-types:GRACE_PERIOD'" {
+        description
+          "Include the period specification when the sub-TLV type is indicated
+          to be of this type";
+      }
+
+      type uint32;
+      units seconds;
+      description
+        "The number of seconds that the router's neighbors should advertise
+        the local system as fully adjacent regardless of database
+        synchronization state";
+      reference "RFC3623";
+    }
+
+    leaf reason {
+      when "../type = 'oc-ospf-types:GRACE_RESTART_REASON'" {
+        description
+          "Include the restart reason when the sub-TLV type specifies this
+          is included";
+      }
+
+      type enumeration {
+        enum UNKNOWN {
+          value 0;
+          description
+            "The reason for the graceful restart is unknown";
+        }
+        enum SOFTWARE_RESTART {
+          value 1;
+          description
+            "The local system is restarting due to a software component
+            restart";
+        }
+        enum SOFTWARE_RELOAD_UPGRADE {
+          value 2;
+          description
+            "The local system is restarting due to a software reload or
+            upgrade";
+        }
+        enum CONTROL_PROCESSOR_SWITCH {
+          value 3;
+          description
+            "The local system is restarting due to a switch to a redundant
+            control plane element";
+        }
+      }
+      description
+        "The reason for the graceful restart event occurring, as advertised
+        by the restarting system";
+      reference "RFC3623";
+    }
+
+    leaf ip-interface-address {
+      when "../type = 'oc-ospf-types:GRACE_IP_INTERFACE_ADDRESS'" {
+        description
+          "Include the interface address when the sub-TLV type specifies that
+          it is included";
+      }
+
+      type inet:ipv4-address-no-zone;
+      description
+        "The restarting system's IP address on the interface via which the
+        Grace LSA is being advertised.";
+    }
+  }
+
+  grouping ospfv2-lsdb-opaque-ri-state {
+    description
+      "State parameters of the Router Information Opaque LSA";
+
+    leaf type {
+      type union {
+        type identityref {
+          base "oc-ospf-types:RI_LSA_TLV_TYPES";
+        }
+        type enumeration {
+          enum UNKNOWN {
+            description
+              "The TLV received within the RI LSA is unknown";
+          }
+        }
+      }
+      description
+        "The type of sub-TLV of the Router Information opaque LSA";
+    }
+  }
+
+  grouping ospfv2-lsdb-opaque-ri-informational-state {
+    description
+      "State parmaeters of the Router Information Informational Capabilities
+      sub-TLV";
+
+    leaf graceful-restart-capable {
+      type boolean;
+      default false;
+      description
+        "When this leaf is set to true, the advertising system is capable of
+        OSPF graceful restart.";
+    }
+
+    leaf graceful-restart-helper {
+      type boolean;
+      default false;
+      description
+        "When this leaf is set to true, the advertising system is capable of
+        being a helper for OSPF graceful restart";
+    }
+
+    leaf stub-router {
+      type boolean;
+      default false;
+      description
+        "When this leaf is set to true, the advertising system is able to
+        advertise its status as a stub router";
+      reference "RFC6987";
+    }
+
+    leaf traffic-engineering {
+      type boolean;
+      default false;
+      description
+        "When this leaf is set to true, the advertising system supports OSPFv2
+        traffic engineering capabilities";
+    }
+
+    leaf point-to-point-over-lan {
+      type boolean;
+      default false;
+      description
+        "When this leaf is set to true, the advertising system supports treating
+        LAN adjacencies as though they were point to point";
+      reference "RFC5309";
+    }
+
+    leaf experimental-te {
+      type boolean;
+      default false;
+      description
+        "When this leaf is set to true, the advertising system supports the
+        experimental extensions to OSPF for TE described in RFC4973";
+      reference "RFC4973";
+    }
+  }
+
+  grouping ospfv2-lsdb-opaque-ri-admintag-state {
+    description
+      "State parameters relating to the administrative tags specified for
+      a node within the RI LSA";
+
+    leaf-list administrative-tags {
+      type uint32;
+      description
+        "The set of administrative tags assigned to the local system by
+        the network operator. The meaning of these tags is opaque to OSPF
+        - and their interpretation is per-domain specific";
+      reference "RFC7777";
+    }
+  }
+
+  grouping ospfv2-lsdb-opaque-ri-unknown-state {
+    description
+      "State parameters relating to an unknown TLV within the RI LSA";
+    uses ospfv2-lsdb-common-unknown-tlv;
+  }
+
+  grouping ospfv2-lsdb-opaque-ri-sralgo-state {
+    description
+      "State parameters relating to the SR Algorithms TLV of the RI LSA";
+
+    leaf-list supported-algorithms {
+      type identityref {
+        base "oc-ospf-types:SR_ALGORITHM";
+      }
+      description
+        "A list of the algorithms that are supported for segment routing
+        by the advertising system";
+    }
+  }
+
+  grouping ospfv2-lsdb-opaque-ri-srrange-tlv-state {
+    description
+      "State parameters relating to the SR SID/Label range TLV of the
+      RI LSA";
+
+    leaf type {
+      type union {
+        type identityref {
+          base "oc-ospf-types:OSPF_RI_SR_SID_LABEL_TLV_TYPES";
+        }
+        type enumeration {
+          enum UNKNOWN {
+            description
+              "The type of the sub-TLV advertised with the SID/Label range
+              TLV of the RI LSA is unknown to the receiving system";
+          }
+        }
+      }
+      description
+        "The type of the sub-TLV received by the local system within the
+        SR SID/Label Range TLV of the RI LSA";
+    }
+
+    leaf range-size {
+      type uint32 {
+        range "0..16777216";
+      }
+      description
+        "The number of entries within the range being described within the
+        SID/Label range TLV";
+    }
+  }
+
+  grouping ospfv2-lsdb-opaque-ri-srrange-sid-label-tlv-state {
+    description
+      "State parameters relating to the SR SID/Label sub-TLV of the SR SID/Label
+      range TLV of the RI LSA";
+
+    leaf entry-type {
+      type oc-ospf-types:sr-sid-type;
+      description
+        "The type of entry that is contained within the sub-TLV. The range may
+        be represented as either a range of MPLS labels, or numeric segment
+        identifiers";
+    }
+
+    leaf first-value {
+      type uint32;
+      description
+        "The first value within the SRGB range being specified. The type of the
+        entry is determined based on the value of the entry type as this value
+        may represent either a segment identifier or an MPLS label.";
+    }
+  }
+
+  grouping ospfv2-lsdb-extended-prefix-state {
+    description
+      "State parameters relating to an Extended Prefix LSA";
+
+    leaf route-type {
+      type enumeration {
+        enum UNSPECIFIED {
+          value 0;
+          description
+            "The prefix described in the extended prefix LSA is of an
+            unspecified type";
+        }
+        enum INTRA_AREA {
+          value 1;
+          description
+            "The prefix described in the extended prefix LSA is an intra-area
+            prefix for the advertising system";
+        }
+        enum INTER_AREA {
+          value 3;
+          description
+            "The prefix described in the extended prefix LSA is an inter-area
+            prefix for the advertising system";
+        }
+        enum AS_EXTERNAL {
+          value 5;
+          description
+            "The prefix described in the extended prefix LSA is external to the
+            autonomous system of the advertising system";
+        }
+        enum NSSA_EXTERNAL {
+          value 7;
+          description
+            "The prefix described in the extended prefix LSA externally
+            advertised from an NSSA area visibile to the advertising system";
+        }
+      }
+      description
+        "The type of prefix that is contained within the Extended Prefix LSA.
+        The information contained in sub-TLVs of the attribute is applicable
+        regardless of this value.";
+    }
+
+    uses ospfv2-lsdb-common-prefix-properties;
+
+    leaf attached {
+      type boolean;
+      default false;
+      description
+        "If this value is set to true, the prefix being advertised was
+        generated by an ABR for an inter-area prefix. The value corresponds
+        to the A-flag of the flags field of the Extended Prefix LSA";
+    }
+
+    leaf node {
+      type boolean;
+      default false;
+      description
+        "If this value is set to true, the prefix being advertised represents
+        the advertising router. Typically, the prefix within the LSA is
+        expected to be globally-reachable prefix associated with a loopback
+        interface";
+    }
+
+    leaf prefix {
+      type inet:ipv4-address-no-zone;
+      description
+        "The IPv4 prefix contained within the extended prefix LSA";
+    }
+  }
+
+  grouping ospfv2-lsdb-extended-link-state {
+    description
+      "State parameters related to an extended link LSA";
+
+    leaf link-type {
+      type identityref {
+        base "oc-ospf-types:OSPFV2_ROUTER_LINK_TYPE";
+      }
+      description
+        "The type of link with which extended attributes are associated";
+    }
+
+    uses ospfv2-lsdb-common-link-specification;
+
+  }
+
+  grouping ospfv2-lsdb-extended-link-tlv-state {
+    description
+      "State parameters relating to a sub-TLV of the extended link LSA";
+
+    leaf type {
+      type identityref {
+        base "oc-ospf-types:OSPFV2_EXTENDED_LINK_SUBTLV_TYPE";
+      }
+      description
+        "The type of the sub-TLV contained within the extended link TLV";
+    }
+  }
+
+  grouping ospfv2-lsdb-extended-prefix-tlv-state {
+    description
+      "State parameters related to a sub-TLV of an Extended Prefix LSA";
+
+    leaf type {
+      type identityref {
+        base "oc-ospf-types:OSPFV2_EXTENDED_PREFIX_SUBTLV_TYPE";
+      }
+      description
+        "The type of sub-TLV as indicated by the Extended Prefix LSA";
+    }
+  }
+
+  grouping ospfv2-lsdb-extended-prefix-range-state {
+    description
+      "Parameters of the Extended Prefix Range SubTLV";
+
+    uses ospfv2-lsdb-common-prefix-properties;
+
+    leaf range-size {
+      type uint16;
+      description
+        "The number of prefixes that are covered by the advertisement.";
+    }
+
+    leaf inter-area {
+      type boolean;
+      default false;
+      description
+        "When this leaf is set to true, then the prefix range is inter-area -
+        the flag is set by the ABR that advertises the Extended Prefix Range
+        TLV";
+    }
+
+    leaf prefix {
+      type inet:ipv4-prefix;
+      description
+        "The first prefix in the range of prefixes being described by the
+        extended prefix range sub-TLV";
+    }
+  }
+
+  grouping ospfv2-lsdb-extended-prefix-prefix-sid-state {
+    description
+      "Parameters of the Prefix-SID sub-TLV";
+
+    leaf no-php {
+      type boolean;
+      default false;
+      description
+        "If this leaf is set the advertising system has indicated that the
+        prefix SID must not be popped before delivering packets to it";
+    }
+
+    leaf mapping-server {
+      type boolean;
+      default false;
+      description
+        "If this leaf is set the SID was advertised by a Segment Routing
+        mapping server";
+    }
+
+    leaf explicit-null {
+      type boolean;
+      default false;
+      description
+        "If this leaf is set, the advertising system has requested that the
+        prefix SID value should be replaced with the explicit null label
+        value";
+    }
+
+    leaf sid-value-type {
+      type enumeration {
+        enum ABSOLUTE {
+          description
+            "The SID contained in the Prefix-SID sub-TLV is an absolute
+            value";
+        }
+        enum INDEX {
+          description
+            "The SID contained in the Prefix-SID sub-TLV is an index to the
+            SRGB";
+        }
+      }
+      description
+        "Specifies the type of the value specified within the Prefix SID
+        sub-TLV - in particular, whether the value is an index or an
+        absolute value. This value corresponds with the V-flag of the Prefix
+        SID sub-TLV";
+    }
+
+    leaf sid-scope {
+      type enumeration {
+        enum LOCAL {
+          description
+            "The value of the SID is
+            significant only to the advertising system";
+        }
+        enum GLOBAL {
+          description
+            "The value of the SID is globally significant";
+        }
+      }
+      description
+        "Specifies the scope of the SID advertisement within the Prefix SID
+        sub-TLV. The scope of the SID is independent of whether the SID
+        contained is an index, or an absolute value";
+    }
+
+    leaf multi-topology-identifier {
+      type uint8;
+      description
+        "The identifier for the topology to which the Prefix SID relates. The
+        value of this leaf is a MT-ID as defined in RFC4915";
+    }
+
+    leaf algorithm {
+      type uint8;
+      description
+        "The algorithm that computes the path associated with the Prefix SID";
+    }
+
+    leaf sid-value {
+      type uint32;
+      description
+        "The value of the Prefix SID. The meaning of this value is dependent
+        upon the type of SID, and its scope. The value contained is either a
+        32-bit value indicating the index of the SID, or a 24-bit label where
+        the 20 right-most bits are used for encoding the label value";
+    }
+  }
+
+  grouping ospfv2-lsdb-extended-prefix-sid-label-binding-state {
+    description
+      "State parameters relating to the extended prefix SID SID/Label binding
+      sub-TLV";
+
+    leaf mirroring {
+      type boolean;
+      default false;
+      description
+        "When set to true, this indicates that the SID/Label Binding sub-TLV
+        entries contained within this TLV are indicative of a mirroring
+        context";
+    }
+
+    leaf multi-topology-identifier {
+      type uint8;
+      description
+        "The identifier for the topology to which the SID/Label Binding
+        sub-TLV is associated. The value of this leaf is a MT-ID as defined
+        in RFC4915";
+    }
+
+    leaf weight {
+      type uint8;
+      description
+        "The weight of the advertised binding when used for load-balancing
+        purposes";
+    }
+  }
+
+  grouping ospfv2-lsdb-extended-prefix-sid-label-binding-tlv-state {
+    description
+      "State parameters directly relating to the SID/Label Binding TLV";
+
+    leaf type {
+      type identityref {
+        base
+         "oc-ospf-types:OSPFV2_EXTENDED_PREFIX_SID_LABEL_BINDING_SUBTLV_TYPE";
+      }
+      description
+        "The type of sub-TLV that is being contained within the SID/Label
+        sub-TLV";
+    }
+  }
+
+  grouping ospfv2-lsdb-extprefix-sid-label-binding-state {
+    description
+      "State parameters relating to the SID/Label binding sub-TLV of the
+      SID/Label/Binding TLV";
+
+    uses ospfv2-lsdb-common-sr-sid-spec;
+  }
+
+  grouping ospfv2-lsdb-extprefix-sid-label-ero-metric-state {
+    description
+      "State parameters relating to the ERO Metric Sub-TLV of the SID/Label
+      Binding TLV";
+
+    leaf metric {
+      type uint32;
+      description
+        "The metric representing the aggregate IGP or TE path cost for the
+        binding included within the SID/Label Binding TLV";
+    }
+  }
+
+  grouping ospfv2-lsdb-extprefix-sid-lbl-ero-path-seg-state {
+    description
+      "State parameters relating to the a segment included within the
+      ERO Path Sub-TLV of the SID/Label Binding TLV";
+
+    leaf type {
+      type identityref {
+        base "oc-ospf-types:OSPFV2_EXTPREFIX_BINDING_ERO_PATH_SEGMENT_TYPE";
+      }
+      description
+        "The type of the segment being specified as part of the ERO";
+    }
+
+    leaf loose {
+      type boolean;
+      default false;
+      description
+        "If this leaf is set the segment is identifier as a loose path
+        segment, otherwise the path strictly follows the path specified";
+    }
+  }
+
+  grouping ospfv2-lsdb-extprefix-sid-lbl-ero-ipv4-state {
+    description
+      "State parameters relating to an IPv4 address segment included within
+      the ERO path";
+
+    leaf address {
+      type inet:ipv4-address-no-zone;
+      description
+        "The IPv4 address of the hop within the ERO";
+    }
+  }
+
+  grouping ospfv2-lsdb-extprefix-sid-lbl-ero-unnum-state {
+    description
+      "State parameters relating to an unnumbered hop within the ERO path";
+
+    leaf router-id {
+      type inet:ipv4-address-no-zone;
+      description
+        "The IPv4 router identtifier of the remote system";
+    }
+
+    leaf interface-id {
+      type uint32;
+      description
+        "The identifier assigned to the link by the remote system";
+    }
+  }
+
+  grouping ospfv2-lsdb-extended-link-adj-sid-state {
+    description
+      "State parameters relating to the Adjacency SID sub-TLV of the
+      Extended Link LSA";
+
+    leaf backup {
+      type boolean;
+      default false;
+      description
+        "When this flag is set, it indicates that the adjacency SID refers to
+        an adjacency which is eligible for protection";
+    }
+
+    leaf group {
+      type boolean;
+      default false;
+      description
+        "When this flag is set it indicates that the adjacency SID refers to
+        a group of adjacencies that have a common value";
+    }
+
+    uses ospfv2-lsdb-common-sr-sid-spec;
+
+    leaf weight {
+      type uint8;
+      description
+        "The weight of the Adjacency SID when used for load-balancing";
+    }
+
+    leaf multi-topology-identifier {
+      type uint8;
+      description
+        "The multi-topology identifier with which the adjacency SID is
+        associated";
+    }
+  }
+
+  grouping ospfv2-lsdb-structure {
+    description
+      "Structural grouping for per-area LSDB contents";
+
+    container lsdb {
+      // Top-level RO, if this were ever to become writeable then
+      // the state containers lower down need config false added
+      config false;
+      description
+        "The link-state database for the OSPFv2 area";
+
+      container state {
+        description
+          "Operational state parameters relating to the OSPFv2
+          area";
+
+        uses ospfv2-lsdb-area-state;
+      }
+
+      container lsa-types {
+        description
+          "Enclosing container for a list of LSA types that are
+          in the LSDB for the specified area";
+
+        list lsa-type {
+          key "type";
+
+          description
+            "List of LSA types in the LSDB for the specified
+            area";
+
+          leaf type {
+            type leafref {
+              path "../state/type";
+            }
+            description
+              "A reference for the LSA type being described within
+              the LSDB";
+          }
+
+          container state {
+            description
+              "Top-level operational state parameters relating to
+              an LSA within the area";
+            uses ospfv2-lsdb-area-lsa-type-state;
+          }
+
+          container lsas {
+            description
+              "Enclosing container for a list of the LSAs of
+              the specified type received by the system";
+
+            list lsa {
+              key "link-state-id";
+
+              description
+                "List of the LSAs of a specified type in the
+                LSDB for the specified area";
+
+              leaf link-state-id {
+                type leafref {
+                  path "../state/link-state-id";
+                }
+                description
+                  "Reference to the Link State ID of the LSA";
+              }
+
+              container state {
+                description
+                  "Operational state parameters relating to all
+                  LSA types";
+                uses ospfv2-lsdb-area-lsa-state;
+              }
+
+              uses ospfv2-lsdb-router-lsa-structure {
+                when "../../state/type = 'oc-ospf-types:ROUTER_LSA'" {
+                  description
+                    "Include the router LSA hierarchy solely when
+                    that LSA type is being described";
+                }
+              }
+
+              uses ospfv2-lsdb-network-lsa-structure {
+                when "../../state/type = 'oc-ospf-types:NETWORK_LSA'" {
+                  description
+                    "Include the network LSA hierarchy solely when
+                    that LSA type is being described";
+                }
+              }
+
+              uses ospfv2-lsdb-summary-lsa-structure {
+                // rjs TODO: check this syntax
+                when "../../state/type = " +
+                  "'oc-ospf-types:SUMMARY_IP_NETWORK_LSA' or " +
+                  "../../state/type = 'oc-ospf-types:SUMMARY_ASBR_LSA'" {
+                  description
+                    "Include the summary LSA hierarchy solely when
+                    that LSA type is being described";
+                }
+              }
+
+              uses ospfv2-lsdb-asexternal-lsa-structure {
+                when "../../state/type = 'oc-ospf-types:AS_EXTERNAL_LSA'" {
+                  description
+                    "Include the AS external LSA hierarchy solely when
+                    that LSA type is being described";
+                }
+              }
+
+              uses ospfv2-lsdb-nssa-external-lsa-structure {
+                when "../../state/type = 'oc-ospf-types:NSSA_AS_EXTERNAL_LSA'" {
+                  description
+                    "Include the NSSA External LSA hierarchy solely
+                    when that LSA type is being described";
+                }
+              }
+
+              uses ospfv2-lsdb-opaque-lsa-structure {
+                when "../../state/type = 'oc-ospf-types:OSPFV2_LINK_SCOPE_OPAQUE_LSA'
+                  or ../../state/type = 'oc-ospf-types:OSPFV2_AREA_SCOPE_OPAQUE_LSA'
+                  or ../../state/type = 'oc-ospf-types:OSPFV2_AS_SCOPE_OPAQUE_LSA'" {
+                  description
+                    "Include the Opaque LSA structure when type of entry
+                    being described in an opaque LSA";
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/models/yang/common/openconfig-ospfv2.yang
+++ b/models/yang/common/openconfig-ospfv2.yang
@@ -1,0 +1,176 @@
+module openconfig-ospfv2 {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/ospfv2";
+
+  prefix "oc-ospfv2";
+
+  // import some basic types
+  //import ietf-inet-types { prefix inet; }
+  import openconfig-extensions { prefix "oc-ext"; }
+
+  // Include submodules
+  // Global:  All global context groupings;
+  include openconfig-ospfv2-global;
+  // Area:    Config/opstate for an area
+  include openconfig-ospfv2-area;
+  // Area Interface:  Config/opstate for an Interface
+  include openconfig-ospfv2-area-interface;
+  // LSDB: Operational state model covering the LSDB
+  include openconfig-ospfv2-lsdb;
+  // Common:  Content included in >1 context
+  include openconfig-ospfv2-common;
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "An OpenConfig model for Open Shortest Path First (OSPF)
+    version 2";
+
+  oc-ext:openconfig-version "0.5.1";
+
+  revision "2023-11-01" {
+    description
+      "Refactor apply policy to separate default policy in it's own common
+      set of groupings";
+    reference "0.5.1";
+  }
+
+  revision "2023-08-25" {
+    description
+      "Add leaf metric to lsdb-summary-lsa-state.";
+    reference "0.5.0";
+  }
+
+  revision "2023-08-09" {
+    description
+      "Update interface key to use interface-id type";
+    reference "0.4.3";
+  }
+
+  revision "2023-07-05" {
+    description
+      "Fix typo in experimental-te leaf description.";
+    reference "0.4.2";
+  }
+
+  revision "2023-03-06" {
+    description
+      "Clarify use of interface-ref.";
+    reference "0.4.1";
+  }
+
+  revision "2022-02-10" {
+    description
+      "Fix spelling error in retransmission-queue-length leaf.";
+    reference "0.4.0";
+  }
+
+  revision "2021-07-28" {
+    description
+      "Add prefix to qualify when statements.";
+    reference "0.3.1";
+  }
+
+  revision "2021-03-17" {
+    description
+      "Add bfd support without augmentation.";
+    reference "0.3.0";
+  }
+
+  revision "2019-11-28" {
+    description
+      "Revert path changes in when statements in LSDB model";
+    reference "0.2.2";
+  }
+
+  revision "2019-11-05" {
+    description
+      "Fix paths in when statements in LSDB model";
+    reference "0.2.1";
+  }
+
+  revision "2019-07-09" {
+    description
+      "Normalise all timeticks64 to be expressed in nanoseconds.";
+    reference "0.2.0";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "0.1.3";
+  }
+
+  revision "2018-06-05" {
+    description
+      "Bug fixes in when statements in lsdb";
+    reference "0.1.2";
+  }
+
+  revision "2017-08-24" {
+    description
+      "Minor formatting fixes.";
+    reference "0.1.1";
+  }
+
+  revision "2017-02-28"{
+    description
+      "Initial public release of OSPFv2";
+    reference "0.1.0";
+  }
+
+  revision "2016-06-24" {
+    description
+      "Initial revision";
+    reference "0.0.1";
+  }
+
+  // OpenConfig specific extensions for module metadata.
+  oc-ext:regexp-posix;
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  grouping ospfv2-top {
+    description
+      "Top-level OSPF configuration and operational state";
+
+    container ospfv2 {
+      description
+        "Top-level configuration and operational state for
+        Open Shortest Path First (OSPF) v2";
+
+      uses ospfv2-global-structural;
+
+      container areas {
+        description
+          "Configuration and operational state relating to an
+	  OSPFv2 area.";
+
+        list area {
+          key "identifier";
+
+          description
+            "The OSPFv2 areas within which the local system exists";
+
+          leaf identifier {
+            type leafref {
+              path "../config/identifier";
+            }
+            description
+              "A reference to the identifier for the area.";
+          }
+
+          uses ospfv2-area-structure;
+        }
+      }
+    }
+  }
+}

--- a/models/yang/common/openconfig-pcep.yang
+++ b/models/yang/common/openconfig-pcep.yang
@@ -1,0 +1,386 @@
+module openconfig-pcep {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/pcep";
+
+  prefix "oc-pcep";
+
+  // import some basic types
+  import openconfig-extensions { prefix "oc-ext";}
+  import openconfig-inet-types { prefix "oc-inet";}
+  import openconfig-types { prefix "oc-types";}
+  import openconfig-keychain { prefix "oc-keychain";}
+
+  // meta
+  organization
+    "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This module defines configuration and operational state data
+    relating to Path Computation Element Protocol (PCEP) for communications
+    between a network element (router) acting as PCC and a PCE server,
+    according to RFC4655 definitions:
+
+     -PCC:  Path Computation Client; any client application requesting a
+      path computation to be performed by a Path Computation Element.
+
+     -PCE:  Path Computation Element; an entity (component, application, or
+      network node) that is capable of computing a network path or route
+      based on a network graph and applying computational constraints.
+
+     Also according to RFC4655, a PCE can be either stateful or
+     stateless. In the former case, there is a strict synchronization
+     between the PCE and not only the network states (in term of
+     topology and resource information), but also the set of computed
+     paths and reserved resources in use in the network. Conversely,
+     stateless PCEs do not have to remember any computed path and each
+     set of request(s) is processed independently of each other. For
+     example, stateless PCEs may compute paths based on current TED
+     information, which could be out of sync with actual network state
+     given other recent PCE-computed paths changes.
+
+     On the other hand, RFC8051 defines for Stateful PCE two modes of
+     operation:
+
+       -Passive Stateful PCE:  a PCE that uses LSP state information
+        learned from PCCs to optimize path computations.  It does not
+        actively update LSP state. A PCC maintains synchronization with
+        the PCE.
+
+       -Active Stateful PCE:  a PCE that may issue recommendations to
+        the network. For example, an Active Stateful PCE may use the
+        Delegation mechanism to update.
+
+      LSP parameters in those PCCs that delegate control over their LSPs to
+      the PCE.";
+
+  oc-ext:openconfig-version "0.1.1";
+
+  revision "2023-04-25" {
+    description
+      "Add clarifying comments on use of interface-ref.";
+    reference "0.1.1";
+  }
+
+  revision "2022-02-11" {
+    description
+      "Initial revision.";
+    reference "0.1.0";
+  }
+
+  // OpenConfig specific extensions for module metadata.
+  oc-ext:regexp-posix;
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  // typedef statements
+
+  typedef pce-mode-type {
+    type enumeration {
+      enum STATELESS {
+        description
+          "PCEP peer announce Stateless capability";
+      }
+      enum STATEFUL_PASSIVE {
+        description
+          "PCEP peer announce Stateful Passive capability";
+      }
+      enum STATEFUL_ACTIVE {
+        description
+          "PCEP peer announce Stateless Active";
+      }
+    }
+    description
+      "The type of PCEP capability supported which is advertised in the
+       Open message when a PCEP session is established. It could be:
+
+        - Stateless PCEs: A PCE that do not have to remember any
+          computed path and each set of request(s) is processed
+          independently of each other(RFC4655).
+
+        - Passive Stateful PCE:  a PCE that uses LSP state information
+          learned from PCCs to optimize path computations, but it does
+          not actively update LSP state(RFC8051). - Active Stateful
+          PCE:  a PCE that may issue recommendations to the network by
+          using the Delegation mechanism to update LSP parameters in
+          those PCCs that delegate control over their LSPs to the PCE
+          (RFC8051).";
+    reference
+      "RFC8051: Applicability of a Stateful Path Computation Element (PCE)";
+  }
+
+  typedef lsp-control-type {
+    type enumeration {
+      enum PCE_DELEGATED {
+        description
+          "PCC (Router) delegates control over LSP path to PCE (stateful active)";
+      }
+      enum PCC_CONTROLLED {
+        description
+          "PCC (Router) don't allow or revoke control over LSP path to
+          PCE (stateless)";
+      }
+      enum PCC_REPORT_ONLY {
+        description
+          "PCC (Router) only inform to a PCE whenever the state of an LSP changes,
+          but without delegating control (stateful passive)";
+      }
+    }
+    description
+      "The LSP path can be delegated to PCE, locally controled by PCC
+      or only report information state to the PCE.";
+    reference
+      "RFC8231: Path Computation Element Communication Protocol (PCEP)";
+  }
+
+  grouping pcep-servers-top {
+    description
+      "Configuration and state data for establishing a PCEP session with PCE servers.";
+
+    container path-computation-servers {
+      description
+        "Defines PCE server parameters.";
+
+      list path-computation-server {
+        key "pce-server-address";
+
+        description
+          "Configuration and state information for communication with a PCE server.";
+
+        leaf pce-server-address {
+          type leafref {
+            path "../config/pce-server-address";
+          }
+          description
+            "IPv4 address of PCE server.";
+        }
+
+        container config {
+          description
+            "PCE server configuration.";
+
+          uses pce-server-config;
+        }
+
+        container state {
+          config false;
+          description
+            "PCE server state.";
+
+          uses pce-server-config;
+        }
+
+	uses pcep-timers-top;
+	uses pcep-authentication-top;
+      }
+    }
+  }
+
+  grouping pce-server-config {
+    description
+      "Configuration data for establishing a PCEP session with pce servers.";
+
+    leaf pce-server-address {
+      type oc-inet:ip-address;
+      description
+      	"The destination IP address of the PCE server for PCEP service.
+      	Specify multiple entries in the path-computation-server-list to provide redundancy.
+      	When multiple candidate servers are specified for a single client,
+      	they are prioritized according to preference.";
+    }
+
+    leaf id {
+      type string;
+      description
+        "A unique name for the PCE server.";
+    }
+
+    leaf port {
+      type oc-inet:port-number;
+      default 4189;
+      description
+	    "The destination TCP port used for PCEP service in the PCE server.";
+    }
+
+    leaf source-address {
+      type oc-inet:ip-address;
+      description
+	    "The source IP address used by PCC(Router) to establish PCEP session.";
+    }
+
+    leaf pce-type {
+      type pce-mode-type;
+      description
+	    "The type of PCEP capability supported which is advertised in the Open
+        message when a PCEP session is established.";
+    }
+
+    leaf preference {
+      type uint8;
+      description
+        "When multiple PCE servers are specified, the candidate PCE server
+        with the highest preference is selected to calculate paths.
+        The greater or lower the value, the higher the preference could
+        dependon vendor implementation. If no preference value is set, indicate
+        the lowest preference or no preference at all.";
+    }
+
+    leaf report-local-lsp {
+      type boolean;
+      default false;
+      description
+      	"Specifies whether the PCC (Router) will advertise LSP existence and state
+      	for LSPs that are not controlled by any PCE (for example, LSPs that are
+      	statically configured at the PCC) but without delegating them.";
+     }
+
+     leaf pce-initiated-capability {
+       type boolean;
+       default false;
+       description
+      	 "Indicates to PCE that PCC (Router) supports PCE-initiated LSP paths instantiation.
+      	 A PCE can initiate LSPs only for PCCs that advertised this capability.";
+     }
+
+     leaf sr-support {
+       type boolean;
+       default false;
+       description
+      	 "Indicates to PCE that PCC (Router) supports Segment-Routing
+      	 to set up LSP paths in addition to RSVP-TE.";
+     }
+  }
+
+  grouping pcep-timers-top {
+    description
+      "Configuration and state data for timers applicable
+      to a established PCEP session with PCE server.";
+
+    container timers {
+      description
+        "This container defines PCEP timers.";
+
+      container config {
+        description
+          "This container defines PCEP timers configuration.";
+
+        uses pcep-timers-config;
+      }
+
+      container state {
+        config false;
+        description
+          "This container defines state information for PCEP timers.";
+
+        uses pcep-timers-config;
+      }
+    }
+  }
+
+  grouping pcep-timers-config  {
+    description
+      "Defines timers that applies to a PCEP session.";
+
+    leaf keepalive {
+      type uint8;
+      units seconds;
+      default 30;
+      description
+        "Interval for sending keepalive messages over PCE session.";
+    }
+
+    leaf dead-timer {
+      type uint8;
+      units seconds;
+      default 120;
+      description
+        "Interval after which PCE session is declared dead.";
+    }
+
+    leaf redelegation-timeout-interval {
+      type uint16;
+      units seconds;
+      description
+        "When a PCEP session is terminated, the period of time a PCC waits
+        before revoking LSP delegation and attempting to redelegate LSPs
+        associated with the terminated PCEP session to an alternate PCE.";
+     }
+
+     leaf state-timeout-interval {
+      type uint16;
+      units seconds;
+      description
+      	"When a PCEP session is terminated, the period of time a PCC waits
+      	before before flushing LSP state associated with that PCEP session
+      	and reverting to operator-defined default parameters or behaviors.";
+      }
+  }
+
+  grouping pcep-authentication-top {
+    description
+      "Grouping containing PCEP authentication attributes";
+
+    container authentication {
+      description
+        "Global PCEP authentication";
+      container config {
+        description
+          "Configuration of PCEP authentication attributes";
+        uses pcep-authentication-config;
+      }
+      container state {
+        config false;
+        description
+          "PCEP authentication state.";
+        uses pcep-authentication-config;
+      }
+    }
+  }
+
+  grouping pcep-authentication-config {
+    description
+      "PCEP authentication parameters container.";
+    leaf enable {
+      type boolean;
+      default false;
+      description
+        "Enables PCEP authentication on the node.";
+    }
+
+    leaf authentication-key {
+      type oc-types:routing-password;
+      description
+        "Password (key) used for securing a PCEP session using
+        TCP-MD5 authentication";
+      reference
+        "RFC1321: The MD5 Message-Digest Algorithm.
+        RFC5440: PCEP Specification";
+    }
+
+   leaf keychain {
+     type oc-keychain:keychain-ref;
+     description
+       "Reference to a predefined keychain that should be used to secure
+       PCEP session";
+  }
+}
+
+  grouping pcep-top {
+    description
+      "Top-level grouping for PCEP configuration.";
+
+    container pcep {
+      description
+        "Top-level PCEP configuration and operational state.";
+
+      uses pcep-servers-top;
+    }
+  }
+
+}

--- a/models/yang/common/openconfig-pf-forwarding-policies.yang
+++ b/models/yang/common/openconfig-pf-forwarding-policies.yang
@@ -1,0 +1,521 @@
+submodule openconfig-pf-forwarding-policies {
+  belongs-to openconfig-policy-forwarding {
+    prefix "oc-pf";
+  }
+
+  import openconfig-extensions { prefix "oc-ext"; }
+  import openconfig-packet-match { prefix "oc-pmatch"; }
+  import openconfig-yang-types { prefix "oc-yang"; }
+  import openconfig-inet-types { prefix "oc-inet"; }
+
+  include openconfig-pf-path-groups;
+
+  organization
+    "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This submodule contains configuration and operational state
+    relating to the definition of policy-forwarding policies.";
+
+  oc-ext:openconfig-version "0.6.1";
+
+  revision "2023-04-25" {
+    description
+      "Clarify use of interface-ref.";
+    reference "0.6.1";
+  }
+
+  revision "2023-03-27" {
+    description
+      "Add support for decap in one NI and further actions in other NIs.";
+    reference "0.6.0";
+  }
+
+  revision "2022-01-25" {
+    description
+      "Add GUE and MPLS-in-UDP decapsulation actions.";
+    reference "0.5.0";
+  }
+
+  revision "2021-08-06" {
+    description
+      "Update path to the network instance action to allow references
+      to other NIs.";
+    reference "0.4.0";
+  }
+
+  revision "2021-05-19" {
+    description
+      "Add a VRF selection policy type, and means to apply the
+      policy.";
+    reference "0.3.0";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "0.2.1";
+  }
+
+  revision "2017-06-21" {
+    description
+      "Amend policy forwarding model based on ACL changes.";
+    reference "0.2.0";
+  }
+
+  revision "2017-02-28" {
+    description
+      "Initial public release of policy forwarding.";
+    reference "0.1.0";
+  }
+
+  revision "2016-11-08" {
+    description
+      "Initial revision";
+    reference "0.0.1";
+  }
+
+  grouping pf-forwarding-policy-structural {
+    description
+      "Structural grouping defining forwarding policies under the
+      policy- forwarding module.";
+
+    container policies {
+      description
+        "Forwarding policies defined to enact policy-based forwarding
+        on the local system.";
+
+      list policy {
+        key "policy-id";
+
+        description
+          "A forwarding policy is defined to have a set of match
+          criteria, allowing particular fields of a packet's header to
+          be matched, and a set of forwarding actions which determines
+          how the local system should forward the packet.";
+
+        leaf policy-id {
+          type leafref {
+            path "../config/policy-id";
+          }
+          description
+            "Reference to the identifier for the forwarding-policy.";
+        }
+
+        container config {
+          description
+            "Configuration options relating to the forwarding
+            policy.";
+          uses pf-forwarding-policy-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state parameters relating to the forwarding
+            policy.";
+          uses pf-forwarding-policy-config;
+        }
+
+        container rules {
+          description
+            "The criteria that should be matched for a packet to be
+            forwarded according to the policy action.";
+
+          list rule {
+            key "sequence-id";
+
+            description
+              "A match rule for the policy. In the case that multiple
+              criteria are specified within a single rule, all criteria
+              must be met for the rule to be applied to a packet.";
+
+            leaf sequence-id {
+              type leafref {
+                path "../config/sequence-id";
+              }
+              description
+                "A unique sequence identifier for the match rule.";
+            }
+
+            container config {
+              description
+                "Configuration parameters relating to the match
+                rule.";
+              uses pf-forwarding-policy-rule-config;
+            }
+
+            container state {
+              config false;
+              description
+                "Operational state parameters relating to the match
+                rule.";
+              uses pf-forwarding-policy-rule-config;
+              uses pf-forwarding-policy-rule-state;
+            }
+
+            uses oc-pmatch:ethernet-header-top;
+            uses oc-pmatch:ipv4-protocol-fields-top;
+            uses oc-pmatch:ipv6-protocol-fields-top;
+            uses oc-pmatch:transport-fields-top;
+
+            container action {
+              description
+                "The forwarding policy action to be applied for
+                packets matching the rule.";
+
+              container config {
+                description
+                  "Configuration parameters relating to the forwarding
+                  rule's action.";
+                uses pf-forwarding-policy-action-config;
+              }
+
+              container state {
+                config false;
+                description
+                  "Operational state parameters relating to the
+                  forwarding rule's action.";
+                uses pf-forwarding-policy-action-config;
+              }
+
+              uses pf-forwarding-policy-action-encapsulate-gre;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  grouping pf-forwarding-policy-config {
+    description
+      "Configuration parameters relating to the forwarding policy.";
+
+    leaf policy-id {
+      type string;
+      description
+        "A unique name identifying the forwarding policy. This name is
+        used when applying the policy to a particular interface.";
+    }
+
+    leaf type {
+      type enumeration {
+        enum PBR_POLICY {
+          description
+            "The policy reflects a policy-based routing policy that supports generic
+            PBR actions.";
+        }
+        enum VRF_SELECTION_POLICY {
+          description
+            "The policy is used only to classify incoming packets into corresponding
+            network instances.";
+        }
+      }
+      default PBR_POLICY;
+      description
+        "The type of the policy. By default policies are generally usable for policy-based
+        routing, and have no restrictions on their implementation. Where there are alternate
+        policy types, this leaf specifies that a policy is expected to conform with a subset
+        of the functionality as described in the specified type.";
+    }
+  }
+
+  grouping pf-forwarding-policy-rule-config {
+    description
+      "Configuration parameters relating to a policy rule.";
+
+    leaf sequence-id {
+      type uint32;
+      description
+        "Unique sequence number for the policy rule.";
+    }
+  }
+
+  grouping pf-forwarding-policy-rule-state {
+    description
+      "Operational state parameters relating to a policy rule.";
+
+    leaf matched-pkts {
+      type oc-yang:counter64;
+      description
+        "Number of packets matched by the rule.";
+    }
+
+    leaf matched-octets {
+      type oc-yang:counter64;
+      description
+        "Bytes matched by the rule.";
+    }
+  }
+
+  grouping pf-forwarding-policy-action-config {
+    description
+      "Forwarding policy action configuration parameters.";
+
+    leaf discard {
+      type boolean;
+      default false;
+      description
+        "When this leaf is set to true, the local system should drop
+        packets that match the rule.";
+    }
+
+    leaf decapsulate-gre {
+      type boolean;
+      default false;
+      description
+        "When this leaf is set to true, the local system should remove
+        the GRE header from the packet matching the rule. Following
+        the decapsulation it should subsequently forward the
+        encapsulated packet according to the relevant lookup (e.g., if
+        the encapsulated packet is IP, the packet should be routed
+        according to the IP destination).";
+    }
+
+    leaf decap-network-instance {
+      type leafref {
+        // this must be an absolute reference to allow another NI
+        // to be referenced.
+        path "/network-instances/network-instance/config/name";
+      }
+      description
+        "This leaf is mutually exclusive with ../network-instance.
+        This leaf should be used along with
+        ../decap-fallback-network-instance and ../post-decap-network-instance.
+        This leaf is normally used with NIs (network instances) that are
+        populated by SDN controllers (e.g. via gRIBI), where we want:
+          - The decapsulation decision to be controlled by the
+            controllers.
+          - The new header after decapsulation is to be looked up in
+            another NI, and the NI is chosen by fields (e.g. source IP,
+            DSCP, etc) that are not used for route resolution.
+        When this leaf is set, packets matching the match criteria for
+        the forwarding rule should be looked up in the specified NI.
+        It is expected that the NI should only contain routes that have
+        next hop action as decapsulation.
+          - If there is a match, the packet should be decapsulated.
+            The route lookup on the new header should happen in the
+            ../post-decap-network-instance.
+          - If there is no match, the packet should be looked up in the
+            NI set by ../decap-fallback-network-instance.";
+    }
+
+    leaf decap-fallback-network-instance {
+      type leafref {
+        // this must be an absolute reference to allow another NI
+        // to be referenced.
+        path "/network-instances/network-instance/config/name";
+      }
+      description
+        "This leaf has to be set when ../decap-network-instance is set.
+        When this leaf is set, the specified NI should be used as a
+        fallback instance for lookup when
+        ../decap-network-instance produces no match for the packet.
+        NI specified by this leaf might contain different mixed next hop
+        actions (e.g. next hop IP, decapsulation, redirect to another NI,
+        etc).";
+    }
+
+    leaf post-decap-network-instance {
+      type leafref {
+        // this must be an absolute reference to allow another NI
+        // to be referenced.
+        path "/network-instances/network-instance/config/name";
+      }
+      description
+        "This leaf can only be set when ../decap-network-instance is set.
+        When this leaf is set, the specified NI should be used for lookup
+        on the new header after ../decap-network-instance does decap for
+        the matched packet. NI specified by this leaf might contain different
+        mixed next hop actions (e.g. next hop IP, decapsulation,
+        redirect to another NI, etc).";
+    }
+
+    leaf network-instance {
+      type leafref {
+        // this must be an absolute reference to allow another NI to be
+        // referenced.
+        path "/network-instances/network-instance/config/name";
+      }
+      description
+        "This leaf is mutually exclusive with ../decap-network-instance.
+        When this leaf is set, packets matching the match criteria
+        for the forwarding rule should be looked up in the
+        network-instance that is referenced rather than the
+        network-instance with which the interface is associated.
+        Such configuration allows policy-routing into multiple
+        sub-topologies from a single ingress access interface, or
+        different send and receive contexts for a particular
+        interface (sometimes referred to as half-duplex VRF).";
+    }
+
+    leaf path-selection-group {
+      type leafref {
+        // We are at:
+        // $NIROOT/policy-forwarding/policies/
+        // policy/rules/rule/action/config/to-path-group
+        path "../../../../../../../path-selection-groups/" +
+             "path-selection-group/config/group-id";
+      }
+      description
+        "When path-selection-group is set, packets matching the
+        match criteria for the forwarding rule should be forwarded
+        only via one of the paths that is specified within the
+        referenced path-selection-group. The next-hop of the packet
+        within the routing context should be used to determine between
+        multiple paths that are specified within the group.";
+    }
+
+    leaf next-hop {
+      type oc-inet:ip-address;
+      description
+        "When an IP next-hop is specified in the next-hop field,
+        packets matching the match criteria for the forwarding rule
+        should be forwarded to the next-hop IP address, bypassing any
+        lookup on the local system.";
+    }
+
+    leaf decapsulate-mpls-in-udp {
+      type boolean;
+      default false;
+      description
+        "When this leaf is set to true, the local system should remove
+        the UDP header from the packet matching the rule.
+        Following the decapsulation it should subsequently forward the
+        encapsulated packet according to the underlying MPLS label.";
+    }
+
+    leaf decapsulate-gue {
+      type boolean;
+      default false;
+      description
+        "When this leaf is set to true, the local system should remove
+        the Generic UDP Encapsulation (GUE) header from the packet matching
+        the rule. Following the decapsulation it should subsequently forward the
+        encapsulated packet according to the underlying IPv4 or IPv6 header.";
+    }
+  }
+
+  grouping pf-forwarding-policy-action-encapsulate-gre {
+    description
+      "Structural grouping covering the encapsulate-gre action of the
+      policy forwarding rule.";
+
+    container encapsulate-gre {
+      description
+        "Packets matching the policy rule should be GRE encapsulated
+        towards the set of targets defined within the target list. Where
+        more than one target is specified, or the target subnet expands
+        to more than one endpoint, packets should be load-balanced across
+        the destination addresses within the subnets.";
+
+      container config {
+        description
+          "Configuration parameters for the GRE encapsulation rules action.";
+        uses pf-forwarding-policy-action-gre-config;
+      }
+
+      container state {
+        description
+          "Operational state parameters for the GRE encapsulation rule
+          action.";
+        config false;
+        uses pf-forwarding-policy-action-gre-config;
+      }
+
+      container targets {
+        description
+          "Surrounding container for the list of GRE tunnel targets that
+          should be encapsulated towards.";
+
+        list target {
+          key "id";
+
+          leaf id {
+            type leafref {
+              path "../config/id";
+            }
+            description
+              "Reference to the unique identifier for the target.";
+          }
+
+          description
+            "Each target specified within this list should be treated as a
+            endpoint to which packets should be GRE encapsulated. Where the
+            set of destinations described within a single entry expands to
+            more than one destination IP address, packets should be load
+            shared across the destination using the local system's ECMP hashing
+            mechanisms.";
+
+          container config {
+            description
+              "Configuration parameters for the GRE target.";
+            uses pf-forwarding-policy-action-gre-target-config;
+          }
+
+          container state {
+            description
+              "Operational state parameters for the GRE target.";
+            config false;
+            uses pf-forwarding-policy-action-gre-target-config;
+          }
+        }
+      }
+    }
+  }
+
+  grouping pf-forwarding-policy-action-gre-config {
+    description
+      "Configuration parameters for the encapsulate-gre forwarding
+      policy action.";
+
+    leaf identifying-prefix {
+      type oc-inet:ip-prefix;
+      description
+        "An IP prefix that can be used to identify the group of
+         GRE endpoints that are being encapsulated towards. Systems
+         that require an IP identifier for the tunnel set
+         should use this prefix as the next-hop identifier.";
+    }
+  }
+
+  grouping pf-forwarding-policy-action-gre-target-config {
+    description
+      "Configuration parameters for each target of a GRE Encapsulation
+      rule";
+
+    leaf id {
+      type string;
+      description
+        "A unique identifier for the target.";
+    }
+
+    leaf source {
+      type oc-inet:ip-address;
+      description
+        "The source IP address that should be used when encapsulating
+        packets from the local system.";
+    }
+
+    leaf destination {
+      type oc-inet:ip-prefix;
+      description
+        "The set of destination addresses that should be encapsulated towards.
+        Where a subnet is specified, each address within the subnet should be
+        treated as an independent destination for encapsulated traffic. Packets
+        should be distributed with ECMP across the set of tunnel destination
+        addresses.";
+    }
+
+    leaf ip-ttl {
+      type uint8;
+      description
+        "The TTL that should be specified in the IP header of the GRE packet
+        encapsulating the packet matching the rule.";
+    }
+  }
+}

--- a/models/yang/common/openconfig-pf-interfaces.yang
+++ b/models/yang/common/openconfig-pf-interfaces.yang
@@ -1,0 +1,182 @@
+submodule openconfig-pf-interfaces {
+  belongs-to openconfig-policy-forwarding {
+    prefix "oc-pf";
+  }
+
+  import openconfig-extensions { prefix "oc-ext"; }
+  import openconfig-interfaces { prefix "oc-if"; }
+
+  include openconfig-pf-forwarding-policies;
+
+  organization
+    "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This submodule contains groupings related to the association
+    between interfaces and policy forwarding rules.";
+
+  oc-ext:openconfig-version "0.6.1";
+
+  revision "2023-04-25" {
+    description
+      "Clarify use of interface-ref.";
+    reference "0.6.1";
+  }
+
+  revision "2023-03-27" {
+    description
+      "Add support for decap in one NI and further actions in other NIs.";
+    reference "0.6.0";
+  }
+
+  revision "2022-01-25" {
+    description
+      "Add GUE and MPLS-in-UDP decapsulation actions.";
+    reference "0.5.0";
+  }
+
+  revision "2021-08-06" {
+    description
+      "Update path to the network instance action to allow references
+      to other NIs.";
+    reference "0.4.0";
+  }
+
+  revision "2021-05-19" {
+    description
+      "Add a VRF selection policy type, and means to apply the
+      policy.";
+    reference "0.3.0";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "0.2.1";
+  }
+
+  revision "2017-06-21" {
+    description
+      "Amend policy forwarding model based on ACL changes.";
+    reference "0.2.0";
+  }
+
+  revision "2017-02-28" {
+    description
+      "Initial public release of policy forwarding.";
+    reference "0.1.0";
+  }
+
+  revision "2016-11-08" {
+    description
+      "Initial revision";
+    reference "0.0.1";
+  }
+
+
+  grouping pf-interfaces-structural {
+    description
+      "Structural grouping for interface to forwarding policy bindings
+      within the policy-forwarding model.";
+
+    container interfaces {
+      description
+        "Configuration and operational state relating policy
+        forwarding on interfaces.";
+
+      list interface {
+        key "interface-id";
+
+        description
+          "Configuration and operationals state relating to the
+          relationship between interfaces and policy-based forwarding
+          rules.
+
+          The interface referenced is based on the interface and
+          subinterface leaves within the interface-ref container -
+          which reference an entry in the /interfaces/interface list -
+          and should not rely on the value of the list key.";
+
+        leaf interface-id {
+          type leafref {
+            path "../config/interface-id";
+          }
+          description
+            "A reference to the unique identifier for the interface
+            being referenced by the policy.";
+        }
+
+        container config {
+          description
+            "Configuration parameters relating to an interface to
+            policy forwarding rule binding.";
+
+          uses pf-interface-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state parameters relating to an interface to
+            policy forwarding rule binding.";
+
+          uses pf-interface-config;
+        }
+
+        uses oc-if:interface-ref;
+      }
+    }
+  }
+
+  grouping pf-interface-config {
+    description
+      "Configuration parameters relating to an interface to policy
+      forwarding rule binding.";
+
+    leaf interface-id {
+      type oc-if:interface-id;
+      description
+        "A unique identifier for the interface.";
+    }
+
+    leaf apply-forwarding-policy {
+      type leafref {
+        // We are at /network-instances/network-instance/
+        // policy-forwarding/interfaces/interface/config/
+        // apply-forwarding-policy
+        path "../../../../policies/policy/config/policy-id";
+      }
+      description
+        "The policy to be applied on the interface. Packets ingress on
+        the referenced interface should be compared to the match
+        criteria within the specified policy, and in the case that
+        these criteria are met, the forwarding actions specified
+        applied. These policies should be applied following quality of
+        service classification, and ACL actions if such entities are
+        referenced by the corresponding interface.";
+    }
+
+    leaf apply-vrf-selection-policy {
+      type leafref {
+        // We are at /network-instances/network-instance/
+        // policy-forwarding/interfaces/interface/config/
+        // apply-vrf-selection-policy
+        path "../../../../policies/policy/config/policy-id";
+      }
+      description
+        "Apply the specific VRF selection policy on the interface.
+        The referenced Interface must be resolved using the Interface
+        and Sub-interface leaves.
+
+        The referenced policy MUST be of the type VRF_SELECTION_POLICY.
+        The VRF selection policy may coexist with a policy-forwarding policy.
+
+        The policy specified in this leaf is used to specifically choose the L3VRF network
+        instance that is used for specific input criteria of packets.";
+    }
+  }
+}

--- a/models/yang/common/openconfig-pf-path-groups.yang
+++ b/models/yang/common/openconfig-pf-path-groups.yang
@@ -1,0 +1,162 @@
+submodule openconfig-pf-path-groups {
+  belongs-to openconfig-policy-forwarding {
+    prefix "oc-pf";
+  }
+
+  import openconfig-extensions { prefix "oc-ext"; }
+
+  organization
+    "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This submodule contains configuration and operational state
+    relating to path-selection-groups which are used to group
+    forwarding entities together to be used as policy forwarding
+    targets.";
+
+  oc-ext:openconfig-version "0.6.1";
+
+  revision "2023-04-25" {
+    description
+      "Clarify use of interface-ref.";
+    reference "0.6.1";
+  }
+
+  revision "2023-03-27" {
+    description
+      "Add support for decap in one NI and further actions in other NIs.";
+    reference "0.6.0";
+  }
+  revision "2022-01-25" {
+    description
+      "Add GUE and MPLS-in-UDP decapsulation actions.";
+    reference "0.5.0";
+  }
+
+  revision "2021-08-06" {
+    description
+      "Update path to the network instance action to allow references
+      to other NIs.";
+    reference "0.4.0";
+  }
+
+  revision "2021-05-19" {
+    description
+      "Add a VRF selection policy type, and means to apply the
+      policy.";
+    reference "0.3.0";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "0.2.1";
+  }
+
+  revision "2017-06-21" {
+    description
+      "Amend policy forwarding model based on ACL changes.";
+    reference "0.2.0";
+  }
+
+  revision "2017-02-28" {
+    description
+      "Initial public release of policy forwarding.";
+    reference "0.1.0";
+  }
+
+  revision "2016-11-08" {
+    description
+      "Initial revision";
+    reference "0.0.1";
+  }
+
+  grouping pf-path-groups-structural {
+    description
+      "Structural grouping containing the definition of path groups
+      within the context of policy-based forwarding.";
+
+    container path-selection-groups {
+      description
+        "Surrounding container for the path selection groups defined
+        within the policy forwarding model.";
+
+      list path-selection-group {
+        key "group-id";
+
+        leaf group-id {
+          type leafref {
+            path "../config/group-id";
+          }
+          description
+            "Reference to a unique identifier for the path selection
+            group";
+
+        }
+
+        description
+          "A path selection group is a set of forwarding resources,
+          which are grouped as eligible paths for a particular
+          policy-based forwarding rule. A policy rule may select a
+          path-selection-group as the egress for a particular type of
+          traffic (e.g., DSCP value). The system then utilises its
+          standard forwarding lookup mechanism to select from the
+          paths that are specified within the group - for IP packets,
+          the destination IP address is used such that the packet is
+          routed to the entity within the path-selection-group that
+          corresponds to the next-hop for the destination IP address
+          of the packet; for L2 packets, the selection is based on the
+          destination MAC address. If multiple paths within the
+          selection group are eligible to be used for forwarding,
+          the packets are load-balanced between them according to
+          the system's usual load balancing logic.";
+
+        container config {
+          description
+            "Configuration parameters relating to the path selection
+            group.";
+          uses pf-path-selection-group-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state parameters relating to the path
+            selection group.";
+          uses pf-path-selection-group-config;
+        }
+      }
+    }
+  }
+
+  grouping pf-path-selection-group-config {
+    description
+      "Configuration parameters relating to a path selection group.";
+
+    leaf group-id {
+      type string;
+      description
+        "A unique name for the path-selection-group";
+    }
+
+    leaf-list mpls-lsp {
+      type leafref {
+        // We are at /network-instances/network-instance/
+        // policy-forwarding/path-selection-groups/
+        // path-selection-group/config/mpls-lsp
+        path "../../../../../mpls/lsps/constrained-path/tunnels/" +
+             "tunnel/config/name";
+      }
+      description
+        "A set of MPLS constrained-path LSPs which should be
+        considered for the policy forwarding next-hop. In order to
+        select between the LSPs within the path-selection-group, the
+        system should determine which LSP provides the best path to
+        the next-hop for the routed packet.";
+    }
+  }
+}

--- a/models/yang/common/openconfig-pf-srte.yang
+++ b/models/yang/common/openconfig-pf-srte.yang
@@ -1,0 +1,297 @@
+module openconfig-pf-srte {
+  yang-version "1";
+  namespace "http://openconfig.net/yang/policy-forwarding/sr-te";
+  prefix "oc-pf-srte";
+
+  import openconfig-extensions { prefix "oc-ext"; }
+  import openconfig-network-instance { prefix "oc-ni"; }
+  import openconfig-mpls-types { prefix "oc-mplst"; }
+  import openconfig-inet-types { prefix "oc-inet"; }
+  import openconfig-segment-routing-types { prefix "oc-srt"; }
+
+  organization
+    "OpenConfig working group";
+
+  contact
+    "OpenConfig Working group
+    www.openconfig.net";
+
+  description
+    "This module defines extensions to the OpenConfig policy forwarding
+    module to support static segment routing traffic engineering policy
+    definitions. Extensions are provided to match:
+
+      - Ingress binding SIDs, such that traffic can be mapped based on
+        an ingress label.
+      - A colour community and endpoint combination, such that the
+        routes can be resolved according to the policy forwarding
+        entries that are to be installed.
+
+    In addition, policy forwarding actions associated with next-hops are
+    added to the model. The next-hop set to be forwarded to is augmented
+    to cover a set of lists of segments. The most common application of
+    such segment lists is to express stacks of MPLS labels which are used
+    as SR segments. In addition, they may be used to expressed segments
+    in the form of IPv6 addresses.";
+
+  oc-ext:openconfig-version "0.2.0";
+
+  revision "2019-10-15" {
+    description
+      "Change imported segment-routing module.";
+    reference "0.2.0";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "0.1.1";
+  }
+
+  revision 2017-10-01 {
+    description
+      "Initial revision of the SR-TE policy SAFI model.";
+    reference "0.1.0";
+  }
+
+  // OpenConfig specific extensions for module metadata.
+  oc-ext:regexp-posix;
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  grouping oc-pf-srte-match-top {
+    description
+      "Top-level grouping used for SR-TE policy match criteria within
+      a policy forwarding rule.";
+
+    container srte {
+      description
+        "Match criteria associated with Segment Routing Traffic Engineering
+        policies.";
+
+      container config {
+        description
+          "Configuration parameters associated with SR-TE policies.";
+        uses oc-pf-srte-match-config;
+      }
+
+      container state {
+        config false;
+        description
+          "Operational state parameters associated with SR-TE policies.";
+        uses oc-pf-srte-match-config;
+      }
+    }
+  }
+
+  grouping oc-pf-srte-match-config {
+    description
+      "Configuration parameters specific to Segment Routing traffic
+      Engineering.";
+
+    leaf mpls-bsid {
+      type oc-mplst:mpls-label;
+      description
+        "The Binding SID (BSID) to be matched expressed as an MPLS label. Packets
+        that are ingress to the system with the top-most label matching
+        the SID value specified in this leaf should be forwarded according
+        to the policy. The top-most label (the specified Binding SID)
+        must be popped from the label stack by the system.";
+    }
+
+    leaf srte-endpoint {
+      type oc-inet:ip-address;
+      description
+        "When the policy forwarding rule is used for RIB resolution
+        to a Segment Routing Traffic Engineering path, the policy is used
+        when the required endpoint (which may be the protocol next-hop)
+        matches the endpoint address specified in this
+        leaf. When the leaf is set to all zeros (0.0.0.0 or ::), the endpoint
+        acts as a wildcard in the policy resolution.";
+    }
+
+    leaf srte-color {
+      type uint32;
+      description
+        "When the policy forwarding rule is used for RIB resolution to a
+        specific Segment Routing Traffic Engineering path, the policy is
+        used when the colour required in the policy (which may be specified
+        based on the value of a BGP extended colour community) matches the
+        value of this leaf. The colour being set to 0 indicates that the
+        colour is a wildcard in the policy resolution.";
+    }
+
+    leaf srte-preference {
+      type uint32;
+      description
+        "When there are multiple policy forwarding rules specified for
+        a particular SR-TE endpoint. The preference is used to resolve
+        between them. These rules may be learnt from a dynamic routing
+        protocol, or interface to the device, or from other static
+        entries configured on the system.";
+    }
+  }
+
+  grouping oc-pf-srte-segment-list-top {
+    description
+      "Top-level grouping for specifying segment lists under a policy
+      forwarding action.";
+
+    container segment-lists {
+      description
+        "A list of SR-TE segment lists that should be applied as an
+        action within this policy. Where a system selects the SR-TE
+        policy to be used, the list of segment lists that is specified
+        should be used as forwarding next-hops.";
+
+      list segment-list {
+        key "index";
+        description
+          "An individual segment list within the list of segment
+          lists used for SR-TE policies.";
+
+        leaf index {
+          type leafref {
+            path "../config/index";
+          }
+          description
+            "Reference to the index leaf which act as a key to the
+            segment-list list.";
+        }
+
+        container config {
+          description
+            "Configuration parameters for the SR-TE segment list.";
+          uses oc-pf-srte-segment-list-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state parameters relating to the SR-TE
+            segment list.";
+          uses oc-pf-srte-segment-list-config;
+        }
+
+        container sids {
+          description
+            "Surrounding container for the list of SIDs that makes up the
+            segment list.";
+
+          list sid {
+            key "index";
+
+            description
+              "List of SIDs that make up the segment list. The segment list
+              is formed by ordering the set of SIDs that are specified by
+              their index in ascending numerical order.";
+
+            leaf index {
+              type leafref {
+                path "../config/index";
+              }
+              description
+                "Reference to the SID's index within the segment list which
+                acts as the key of the list.";
+            }
+
+            container config {
+              description
+                "Configuration parameters relating to the SID within the
+                segment list.";
+              uses oc-pf-srte-segment-list-sid-config;
+            }
+
+            container state {
+              config false;
+              description
+                "Operational state parameters relating to the SID within
+                the segment list.";
+              uses oc-pf-srte-segment-list-sid-config;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  grouping oc-pf-srte-segment-list-config {
+    description
+      "Configuration parameters relating to a segment list.";
+
+    leaf index {
+      type uint64;
+      description
+        "Unique integer identifying the segment list within the set
+        of segment lists used for the SR-TE policy action.";
+    }
+
+    leaf weight {
+      type uint32;
+      description
+        "The weight of the segment list within the set of segment lists
+        specified for the policy. The traffic that is forwarded according
+        to the policy is distributed across the set of paths such that
+        each list receives weight/(sum of all weights) traffic.";
+    }
+  }
+
+  grouping oc-pf-srte-segment-list-sid-config {
+    description
+      "Configuration parameters relating to a SID within an SR-TE segment
+      list";
+
+    leaf index {
+      type uint64;
+      description
+        "The index of the SID within the segment list. The segment list is
+        applied by ordering the SID entries in ascending numerical order
+        beginning at 0.";
+    }
+
+    leaf value {
+      type oc-srt:sr-sid-type;
+      description
+        "The value of the SID that is to be used. Specified as an MPLS
+        label or IPv6 address.";
+    }
+
+    leaf mpls-ttl {
+      type uint8;
+      default 0;
+      description
+        "The TTL to be set if the type of the SID is an MPLS label. If the
+        value of the TTL is set to be 0, the value is picked by the local
+        implementation.";
+    }
+
+    leaf mpls-tc {
+      type uint8 {
+        range "0..7";
+      }
+      default 0;
+      description
+        "The value of the MPLS Traffic Class (TC) bits to be used if the
+        value of the SID is an MPLS label. In the case that the value is
+        set to 0, then the local implementation should choose the value.";
+    }
+  }
+
+  augment "/oc-ni:network-instances/oc-ni:network-instance/oc-ni:policy-forwarding/" +
+          "oc-ni:policies/oc-ni:policy/oc-ni:rules/oc-ni:rule" {
+    description
+      "Add the SR-TE specific policy forwarding match criteria to the
+      policy forwarding model.";
+
+    uses oc-pf-srte-match-top;
+  }
+
+  augment "/oc-ni:network-instances/oc-ni:network-instance/oc-ni:policy-forwarding/" +
+          "oc-ni:policies/oc-ni:policy/oc-ni:rules/oc-ni:rule/oc-ni:action" {
+    description
+      "Add the SR-TE specific policy forwarding actions to the
+      policy forwarding model.";
+
+    uses oc-pf-srte-segment-list-top;
+  }
+}

--- a/models/yang/common/openconfig-pim-types.yang
+++ b/models/yang/common/openconfig-pim-types.yang
@@ -1,0 +1,85 @@
+module openconfig-pim-types {
+
+    yang-version "1";
+
+    // namespace
+    namespace "http://openconfig.net/yang/pim/types";
+
+    prefix "oc-pim-types";
+
+    // import some basic types
+    import openconfig-extensions { prefix "oc-ext"; }
+
+    // meta
+    organization
+      "OpenConfig working group";
+
+    contact
+      "OpenConfig working group
+      www.openconfig.net";
+
+    description
+      "This module defines types related to the PIM protocol model.";
+
+    oc-ext:openconfig-version "0.1.1";
+
+    revision "2018-11-21" {
+      description
+        "Add OpenConfig module metadata extensions.";
+      reference "0.1.1";
+    }
+
+    revision "2018-02-19" {
+        description
+          "Initial revision.";
+        reference "0.1.0";
+    }
+
+    // OpenConfig specific extensions for module metadata.
+    oc-ext:regexp-posix;
+    oc-ext:catalog-organization "openconfig";
+    oc-ext:origin "openconfig";
+
+    // identity statements
+
+    identity PIM_MODE {
+        description
+          "Base identity for the operating modes of Protocol-Independent
+          Multicast.";
+    }
+
+    identity PIM_MODE_SPARSE {
+        base PIM_MODE;
+        description
+          "PIM sparse mode (PIM-SM).";
+        reference "RFC7761";
+    }
+
+    identity PIM_MODE_DENSE {
+        base PIM_MODE;
+        description
+          "PIM dense mode (PIM-DM).";
+        reference "RFC3973";
+    }
+
+    // typedef statements
+
+    typedef dr-priority-type {
+        type uint32;
+        description
+          "The port's designated router priority. Larger always preferred.
+          DR Priority is a 32-bit unsigned number, ranges 0-4294967295.";
+        reference "RFC7761 4.3.1 page 33";
+    }
+
+    typedef pim-interval-type {
+        type uint8 {
+          range 1..255;
+        }
+        units "seconds";
+        description
+          "Interval at which the router sends the PIM message toward the
+          upstream RPF neighbor.";
+        reference "RFC7761 4.5 page 44, 4.3.1 page 29";
+    }
+}

--- a/models/yang/common/openconfig-pim.yang
+++ b/models/yang/common/openconfig-pim.yang
@@ -1,0 +1,547 @@
+module openconfig-pim {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/pim";
+
+  prefix "oc-pim";
+
+  // import some basic types/interfaces
+  import openconfig-pim-types { prefix oc-pim-types; }
+  import openconfig-interfaces { prefix oc-if; }
+  import openconfig-acl { prefix oc-acl; }
+  import openconfig-types { prefix "oc-types"; }
+  import openconfig-extensions { prefix "oc-ext"; }
+  import ietf-inet-types { prefix "inet"; }
+  import openconfig-bfd { prefix "oc-bfd"; }
+
+  // meta
+  organization
+    "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "An OpenConfig model for Protocol Independent Multicast (PIM).";
+
+  oc-ext:openconfig-version "0.4.3";
+
+  revision "2023-03-06" {
+    description
+      "Clarify use of interface-ref.";
+    reference "0.4.3";
+  }
+
+  revision "2021-06-16" {
+    description
+      "Remove trailing whitespace";
+    reference "0.4.2";
+  }
+
+  revision "2021-04-21" {
+    description
+      "Reindent to two spaces and remove trailing whitespace ";
+    reference "0.4.1";
+  }
+
+  revision "2021-04-21" {
+    description
+      "Allow to limit the maximum number of groups to join
+      via PIM protocol. It can be configured at two levels,
+      depending on hardware implementation:
+      1. Network-instance level, the limit will apply
+      to all PIM sessions/joins ending in that network-instance.
+      2. Interface level, the limit would be discriminated per interface.";
+    reference "0.4.0";
+  }
+
+  revision "2021-03-17" {
+    description
+      "Add bfd support without augmentation.";
+    reference "0.3.0";
+  }
+
+  revision "2019-07-09" {
+    description
+      "Reindent to two spaces.
+      Ensure that timeticks64 is consistently expressed in nanoseconds.";
+    reference "0.2.0";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "0.1.1";
+  }
+
+  revision "2018-02-09" {
+    description
+      "Initial revision.";
+    reference "0.1.0";
+  }
+
+  // OpenConfig specific extensions for module metadata.
+  oc-ext:regexp-posix;
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  grouping admin-config {
+    description
+      "Re-usable grouping to enable or disable a particular feature.";
+
+    leaf enabled {
+      type boolean;
+      default false;
+      description
+        "When set to true, the functionality within which this
+        leaf is defined is enabled, when set to false it is
+        explicitly disabled.";
+    }
+  }
+
+  grouping pim-counters-state {
+    description
+      "Counters related to PIM messages.";
+
+    leaf hello-messages {
+      type uint32;
+      description
+        "Number of hello messages received.";
+      reference "RFC7761 4.9.2 page 108";
+    }
+
+    leaf join-prune-messages {
+      type uint32;
+      description
+        "Number of join/prune messages received.";
+      reference "RFC7761 4.5 page 44";
+    }
+
+    leaf bootstrap-messages {
+      type uint32;
+      description
+        "Number of bootstrap router messages received.";
+      reference "RFC7761 3.7 page 12";
+    }
+  }
+
+  grouping pim-interface-config {
+    description
+      "Configuration data for PIM on each interface.";
+
+    uses admin-config;
+
+    leaf interface-id {
+      type oc-if:interface-id;
+      description
+        "Reference to an interface on which PIM is enabled.";
+    }
+
+    leaf mode {
+      type identityref {
+        base oc-pim-types:PIM_MODE;
+      }
+      description
+        "PIM mode to use when delivering multicast traffic via this
+        interface.";
+    }
+
+    leaf bsr-border {
+      type boolean;
+      default false;
+      description
+        "When set to true the device will not send bootstrap router
+        messages over this interface. By default these are transmitted
+        over all PIM sparse mode (PIM-SM) enabled interfaces.";
+    }
+
+    leaf border-router {
+      type boolean;
+      default false;
+      description
+        "When set to true the interface is set as MBR (multicast border
+        router) and allows multicast traffic from sources that are
+        outside of the PIM domain.";
+    }
+
+    leaf dr-priority {
+      type oc-pim-types:dr-priority-type;
+      description
+        "The designated router priority of this interface. Larger always
+        preferred.";
+    }
+
+    leaf join-prune-interval {
+      type oc-pim-types:pim-interval-type;
+      description
+        "Interval at which the router sends the PIM join/prune messages
+        toward the upstream RPF neighbor.";
+    }
+
+    leaf hello-interval {
+      type oc-pim-types:pim-interval-type;
+      description
+        "Interval at which the router sends the PIM hello messages.";
+    }
+
+    leaf dead-timer {
+      type uint16 {
+        range 1..65535;
+      }
+      description
+        "Number of missed hello messages after which a neighbor is
+        expired.";
+    }
+
+    leaf maximum-groups {
+      type uint32;
+      description
+        "Limit the number of (S, G) and (*, G) PIM
+        entries accepted on the interface.
+        This feature depends on hardware implementation.";
+    }
+  }
+
+  grouping pim-neighbor-state {
+    description
+      "PIM neighbor state.";
+
+    leaf neighbor-address {
+      type inet:ipv4-address;
+      description
+        "IPv4 address of neighbor router.";
+    }
+
+    leaf dr-address {
+      type inet:ipv4-address;
+      description
+         "IPv4 address of designated router.";
+    }
+
+    leaf neighbor-established {
+      type oc-types:timeticks64;
+      description
+        "This timestamp indicates the time that the
+        PIM neighbor adjacency established. It is expressed
+        relative to the Unix Epoch (Jan 1, 1970 00:00:00 UTC).
+
+        The PIM session uptime can be computed by clients
+        as the difference between this value and the
+        current time in UTC.";
+    }
+
+    leaf neighbor-expires {
+      type oc-types:timeticks64;
+      description
+        "This timestamp indicates the time that the
+        PIM neighbor adjacency will expire should hello
+        messages fail to arrive from the neighbor. The value
+        is expressed relative to the Unix Epoch (Jan 1, 1970
+        00:00:00 UTC).";
+    }
+
+    leaf mode {
+      type identityref {
+        base oc-pim-types:PIM_MODE;
+      }
+      description
+        "PIM mode in use when delivering multicast traffic
+        via this neighbor.";
+    }
+  }
+
+  grouping pim-neighbors-top {
+    description
+      "Details about PIM neighbors.";
+
+    container neighbors {
+      config false;
+      description
+        "Details about PIM neighbors.";
+
+      list neighbor {
+        key "neighbor-address";
+        description
+          "Details about a specific PIM neighbor.";
+
+        leaf neighbor-address {
+          type leafref {
+            path "../state/neighbor-address";
+          }
+          description
+            "IPv4 address of neighbor router.";
+        }
+
+        container state {
+          config false;
+          description
+            "Details about a specific PIM neighbor.";
+
+          uses pim-neighbor-state;
+        }
+      }
+    }
+  }
+
+  grouping pim-interfaces-top {
+    description
+      "Configuration and state data for PIM on each interface.";
+
+    container interfaces {
+      description
+        "Configuration and state data for PIM on each interface.";
+
+      list interface {
+        key "interface-id";
+        description
+          "This container defines interface PIM configuration and
+          state information.
+
+          The interface referenced is based on the interface and
+          subinterface leaves within the interface-ref container -
+          which reference an entry in the /interfaces/interface list -
+          and should not rely on the value of the list key.";
+
+        leaf interface-id {
+          type leafref {
+            path "../config/interface-id";
+          }
+          description
+            "Reference to an interface on which PIM is enabled.";
+        }
+
+        container config {
+          description
+            "PIM interface configuration.";
+
+          uses pim-interface-config;
+        }
+
+        container state {
+          config false;
+          description
+            "State information for PIM interfaces.";
+
+          uses pim-interface-config;
+          container counters {
+            description
+              "PIM counters for each interface.";
+
+            uses pim-counters-state;
+          }
+        }
+
+        uses pim-neighbors-top;
+        uses oc-if:interface-ref;
+        uses oc-bfd:bfd-enable;
+      }
+    }
+  }
+
+
+  grouping pim-global-config {
+    description
+      "Configuration data for PIM.";
+    leaf maximum-groups {
+      type uint32;
+      description
+         "Limit the number of accepted (S, G) and (*, G)
+         PIM join states on the network-instance.";
+    }
+  }
+
+  grouping pim-global-state {
+    description
+      "State and session data for PIM on each interface.";
+    leaf neighbor-count {
+      type uint8;
+      description
+        "Number of adjacent PIM neighbors.";
+    }
+
+    container counters {
+      description
+        "Global PIM counters.";
+
+      uses pim-counters-state;
+    }
+  }
+
+  grouping pim-sources-joined-top {
+    description
+     "List of multicast sources joined.";
+
+    container sources-joined {
+      config false;
+      description
+        "List of multicast sources joined.";
+
+      list source {
+        key "address";
+        description
+          "A multicast source that has been joined.";
+
+        leaf address {
+          type leafref {
+            path "../state/address";
+          }
+          description
+            "Source address of multicast.";
+        }
+
+        container state {
+          config false;
+          description
+            "State for a multicast source that has been joined.";
+
+          leaf address {
+            type inet:ipv4-address;
+            description
+              "Source address of multicast.";
+          }
+
+          leaf group {
+            type inet:ipv4-address;
+            description
+              "Multicast address.";
+          }
+
+          leaf upstream-interface-id {
+            type oc-if:interface-id;
+            description
+              "The upstream interface for this multicast source.";
+          }
+        }
+      }
+    }
+  }
+
+  grouping pim-global-ssm-config {
+    description
+      "Source specific multicast (SSM) configuration.";
+
+    leaf ssm-ranges {
+      type leafref {
+        path "/oc-acl:acl/oc-acl:acl-sets/oc-acl:acl-set/" +
+        "oc-acl:config/oc-acl:name";
+      }
+      description
+        "List of accepted source specific multicast (SSM) address
+        ranges.";
+    }
+  }
+
+  grouping pim-global-rp-addresses-config {
+    description
+      "Defines rendezvous points for sparse mode multicast.";
+
+    leaf address {
+      type inet:ipv4-address;
+      description
+        "IPv4 address of rendezvous point.";
+    }
+
+    leaf multicast-groups {
+      type string;
+      // TODO should this be an ACL or prefix-list reference or prefix list?
+      // Cisco it's an ACL, Juniper it's an inline prefix list
+      description
+        "List of multicast groups (multicast IP address ranges) for which
+        this entry will be used as a rendezvous point. When not
+        present the default is equivalent to all valid IP multicast
+        addresses.";
+    }
+  }
+
+  grouping pim-global-top {
+    description
+      "Top level grouping for global PIM configuration.";
+
+    container config {
+      description
+        "Configuration for global PIM parameters";
+      uses pim-global-config;
+    }
+
+    container state {
+      config false;
+      description
+        "Global PIM state.";
+      uses pim-global-config;
+      uses pim-global-state;
+    }
+
+    container ssm {
+      description
+        "Source specific multicast (SSM).";
+
+      container config {
+        description
+          "Configuration for source specific multicast (SSM).";
+        uses pim-global-ssm-config;
+      }
+      container state {
+        config false;
+        description
+          "State for source specific multicast (SSM).";
+        uses pim-global-ssm-config;
+      }
+    }
+
+    container rendezvous-points {
+      description
+        "Defines rendezvous points for sparse mode multicast.";
+
+      list rendezvous-point {
+        key "address";
+        description
+          "Defines a rendezvous point (RP) for sparse mode multicast.";
+
+        leaf address {
+          type leafref {
+            path "../config/address";
+          }
+          description
+            "IPv4 address of rendezvous point.";
+        }
+
+        container config {
+          description
+            "Rendezvous point configuration.";
+          uses pim-global-rp-addresses-config;
+        }
+        container state {
+          config false;
+          description
+            "Rendezvous point state.";
+          uses pim-global-rp-addresses-config;
+        }
+      }
+    }
+    uses pim-sources-joined-top;
+  }
+
+  grouping pim-top {
+    description
+      "Top-level grouping for PIM.";
+
+    container pim {
+      description
+        "Top-level PIM configuration and operational state.";
+
+      container global {
+        description
+          "This container defines global PIM configuration and state
+          information.";
+        uses pim-global-top;
+      }
+
+      uses pim-interfaces-top;
+    }
+  }
+
+  // data definition statements
+}

--- a/models/yang/common/openconfig-platform-common.yang
+++ b/models/yang/common/openconfig-platform-common.yang
@@ -1,0 +1,269 @@
+submodule openconfig-platform-common {
+
+  yang-version "1";
+
+  belongs-to openconfig-platform {
+    prefix "oc-platform";
+  }
+
+  import openconfig-platform-types { prefix oc-platform-types; }
+  import openconfig-extensions { prefix oc-ext; }
+  import openconfig-types { prefix oc-types; }
+
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This modules contains common groupings that are used in multiple
+    components within the platform module.";
+
+  oc-ext:openconfig-version "0.27.0";
+
+  revision "2024-05-29" {
+    description
+      "Change install-position from leaf-ref to string.";
+    reference "0.27.0";
+  }
+
+   revision "2024-04-12" {
+    description
+      "Add install-position, install-component and deprecate location and
+      slot-id.";
+    reference "0.26.0";
+  }
+
+  revision "2024-01-30" {
+    description
+      "Updated description for component-power-type";
+    reference "0.25.0";
+  }
+
+  revision "2023-11-28" {
+    description
+      "Add model-name";
+    reference "0.24.0";
+  }
+
+  revision "2023-02-13" {
+    description
+      "Refactor resource utilization threshold config into a separate grouping.
+      Update 'utilization resource' to 'resource utilization'.";
+    reference "0.23.0";
+  }
+
+  revision "2022-12-20" {
+    description
+      "Add threshold and threshold-exceeded for resource usage.";
+    reference "0.22.0";
+  }
+
+  revision "2022-12-19" {
+    description
+      "Update last-high-watermark timestamp documentation.";
+    reference "0.21.1";
+  }
+
+  revision "2022-09-26" {
+    description
+      "Add state data for base-mac-address.";
+    reference "0.21.0";
+  }
+
+  revision "2022-08-31" {
+    description
+      "Add new state data for component CLEI code.";
+    reference "0.20.0";
+  }
+
+  revision "2022-07-28" {
+    description
+      "Add grouping for component power management";
+    reference "0.19.0";
+  }
+
+  revision "2022-07-11" {
+    description
+      "Add switchover ready";
+    reference "0.18.0";
+  }
+
+  revision "2022-06-10" {
+    description
+      "Specify units and epoch for switchover and reboot times.";
+    reference "0.17.0";
+  }
+
+  revision "2022-04-21" {
+    description
+      "Add platform utilization.";
+    reference "0.16.0";
+  }
+
+  // extension statements
+
+  // feature statements
+
+  // identity statements
+
+  // typedef statements
+
+  // grouping statements
+
+  grouping platform-resource-utilization-top {
+    description
+      "Top level grouping of platform resource utilization.";
+
+    container utilization {
+      description
+        "Resource utilization of the component.";
+
+      container resources {
+        description
+          "Enclosing container for the resources in this component.";
+
+        list resource {
+          key "name";
+          description
+            "List of resources, keyed by resource name.";
+
+          leaf name {
+            type leafref {
+              path "../config/name";
+            }
+            description
+              "References the resource name.";
+          }
+
+          container config {
+            description
+              "Configuration data for each resource.";
+
+            uses platform-resource-utilization-config;
+          }
+
+          container state {
+            config false;
+            description
+              "Operational state data for each resource.";
+
+            uses platform-resource-utilization-config;
+            uses platform-resource-utilization-state;
+          }
+        }
+      }
+    }
+  }
+
+  grouping resource-utilization-threshold-common {
+    description
+      "Common threshold configuration model for resource utilization.";
+    leaf used-threshold-upper {
+      type oc-types:percentage;
+      description
+        "The used percentage value (used / (used + free) * 100) that
+        when crossed will set utilization-threshold-exceeded to 'true'.";
+    }
+
+    leaf used-threshold-upper-clear {
+      type oc-types:percentage;
+      description
+        "The used percentage value (used / (used + free) * 100) that when
+        crossed will set utilization-threshold-exceeded to 'false'.";
+    }
+  }
+
+  grouping platform-resource-utilization-config {
+    description
+      "Configuration data for resource utilization.";
+
+    leaf name {
+      type string;
+      description
+        "Resource name within the component.";
+    }
+
+    uses resource-utilization-threshold-common;
+  }
+
+  grouping platform-resource-utilization-state {
+    description
+      "Operational state data for resource utilization.";
+
+    leaf used {
+      type uint64;
+      description
+        "Number of entries currently in use for the resource.";
+    }
+
+    leaf committed {
+      type uint64;
+      description
+        "Number of entries currently reserved for this resource. This is only
+        relevant to tables which allocate a block of resource for a given
+        feature.";
+    }
+
+    leaf free {
+      type uint64;
+      description
+        "Number of entries available to use.";
+    }
+
+    leaf max-limit {
+      type uint64;
+      description
+        "Maximum number of entries available for the resource. The value
+        is the theoretical maximum resource utilization possible.";
+    }
+
+    leaf high-watermark {
+      type uint64;
+      description
+        "A watermark of highest number of entries used for this resource.";
+    }
+
+    leaf last-high-watermark {
+      type oc-types:timeticks64;
+      description
+        "The timestamp when the high-watermark was last updated. The value
+        is the timestamp in nanoseconds relative to the Unix Epoch
+        (Jan 1, 1970 00:00:00 UTC).";
+    }
+
+    leaf used-threshold-upper-exceeded {
+      type boolean;
+      description
+        "This value is set to true when the used percentage value
+        (used / (used + free) * 100) has crossed the used-threshold-upper for this
+        resource and false when the used percentage value has crossed the configured
+        used-threshold-upper-clear value for this resource.";
+    }
+  }
+
+  grouping component-power-management {
+    description
+      "Common grouping for managing component power";
+
+    leaf power-admin-state {
+      type oc-platform-types:component-power-type;
+      default POWER_ENABLED;
+      description
+        "When set to POWER_DISABLED, the component should be shut down by removing
+        electrical power.  This is intended to be used to prevent the component
+        from becoming active even after a reboot of the system. A component
+        (if controller-card) may not honor power-admin-state depending on rules
+        defined in the description of the component config container.";
+    }
+  }
+
+  // data definition statements
+
+  // augment statements
+
+  // rpc statements
+
+  // notification statements
+}

--- a/models/yang/common/openconfig-platform-controller-card.yang
+++ b/models/yang/common/openconfig-platform-controller-card.yang
@@ -1,0 +1,93 @@
+module openconfig-platform-controller-card {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/platform/controller-card";
+
+  prefix "oc-ctrl-card";
+
+  import openconfig-platform { prefix oc-platform; }
+  import openconfig-extensions { prefix oc-ext; }
+
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This module defines data related to CONTROLLER_CARD components in
+    the openconfig-platform model";
+
+  oc-ext:openconfig-version "0.2.0";
+
+  revision "2024-04-10" {
+    description
+      "Added details on power-admin-state leaf";
+    reference "0.2.0";
+  }
+
+  revision "2022-07-28" {
+    description
+      "Initial revision";
+    reference "0.1.0";
+  }
+
+  // OpenConfig specific extensions for module metadata.
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  // extension statements
+
+  // feature statements
+
+  // identity statements
+
+  // typedef statements
+
+  // grouping statements
+
+  grouping controller-card-config {
+    description
+      "Configuration data for controller card components";
+
+    uses oc-platform:component-power-management;
+  }
+
+  // data definition statements
+
+  // augment statements
+
+  augment "/oc-platform:components/oc-platform:component/" +
+    "oc-platform:controller-card/oc-platform:config" {
+    description
+      "Configuration data for controller card components.
+      A controller-card can be configured for persistent powered-off
+      mode using the config/power-admin-state leaf. The reference
+      path below defines rules for such a configuration.";
+
+    reference
+      "Rules around power-off configuration in controller-cards:
+      https://github.com/openconfig/public/blob/master/doc/controller-card_poweroff.md";
+
+    uses controller-card-config;
+  }
+
+  augment "/oc-platform:components/oc-platform:component/" +
+    "oc-platform:controller-card/oc-platform:state" {
+    description
+      "Adding controller card data to physical inventory. This subtree
+      is only valid when the type of the component is CONTROLLER_CARD.";
+
+    uses controller-card-config;
+  }
+
+  // rpc statements
+
+  // notification statements
+
+}
+

--- a/models/yang/common/openconfig-platform-cpu.yang
+++ b/models/yang/common/openconfig-platform-cpu.yang
@@ -1,0 +1,72 @@
+module openconfig-platform-cpu {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/platform/cpu";
+
+  prefix "oc-cpu";
+
+  import openconfig-platform { prefix oc-platform; }
+  import openconfig-types { prefix oc-types; }
+  import openconfig-extensions { prefix oc-ext; }
+
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This module defines data related to FAN components in the
+    OpenConfig platform model.";
+
+  oc-ext:openconfig-version "0.1.1";
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "0.1.1";
+  }
+
+  revision "2018-01-30" {
+    description
+      "Initial revision";
+    reference "0.1.0";
+  }
+
+  // OpenConfig specific extensions for module metadata.
+  oc-ext:regexp-posix;
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  grouping component-cpu-utilization {
+    description
+      "Per-component CPU statistics";
+
+    container utilization {
+      description
+        "Statistics representing CPU utilization of the
+        component.";
+
+      container state {
+        config false;
+        description
+          "Operational state variables relating to the utilization
+           of the CPU.";
+
+        uses oc-types:avg-min-max-instant-stats-pct;
+      }
+    }
+  }
+
+  augment "/oc-platform:components/oc-platform:component/" +
+    "oc-platform:cpu" {
+    description
+      "Adding CPU utilization data to component model";
+
+    uses component-cpu-utilization;
+  }
+}

--- a/models/yang/common/openconfig-platform-ext.yang
+++ b/models/yang/common/openconfig-platform-ext.yang
@@ -1,0 +1,82 @@
+module openconfig-platform-ext {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/platform/extension";
+
+  prefix "oc-platform-ext";
+
+  import openconfig-platform { prefix oc-platform; }
+  import openconfig-extensions { prefix oc-ext; }
+
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This module defines optional extensions to the OpenConfig
+    platform model.";
+
+  oc-ext:openconfig-version "0.1.1";
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "0.1.1";
+  }
+
+  revision "2018-01-18" {
+    description
+      "Initial revision";
+    reference "0.1.0";
+  }
+
+  // OpenConfig specific extensions for module metadata.
+  oc-ext:regexp-posix;
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  // identity statements
+
+  // typedef statements
+
+  // grouping statements
+
+
+  grouping platform-component-ext-state {
+    description
+      "Operational state data for platform components";
+
+    leaf entity-id {
+      type uint32;
+      description
+        "A unique numeric identifier assigned by the system to the
+        component. This identifier may be used to represent the
+        corresponding SNMP Entity MIB identifier.";
+    }
+  }
+
+
+  // data definition statements
+
+  // augment statements
+
+  augment "/oc-platform:components/oc-platform:component/" +
+    "oc-platform:state" {
+    description
+      "Adding extension state data to components";
+
+    uses platform-component-ext-state;
+  }
+
+  // rpc statements
+
+  // notification statements
+
+}
+

--- a/models/yang/common/openconfig-platform-fabric.yang
+++ b/models/yang/common/openconfig-platform-fabric.yang
@@ -1,0 +1,81 @@
+module openconfig-platform-fabric {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/platform/fabric";
+
+  prefix "oc-fabric";
+
+  import openconfig-platform { prefix oc-platform; }
+  import openconfig-extensions { prefix oc-ext; }
+
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This module defines data related to FABRIC components in
+    the openconfig-platform model";
+
+  oc-ext:openconfig-version "0.1.0";
+
+  revision "2022-07-28" {
+    description
+      "Initial revision";
+    reference "0.1.0";
+  }
+
+  // OpenConfig specific extensions for module metadata.
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  // extension statements
+
+  // feature statements
+
+  // identity statements
+
+  // typedef statements
+
+  // grouping statements
+
+  grouping fabric-config {
+    description
+      "Configuration data for fabric components";
+
+    uses oc-platform:component-power-management;
+  }
+
+  // data definition statements
+
+  // augment statements
+
+  augment "/oc-platform:components/oc-platform:component/" +
+    "oc-platform:fabric/oc-platform:config" {
+    description
+      "Adding fabric data to physical inventory. This subtree
+      is only valid when the type of the component is FABRIC.";
+
+    uses fabric-config;
+  }
+
+  augment "/oc-platform:components/oc-platform:component/" +
+    "oc-platform:fabric/oc-platform:state" {
+    description
+      "Adding fabric data to physical inventory. This subtree
+      is only valid when the type of the component is FABRIC.";
+
+    uses fabric-config;
+  }
+
+  // rpc statements
+
+  // notification statements
+
+}
+

--- a/models/yang/common/openconfig-platform-fan.yang
+++ b/models/yang/common/openconfig-platform-fan.yang
@@ -1,0 +1,76 @@
+module openconfig-platform-fan {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/platform/fan";
+
+  prefix "oc-fan";
+
+  import openconfig-platform { prefix oc-platform; }
+  import openconfig-extensions { prefix oc-ext; }
+
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This module defines data related to FAN components in the
+    OpenConfig platform model.";
+
+  oc-ext:openconfig-version "0.1.1";
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "0.1.1";
+  }
+
+  revision "2018-01-18" {
+    description
+      "Initial revision";
+    reference "0.1.0";
+  }
+
+  // OpenConfig specific extensions for module metadata.
+  oc-ext:regexp-posix;
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  // identity statements
+
+  // typedef statements
+
+  // grouping statements
+
+  grouping fan-state {
+    description
+      "Operational state data for fan components";
+
+    leaf speed {
+      type uint32;
+      units rpm;
+      description
+        "Current (instantaneous) fan speed";
+    }
+  }
+
+
+  // data definition statements
+
+  // augment statements
+
+  augment "/oc-platform:components/oc-platform:component/" +
+    "oc-platform:fan/oc-platform:state" {
+    description
+      "Adding fan data to component model";
+
+    uses fan-state;
+  }
+
+}
+

--- a/models/yang/common/openconfig-platform-healthz.yang
+++ b/models/yang/common/openconfig-platform-healthz.yang
@@ -1,0 +1,137 @@
+module openconfig-platform-healthz {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/platform/healthz";
+
+  prefix "oc-platform-healthz";
+
+  import openconfig-extensions { prefix oc-ext; }
+  import openconfig-types { prefix oc-types; }
+  import openconfig-platform { prefix oc-platform; }
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This model defines health-related variables for components
+     within the openconfig-platform model (which defines the
+     the /components hierarchy). It is designed to be used in
+     conjunction with the gNOI Healthz service (see
+     https://github.com/openconfig/gnoi/blob/main/healthz/README.md).
+
+     The health variables included in this model are streamed via
+     telemetry interfaces, where gNOI.Healthz is used to retrieve
+     further diagnostic and debugging informaton from a network
+     device.";
+
+  oc-ext:openconfig-version "0.1.1";
+
+  revision "2023-04-11" {
+    description
+      "Clarification for healthz state transition and unhealthy-count leaf";
+    reference "0.1.1";
+  }
+
+  revision "2023-01-23" {
+    description
+      "Initial healthz variable revision";
+    reference "0.1.0";
+  }
+
+
+  grouping platform-health-top {
+    description
+      "Grouping containing health-related parameters.";
+
+    container healthz {
+      description
+        "The health of the component. The paramaters within this
+        container indicate the status of the component beyond whether
+        it is operationally up or down. When a signal is received
+        that a component is in an unhealthy state the gNOI.Healthz
+        service can be used to retrieve further diagnostic information
+        relating to the component.
+
+        The contents of this directory relate only to the specific
+        component that it is associated with. In the case that child
+        components become unhealthy and this causes a parent component
+        to be unhealthy, the new unhealthy status should be reported at
+        both components, such that an interested system can take the
+        relevant actions (e.g., retrieve the Healthz output, or
+        apply mitigation actions).";
+      reference
+        "https://github.com/openconfig/gnoi/tree/main/healthz";
+
+      container state {
+        config false;
+        description
+          "Operational state parameters relating to component health.";
+        uses platform-health-state;
+      }
+    }
+  }
+
+  grouping platform-health-state {
+    description
+      "Operational state parameters relating to a platform component's
+      health.";
+
+    leaf status {
+      type enumeration {
+        enum UNSPECIFIED {
+          description
+            "The component's health status has not yet been checked
+            by the system.";
+        }
+
+        enum HEALTHY {
+          description
+            "The component is in a HEALTHY state, and is operating
+            within the expected parameters.";
+        }
+
+        enum UNHEALTHY {
+          description
+            "The component is in a unhealthy state, it is not
+            performing the function expected of it.";
+        }
+      }
+      description
+        "The status of the component, indicating its current health.";
+      oc-ext:telemetry-on-change;
+    }
+
+    leaf last-unhealthy {
+      type oc-types:timeticks64;
+      description
+        "The time at which the component as last observed to be unhealthy
+        represented as nanoseconds since the Unix epoch. Unhealthy is defined
+        as the component being in a state other than HEALTHY.";
+      oc-ext:telemetry-on-change;
+    }
+
+    leaf unhealthy-count {
+      type uint64;
+      description
+        "The number of status checks that have determined this component
+        to be in an unhealthy state. This counter should be incremented
+        when the component transitions from the HEALTHY to any other
+        state such that the value reflects the number of times the
+        component has become unhealthy.";
+      oc-ext:telemetry-on-change;
+    }
+  }
+
+  augment "/oc-platform:components/oc-platform:component" {
+    description
+      "Augment healthz information into the /components/component hierarchy.";
+
+    uses platform-health-top;
+  }
+}

--- a/models/yang/common/openconfig-platform-integrated-circuit.yang
+++ b/models/yang/common/openconfig-platform-integrated-circuit.yang
@@ -1,0 +1,180 @@
+module openconfig-platform-integrated-circuit {
+  yang-version "1";
+
+  namespace "http://openconfig.net/yang/platform/integrated-circuit";
+
+  prefix "oc-ic";
+
+  import openconfig-platform { prefix oc-platform; }
+  import openconfig-extensions { prefix oc-ext; }
+
+  organization "OpenConfig working group";
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This module defines extensions to the OpenConfig platform model
+    that apply to integrated circuit (INTEGRATED_CIRCUIT) components.
+    These components are generically forwarding NPUs or ASICs within
+    the system for which configuration or state is applicable.";
+
+  oc-ext:openconfig-version "0.3.1";
+
+  revision "2022-04-20" {
+    description
+      "Remove unused import";
+    reference "0.3.1";
+  }
+
+  revision "2021-08-09" {
+    description
+      "Amendments to the platform capacity model.";
+    reference "0.3.0";
+  }
+
+  revision "2021-07-08" {
+    description
+      "Adding integrated circuit memory parity error counters.";
+    reference "0.2.0";
+  }
+
+  revision "2021-06-21" {
+    description
+      "Fix typos in description statements.";
+    reference "0.1.2";
+  }
+
+  revision "2021-06-16" {
+    description
+      "Remove trailing whitespace.";
+    reference "0.1.1";
+  }
+
+  revision "2021-05-16" {
+    description
+      "Initial revision with platform capacity.";
+    reference "0.1.0";
+  }
+
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  grouping backplane-facing-capacity-structural {
+    description
+      "Structural grouping for reporting on backplane-facing capacity of an integrated
+      circuit.";
+
+    container backplane-facing-capacity {
+      description
+        "This container allows a particular INTEGRATED_CIRCUIT to report its
+        available backplane-facing bandwidth. Where an integrated circuit is connected
+        by one or more links to the system's backplane, the capacity is the total cross-
+        sectional bandwidth available from the input ports of the integrated circuit
+        across the fabric. The capacity should also reflect the operational status of
+        the links.";
+
+      container state {
+        config false;
+        description
+          "Operational state parameters relating to backplane capacity.";
+
+        uses backplane-capacity-state;
+      }
+    }
+  }
+
+  grouping backplane-capacity-state {
+    description
+      "Operational state relating to backplane capacity.";
+
+    leaf total {
+      type uint64;
+      units "bits per second";
+      description
+        "Total backplane-facing capacity that is available in the presence
+        of no link failures or degradation.";
+      oc-ext:telemetry-on-change;
+    }
+
+    leaf total-operational-capacity {
+      type uint64;
+      units "bits per second";
+      description
+        "Total backplane-facing capacity that is currently available based
+        on the active links.";
+      oc-ext:telemetry-on-change;
+    }
+
+    leaf consumed-capacity {
+      type uint64;
+      units "bits per second";
+      description
+        "Backplane-facing capacity that is consumed by front-panel ports that are connected
+        to the integrated circuit and are operationally up.";
+      oc-ext:telemetry-on-change;
+    }
+
+    leaf available-pct {
+      type uint16;
+      description
+        "Percentage of the total backplane-facing capacity that is currently available to the front
+        panel ports taking into account failures and/or degradation within the system.
+
+        In the case that there is more backplane-facing capacity available than the front-panel
+        ports consume, this value may be greater than 100%.";
+      oc-ext:telemetry-on-change;
+    }
+  }
+
+  grouping integrated-circuit-memory {
+    description
+      "Structural grouping for integrated circuit memory.";
+
+    container memory {
+      description
+        "Container for integrated circuit memory.";
+
+      container state {
+        config false;
+        description
+          "Operational state parameters relating to integrated circuit memory.";
+
+        uses integrated-circuit-memory-state;
+      }
+    }
+  }
+
+  grouping integrated-circuit-memory-state {
+    description
+      "Counters that correspond to parity errors in integrated circuit memory";
+
+    leaf corrected-parity-errors {
+      type uint64;
+      description
+        "Number of corrected parity errors. Single bit ECC errors can be
+        detected and corrected by most integrated circuits.";
+    }
+
+    leaf uncorrected-parity-errors {
+      type uint64;
+      description
+        "Number of uncorrected parity errors. Multi-bit ECC errors can be
+        detected but cannot be corrected by most integrated circuits.";
+    }
+
+    leaf total-parity-errors {
+      type uint64;
+      description
+        "Total number of parity errors. This includes both the corrected and
+        uncorrected parity errors.";
+    }
+  }
+
+  augment "/oc-platform:components/oc-platform:component/oc-platform:integrated-circuit" {
+    description
+      "Augment integrated circuit components with backplane-facing capacity and memory errors.";
+    uses backplane-facing-capacity-structural;
+    uses integrated-circuit-memory;
+  }
+}

--- a/models/yang/common/openconfig-platform-linecard.yang
+++ b/models/yang/common/openconfig-platform-linecard.yang
@@ -1,0 +1,157 @@
+module openconfig-platform-linecard {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/platform/linecard";
+
+  prefix "oc-linecard";
+
+  import openconfig-platform { prefix oc-platform; }
+  import openconfig-extensions { prefix oc-ext; }
+
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This module defines data related to LINECARD components in
+    the openconfig-platform model";
+
+oc-ext:openconfig-version "1.2.0";
+
+   revision "2024-04-12" {
+    description
+      "Add install-position, install-component and deprecate location and
+      slot-id.";
+    reference "1.2.0";
+  }
+
+  revision "2023-02-13" {
+    description
+      "Renamed platform-utilization-top to platform-resource-utilization-top.";
+    reference "1.1.0";
+  }
+
+  revision "2022-07-28" {
+    description
+      "Remove leaf power-admin-state and use a common definition
+      instead.";
+    reference "1.0.0";
+  }
+
+  revision "2022-04-21" {
+    description
+      "Add platform utilization to linecard.";
+    reference "0.2.0";
+  }
+
+  revision "2020-05-10" {
+    description
+      "Remove when statement that references read-only entity from
+      a read-write context.";
+    reference "0.1.2";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "0.1.1";
+  }
+
+  revision "2017-08-03" {
+    description
+      "Initial revision";
+    reference "0.1.0";
+  }
+
+  // OpenConfig specific extensions for module metadata.
+  oc-ext:regexp-posix;
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  // extension statements
+
+  // feature statements
+
+  // identity statements
+
+  // typedef statements
+
+  // grouping statements
+
+  grouping linecard-config {
+    description
+      "Configuration data for linecard components";
+
+    uses oc-platform:component-power-management;
+  }
+
+  grouping linecard-state {
+    description
+      "Operational state data for linecard components";
+
+    leaf slot-id {
+      status deprecated;
+      type string;
+      description
+        "Identifier for the slot or chassis position in which the
+        linecard is installed.
+
+        This leaf is deprecated and will be replaced by install-position
+        and install-component leaves in a future major revision of this
+        model.";
+    }
+  }
+
+  grouping linecard-top {
+    description
+      "Top-level grouping for linecard data";
+
+    container linecard {
+      description
+        "Top-level container for linecard data";
+
+      container config {
+        description
+          "Configuration data for linecards";
+
+        uses linecard-config;
+      }
+
+      container state {
+
+        config false;
+
+        description
+          "Operational state data for linecards";
+
+        uses linecard-config;
+        uses linecard-state;
+      }
+      uses oc-platform:platform-resource-utilization-top;
+    }
+  }
+
+  // data definition statements
+
+  // augment statements
+
+  augment "/oc-platform:components/oc-platform:component" {
+    description
+      "Adding linecard data to physical inventory. This subtree
+      is only valid when the type of the component is LINECARD.";
+
+    uses linecard-top;
+  }
+
+  // rpc statements
+
+  // notification statements
+
+}
+

--- a/models/yang/common/openconfig-platform-pipeline-counters.yang
+++ b/models/yang/common/openconfig-platform-pipeline-counters.yang
@@ -1,0 +1,1421 @@
+module openconfig-platform-pipeline-counters {
+
+  yang-version "1";
+
+  namespace "http://openconfig.net/yang/platform-pipeline-counters";
+  prefix "oc-ppc";
+
+  import openconfig-yang-types { prefix oc-yang; }
+  import openconfig-types { prefix oc-types; }
+  import openconfig-extensions { prefix oc-ext; }
+  import openconfig-platform { prefix oc-platform; }
+
+  organization
+    "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "Provide fine grain, per-Integrated Circuit (IC), telemetry data streams
+    that will identify the health, any packet drops, and any errors on the IC.
+    With this additional telemetry, the health of the IC, packet drops and
+    errors, can be explicitly monitored not only on a specific router, but also
+    on a specific IC on a specific router. The IC is divided into 5 platform
+    independent sub-blocks.
+      1. IC Interface Subsystem
+      2. Queueing Subsystem
+      3. Lookup Subsystem
+      4. Host Interface
+      5. Fabric Interface.
+    +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    |                                                                   |
+    | +---------------------------------------------------------------+ |
+    | | Integrated +---------------------------------------+          | |
+    | | Circuit    |     Host Interface                    |          | |
+    | |            +---------------------------------------+          | |
+    | |               +------------+                                  | |
+    | | +-----------+ |  Lookup    |                  +-------------+ | |
+    | | | IC        | |  Subsystem |                  |  Fabric     | | |
+    | | | Interface | |            |                  | Interface   | | |
+    | | | Subsystem | +------------+                  |             | | |
+    | | +-----------+                +-------------+  +-------------+ | |
+    | |                              | Queueing    |                  | |
+    | |                              | Subsystem   |                  | |
+    | |                              +-------------+                  | |
+    | |                                                               | |
+    | +---------------------------------------------------------------+ |
+    |                                                                   |
+    +-------------------------------------------------------------------+
+    Each IC implementation inside forwarding engines may have a different set of
+    counters. Some counters have different names but the same
+    functionality and can be grouped together. Most counters are different
+    between IC families and will have to be aggregated as generic counters. The
+    aggregation could mean either a specific IC counter needs to be mapped to
+    one of the values specified in this model, or it may require multiple IC
+    counters aggregated to produce one of the values in this model.
+    The following classes of counters will generalize the types of
+    statistics that are provided from each of the above 5 blocks.
+      A. Packet Counters
+      B. Drop Counters
+      C. Error Counters
+    The advantage of grouping all the packet counters for all 5 blocks,
+    all drop counters from all 5 blocks, and all error counters from all
+    5 blocks, is to have the abililty to receive all drop counters from
+    all 5 blocks, for example, with one request.";
+
+  oc-ext:openconfig-version "0.5.1";
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  revision "2023-10-08" {
+    description
+      "More detail description of pipe-line aggregated drop counters";
+    reference "0.5.1";
+  }
+
+  revision "2023-09-26" {
+    description
+      "Add no-route aggregate drop counter.";
+    reference "0.5.0";
+  }
+
+  revision "2023-02-03" {
+    description
+      "Add vendor-specific control-plane traffic queue counters";
+    reference "0.4.0";
+  }
+
+  revision "2022-12-01" {
+    description
+      "Add uRPF aggregate drop counter.";
+    reference "0.3.1";
+  }
+
+  revision "2022-11-09" {
+    description
+      "Add container for vendor specific drop counters.";
+    reference "0.3.0";
+  }
+
+  revision "2022-01-19" {
+    description
+      "Fixed typo for aggregate field.";
+    reference "0.2.1";
+  }
+
+  revision "2021-10-16" {
+    description
+      "Update pipeline error counters to allow for multiple errors
+      per block.";
+    reference "0.2.0";
+  }
+
+  revision "2020-07-31" {
+    description
+      "Initial revision of platform pipeline counters.";
+    reference "0.1.0";
+  }
+
+  grouping platform-pipeline-top {
+    description
+      "Top-level structural grouping for platform pipeline
+      counters.";
+
+    container pipeline-counters {
+      config false;
+      description
+        "Top-level container for the packet, drop, and error counters for the
+        five NPU sub-blocks.";
+      container packet {
+        description
+          "IC packet counters for all five NPU sub-blocks.";
+        container interface-block {
+          description
+            "The IC interface subsystem connects the IC to the external PHY or
+            MAC.";
+
+          // We do not need a 'config' container here since there is no configurable state for a particular
+          // entity.
+
+          container state {
+            description
+              "State and counters corresponding to the interface subsystem of
+              the IC.";
+
+            uses pipeline-counters-packet-interface-block-state;
+          }
+        }
+
+        container lookup-block {
+          description
+            "The IC lookup subsystem perform the next hop lookup of the packet
+            and other forwarding features such as firewall filters.";
+
+          container state {
+            description
+              "State and counters corresponding to the lookup subsystem of the
+              IC.";
+
+            uses pipeline-counters-packet-lookup-block-state;
+          }
+        }
+
+        container queueing-block {
+          description
+            "The IC queueing subsystem buffers the packet while processing it
+            and queues the packet for delivery to the next stage";
+
+          container state {
+            description
+              "State and counters corresponding to the queueing subsystem of
+              the IC.";
+
+            uses pipeline-counters-packet-queueing-block-state;
+          }
+        }
+
+        container fabric-block {
+          description
+            "The IC fabric block subsystem connects the IC to the external
+            systems fabric subsystem";
+
+          container state {
+            description
+              "State and counters corresponding to the fabric subsystem of the
+              IC.";
+
+            uses pipeline-counters-packet-fabric-block-state;
+          }
+        }
+
+        container host-interface-block {
+          description
+            "The IC host interface block subsystem connects the IC to the
+            external systems host or control subsystem";
+
+          container state {
+            description
+              "State and counters corresponding to the host interface subsystem
+              of the IC.";
+
+            uses pipeline-counters-packet-host-interface-block-state;
+          }
+        }
+      }
+
+      container drop {
+        description
+          "IC drop counters for all five NPU sub-blocks.";
+        container state {
+          description
+            "State container for IC drop counters";
+
+          uses pipeline-drop-packet-state;
+        }
+
+
+        container interface-block {
+          description
+            "The IC interface subsystem connects the IC to the external PHY or
+            MAC.";
+
+          // We do not need a 'config' container here since there is no configurable state for a particular
+          // entity.
+
+          container state {
+            description
+              "Drop counters corresponding to the interface subsystem of the
+              IC.";
+
+            uses pipeline-drop-packet-interface-block-state;
+          }
+        }
+
+        container lookup-block {
+          description
+            "The IC lookup subsystem perform the next hop lookup of the packet
+            and other forwarding features such as firewall filters.";
+
+          container state {
+            description
+              "Drop counters corresponding to the lookup subsystem of the IC.";
+
+            uses pipeline-drop-packet-lookup-block-state;
+          }
+        }
+
+        container queueing-block {
+          description
+            "The IC queueing subsystem buffers the packet while processing it
+            and queues the packet for delivery to the next stage";
+
+          container state {
+            description
+              "Drop counters corresponding to the queueing subsystem of the
+              IC.";
+
+            uses pipeline-drop-packet-queueing-block-state;
+          }
+        }
+
+        container fabric-block {
+          description
+            "The IC fabric block subsystem connects the IC to the external
+            systems fabric subsystem";
+
+          container state {
+            description
+              "Drop counters corresponding to the fabric subsystem of the IC.";
+
+            uses pipeline-drop-packet-fabric-block-state;
+          }
+        }
+
+        container host-interface-block {
+          description
+            "The IC host interface block subsystem connects the IC to the
+            external systems host or control subsystem";
+
+          container state {
+            description
+              "Drop counters corresponding to the host interface subsystem of
+              the IC.";
+
+            uses pipeline-drop-packet-host-interface-block-state;
+          }
+        }
+
+        uses pipeline-vendor-drop-packets;
+      }
+
+      container errors {
+        description
+          "IC errors for all five NPU sub-blocks.";
+        container interface-block {
+          description
+            "The IC interface subsystem connects the IC to the external PHY or
+            MAC.";
+
+          list interface-block-error {
+            key "name";
+            description
+              "An individual error within the interface block. Each error counter
+              is uniquely identified by the name of the error.";
+
+            leaf name {
+              type leafref {
+                path "../state/name";
+              }
+              description
+                "Reference to the name of the error being described.";
+            }
+
+            container state {
+              description
+                "Errors corresponding to the interface subsystem of the IC.";
+
+              uses pipeline-errors-packet-interface-block-state;
+            }
+          }
+        }
+
+        container lookup-block {
+          description
+            "The IC lookup subsystem perform the next hop lookup of the packet
+            and other forwarding features such as firewall filters.";
+
+          list lookup-block-error {
+            key "name";
+            description
+              "An individual error within the lookup block. Each error counter
+              is uniquely identified by the name of the error.";
+
+            leaf name {
+              type leafref {
+                path "../state/name";
+              }
+              description
+                "Reference to the name of the error being described.";
+            }
+
+            container state {
+              description
+                "Errors corresponding to the lookup subsystem of the IC.";
+
+              uses pipeline-errors-packet-lookup-block-state;
+            }
+          }
+        }
+
+        container queueing-block {
+          description
+            "The IC queueing subsystem buffers the packet while processing it
+            and queues the packet for delivery to the next stage";
+
+          list queueing-block-error {
+            key "name";
+            description
+              "An individual error within the queueing block. Each error counter
+              is uniquely identified by the name of the error.";
+
+            leaf name {
+              type leafref {
+                path "../state/name";
+              }
+              description
+                "Reference to the name of the error being described.";
+            }
+
+            container state {
+              description
+                "Errors corresponding to the queueing subsystem of the IC.";
+
+              uses pipeline-errors-packet-queueing-block-state;
+            }
+          }
+        }
+
+        container fabric-block {
+          description
+            "The IC fabric block subsystem connects the IC to the external
+            systems fabric subsystem";
+
+          list fabric-block-error {
+            key "name";
+            description
+              "An individual error within the fabric block. Each error counter
+              is uniquely identified by the name of the error.";
+
+            leaf name {
+              type leafref {
+                path "../state/name";
+              }
+              description
+                "Reference to the name of the error being described.";
+            }
+
+            container state {
+              description
+                "Errors corresponding to the fabric subsystem of the IC.";
+
+              uses pipeline-errors-packet-fabric-block-state;
+            }
+          }
+        }
+
+        container host-interface-block {
+          description
+            "The IC host interface block subsystem connects the IC to the
+            external systems host or control subsystem";
+
+          list host-interface-error {
+            key "name";
+            description
+              "An individual error within the host interface block. Each error
+              counter is uniquely identified by the name of the error.";
+
+            leaf name {
+              type leafref {
+                path "../state/name";
+              }
+              description
+                "Reference to the name of the error being described.";
+            }
+
+            container state {
+              description
+                "Errors corresponding to the host interface subsystem of
+                the IC.";
+
+              uses pipeline-errors-packet-host-interface-block-state;
+            }
+          }
+        }
+      }
+
+      uses pipeline-control-plane-top;
+    }
+  }
+
+  grouping pipeline-packets-common {
+    description
+      "A common set of packet counters that apply to multiple packet sections.";
+
+    leaf in-packets {
+      type oc-yang:counter64;
+      description
+        "Incoming packets towards the integrated-circuit interface
+        subsystem block from the line interfaces or fabric.";
+    }
+
+    leaf out-packets {
+      type oc-yang:counter64;
+      description
+        "Outgoing packets towards the line interfaces or fabric from the
+        integrated-circuit interface subsystem block.";
+    }
+
+    leaf in-bytes {
+      type oc-yang:counter64;
+      description
+        "Incoming bytes towards the integrated-circuit interface
+        subsystem block from the line interfaces or fabric.";
+    }
+
+    leaf out-bytes {
+      type oc-yang:counter64;
+      description
+        "Outgoing bytes towards the line interfaces or fabric from the
+        integrated-circuit interface subsystem block.";
+    }
+  }
+
+  grouping pipeline-counters-common-high-low-packets {
+    description
+      "A common set of high and low priority packet counters that apply to
+      multiple packet sections.";
+
+    leaf in-high-priority-packets {
+      type oc-yang:counter64;
+      description
+        "Incoming high priority packets towards the integrated-circuit
+        fabric subsystem block from the previous NPU sub block.";
+    }
+
+    leaf out-high-priority-packets {
+      type oc-yang:counter64;
+      description
+        "Outgoing high priority packets towards the fabric from the
+        integrated-circuit fabric subsystem block.";
+    }
+
+    leaf in-low-priority-packets {
+      type oc-yang:counter64;
+      description
+        "Incoming low priority packets towards the integrated-circuit fabric
+        subsystem block from the previous NPU sub block.";
+    }
+
+    leaf out-low-priority-packets {
+      type oc-yang:counter64;
+      description
+        "Outgoing low priority packets towards the fabric from the
+        integrated-circuit fabric subsystem block.";
+    }
+
+  }
+
+  grouping pipeline-counters-packet-interface-block-state {
+    description
+      "Each counter will aggregate incoming and outgoing packets and bytes
+      that connect the IC to the external MAC or PHY.";
+
+    uses pipeline-packets-common;
+
+  }
+
+  grouping pipeline-counters-packet-lookup-block-state {
+    description
+      "The IC lookup subsystem counters include total packets/bytes in/out of
+      the lookup subsystem and performance metrics for key functionality of this
+      subsystem such as lookup memory usage, nexthop memory usage, ACL,
+      and firewall usage";
+
+    leaf lookup-utilization {
+      type oc-types:percentage;
+      description
+        "The integrated-circuit lookup subsystem block utilization percentage.";
+    }
+
+    uses pipeline-packets-common;
+
+    leaf lookup-memory {
+      type uint64;
+      units bytes;
+      description
+        "The total amount of memory available in the lookup subsystem.";
+    }
+
+    leaf lookup-memory-used {
+      type uint64;
+      units bytes;
+      description
+        "The amount of memory used in the lookup subsystem.";
+    }
+
+    leaf nexthop-memory {
+      type uint64;
+      units bytes;
+      description
+        "The total amount of nexthop memory available in the lookup subsystem.";
+    }
+
+    leaf nexthop-memory-used {
+      type uint64;
+      units bytes;
+      description
+        "The amount of nexthops memory used in the lookup subsystem.";
+    }
+
+    leaf acl-memory-total-entries {
+      type uint64;
+      description
+        "Total firewall or ACL memory counter measured in entries.";
+    }
+
+    leaf acl-memory-used-entries {
+      type uint64;
+      description
+        "Amount of used firewall or ACL memory counter measured in entries.
+        The number of used entries must include the entries
+        that are 'allocated but free' if the memory reaping algorithm makes
+        these entries practically unusable.";
+    }
+
+    leaf acl-memory-total-bytes {
+      type uint64;
+      units bytes;
+      description
+        "Total firewall or ACL memory counter measured in bytes.";
+    }
+
+    leaf acl-memory-used-bytes {
+      type uint64;
+      units bytes;
+      description
+        "Amount of used firewall or ACL memory counter measured in bytes.
+        The number of used bytes must include the bytes
+        that are 'allocated but free' if the memory reaping algorithm makes
+        these bytes practically unusable";
+    }
+
+    leaf fragment-total-pkts {
+      type oc-yang:counter64;
+      description
+        "Total number of fragments generated by the CPU.";
+    }
+
+  }
+
+  grouping pipeline-counters-packet-queueing-block-state {
+    description
+      "The IC queueing subsystem counters include packets/bytes in/out of the
+      queueing subsystem and performance metrics for key functionality of this
+      subsystem such as memory used and loopback counts.";
+
+    uses pipeline-packets-common;
+
+    leaf queue-memory {
+      type uint64;
+      units bytes;
+      description
+        "The total amount of memory available in the queue subsystem.";
+    }
+
+    leaf queue-memory-used {
+      type uint64;
+      units bytes;
+      description
+        "The amount of memory used in the queue subsystem.";
+    }
+
+    leaf loopback-packets {
+      type oc-yang:counter64;
+      description
+        "The number of packets in the loopback or re-circulate subsystem.";
+    }
+
+    leaf loopback-bytes {
+      type uint64;
+      units bytes;
+      description
+        "The number of bytes in the loopback or re-circulate subsystem.";
+    }
+
+  }
+
+  grouping pipeline-counters-packet-fabric-block-state {
+    description
+      "The IC fabric subsystem counters include packets/cells in/out of the
+      fabric subsystem and performance metrics for key functionality of this
+      subsystem such as high and low priority packet counts.";
+
+    leaf in-cells {
+      type oc-yang:counter64;
+      description
+        "Incoming cells towards the integrated-circuit fabric
+        subsystem block from the previous NPU sub block.";
+    }
+
+    leaf out-cells {
+      type oc-yang:counter64;
+      description
+        "Outgoing cells towards the fabric from the
+        integrated-circuit fabric subsystem block.";
+    }
+
+    uses pipeline-packets-common;
+
+    leaf in-high-priority-cells {
+      type oc-yang:counter64;
+      description
+        "Incoming high priority cells towards the integrated-circuit fabric
+        subsystem block from the previous NPU sub block.";
+    }
+
+    leaf out-high-priority-cells {
+      type oc-yang:counter64;
+      description
+        "Outgoing high priority cells towards the fabric from the
+        integrated-circuit fabric subsystem block.";
+    }
+
+    leaf in-low-priority-cells {
+      type oc-yang:counter64;
+      description
+        "Incoming low priority cells towards the integrated-circuit fabric
+        subsystem block from the previous NPU sub block.";
+    }
+
+    leaf out-low-priority-cells {
+      type oc-yang:counter64;
+      description
+        "Outgoing low priority cells towards the fabric from the
+        integrated-circuit fabric subsystem block.";
+    }
+
+    uses pipeline-counters-common-high-low-packets;
+
+  }
+
+  grouping pipeline-counters-packet-host-interface-block-state {
+    description
+      "The IC host interface counters include packets/bytes in/out of the
+      host interface subsystem and performance metrics for key functionality
+      of this subsystem such as fragmented packet counts and hi/low priority
+      packet counts";
+
+    uses pipeline-packets-common;
+
+    leaf fragment-punt-pkts{
+      type oc-yang:counter64;
+      description
+        "The packets that were successfully punted to CPU due to egress MTU
+        exceeded.";
+    }
+
+    uses pipeline-counters-common-high-low-packets;
+
+  }
+
+  grouping pipeline-drops-common {
+    description
+      "A common set of drop counters that apply to multiple drop sections.";
+
+    leaf oversubscription {
+      type oc-yang:counter64;
+      description
+        "Number of packets dropped due to oversubscription of the
+        integrated-circuit subsystem block.";
+    }
+  }
+
+  grouping pipeline-drops-common-high-low {
+    description
+      "A common set of drop counters for high and low priority.";
+
+    leaf in-high-priority {
+      type oc-yang:counter64;
+      description
+        "Incoming high priority drops towards this integrated-circuit
+        subsystem block from the previous NPU sub-block or interface.";
+    }
+
+    leaf out-high-priority {
+      type oc-yang:counter64;
+      description
+        "Outgoing high priority drops towards the fabric/interface from this
+        integrated-circuit subsystem block.";
+    }
+
+    leaf in-low-priority {
+      type oc-yang:counter64;
+      description
+        "Incoming low priority drops towards this integrated-circuit
+        subsystem block from the previous NPU sub-block or interface.";
+    }
+
+    leaf out-low-priority {
+      type oc-yang:counter64;
+      description
+        "Outgoing low priority drops towards the fabric/interface from this
+        integrated-circuit subsystem block.";
+    }
+  }
+
+  grouping pipeline-drop-packet-interface-block-state {
+    description
+      "Each drop counter will aggregate incoming and outgoing packets, and
+      oversubscription drops that connect the IC to the external MAC or PHY.";
+
+    uses pipeline-drops-common;
+
+    leaf in-drops {
+      type oc-yang:counter64;
+      description
+        "Incoming drops towards the integrated-circuit interface
+        subsystem block from the interfaces due to any reason.";
+    }
+
+    leaf out-drops {
+      type oc-yang:counter64;
+      description
+        "Outgoing drops towards the interfaces from the
+        integrated-circuit interface subsystem block due to any reason.";
+    }
+
+  }
+
+  grouping pipeline-drop-packet-lookup-block-state {
+    description
+      "The IC lookup subsystem drop counters track key functionality of this
+      subsystem such as Oversubscription, no-route, no-label, no-NH, invalid-
+      packets, forwarding-policy, incorrect-software, rate-limit, fragments,
+      and firewall drops";
+
+    uses pipeline-drops-common;
+
+    leaf no-route {
+      type oc-yang:counter64;
+      description
+        "Packets dropped due to no FIB entry for this ipv4 or ipv6 lookup.";
+    }
+
+    leaf no-label {
+      type oc-yang:counter64;
+      description
+        "Packets dropped due to no FIB entry for this MPLS label.";
+    }
+
+    leaf no-nexthop {
+      type oc-yang:counter64;
+      description
+        "Packets dropped due to no nexthop information - either the nexthop is
+        not programmed, or there is an invalid nexthop, or there is no ARP
+        information so the nexthop is in invalid state.";
+    }
+
+    leaf invalid-packet {
+      type oc-yang:counter64;
+      description
+        "Packets dropped due to invalid packet format for ipv4, ipv6, or MPLS.";
+    }
+
+    leaf forwarding-policy {
+      type oc-yang:counter64;
+      description
+        "Packets dropped due to either a filter applied as part of a forwarding
+        policy or dropped due to a policy-based-routing policy lookup.";
+    }
+
+    leaf incorrect-software-state {
+      type oc-yang:counter64;
+      description
+        "Packets dropped due to any incorrect or invalid software state of the
+        forwarding structures during lookup.";
+    }
+
+    leaf rate-limit {
+      type oc-yang:counter64;
+      description
+        "Packets dropped due to rate limiters - either user configured rate
+        limiters or system rate limiters in the forwarding path.";
+    }
+
+    leaf fragment-total-drops {
+      type oc-yang:counter64;
+      description
+        "Total number of packets dropped that could not be fragmented by NPU
+        due to DF bit.";
+    }
+
+    leaf lookup-aggregate {
+      type oc-yang:counter64;
+      description
+        "Packets dropped due to aggregate lookup drop counters - this counter
+        is sometimes referred to as Normal Discards or
+        ENQ_DISCARDED_PACKET_COUNTER.";
+    }
+
+    leaf acl-drops {
+      type oc-yang:counter64;
+      description
+        "Packets dropped due to firewall or acl terms.";
+    }
+
+  }
+
+  grouping pipeline-drop-packet-queueing-block-state {
+    description
+      "The IC queueing subsystem drop counters track key functionality of this
+      subsystem such as oversubscription, memory-limit, incorrect-state, and
+      loopback drops.";
+
+    uses pipeline-drops-common;
+
+    leaf memory-limit {
+      type oc-yang:counter64;
+      description
+        "Packets dropped due to running out of the queue memory.";
+    }
+
+    leaf incorrect-state {
+      type oc-yang:counter64;
+      description
+        "Packets dropped due to hardware of software incorrect state of VOQs,
+        or fabric queues, or interface queues.";
+    }
+
+    leaf lookup-queue {
+      type oc-yang:counter64;
+      description
+        "Packets dropped in either the lookup or recirculation path.";
+    }
+
+  }
+
+  grouping pipeline-drop-packet-fabric-block-state {
+    description
+      "The IC fabric subsystem drop counters track key functionality of this
+      subsystem such as oversubscription, lost-packets, high and low priority
+      packet drops.";
+
+    uses pipeline-drops-common;
+
+    leaf lost-packets {
+      type oc-yang:counter64;
+      description
+        "Fabric drops due to re-ordering, or due to packets arriving late, or
+        due to some loss in the fabric.";
+    }
+
+    uses pipeline-drops-common-high-low;
+
+    leaf fabric-aggregate {
+      type oc-yang:counter64;
+      description
+        "Aggregate of fabric-in and fabric-out drops.";
+    }
+
+  }
+
+  grouping pipeline-drop-packet-host-interface-block-state {
+    description
+      "The IC host interface drop counters track key funcitonality of this
+      subsystem such as oversubscription, rate-limit, fragment, and
+      hi/low priority drop counts";
+
+    uses pipeline-drops-common;
+
+    leaf rate-limit {
+      type oc-yang:counter64;
+      description
+        "Packet drops due to the rate limit in the integrated-circuit host
+        subsystem block.";
+    }
+
+    uses pipeline-drops-common-high-low;
+
+    leaf fragment-punt {
+      type oc-yang:counter64;
+      description
+        "The packets that were failed to punt to CPU due to policing rate.";
+    }
+
+    leaf host-aggregate {
+      type oc-yang:counter64;
+      description
+        "Aggregate of all the drops in the host path.";
+    }
+
+  }
+
+  grouping pipeline-errors-common {
+    description
+      "A common set of error counters that apply to multiple error sections.";
+
+    leaf name {
+      type string;
+      description
+        "Name of the interrupt, hardware error, or software error in the NPU.";
+    }
+
+    leaf count {
+      type uint64;
+      description
+        "Total count of errors of this type.";
+    }
+
+    leaf threshold {
+      type uint64;
+      description
+        "Number of errors before a recovery action is automatically
+        taken by the system.";
+    }
+
+    leaf-list action {
+      type enumeration {
+        enum LOG {
+          description
+            "Log a descriptive message.";
+        }
+        enum LINECARD_REBOOT {
+          description
+            "The line card is brought offline and then back online.";
+        }
+        enum LINECARD_OFFLINE {
+          description
+            "The line card is brought offline.";
+        }
+        enum NPU_RESET {
+          description
+            "The NPU is brought offline and then back online.";
+        }
+        enum NPU_OFFLINE {
+          description
+            "The NPU is brought offline.";
+        }
+        enum GET_DIAGNOSTIC_INFO {
+          description
+            "Diagnostic data is gathered at the time of the problem.";
+        }
+        enum ALARM {
+          description
+            "An Alarm is raised";
+        }
+      }
+      description
+        "Error actions that are taken by the system - log, linecard reboot,
+        linecard offline, NPU reset, NPU offline, gather diagnostic data,
+        raise an alarm.";
+    }
+
+    leaf active {
+      type boolean;
+      default false;
+      description
+        "The error is currently in an active state. When the system detects
+        that the specified threshold is exceeded, this value should be set to
+        true.";
+      oc-ext:telemetry-on-change;
+    }
+
+    leaf level {
+      type enumeration {
+        enum FATAL {
+          description
+            "The Fatal error causes total packet loss";
+        }
+        enum MAJOR {
+          description
+            "The Major error causes persistent packet loss";
+        }
+        enum MINOR {
+          description
+            "The Minor error is an indication of some past problem, but now is
+            corrected";
+        }
+        enum INFORMATIONAL {
+          description
+            "Some problem happened that is not packet loss affecting.";
+        }
+      }
+      description
+        "The severity of the error that is being recorded by the system. This
+        value can be used by a consumer to determine the action when this error
+        is recorded.";
+    }
+  }
+
+  grouping pipeline-errors-packet-interface-block-state {
+    description
+      "Error counter will aggregate the errors that connect the IC to the
+      external MAC or PHY. Each error should contain the name, count,
+      last-occurrence, threshold, action, and severity level.";
+
+    uses pipeline-errors-common;
+
+  }
+
+  grouping pipeline-errors-packet-lookup-block-state {
+    description
+      "The IC lookup subsystem error counters include the errors encountered by
+      the lookup subsystem. Each error should contain the name, count,
+      last-occurrence, threshold, action, and severity level.";
+
+    uses pipeline-errors-common;
+
+  }
+
+  grouping pipeline-errors-packet-queueing-block-state {
+    description
+      "The IC queueing subsystem error counters include the errors encountered
+      by the queueing subsystem. Each error should contain the name, count,
+      last-occurrence, threshold, action, and severity level.";
+
+    uses pipeline-errors-common;
+
+  }
+
+  grouping pipeline-errors-packet-fabric-block-state {
+    description
+      "The IC fabric subsystem error counters include the errors encountered by
+      the fabric subsystem. Each error should contain the name, count,
+      last-occurrence, threshold, action, and severity level.";
+
+    uses pipeline-errors-common;
+
+  }
+
+  grouping pipeline-errors-packet-host-interface-block-state {
+    description
+      "The IC host interface error counters include the errors encountered by
+      the host interface subsystem. Each error should contain the name, count,
+      last-occurrence, threshold, action, and severity level.";
+
+    uses pipeline-errors-common;
+
+  }
+
+  grouping pipeline-drop-packet-state {
+    description
+      "Grouping of pipeline drop packet state.";
+
+    leaf adverse-aggregate {
+      type oc-yang:counter64;
+      description
+        "This captures the aggregation of all counters where the switch is
+        unexpectedly dropping packets. Occurrence of these drops on a stable
+        (no recent hardware or config changes) and otherwise healthy
+        switch needs further investigation.
+        This leaf counts packet discarded as result of corrupted
+        programming state in an INTEGRATED_CIRCUIT or corrupted data
+        structures of packet descriptors.
+
+        Note: corrupted packets received on ingress interfaces should be counted
+        in `/interfaces/interface/state/counters/in-errors` and NOT counted as
+        adverse-aggregate. This is because incoming corrupted packets are NOT
+        a signal of adverse state of an INTEGRATED_CIRCUIT but rather of an
+        entity adjacent to the Interface, such as a cable or transceiver). Therefore
+        such drops SHOULD NOT be counted as adverse-aggregate to preserve
+        a clean signal of INTEGRATED_CIRCUIT adverse state.";
+    }
+
+    leaf congestion-aggregate {
+      type oc-yang:counter64;
+      description
+        "This tracks the aggregation of all counters where the expected
+        conditions of packet drops due to internal congestion in some block of
+        the hardware that may not be visible in through other congestion
+        indicators like interface discards or queue drop counters.
+
+        This leaf counts packet discarded as result of exceeding
+        performance limits of an INTEGRATED_CIRCUT, when it processes
+        non-corrupted packets using legitimate, non-corrupted programming
+        state of the INTEGRATED_CIRCUIT.
+
+        The typical example is overloading given IC with higher packet rate (pps)
+        then given chip can handle. For example, let's assume chip X can process
+        3.6Bpps of incoming traffic and 2000 Mpps. However if average incoming
+        packet size is 150B, at full ingress rate this become 3000Mpps. Hence
+        1/3 of packets would be cropped and should be counted against
+        congestion-aggregate.
+
+        Another example is the case when some INTEGRATED_CIRCUIT internal data bus is
+        too narrow/slow for handling traffic. For example let's assume chip X needs to send
+        3Tbps of traffic to an external buffer memory which has only 2Tbps access I/O.  In
+        this case packets would be discarded, because of congestion of memory I/O bus
+        which is part of the INTEGRATED_CIRCUIT.  Depending on the design of the
+        INTEGRATED_CIRCUIT, packets could be discarded even if interface queues are
+        not full, hence this scenario is NOT treated as QoS queue tail-drops nor WRED drops.
+
+        Yet another example is the case where extremely large and long
+        ACL/filter requires more cycles to process than the INTEGRATED_CIRCUIT
+        has budgeted. ";
+    }
+
+    leaf packet-processing-aggregate {
+      type oc-yang:counter64;
+      description
+        "This aggregation of counters represents the conditions in which
+        packets are dropped due to legitimate forwarding decisions (ACL drops,
+        No Route etc.)
+        This counter counts packet discarded as result of processing
+        non-corrupted packet against legitimate, non-corrupted state
+        of INTEGRATED_CIRCUIT program (FIB content, ACL content, rate-limiting token-buckets)
+        which mandate packet drop. The examples of this class of discard are:
+        - dropping packets which destination address to no match any FIB entry
+        - dropping packets which destination address matches FIB entry pointing
+        to discard next-hop (e.g. route to null0)
+        - dropping packts due to ACL/packet filter decission
+        - dropping packets due to its TTL = 1
+        - dropping packets due to its size exceeds egress interface MTU and
+        packet can't be fragmented (IPv6 or do not fragment bit is set)
+        -  dropping packets due to uRPF rules (note: packet is counted here and
+        in separate, urpf-aggregate counter simultaneously)
+        - etc
+
+      Note:The INTEGRATED_CIRCUIT is doing exactly what it is programmed
+      to do, and the packet is parsable.
+      ";
+    }
+
+    leaf urpf-aggregate {
+      type oc-yang:counter64;
+      description
+        "This aggregation of counters represents the conditions in which
+        packets are dropped due to failing uRPF lookup check.  This counter
+        and the packet-processing-aggregate counter should be incremented
+        for each uRPF packet drop.
+        This counter counts packet discarded as result of Unicast Reverse
+        Path Forwarding verification.";
+      reference
+        "RFC2827: Network Ingress Filtering: Defeating Denial of Service Attacks which employ IP Source Address Spoofing
+        RFC3704: Ingress Filtering for Multihomed Networks";
+    }
+
+    leaf no-route {
+      type oc-yang:counter64;
+      description
+        "This aggregation of counters represents the conditions in which
+        packets are dropped due to no FIB entry for this ipv4 or ipv6 lookup.
+
+        This counter and the packet-processing-aggregate counter should be
+        incremented for each no-route packet drop.";
+    }
+
+  }
+
+  grouping pipeline-vendor-drop-packets {
+    description
+      "Grouping for vendor specific drop packets";
+
+    container vendor {
+      description
+        "Counters within these containers are defined and augmented by vendors.
+        As each ASIC and vendor has different implementation and internal
+        parts where packets may be dropped at any point in time. Providing
+        specific hardware counters provides better visibility into traffic drop.
+
+        The recommended usage of this container is to create an augment at
+        .../pipeline-counter/drop/vendor that contains additional vendor/platform
+        specific containers.
+
+        e.g.
+        augment /components/component/integrated-circuit/pipeline-counter/drop/vendor {
+          container <vendor name> {
+            container <platform name> {
+              uses pipeline-vendor-drop-containers;
+            }
+          }
+        }";
+
+      reference
+        "https://github.com/openconfig/public/tree/master/doc/vendor_counter_guide.md";
+    }
+  }
+
+  grouping pipeline-vendor-drop-containers {
+    description
+      "A utility grouping for vendors to insert when augmenting the vendor
+      drop counters container .../pipeline-counter/drop/vendor.
+
+      Counters that cannot differentiate between adverse, congestion, and
+      packet-processing should still be exposed as a vendor-specific,
+      packet-processing counter.";
+
+    reference
+      "https://github.com/openconfig/public/tree/master/doc/vendor_counter_guide.md";
+
+    container adverse {
+      description
+        "These counters capture where the switch is unexpectedly dropping
+        packets. Occurrence of these drops on a stable (no recent hardware
+        or config changes) and otherwise healthy switch needs further
+        investigation.
+
+        The sum of all counters under this container should match the value in
+        .../pipeline-counters/drop/state/adverse-aggregate";
+
+      container state {
+        description
+          "State container for vendor specific adverse counters.";
+      }
+    }
+
+    container congestion {
+      description
+        "These counters track expected conditions of packet drops due to
+        internal congestion in some block of the hardware that may not be
+        visible in through other congestion indicators like interface
+        discards or queue drop counters.
+
+        The sum of all counters under this container should match the value in
+        .../pipeline-counters/drop/state/congestion-aggregate";
+
+      container state {
+        description
+          "State container for vendor specific congestion counters.";
+      }
+    }
+
+    container packet-processing {
+      description
+        "These counters represent the conditions in which packets are dropped
+        due to legitimate forwarding decisions (ACL drops, No Route etc.)
+
+        The sum of all counters under this container should match the value in
+        .../pipeline-counters/drop/state/packet-processing-aggregate";
+
+      container state {
+        description
+          "State container for vendor specific packet processing counters.";
+      }
+    }
+  }
+
+  grouping control-plane-traffic-counters-state {
+    description
+      "Control plane traffic counter state grouping.";
+
+    leaf queued-aggregate {
+      type oc-yang:counter64;
+      description
+        "This captures the aggregation of all counters where the switch has enqueued
+        traffic related to the control-plane.";
+    }
+
+    leaf queued-bytes-aggregate {
+      type oc-yang:counter64;
+      description
+        "This captures the aggregation of all counters in bytes where the switch has
+        enqueued traffic related to the control-plane.";
+    }
+
+    leaf dropped-aggregate {
+      type oc-yang:counter64;
+      description
+        "This captures the aggregation of all counters where the switch has dropped
+        traffic related to the control-plane.";
+    }
+
+    leaf dropped-bytes-aggregate {
+      type oc-yang:counter64;
+      description
+        "This captures the aggregation of all counters in bytes where the switch has
+        dropped traffic related to the control-plane.";
+    }
+  }
+
+  grouping control-plane-traffic-vendor-counters {
+    description
+      "A utility grouping for vendors to use when augmenting the vendor-specific
+      control-plane traffic container.";
+
+    leaf queued {
+      type oc-yang:counter64;
+      description
+        "This counter counts the number of packets enqueued.
+
+        This counter should contribute to the total aggregate of
+        .../pipeline-counters/control-plane-traffic/state/queued-aggregate.";
+    }
+
+    leaf queued-bytes {
+      type oc-yang:counter64;
+      description
+        "This counter counts the number of bytes enqueued.
+
+        This counter should contribute to the total aggregate of
+        .../pipeline-counters/control-plane-traffic/state/queued-bytes-aggregate.";
+    }
+
+    leaf dropped {
+      type oc-yang:counter64;
+      description
+        "This counter counts the number of packets dropped.
+
+        This counter should contribute to the total aggregate of
+        .../pipeline-counters/control-plane-traffic/state/dropped-aggregate.";
+    }
+
+    leaf dropped-bytes {
+      type oc-yang:counter64;
+      description
+        "This counter counts the number of bytes dropped.
+
+        This counter should contribute to the total aggregate of
+        .../pipeline-counters/control-plane-traffic/state/dropped-bytes-aggregate.";
+    }
+  }
+
+  grouping pipeline-control-plane-top {
+    description
+      "Top-level structural grouping for control-plane traffic counters.";
+
+    container control-plane-traffic {
+      description
+        "Counters that are related to traffic destined to the control-plane.";
+
+      container state {
+        config false;
+        description
+          "State container for control-plane traffic counters.";
+
+        uses control-plane-traffic-counters-state;
+      }
+
+      container vendor {
+        description
+          "Counters within these containers are defined and augmented by vendors.
+          As each ASIC and vendor has different implementation and internal
+          parts where packets may be dropped at any point in time. Providing
+          vendor-specific counters provides better visibility into control-plane traffic.
+
+          The recommended usage of this container is to create an augment at
+          .../pipeline-counter/control-plane-traffic/vendor that contains additional
+          vendor/platform specific containers.
+
+          e.g.
+          augment /components/component/integrated-circuit/pipeline-counter/control-plane-traffic/vendor {
+            container <vendor name> {
+              container <platform name> {
+                container state {
+                  leaf counter-a {
+                    uses control-plane-traffic-vendor-counters;
+                  }
+
+                  leaf counter-b {
+                    uses control-plane-traffic-vendor-counters;
+                  }
+                }
+              }
+            }
+          }";
+
+        reference
+          "https://github.com/openconfig/public/tree/master/doc/vendor_counter_guide.md";
+      }
+    }
+  }
+
+  augment "/oc-platform:components/oc-platform:component/oc-platform:integrated-circuit" {
+    description
+      "Add operational state data that corresponds to sub-blocks of an integrated
+      circuit (NPU, ASIC) to the platform model.";
+
+    uses platform-pipeline-top;
+  }
+}

--- a/models/yang/common/openconfig-platform-port.yang
+++ b/models/yang/common/openconfig-platform-port.yang
@@ -1,0 +1,327 @@
+module openconfig-platform-port {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/platform/port";
+
+  prefix "oc-port";
+
+  // import some basic types
+  import openconfig-platform { prefix oc-platform; }
+  import openconfig-interfaces { prefix oc-if; }
+  import openconfig-if-ethernet { prefix oc-eth; }
+  import openconfig-extensions { prefix oc-ext; }
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This module defines data related to PORT components in the
+    openconfig-platform model";
+
+  oc-ext:openconfig-version "1.0.1";
+
+  revision "2023-03-22" {
+    description
+      "Clarify use of the interface-ref type.";
+    reference "1.0.1";
+  }
+
+  revision "2023-01-19" {
+    description
+      "Add clarification of the definition of a physical channel, and
+      example configurations.";
+    reference "1.0.0";
+  }
+
+  revision "2021-10-01" {
+    description
+      "Fix indentation for 'list group'";
+    reference "0.4.2";
+  }
+
+  revision "2021-06-16" {
+    description
+      "Remove trailing whitespace";
+    reference "0.4.1";
+  }
+
+  revision "2021-04-22" {
+    description
+      "Adding support for flexible port breakout.";
+    reference "0.4.0";
+  }
+
+  revision "2020-05-06" {
+    description
+      "Ensure that when statements in read-write contexts
+      reference only read-write leaves.";
+    reference "0.3.3";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "0.3.2";
+  }
+
+  revision "2018-11-07" {
+    description
+      "Fixed error in when statement path";
+    reference "0.3.1";
+  }
+
+  revision "2018-01-20" {
+    description
+      "Added augmentation for interface-to-port reference";
+    reference "0.3.0";
+  }
+
+  revision "2017-11-17" {
+    description
+      "Corrected augmentation path for port data";
+    reference "0.2.0";
+  }
+
+  revision "2016-10-24" {
+    description
+      "Initial revision";
+    reference "0.1.0";
+  }
+
+  // OpenConfig specific extensions for module metadata.
+  oc-ext:regexp-posix;
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  // extension statements
+
+  // feature statements
+
+  // identity statements
+
+  // typedef statements
+
+  // grouping statements
+
+  grouping group-config {
+    description
+      "Configuration data for the breakout group.";
+
+    leaf index {
+      type uint8;
+      description
+        "Each index specifies breakouts that are identical in
+        terms of speed and the number of physical channels.";
+    }
+
+    leaf num-breakouts {
+      type uint8;
+      description
+        "Sets the number of interfaces using this breakout group.";
+    }
+
+    leaf breakout-speed {
+      type identityref {
+        base oc-eth:ETHERNET_SPEED;
+      }
+      description
+        "Speed of interfaces in this breakout group, supported
+        values are defined by the ETHERNET_SPEED identity.";
+    }
+
+    leaf num-physical-channels {
+      type uint8;
+      description
+        "Sets the number of lanes or physical channels assigned
+        to the interfaces in this breakout group. This leaf need
+        not be set if there is only one breakout group where all
+        the interfaces are of equal speed and have equal number
+        of physical channels.
+
+        The physical channels referred to by this leaf are
+        electrical channels towards the transceiver.";
+    }
+  }
+
+  grouping group-state {
+    description
+      "Operational state data for the port breakout group.";
+  }
+
+  grouping port-breakout-top {
+    description
+      "Top-level grouping for port breakout data.";
+
+    container breakout-mode {
+      description
+        "Top-level container for port breakout-mode data.";
+
+      container groups {
+        description
+          "Top level container for breakout groups data.
+
+           When a device has the capability to break a port into
+           interfaces of different speeds and different number of
+           physical channels, it can breakout a 400G OSFP port with
+           8 physical channels (with support for 25G NRZ, 50G PAM4
+           and 100G PAM4) into  mixed speed interfaces. Particularly, to
+           break out into two 100G ports with different modulation, and a 200G
+           port, a user must configure 1 interface with 2 physical channels
+          1 interface with 4 physical channels and 1 interface with
+           2 physical channels. With this configuration the interface in
+           1st breakout group would use 50G PAM4 modulation, interface
+           in 2nd breakout group would use 25G NRZ modulation and the
+           interface in 3rd breakout group would use 100G PAM4 modulation
+           This configuration would result in 3 entries in the breakout
+           groups list. The example configuration for this case is shown below:
+
+              {
+                \"groups\": {
+                  \"group\": [
+                    {
+                      \"config\": {
+                        \"breakout-speed\": \"SPEED_100GB\",
+                        \"index\": 0,
+                        \"num-breakouts\": 1,
+                        \"num-physical-channels\": 2
+                      },
+                      \"index\": 0
+                    },
+                    {
+                      \"config\": {
+                        \"breakout-speed\": \"SPEED_100GB\",
+                        \"index\": 1,
+                        \"num-breakouts\": 1,
+                        \"num-physical-channels\": 4
+                      },
+                      \"index\": 1
+                    },
+                    {
+                      \"config\": {
+                        \"breakout-speed\": \"SPEED_200GB\",
+                        \"index\": 2,
+                        \"num-breakouts\": 1,
+                        \"num-physical-channels\": 2
+                      },
+                      \"index\": 2
+                    }
+                  ]
+                }
+              }
+
+           When a device does not have the capability to break a port
+           into interfaces of different speeds and different number of
+           physical channels, in order to  breakout a 400G OSFP port with
+           8 physical channels into 50G breakout ports it would use 8 interfaces
+           with 1 physical channel each. This would result in 1 entry in the
+           breakout groups list. The example configuration for this case is
+           shown below:
+
+            {
+              \"groups\": {
+                \"group\": [
+                  {
+                    \"config\": {
+                      \"breakout-speed\": \"SPEED_50GB\",
+                      \"index\": 0,
+                      \"num-breakouts\": 8,
+                      \"num-physical-channels\": 1
+                    },
+                    \"index\": 0
+                  }
+                ]
+              }
+            }
+
+           Similarly, if a 400G-DR4 interface (8 electrical channels at 50Gbps)
+           is to be broken out into 4 100Gbps ports, the following configuration
+           is used:
+
+            {
+              \"groups\": {
+                \"group\": [
+                  {
+                    \"config\": {
+                      \"breakout-speed\": \"SPEED_100GB\",
+                      \"index\": 0,
+                      \"num-breakouts\": 4,
+                      \"num-physical-channels\": 2
+                    },
+                    \"index\": 0
+                  }
+                ]
+              }
+            }";
+
+        list group {
+          key "index";
+          description
+            "List of breakout groups.";
+
+          leaf index {
+            type leafref {
+              path "../config/index";
+            }
+            description
+              "Index of the breakout group entry in the breakout groups list.";
+          }
+
+          container config {
+            description
+              "Configuration data for breakout group.";
+            uses group-config;
+          }
+
+          container state {
+            config false;
+            description
+              "Operational state data for breakout group.";
+
+            uses group-config;
+            uses group-state;
+          }
+        }
+      }
+    }
+  }
+
+  // data definition statements
+
+  // augment statements
+
+  augment "/oc-platform:components/oc-platform:component/" +
+    "oc-platform:port" {
+    description
+      "Adding port breakout data to physical platform data. This subtree
+      is only valid when the type of the component is PORT.";
+
+    uses port-breakout-top;
+  }
+
+  augment "/oc-if:interfaces/oc-if:interface/oc-if:state" {
+    description
+      "Adds a reference from the base interface to the corresponding
+      port component in the device inventory.";
+
+    leaf hardware-port {
+      type leafref {
+        path "/oc-platform:components/oc-platform:component/" +
+          "oc-platform:name";
+      }
+      description
+        "For non-channelized interfaces, references the hardware port
+        corresponding to the base interface.";
+    }
+  }
+
+  // rpc statements
+
+  // notification statements
+
+}

--- a/models/yang/common/openconfig-platform-psu.yang
+++ b/models/yang/common/openconfig-platform-psu.yang
@@ -1,0 +1,146 @@
+module openconfig-platform-psu {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/platform/psu";
+
+  prefix "oc-platform-psu";
+
+  // import some basic types
+  import openconfig-extensions { prefix oc-ext; }
+  import openconfig-types { prefix oc-types; }
+  import openconfig-platform { prefix oc-platform; }
+
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This module defines a schema for power supply components in
+    the OpenConfig platform model.";
+
+  oc-ext:openconfig-version "0.2.1";
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "0.2.1";
+  }
+
+  revision "2018-01-16" {
+    description
+      "Changed admin state leaf name";
+    reference "0.2.0";
+  }
+
+  revision "2017-12-21" {
+    description
+      "Initial revision";
+    reference "0.1.0";
+  }
+
+  // OpenConfig specific extensions for module metadata.
+  oc-ext:regexp-posix;
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  // identity statements
+
+  // typedef statements
+
+  // grouping statements
+
+  grouping psu-config {
+    description
+      "Configuration data for power supply components";
+
+    leaf enabled {
+      type boolean;
+      default true;
+      description
+        "Adminsitrative control on the on/off state of the power
+        supply unit.";
+    }
+  }
+
+  grouping psu-state {
+    description
+      "Operational state data for power supply components";
+
+
+    // TODO(aashaikh): May need to convert some of these to
+    // interval statistics once decided on which leaves to include.
+    leaf capacity {
+      type oc-types:ieeefloat32;
+      units watts;
+      description
+        "Maximum power capacity of the power supply.";
+    }
+
+    leaf input-current {
+      type oc-types:ieeefloat32;
+      units amps;
+      description
+        "The input current draw of the power supply.";
+    }
+
+    leaf input-voltage {
+      type oc-types:ieeefloat32;
+      units volts;
+      description
+        "Input voltage to the power supply.";
+    }
+
+    leaf output-current {
+      type oc-types:ieeefloat32;
+      units amps;
+      description
+        "The output current supplied by the power supply.";
+    }
+
+    leaf output-voltage {
+      type oc-types:ieeefloat32;
+      units volts;
+      description
+        "Output voltage supplied by the power supply.";
+    }
+
+    leaf output-power {
+      type oc-types:ieeefloat32;
+      units watts;
+      description
+        "Output power supplied by the power supply.";
+    }
+  }
+
+  // data definition statements
+
+  // augment statements
+
+  augment "/oc-platform:components/oc-platform:component/" +
+    "oc-platform:power-supply/oc-platform:config" {
+    description
+      "Adds power supply data to component operational state.";
+
+    uses psu-config;
+  }
+
+  augment "/oc-platform:components/oc-platform:component/" +
+    "oc-platform:power-supply/oc-platform:state" {
+    description
+      "Adds power supply data to component operational state.";
+
+    uses psu-config;
+    uses psu-state;
+  }
+
+
+  // rpc statements
+
+  // notification statements
+}

--- a/models/yang/common/openconfig-platform-software.yang
+++ b/models/yang/common/openconfig-platform-software.yang
@@ -1,0 +1,100 @@
+module openconfig-platform-software {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/platform/software-module";
+
+  prefix "oc-sw-module";
+
+  import openconfig-platform {
+      prefix oc-platform;
+  }
+
+  import openconfig-extensions {
+      prefix oc-ext;
+  }
+
+  // meta
+  organization
+    "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+      www.openconfig.net";
+
+  description
+    "This module defines data related to software components in
+      the openconfig-platform model";
+
+  oc-ext:openconfig-version "0.1.1";
+
+  revision "2021-06-16" {
+    description
+      "Remove trailing whitespace";
+    reference "0.1.1";
+  }
+
+  revision "2021-01-18" {
+      description
+        "Initial revision.";
+      reference "0.1.0";
+  }
+
+  // OpenConfig specific extensions for module metadata.
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  // extension statements
+  // feature statements
+  // identity statements
+  identity SOFTWARE_MODULE_TYPE {
+    description
+      "Base identity for defining various types of software
+      modules.";
+  }
+
+  identity USERSPACE_PACKAGE_BUNDLE {
+    base SOFTWARE_MODULE_TYPE;
+    description
+      "A collection of userspace software modules that are grouped, and
+      possibly versioned, together.  A package bundle may have
+      subcomponents that represent individual elements in the bundle
+      and their properties.";
+  }
+
+  identity USERSPACE_PACKAGE {
+    base SOFTWARE_MODULE_TYPE;
+    description
+      "An individual software package that runs in user space. The
+      package may be part of a package bundle.";
+  }
+
+  // typedef statements
+  // grouping statements
+  grouping sw-module-state {
+    description
+      "Operational state data for software module components";
+
+    leaf module-type {
+      type identityref {
+          base SOFTWARE_MODULE_TYPE;
+      }
+      description
+        "Type of the software module";
+    }
+  }
+
+  // data definition statements
+  // augment statements
+  augment "/oc-platform:components/oc-platform:component/" +
+  "oc-platform:software-module/oc-platform:state" {
+      description
+        "Adding software module operational data to physical inventory.
+        This subtree is only valid when the type of the component is
+        SOFTWARE_MODULE.";
+
+      uses sw-module-state;
+  }
+}
+

--- a/models/yang/common/openconfig-platform-transceiver.yang
+++ b/models/yang/common/openconfig-platform-transceiver.yang
@@ -1,0 +1,985 @@
+module openconfig-platform-transceiver {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/platform/transceiver";
+
+  prefix "oc-transceiver";
+
+  // import some basic types
+  import ietf-yang-types { prefix yang; }
+  import openconfig-platform { prefix oc-platform; }
+  import openconfig-platform-types { prefix oc-platform-types; }
+  import openconfig-platform-port { prefix oc-port; }
+  import openconfig-interfaces { prefix oc-if; }
+  import openconfig-transport-types { prefix oc-opt-types; }
+  import openconfig-types { prefix oc-types; }
+  import openconfig-extensions { prefix oc-ext; }
+  import openconfig-yang-types { prefix oc-yang; }
+  import openconfig-alarm-types { prefix oc-alarm-types; }
+
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This module defines configuration and operational state data
+    for transceivers (i.e., pluggable optics).  The module should be
+    used in conjunction with the platform model where other
+    physical entity data are represented.
+
+    In the platform model, a component of type=TRANSCEIVER is
+    expected to be a subcomponent of a PORT component.  This
+    module defines a concrete schema for the associated data for
+    components with type=TRANSCEIVER.
+
+    A transceiver will always contain physical-channel(s), however
+    when a line side optical-channel is present (i.e. ZR+ optics)
+    the physical-channel will reference its optical-channel.
+    In this case, the optical-channels components must be
+    subcomponents of the transceiver. The relationship between the
+    physical-channel and the optical-channel allows for multiple
+    optical-channels to be associated with a transceiver in addition
+    to ensuring certain leaves (i.e. output-power) are not duplicated
+    in multiple components.
+
+    If a transceiver contains a digital signal processor (DSP), such
+    as with ZR+ optics, the modeling will utilize hierarchical
+    components as follows:
+    PORT --> TRANSCEIVER --> OPTICAL_CHANNEL(s)
+    The signal will then traverse through a series of
+    terminal-device/logical-channels as required. The first
+    logical-channel connected to the OPTICAL_CHANNEL will utilize the
+    assignment/optical-channel leaf to create the relationship. At the
+    conclusion of the series of logical-channels, the logical-channel
+    will be associated to its host / client side based on:
+    * If the TRANSCEIVER is directly within a router or switch, then
+      it will use the logical-channel ingress leaf to specify the
+      interface it is associated with.
+    * If the TRANSCEIVER is within a dedicated terminal (Layer 1)
+      device, then it will use the logical-channel ingress leaf to
+      specify a physical-channel within a TRANSCEIVER component
+      (i.e. gray optic) that it is associated with.";
+
+  oc-ext:openconfig-version "0.14.0";
+
+revision "2023-08-30" {
+    description
+      "Clarify transceiver module threshold for input-power.";
+    reference "0.14.0";
+  }
+
+revision "2023-08-30" {
+    description
+      "Add transceiver module temperature thresholds";
+    reference "0.13.0";
+  }
+
+  revision "2023-06-27" {
+    description
+      "Add tx bias and voltage thresholds";
+    reference "0.12.0";
+  }
+
+  revision "2023-05-03" {
+    description
+      "Increase max length of vendor-rev to 4.";
+    reference "0.11.0";
+  }
+
+  revision "2023-02-10" {
+    description
+      "Fixing linting issues.";
+    reference "0.10.1";
+  }
+
+  revision "2023-01-12" {
+    description
+      "Add laser power and temperature thresholds";
+    reference "0.10.0";
+  }
+
+  revision "2021-07-29" {
+    description
+      "Add several media-lane-based VDM defined by CMIS to physical channel";
+    reference "0.9.0";
+  }
+
+  revision "2021-02-23" {
+    description
+      "Add leafref to an optical channel from a physical channel.";
+    reference "0.8.0";
+  }
+
+  revision "2020-05-06" {
+    description
+      "Ensure that when statements in read-write contexts reference
+      only read-write leaves.";
+    reference "0.7.1";
+  }
+
+  revision "2018-11-25" {
+    description
+      "Add augment for leafref to transceiver component;
+      Correct paths in physical channels leafref.";
+    reference "0.7.0";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "0.6.1";
+  }
+
+  revision "2018-11-16" {
+    description
+      "Added transceiver FEC configuration and state";
+    reference "0.6.0";
+  }
+
+  revision "2018-05-15" {
+    description
+      "Remove internal-temp state leaf, since we prefer
+      the generic /components/component/state/temperature
+      container for temperature information.";
+    reference "0.5.0";
+  }
+
+  revision "2018-01-22" {
+    description
+      "Fixed physical-channel path reference";
+    reference "0.4.1";
+  }
+
+  revision "2017-09-18" {
+    description
+      "Use openconfig-yang-types module";
+    reference "0.4.0";
+  }
+
+  revision "2017-07-08" {
+    description
+      "Adds clarification on aggregate power measurement data";
+    reference "0.3.0";
+  }
+
+  revision "2016-12-22" {
+    description
+      "Adds preconfiguration data and clarified units";
+    reference "0.2.0";
+  }
+
+  // OpenConfig specific extensions for module metadata.
+  oc-ext:regexp-posix;
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  // identity statements
+
+  // typedef statements
+
+  // grouping statements
+
+  grouping optical-power-state {
+    description
+      "Reusable leaves related to optical power state -- these
+      are read-only state values. If avg/min/max statistics are
+      not supported, the target is expected to just supply the
+      instant value";
+
+    container output-power {
+      description
+        "The output optical power of a physical channel in units
+        of 0.01dBm, which may be associated with individual
+        physical channels, or an aggregate of multiple physical
+        channels (i.e., for the overall transceiver). For an
+        aggregate, this may be a measurement from a photodetector
+        or a a calculation performed on the device by summing up
+        all of the related individual physical channels.
+        Values include the instantaneous, average, minimum, and
+        maximum statistics. If avg/min/max statistics are not
+        supported, the target is expected to just supply the
+        instant value";
+
+      uses oc-types:avg-min-max-instant-stats-precision2-dBm;
+    }
+
+    container input-power {
+      description
+        "The input optical power of a physical channel in units
+        of 0.01dBm, which may be associated with individual
+        physical channels, or an aggregate of multiple physical
+        channels (i.e., for the overall transceiver). For an
+        aggregate, this may be a measurement from a photodetector
+        or a a calculation performed on the device by summing up
+        all of the related individual physical channels.
+        Values include the instantaneous, average, minimum, and
+        maximum statistics. If avg/min/max statistics are not
+        supported, the target is expected to just supply the
+        instant value";
+
+      uses oc-types:avg-min-max-instant-stats-precision2-dBm;
+    }
+
+    container laser-bias-current {
+      description
+        "The current applied by the system to the transmit laser to
+        achieve the output power. The current is expressed in mA
+        with up to two decimal precision. Values include the
+        instantaneous, average, minimum, and maximum statistics.
+        If avg/min/max statistics are not supported, the target is
+        expected to just supply the instant value";
+
+      uses oc-types:avg-min-max-instant-stats-precision2-mA;
+    }
+  }
+
+  grouping output-optical-frequency {
+    description
+      "Reusable leaves related to optical output power -- this is
+      typically configurable on line side and read-only on the
+      client-side";
+
+    leaf output-frequency {
+      type oc-opt-types:frequency-type;
+      description
+        "The frequency in MHz of the individual physical channel
+        (e.g. ITU C50 - 195.0THz and would be reported as
+        195,000,000 MHz in this model). This attribute is not
+        configurable on most client ports.";
+    }
+  }
+
+
+  grouping physical-channel-config {
+    description
+      "Configuration data for physical client channels";
+
+    leaf index {
+      type uint16 {
+        range 0..max;
+      }
+      description
+        "Index of the physical channnel or lane within a physical
+        client port";
+    }
+
+    leaf associated-optical-channel {
+      type leafref {
+        path "/oc-platform:components/oc-platform:component/" +
+          "oc-platform:name";
+      }
+      description
+        "A physical channel may reference an optical channel
+        component. If the physical channel does make this optional
+        reference, then a limited set of leaves will apply within
+        the physical channel to avoid duplication within the optical
+        channel.";
+    }
+
+    leaf description {
+      type string;
+      description
+        "Text description for the client physical channel";
+    }
+
+    leaf tx-laser {
+      type boolean;
+      description
+        "Enable (true) or disable (false) the transmit label for the
+        channel";
+    }
+
+    uses physical-channel-config-extended {
+      when "../../../config/module-functional-type = 'oc-opt-types:TYPE_STANDARD_OPTIC'" {
+        description
+          "When the physical channel is of TYPE_STANDARD_OPTIC, the
+          extended config will be used";
+      }
+    }
+  }
+
+  grouping physical-channel-config-extended {
+    description
+      "Extended configuration data for physical client channels
+      for applications where the full physical channel config and
+      state are used. In some cases, such as when the physical
+      channel has a leafref to an optical channel component and the
+      module-functional-type is TYPE_DIGITAL_COHERENT_OPTIC this
+      grouping will NOT be used.";
+
+    leaf target-output-power {
+      type decimal64 {
+        fraction-digits 2;
+      }
+      units dBm;
+      description
+        "Target output optical power level of the optical channel,
+        expressed in increments of 0.01 dBm (decibel-milliwats)";
+    }
+  }
+
+  grouping physical-channel-state {
+    description
+      "Operational state data for client channels. In some cases,
+      such as when the physical channel has a leafref to an optical
+      channel component and the module-functional-type is
+      TYPE_DIGITAL_COHERENT_OPTIC this grouping will NOT be used.";
+
+    leaf laser-age {
+      type oc-types:percentage;
+      description
+        "Laser age (0% at beginning of life, 100% end of life) in integer
+        percentage. This term is defined by Common Management Interface
+        Specification (CMIS).";
+
+      reference "QSFP-DD CMIS 5.0 Table 8-122";
+    }
+
+    container laser-temperature {
+      description
+        "Laser temperature for the cooled laser in degrees Celsius with 1
+        decimal precision. This term is defined by Common Management
+        Interface Specification (CMIS). Values include the instantaneous,
+        average, minimum, and maximum statistics. If avg/min/max statistics
+        are not supported, the target is expected to just supply the
+        instant value.";
+
+      reference "QSFP-DD CMIS 5.0 Table 8-122";
+
+      uses oc-platform-types:avg-min-max-instant-stats-precision1-celsius;
+    }
+
+    container target-frequency-deviation {
+      description
+        "The difference in MHz with 1 decimal precision between the target
+        center frequency and the actual current center frequency . This term
+        is defined by Common Management Interface Specification (CMIS) and
+        referred to as laser frequency error or laser ferquency deviation.
+        Values include the instantaneous, average, minimum, and maximum
+        statistics. If avg/min/max statistics are not supported, the target
+        is expected to just supply the instant value.";
+
+      reference "QSFP-DD CMIS 5.0 Section Table 8-122";
+
+      uses oc-opt-types:avg-min-max-instant-stats-precision1-mhz;
+    }
+
+    container tec-current {
+      description
+        "The amount of current flowing to the TC of a cooled laser in percentage
+        with 2 decimal precision. This term is defined by Common Management
+        Interface Specification (CMIS). Values include the instantaneous,
+        average, minimum, and maximum statistics. If avg/min/max statistics
+        are not supported, the target is expected to just supply the instant
+        value.";
+
+      reference "QSFP-DD CMIS 5.0 Table 8-122";
+
+      uses oc-opt-types:avg-min-max-instant-stats-precision2-pct;
+    }
+
+    uses physical-channel-state-extended {
+      when "../../../state/module-functional-type = 'oc-opt-types:TYPE_STANDARD_OPTIC'" {
+        description
+          "When the physical channel is of TYPE_STANDARD_OPTIC, the
+          extended state will be used";
+      }
+    }
+  }
+
+  grouping physical-channel-state-extended {
+    description
+      "Extended operational state data for physical client channels
+      for applications where the full physical channel config and
+      state are used. In some cases, such as when the physical
+      channel has a leafref to an optical channel component and the
+      module-functional-type is TYPE_DIGITAL_COHERENT_OPTIC this
+      grouping will NOT be used.";
+
+    uses output-optical-frequency;
+    uses optical-power-state;
+  }
+
+  grouping physical-channel-top {
+    description
+      "Top-level grouping for physical client channels";
+
+    container physical-channels {
+      description
+        "Enclosing container for client channels";
+
+      list channel {
+        key "index";
+        description
+          "List of client channels, keyed by index within a physical
+          client port.  A physical port with a single channel would
+          have a single zero-indexed element";
+
+        leaf index {
+          type leafref {
+            path "../config/index";
+          }
+          description
+            "Reference to the index number of the channel";
+        }
+
+        container config {
+          description
+            "Configuration data for physical channels";
+
+          uses physical-channel-config;
+        }
+
+        container state {
+
+          config false;
+
+          description
+            "Operational state data for channels";
+
+          uses physical-channel-config;
+          uses physical-channel-state;
+        }
+      }
+    }
+  }
+
+  grouping transceiver-threshold-top {
+    description
+      "Top-level grouping for transceiver alarm thresholds for
+      various sensors.";
+
+    container thresholds {
+      description
+        "Enclosing container for transceiver alarm thresholds.";
+
+      list threshold {
+        key "severity";
+        config false;
+        description
+          "List of transceiver alarm thresholds, indexed by
+          alarm severity.";
+
+        leaf severity {
+          type leafref {
+            path "../state/severity";
+          }
+          config false;
+          description
+           "The severity applied to the group of thresholds.
+            An implementation's highest severity threshold
+            should be mapped to OpenConfig's `CRITICAL`
+            severity level.";
+        }
+
+        container state {
+          config false;
+          description
+            "Operational alarm thresholds for the transceiver.";
+
+          uses transceiver-threshold-state;
+        }
+      }
+    }
+  }
+
+  grouping port-transceiver-config {
+    description
+      "Configuration data for client port transceivers";
+
+    leaf enabled {
+      type boolean;
+      description
+        "Turns power on / off to the transceiver -- provides a means
+        to power on/off the transceiver (in the case of SFP, SFP+,
+        QSFP,...) or enable high-power mode (in the case of CFP,
+        CFP2, CFP4) and is optionally supported (device can choose to
+        always enable).  True = power on / high power, False =
+        powered off";
+    }
+
+    leaf form-factor-preconf {
+      type identityref {
+        base oc-opt-types:TRANSCEIVER_FORM_FACTOR_TYPE;
+      }
+      description
+        "Indicates the type of optical transceiver used on this
+        port.  If the client port is built into the device and not
+        pluggable, then non-pluggable is the corresponding state. If
+        a device port supports multiple form factors (e.g. QSFP28
+        and QSFP+, then the value of the transceiver installed shall
+        be reported. If no transceiver is present, then the value of
+        the highest rate form factor shall be reported
+        (QSFP28, for example).
+
+        The form factor is included in configuration data to allow
+        pre-configuring a device with the expected type of
+        transceiver ahead of deployment.  The corresponding state
+        leaf should reflect the actual transceiver type plugged into
+        the system.";
+    }
+
+    leaf ethernet-pmd-preconf {
+      type identityref {
+        base oc-opt-types:ETHERNET_PMD_TYPE;
+      }
+      description
+        "The Ethernet PMD is a property of the optical transceiver
+        used on the port, indicating the type of physical connection.
+        It is included in configuration data to allow pre-configuring
+        a port/transceiver with the expected PMD.  The actual PMD is
+        indicated by the ethernet-pmd state leaf.";
+    }
+
+    leaf fec-mode {
+      type identityref {
+        base oc-platform-types:FEC_MODE_TYPE;
+      }
+      description
+        "The FEC mode indicates the mode of operation for the
+        transceiver's FEC. This defines typical operational modes
+        and does not aim to specify more granular FEC capabilities.";
+    }
+
+    leaf module-functional-type {
+      type identityref {
+        base oc-opt-types:TRANSCEIVER_MODULE_FUNCTIONAL_TYPE;
+      }
+      description
+        "Indicates the module functional type which represents the
+        functional capability of the transceiver. For example, this
+        would specify the module is a digital coherent optic or a
+        standard grey optic that performs on-off keying.";
+    }
+  }
+
+  grouping port-transceiver-state {
+    description
+      "Operational state data for client port transceivers";
+
+    leaf present {
+      type enumeration {
+        enum PRESENT {
+          description
+            "Transceiver is present on the port";
+        }
+        enum NOT_PRESENT {
+          description
+            "Transceiver is not present on the port";
+        }
+      }
+      description
+        "Indicates whether a transceiver is present in
+        the specified client port.";
+    }
+
+    leaf form-factor {
+      type identityref {
+        base oc-opt-types:TRANSCEIVER_FORM_FACTOR_TYPE;
+      }
+      description
+        "Indicates the type of optical transceiver used on this
+        port.  If the client port is built into the device and not
+        pluggable, then non-pluggable is the corresponding state. If
+        a device port supports multiple form factors (e.g. QSFP28
+        and QSFP+, then the value of the transceiver installed shall
+        be reported. If no transceiver is present, then the value of
+        the highest rate form factor shall be reported
+        (QSFP28, for example).";
+    }
+
+    leaf connector-type {
+      type identityref {
+        base oc-opt-types:FIBER_CONNECTOR_TYPE;
+      }
+      description
+        "Connector type used on this port";
+    }
+
+    leaf vendor {
+      type string {
+        length 1..16;
+      }
+      description
+        "Full name of transceiver vendor. 16-octet field that
+        contains ASCII characters, left-aligned and padded on the
+        right with ASCII spaces (20h)";
+    }
+
+    leaf vendor-part {
+      type string {
+        length 1..16;
+      }
+      description
+        "Transceiver vendor's part number. 16-octet field that
+        contains ASCII characters, left-aligned and padded on the
+        right with ASCII spaces (20h). If part number is undefined,
+        all 16 octets = 0h";
+    }
+
+    leaf vendor-rev {
+      type string {
+        length 1..4;
+      }
+      description
+        "Transceiver vendor's revision number. Field of 1 to 4 octets that
+        contains ASCII characters, left-aligned and padded on the
+        right with ASCII spaces (20h)";
+    }
+
+    //TODO: these compliance code leaves should be active based on
+    //the type of port
+    leaf ethernet-pmd {
+      type identityref {
+        base oc-opt-types:ETHERNET_PMD_TYPE;
+      }
+      description
+        "Ethernet PMD (physical medium dependent sublayer) that the
+        transceiver supports. The SFF/QSFP MSAs have registers for
+        this and CFP MSA has similar.";
+    }
+
+    leaf sonet-sdh-compliance-code {
+      type identityref {
+        base oc-opt-types:SONET_APPLICATION_CODE;
+      }
+      description
+        "SONET/SDH application code supported by the port";
+    }
+
+    leaf otn-compliance-code {
+      type identityref {
+        base oc-opt-types:OTN_APPLICATION_CODE;
+      }
+      description
+        "OTN application code supported by the port";
+    }
+
+    leaf serial-no {
+      type string {
+        length 1..16;
+      }
+      description
+        "Transceiver serial number. 16-octet field that contains
+        ASCII characters, left-aligned and padded on the right with
+        ASCII spaces (20h). If part serial number is undefined, all
+        16 octets = 0h";
+    }
+
+    leaf date-code {
+      type oc-yang:date-and-time;
+      description
+        "Representation of the transceiver date code, typically
+        stored as YYMMDD.  The time portion of the value is
+        undefined and not intended to be read.";
+    }
+
+    leaf fault-condition {
+      type boolean;
+      description
+        "Indicates if a fault condition exists in the transceiver";
+    }
+
+    leaf fec-status {
+      type identityref {
+        base oc-platform-types:FEC_STATUS_TYPE;
+      }
+      description
+        "Operational status of FEC";
+    }
+
+    leaf fec-uncorrectable-blocks {
+      type yang:counter64;
+      description
+        "The number of blocks that were uncorrectable by the FEC";
+    }
+
+    leaf fec-uncorrectable-words {
+      type yang:counter64;
+      description
+        "The number of words that were uncorrectable by the FEC";
+    }
+
+    leaf fec-corrected-bytes {
+      type yang:counter64;
+      description
+        "The number of bytes that were corrected by the FEC";
+    }
+
+    leaf fec-corrected-bits {
+      type yang:counter64;
+      description
+        "The number of bits that were corrected by the FEC";
+    }
+
+    container pre-fec-ber {
+      description
+        "Bit error rate before forward error correction -- computed
+        value with 18 decimal precision. Note that decimal64
+        supports values as small as i x 10^-18 where i is an
+        integer. Values smaller than this should be reported as 0
+        to inidicate error free or near error free performance.
+        Values include the instantaneous, average, minimum, and
+        maximum statistics. If avg/min/max statistics are not
+        supported, the target is expected to just supply the
+        instant value";
+
+      uses oc-opt-types:avg-min-max-instant-stats-precision18-ber;
+    }
+
+    container post-fec-ber {
+      description
+        "Bit error rate after forward error correction -- computed
+        value with 18 decimal precision. Note that decimal64
+        supports values as small as i x 10^-18 where i is an
+        integer. Values smaller than this should be reported as 0
+        to inidicate error free or near error free performance.
+        Values include the instantaneous, average, minimum, and
+        maximum statistics. If avg/min/max statistics are not
+        supported, the target is expected to just supply the
+        instant value";
+
+      uses oc-opt-types:avg-min-max-instant-stats-precision18-ber;
+    }
+
+    container supply-voltage {
+      description
+        "Supply voltage to the transceiver in volts with 2 decimal
+        precision. Values include the instantaneous, average, minimum,
+        and maximum statistics. If avg/min/max statistics are not
+        supported, the target is expected to just supply the instant
+        value.";
+
+      uses oc-platform-types:avg-min-max-instant-stats-precision2-volts;
+    }
+
+    uses optical-power-state;
+  }
+
+  grouping transceiver-threshold-state {
+    description
+      "Grouping for all alarm threshold configs for a particular
+      severity level.";
+    leaf severity {
+      type identityref {
+        base oc-alarm-types:OPENCONFIG_ALARM_SEVERITY;
+      }
+      description
+        "The type of alarm to which the thresholds apply.";
+    }
+    leaf laser-temperature-upper {
+      type decimal64 {
+        fraction-digits 1;
+      }
+      units celsius;
+      description
+        "The upper temperature threshold for the laser temperature sensor.
+        This leaf value is compared to the instant value of
+        laser-temperature.";
+    }
+    leaf laser-temperature-lower {
+      type decimal64 {
+        fraction-digits 1;
+      }
+      units celsius;
+      description
+        "The lower temperature threshold for the laser temperature sensor.
+        This leaf value is compared to the instant value of
+        laser-temperature.";
+    }
+    leaf output-power-upper{
+      type decimal64 {
+        fraction-digits 2;
+      }
+      units dBm;
+      description
+        "The upper power threshold for the laser output power. This threshold
+        applies to every physical-channel on the transceiver and does not
+        apply to the aggregate transceiver optical-output-power. This leaf
+        value is compared to the instant value of optical-output-power.";
+    }
+    leaf output-power-lower{
+      type decimal64 {
+        fraction-digits 2;
+      }
+      units dBm;
+      description
+        "The lower power threshold for the laser output power. This threshold
+        applies to every physical-channel on the transceiver and does not
+        apply to the aggregate transceiver optical-output-power. This leaf
+        value is compared to the instant value of optical-output-power.";
+    }
+    leaf input-power-upper{
+      type decimal64 {
+        fraction-digits 2;
+      }
+      units dBm;
+      description
+        "The upper power threshold for the laser input power. This threshold
+        applies to every physical-channel on the transceiver and does not
+        apply to the aggregate transceiver optical-input-power. This leaf
+        value is compared to the instant value of optical-input-power.";
+    }
+    leaf input-power-lower{
+      type decimal64 {
+        fraction-digits 2;
+      }
+      units dBm;
+      description
+        "The lower power threshold for the laser input power. This threshold
+        applies to every physical-channel on the transceiver and does not
+        apply to the aggregate transceiver optical-input-power. This leaf
+        value is compared to the instant value of optical-input-power.";
+    }
+    leaf laser-bias-current-upper{
+      description
+        "The upper threshold for the laser bias current. This leaf value is
+        compared to the instant value of last-bias-current.";
+      type decimal64 {
+        fraction-digits 2;
+      }
+      units mA;
+    }
+    leaf laser-bias-current-lower{
+      description
+        "The lower threshold for the laser bias current. This leaf value is
+        compared to the instant value of last-bias-current.";
+      type decimal64 {
+        fraction-digits 2;
+      }
+      units mA;
+    }
+    leaf supply-voltage-upper{
+      description
+        "The upper threshold for the transceiver supply voltage. This leaf
+        value is compared to the instant value of supply-voltage.";
+      type decimal64 {
+        fraction-digits 2;
+      }
+      units volts;
+    }
+    leaf supply-voltage-lower{
+      description
+        "The lower threshold for the transceiver supply voltage. This leaf
+        value is compared to the instant value of supply-voltage.";
+      type decimal64 {
+        fraction-digits 2;
+      }
+      units volts;
+    }
+    leaf module-temperature-lower {
+      type decimal64 {
+        fraction-digits 1;
+      }
+      units celsius;
+      description
+        "The lower temperature threshold for the transceiver module. This
+        leaf value is compared to the instant value of module-temperature.";
+    }
+    leaf module-temperature-upper {
+      type decimal64 {
+        fraction-digits 1;
+      }
+      units celsius;
+      description
+        "The upper temperature threshold for the transceiver module. This
+        leaf value is compared to the instant value of module-temperature.";
+    }
+  }
+
+  grouping port-transceiver-top {
+    description
+      "Top-level grouping for client port transceiver data";
+
+    container transceiver {
+      description
+        "Top-level container for client port transceiver data";
+
+      container config {
+        description
+          "Configuration data for client port transceivers";
+
+        uses port-transceiver-config;
+      }
+
+      container state {
+
+        config false;
+
+        description
+          "Operational state data for client port transceivers";
+
+        uses port-transceiver-config;
+        uses port-transceiver-state;
+      }
+      // physical channels are associated with a transceiver
+      // component
+      uses physical-channel-top;
+      uses transceiver-threshold-top;
+    }
+  }
+
+  // data definition statements
+
+  // augment statements
+
+  augment "/oc-platform:components/oc-platform:component" {
+    description
+      "Adding transceiver data to physical inventory. This subtree is
+      only valid when the type of the component is TRANSCEIVER.";
+
+    uses port-transceiver-top;
+  }
+
+  augment "/oc-if:interfaces/oc-if:interface/oc-if:state" {
+    description
+      "Adds a reference from an interface to the corresponding
+      transceiver component.";
+
+    leaf transceiver {
+      type leafref {
+        path "/oc-platform:components/" +
+          "oc-platform:component[oc-platform:name=current()/../oc-port:hardware-port]/" +
+          "oc-platform:subcomponents/oc-platform:subcomponent/" +
+          "oc-platform:name";
+      }
+      description
+        "Provides a reference to the transceiver subcomponent that
+        corresponds to the physical port component for this interface.
+        The device must only populate this leaf with a reference to
+        a component of type TRANSCEIVER.";
+    }
+  }
+
+  augment "/oc-if:interfaces/oc-if:interface/oc-if:state" {
+    description
+      "Adds a reference from the base interface to its corresponding
+      physical channels.";
+
+    leaf-list physical-channel {
+      type leafref {
+        path "/oc-platform:components/" +
+          "oc-platform:component[oc-platform:name=current()/../oc-transceiver:transceiver]/" +
+          "oc-transceiver:transceiver/" +
+          "oc-transceiver:physical-channels/oc-transceiver:channel/" +
+          "oc-transceiver:index";
+      }
+      description
+        "For a channelized interface, list of references to the
+        physical channels (lanes) corresponding to the interface.
+        The physical channels are elements of a transceiver component
+        in the platform model.";
+    }
+  }
+
+  // rpc statements
+
+  // notification statements
+
+}

--- a/models/yang/common/openconfig-platform-types.yang
+++ b/models/yang/common/openconfig-platform-types.yang
@@ -10,9 +10,9 @@ module openconfig-platform-types {
   import openconfig-types { prefix oc-types; }
   import openconfig-extensions { prefix oc-ext; }
 
-
   // meta
-  organization "OpenConfig working group";
+  organization
+    "OpenConfig working group";
 
   contact
     "OpenConfig working group
@@ -22,7 +22,56 @@ module openconfig-platform-types {
     "This module defines data types (e.g., YANG identities)
     to support the OpenConfig component inventory model.";
 
-  oc-ext:openconfig-version "1.0.0";
+  oc-ext:openconfig-version "1.8.0";
+
+
+  revision "2024-04-30" {
+    description
+      "Add FAN_TRAY";
+    reference "1.8.0";
+  }
+
+  revision "2024-01-30" {
+    description
+      "Add component-last-poweroff-reason grouping";
+    reference "1.7.0";
+  }
+
+  revision "2023-06-27" {
+    description
+      "Add WIFI_ACCESS_POINT";
+    reference "1.6.0";
+  }
+
+  revision "2022-07-28" {
+    description
+      "Add grouping for component power management";
+    reference "1.5.0";
+  }
+
+  revision "2022-03-27" {
+    description
+      "Add identity for BIOS";
+    reference "1.4.0";
+  }
+
+  revision "2022-02-02" {
+    description
+      "Add support for component reboot and switchover.";
+    reference "1.3.0";
+  }
+
+  revision "2021-07-29" {
+    description
+      "Add several avg-min-max-instant-stats groupings";
+    reference "1.2.0";
+  }
+
+  revision "2021-01-18" {
+    description
+      "Add identity for software modules";
+    reference "1.1.0";
+  }
 
   revision "2019-06-03" {
     description
@@ -81,8 +130,6 @@ module openconfig-platform-types {
   oc-ext:origin "openconfig";
 
   // grouping statements
-
-
   grouping avg-min-max-instant-stats-precision1-celsius {
     description
       "Common grouping for recording temperature values in
@@ -132,8 +179,112 @@ module openconfig-platform-types {
     uses oc-types:min-max-time;
   }
 
-  // identity statements
+  grouping avg-min-max-instant-stats-precision2-volts {
+    description
+      "Common grouping for recording voltage values in
+      volts with 2 decimal precision. Values include the
+      instantaneous, average, minimum, and maximum statistics.
+      If supported by the device, the time interval over which
+      the statistics are computed, and the times at which the
+      minimum and maximum values occurred, are also reported.";
 
+    leaf instant {
+      type decimal64 {
+        fraction-digits 2;
+      }
+      units volts;
+      description
+        "The instantaneous value of the statistic.";
+    }
+
+    leaf avg {
+      type decimal64 {
+        fraction-digits 2;
+      }
+      units volts;
+      description
+        "The arithmetic mean value of the statistic over the
+        sampling period.";
+    }
+
+    leaf min {
+      type decimal64 {
+        fraction-digits 2;
+      }
+      units volts;
+      description
+        "The minimum value of the statistic over the sampling
+        period";
+    }
+
+    leaf max {
+      type decimal64 {
+        fraction-digits 2;
+      }
+      units volts;
+      description
+        "The maximum value of the statistic over the sampling
+        period";
+    }
+
+    uses oc-types:stat-interval-state;
+    uses oc-types:min-max-time;
+  }
+
+  grouping component-last-poweroff-reason {
+    description
+      "Common grouping for recording the reason of a component's
+      power-off state";
+
+    leaf trigger {
+      type component-last-poweroff-reason-trigger;
+      description
+        "Records the generic triggers for the last poweroff
+        event. Component power-off can be triggered
+        in various ways,
+           - USER_INITIATED
+           - SYSTEM_INITIATED
+           - POWER_FAILURE
+        This field is not updated during reboots; those are
+        tracked in the 'last-reboot-reason' leaf.";
+    }
+
+    leaf details {
+      type string;
+      description
+        "Provides a detailed reason for component power-off.
+        For system-initiated power-offs, this field can include
+        specific causes (e.g., critical errors resulting in a
+        controller-card bootloop).";
+    }
+  }
+
+  grouping component-redundant-role-switchover-reason {
+    description
+      "Common grouping for recording the reason of a component's
+      redundant role switchover. For example two supervisors in
+      a device, one as primary the other as secondary, switchover
+      can happen in different scenarios, e.g. user requested,
+      system error, priority contention, etc.";
+
+    leaf trigger {
+      type component-redundant-role-switchover-reason-trigger;
+      description
+        "Records the generic triggers, e.g. user or system
+        initiated the switchover.";
+    }
+
+    leaf details {
+      type string;
+      description
+        "Records detailed description of why the switchover happens.
+        For example, when system initiated the switchover, this leaf
+        can be used to record the specific reason, e.g. due to critical
+        errors of the routing daemon in the primary role.";
+    }
+  }
+
+  // identity statements
   identity OPENCONFIG_HARDWARE_COMPONENT {
     description
       "Base identity for hardware related components in a managed
@@ -143,7 +294,6 @@ module openconfig-platform-types {
       "IANA Entity MIB and RFC 6933";
   }
 
-
   identity OPENCONFIG_SOFTWARE_COMPONENT {
     description
       "Base identity for software-related components in a managed
@@ -151,7 +301,6 @@ module openconfig-platform-types {
   }
 
   // hardware types
-
   identity CHASSIS {
     base OPENCONFIG_HARDWARE_COMPONENT;
     description
@@ -184,6 +333,12 @@ module openconfig-platform-types {
       "Cooling fan, or could be some other heat-reduction component";
   }
 
+  identity FAN_TRAY {
+    base OPENCONFIG_HARDWARE_COMPONENT;
+    description
+      "Contains multiple fans that work in unison to cool the router components.";
+  }
+
   identity SENSOR {
     base OPENCONFIG_HARDWARE_COMPONENT;
     description
@@ -207,7 +362,7 @@ module openconfig-platform-types {
     base OPENCONFIG_HARDWARE_COMPONENT;
     description
       "A type of linecard whose primary role is management or control
-       rather than data forwarding.";
+      rather than data forwarding.";
   }
 
   identity PORT {
@@ -243,6 +398,13 @@ module openconfig-platform-types {
       chip, etc.)";
   }
 
+  identity WIFI_ACCESS_POINT {
+    base OPENCONFIG_HARDWARE_COMPONENT;
+    description
+      "A device that attaches to a an Ethernet network and creates a wireless
+       local area network";
+  }
+
   identity OPERATING_SYSTEM {
     base OPENCONFIG_SOFTWARE_COMPONENT;
     description
@@ -260,6 +422,30 @@ module openconfig-platform-types {
       installed software packages using this type -- but rather
       updates that are bundled together as a single installable
       item";
+  }
+
+  identity BIOS {
+    base OPENCONFIG_SOFTWARE_COMPONENT;
+    description
+      "Legacy BIOS or UEFI firmware interface responsible for
+      initializing hardware components and first stage boot loader.";
+  }
+
+  identity BOOT_LOADER {
+    base OPENCONFIG_SOFTWARE_COMPONENT;
+    description
+      "Software layer responsible for loading and booting the
+      device OS or network OS.";
+  }
+
+  identity SOFTWARE_MODULE {
+    base OPENCONFIG_SOFTWARE_COMPONENT;
+    description
+      "A base identity for software modules installed and/or
+      running on the device.  Modules include user-space programs
+      and kernel modules that provide specific functionality.
+      A component with type SOFTWARE_MODULE should also have a
+      module type that indicates the specific type of software module";
   }
 
   identity COMPONENT_OPER_STATUS {
@@ -327,7 +513,6 @@ module openconfig-platform-types {
   }
 
   // typedef statements
-
   typedef component-power-type {
     type enumeration {
       enum POWER_ENABLED {
@@ -344,4 +529,80 @@ module openconfig-platform-types {
       is powered on or off";
   }
 
+  identity COMPONENT_REBOOT_REASON {
+    description
+      "Base entity for component reboot reasons.";
+  }
+
+  identity REBOOT_USER_INITIATED {
+    base COMPONENT_REBOOT_REASON;
+    description
+      "User initiated the reboot of the componenent.";
+  }
+
+  identity REBOOT_POWER_FAILURE {
+    base COMPONENT_REBOOT_REASON;
+    description
+      "The component reboots due to power failure.";
+  }
+
+  identity REBOOT_CRITICAL_ERROR {
+    base COMPONENT_REBOOT_REASON;
+    description
+      "The component reboots due to critical errors.";
+  }
+
+  typedef component-redundant-role {
+    type enumeration {
+      enum PRIMARY {
+        description
+          "Component is acting the primary role.";
+      }
+      enum SECONDARY {
+        description
+          "Component is acting the secondary role.";
+      }
+    }
+    description
+      "A generic type reflecting the component's redundanty role.
+      For example, a device might have dual supervisors components
+      for redundant purpose, with one being the primary and the
+      other secondary.";
+  }
+
+  typedef component-redundant-role-switchover-reason-trigger {
+    type enumeration {
+      enum USER_INITIATED {
+        description
+          "User initiated the switchover, e.g. via command line.";
+      }
+      enum SYSTEM_INITIATED {
+        description
+          "The system initiated the switchover, e.g. due to
+          critical errors in the component of the primar role.";
+      }
+    }
+    description
+      "Records how the role switchover is triggered.";
+  }
+
+  typedef component-last-poweroff-reason-trigger {
+      type enumeration {
+        enum USER_INITIATED {
+          description
+            "User initiated the power-off, e.g. via command line.";
+        }
+        enum SYSTEM_INITIATED {
+          description
+            "The system initiated the power-off, e.g. due to
+            critical errors in the component of the primary role.";
+        }
+        enum POWER_FAILURE {
+          description
+            "The last power-off was due to power failure.";
+        }
+      }
+      description
+        "Records how the last power-off was triggered.";
+    }
 }

--- a/models/yang/common/openconfig-policy-forwarding.yang
+++ b/models/yang/common/openconfig-policy-forwarding.yang
@@ -1,0 +1,161 @@
+module openconfig-policy-forwarding {
+  yang-version "1";
+
+  namespace "http://openconfig.net/yang/policy-forwarding";
+
+  prefix "oc-pf";
+
+  import openconfig-extensions { prefix "oc-ext"; }
+
+  // Include submodules.
+  include openconfig-pf-forwarding-policies;
+  include openconfig-pf-path-groups;
+  include openconfig-pf-interfaces;
+
+  organization
+    "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This module defines configuration and operational state data
+    relating to policy-based forwarding. Policy-based forwarding is
+    utilised when a system chooses how to forward packets (including
+    applying data-plane operations such as encapsulation or
+    decapsulation) based on policies other than destination L2 or L3
+    header. Typically, systems may implement:
+
+     - IP policy-based routing, where routing may be done based on the
+       source plus destination of an IP packet; information within the
+       L4 header; or some combination of both.
+     - Encapsulation or decapsulation based on certain policy
+       information - for example, matching particular IP destinations
+       and decapsulating GRE headers.
+     - Class-based selection of egress routes - such as class-based
+       selection of an egress MPLS path.
+
+    The policies that are defined in this model are applied to a
+    particular ingress context of a network element (e.g., interface)
+    and are defined to apply following other interface policy such as
+    QoS classification and access control lists.
+
+    This module defines:
+
+     - policy-forwarding
+    |
+    |--- policies
+    |    |-- policy
+    |        |-- [match criteria]    How packets are defined to
+    |        |                       match policy.
+    |        |-- [forwarding-action] How packets matching should
+    |                                 be forwarded.
+    |--- interfaces
+    |    |-- interfaces
+    |        | -- apply-forwarding-policy  Forwarding policy to
+    |                                      used on the interface.
+    |--- path-selection-groups
+         |-- path-selection-group     A group of forwarding resources
+                                      that are grouped for purposes
+                                      of next-hop selection.
+
+    A forwarding-policy specifies the match criteria that it intends
+    to use to determine the packets that it reroutes - this may
+    consist of a number of criteria, such as DSCP. The action of the
+    policy results in a forwarding action being applied to matching
+    packets. For example, decapsulating the packet from a GRE header.
+    In order to enact the policy based on particular interfaces - the
+    forwarding-policy is applied to an interface via referencing it
+    within an 'apply-forwarding-policy' statement associated with an
+    interface.
+
+    In some cases (e.g., Class-Based Tunnel Selection) the forwarding
+    action does not resolve to a single egress action, and rather
+    normal forwarding rules are to be applied but considering a subset
+    of forwarding resources. In these cases, a path-selection-group
+    can be created, referencing the subset of forwarding paths that
+    should be used for the egress selection. In the case that a subset
+    of MPLS LSPs are eligible for, say, DSCP 46 marked packets, a
+    path-selection-group is created, referencing the subset of LSPs.
+    The forwarding action of the corresponding policy is set to
+    PATH_GROUP and references the configured group of LSPs.";
+
+  oc-ext:openconfig-version "0.6.1";
+
+  revision "2023-04-25" {
+    description
+      "Clarify use of interface-ref.";
+    reference "0.6.1";
+  }
+
+  revision "2023-03-27" {
+    description
+      "Add support for decap in one NI and further actions in other NIs.";
+    reference "0.6.0";
+  }
+
+  revision "2022-01-25" {
+    description
+      "Add GUE and MPLS-in-UDP decapsulation actions.";
+    reference "0.5.0";
+  }
+
+  revision "2021-08-06" {
+    description
+      "Update path to the network instance action to allow references
+      to other NIs.";
+    reference "0.4.0";
+  }
+
+  revision "2021-05-19" {
+    description
+      "Add a VRF selection policy type, and means to apply the
+      policy.";
+    reference "0.3.0";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "0.2.1";
+  }
+
+  revision "2017-06-21" {
+    description
+      "Amend policy forwarding model based on ACL changes.";
+    reference "0.2.0";
+  }
+
+  revision "2017-02-28" {
+    description
+      "Initial public release of policy forwarding.";
+    reference "0.1.0";
+  }
+
+  revision "2016-11-08" {
+    description
+      "Initial revision.";
+    reference "0.0.1";
+  }
+
+  // OpenConfig specific extensions for module metadata.
+  oc-ext:regexp-posix;
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  grouping policy-forwarding-top {
+    description
+      "Top-level grouping for Policy Forwarding";
+
+    container policy-forwarding {
+      description
+        "Configuration and operational state relating to policy-forwarding within
+        a network instance.";
+
+      uses pf-forwarding-policy-structural;
+      uses pf-interfaces-structural;
+      uses pf-path-groups-structural;
+    }
+  }
+}

--- a/models/yang/common/openconfig-policy-types.yang
+++ b/models/yang/common/openconfig-policy-types.yang
@@ -1,0 +1,297 @@
+module openconfig-policy-types {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/policy-types";
+
+  prefix "oc-pol-types";
+
+  // import some basic types
+  import ietf-yang-types { prefix yang; }
+  import openconfig-extensions { prefix oc-ext; }
+  import openconfig-yang-types { prefix oc-yang; }
+
+  // meta
+  organization
+    "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    netopenconfig@googlegroups.com";
+
+  description
+    "This module contains general data definitions for use in routing
+    policy.  It can be imported by modules that contain protocol-
+    specific policy conditions and actions.";
+
+  oc-ext:openconfig-version "3.3.0";
+
+  revision "2024-05-14" {
+    description
+      "Add hex-string-prefixed to typedef tag-type.";
+    reference "3.3.0";
+  }
+
+revision "2022-11-08" {
+    description
+      "Add INSTALL_PROTOCOL_TYPE local.";
+    reference "3.2.3";
+  }
+
+  revision "2022-02-11" {
+    description
+      "Add PCEP to INSTALL_PROTOCOL_TYPES identity";
+    reference "3.2.2";
+  }
+
+  revision "2021-12-10" {
+    description
+      "Add INSTALL_PROTOCOL_TYPE gRIBI.";
+    reference "3.2.1";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "3.1.1";
+  }
+
+  revision "2018-06-05" {
+    description
+      "Add PIM, IGMP to INSTALL_PROTOCOL_TYPES identity";
+    reference "3.1.0";
+  }
+
+  revision "2017-07-14" {
+    description
+      "Replace policy choice node/type with policy-result
+      enumeration;simplified defined set naming;removed generic
+      IGP actions; migrate to OpenConfig types; added mode for
+      prefix sets";
+    reference "3.0.0";
+  }
+
+  revision "2016-05-12" {
+    description
+      "OpenConfig public release";
+    reference "2.0.1";
+  }
+
+  // OpenConfig specific extensions for module metadata.
+  oc-ext:regexp-posix;
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  // identity statements
+
+  identity ATTRIBUTE_COMPARISON {
+    description
+      "base type for supported comparison operators on route
+      attributes";
+  }
+
+  identity ATTRIBUTE_EQ {
+    base ATTRIBUTE_COMPARISON;
+    description "== comparison";
+  }
+
+  identity ATTRIBUTE_GE {
+    base ATTRIBUTE_COMPARISON;
+    description ">= comparison";
+  }
+
+  identity ATTRIBUTE_LE {
+    base ATTRIBUTE_COMPARISON;
+    description "<= comparison";
+  }
+
+  typedef match-set-options-type {
+    type enumeration {
+      enum ANY {
+        description "match is true if given value matches any member
+        of the defined set";
+      }
+      enum ALL {
+        description "match is true if given value matches all
+        members of the defined set";
+      }
+      enum INVERT {
+        description "match is true if given value does not match any
+        member of the defined set";
+      }
+    }
+    default ANY;
+    description
+      "Options that govern the behavior of a match statement.  The
+      default behavior is ANY, i.e., the given value matches any
+      of the members of the defined set";
+  }
+
+  typedef match-set-options-restricted-type {
+    type enumeration {
+      enum ANY {
+        description "match is true if given value matches any member
+        of the defined set";
+      }
+      enum INVERT {
+        description "match is true if given value does not match any
+        member of the defined set";
+      }
+    }
+    default ANY;
+    description
+      "Options that govern the behavior of a match statement.  The
+      default behavior is ANY, i.e., the given value matches any
+      of the members of the defined set.  Note this type is a
+      restricted version of the match-set-options-type.";
+      //TODO: restriction on enumerated types is only allowed in
+      //YANG 1.1.  Until then, we will require this additional type
+  }
+
+  grouping attribute-compare-operators {
+    description "common definitions for comparison operations in
+    condition statements";
+
+    leaf operator {
+        type identityref {
+          base ATTRIBUTE_COMPARISON;
+        }
+        description
+          "type of comparison to be performed";
+      }
+
+    leaf value {
+      type uint32;
+      description
+        "value to compare with the community count";
+    }
+  }
+
+  typedef tag-type {
+    type union {
+      type uint32;
+      type yang:hex-string;
+      type oc-yang:hex-string-prefixed {
+        length "3..18";
+      }
+    }
+    description
+      "Type for expressing route tags on a local system, including IS-IS
+      and OSPF; This may be expressed as either decimal or hexidecimal
+      integer.";
+    reference
+      "RFC 2178 OSPF Version 2 specifies a 32 bit value
+      RFC 5130 A Policy Control Mechanism in IS-IS Using
+      Administrative Tags specifies 32 bit and 64 bit values.";
+  }
+
+  identity INSTALL_PROTOCOL_TYPE {
+    description
+      "Base type for routing protocols, including those which may
+      install prefixes into the RIB";
+  }
+
+  identity BGP {
+    base INSTALL_PROTOCOL_TYPE;
+    description
+      "BGP";
+    reference
+      "RFC 4271";
+  }
+
+  identity ISIS {
+    base INSTALL_PROTOCOL_TYPE;
+    description
+      "IS-IS";
+    reference
+      "ISO/IEC 10589";
+  }
+
+  identity OSPF {
+    base INSTALL_PROTOCOL_TYPE;
+    description
+      "OSPFv2";
+    reference
+      "RFC 2328";
+  }
+
+  identity OSPF3 {
+    base INSTALL_PROTOCOL_TYPE;
+    description
+      "OSPFv3";
+    reference
+      "RFC 5340";
+  }
+
+  identity STATIC {
+    base INSTALL_PROTOCOL_TYPE;
+    description
+      "Locally-installed static route";
+  }
+
+  identity DIRECTLY_CONNECTED {
+    base INSTALL_PROTOCOL_TYPE;
+    description
+      "A directly connected route";
+  }
+
+  identity LOCAL_AGGREGATE {
+    base INSTALL_PROTOCOL_TYPE;
+    description
+      "Locally defined aggregate route";
+  }
+
+  identity PIM {
+    base INSTALL_PROTOCOL_TYPE;
+    description
+      "Protocol Independent Multicast";
+    reference
+      "RFC 7761";
+  }
+
+  identity IGMP {
+    base INSTALL_PROTOCOL_TYPE;
+    description
+      "Internet Group Management Protocol";
+    reference
+      "RFC 3376";
+  }
+
+  identity GRIBI {
+    base INSTALL_PROTOCOL_TYPE;
+    description "gRPC Routing Information Base Interface";
+  }
+
+  identity PCEP {
+    base INSTALL_PROTOCOL_TYPE;
+    description
+      "Path Computation Element Communication Protocol";
+    reference
+      "RFC 5440";
+  }
+
+  identity LOCAL {
+    base INSTALL_PROTOCOL_TYPE;
+    description
+      "A local route.
+
+      Local routes define a route for the one specific IP
+      address configured on the router interface. They are
+      created in association with directly connected routes.
+      Local routes must end with a /32 in the case of ipv4
+      or /128 for ipv6.
+      For example, when configuring an interface with the ip
+      address
+
+      10.244.136.79/31
+
+      the derived DIRECTLY_CONNECTED route is
+
+      10.244.136.78/31
+
+      and the derived LOCAL route is
+
+      10.244.136.79/32.";
+  }
+}

--- a/models/yang/common/openconfig-procmon.yang
+++ b/models/yang/common/openconfig-procmon.yang
@@ -11,6 +11,7 @@ module openconfig-procmon {
   // import some basic types
   import openconfig-extensions { prefix oc-ext; }
   import openconfig-types { prefix oc-types; }
+  import openconfig-yang-types { prefix oc-yang; }
 
 
   // meta
@@ -24,7 +25,16 @@ module openconfig-procmon {
     "This module provides data definitions for process health
     monitoring of one or more processes running on the system.";
 
-  oc-ext:openconfig-version "0.3.1";
+  oc-ext:openconfig-version "0.4.0";
+
+  revision "2019-03-15" {
+    description
+      "Update process start time to be an absolute timestamp,
+      ensure that the units for CPU time are expressed correctly.
+      Update cpu-usage leaves to commonly use counter64 for consumed
+      CPU time.";
+    reference "0.4.0";
+  }
 
   revision "2018-11-21" {
     description
@@ -119,30 +129,25 @@ module openconfig-procmon {
     }
 
     leaf start-time {
-      type uint64;
-      units "ns";
+      type oc-types:timeticks64;
       description
         "The time at which this process started,
-        reported as nanoseconds since the UNIX epoch.  The
-        system must be synchronized such that the start-time
-        can be reported accurately, otherwise it should not be
-        reported.";
+        relative to the UNIX epoch.  The system must be
+        synchronized such that the start-time can be
+        reported accurately, otherwise it should not be reported.";
      }
 
-    leaf uptime {
-      type oc-types:timeticks64;
-      description
-        "Amount of time elapsed since this process started.";
-    }
-
     leaf cpu-usage-user {
-      type oc-types:timeticks64;
+      type oc-yang:counter64;
+      units "nanoseconds";
       description
-        "CPU time consumed by this process in user mode.";
+        "CPU time consumed by this process in user mode in
+        nanoseconds.";
     }
 
     leaf cpu-usage-system {
-      type oc-types:timeticks64;
+      type oc-yang:counter64;
+      units "nanoseconds";
       description
         "CPU time consumed by this process in kernel mode.";
     }

--- a/models/yang/common/openconfig-qos-elements.yang
+++ b/models/yang/common/openconfig-qos-elements.yang
@@ -1,0 +1,1405 @@
+submodule openconfig-qos-elements {
+
+  belongs-to openconfig-qos {
+    prefix "oc-qos";
+  }
+
+  import openconfig-extensions { prefix oc-ext; }
+  import openconfig-qos-types { prefix oc-qos-types; }
+  import openconfig-packet-match { prefix oc-pkt-match; }
+  import openconfig-platform { prefix oc-platform; }
+  import openconfig-types { prefix oc-types; }
+
+
+  organization
+    "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+     www.openconfig.net";
+
+  description
+    "This submodule defines configuration and operational state
+    data associated with QoS elements.  The primary elements of
+    the model include:
+
+      classifiers: match packets with a specific characteristic
+
+      forwarding groups: logical class of packets that receive
+      common forwarding treatment
+
+      queues:  collection of packets to be scheduled, including
+      a queue management scheme
+
+      schedulers: sequence of one more elements that schedule
+      packets for transmission, including policer and shaper
+      functions";
+
+  oc-ext:openconfig-version "0.11.2";
+
+  revision "2023-10-13" {
+    description
+      "Fix revision statement date";
+    reference "0.11.2";
+  }
+
+  revision "2023-10-08" {
+    description
+      "Clarification on WRED weight in case it is not present";
+    reference "0.11.1";
+  }
+
+  revision "2023-09-15" {
+    description
+      "Add support for ECN counters";
+    reference "0.11.0";
+  }
+
+  revision "2023-07-26" {
+    description
+      "Add buffer management parameters in time unts (microseconds).
+       Make profiles reusable across LAGs and PHY of different speed";
+    reference "0.10.0";
+  }
+
+  revision "2023-04-25" {
+    description
+      "Clarify interface-ref usage.";
+    reference "0.9.1";
+  }
+
+  revision "2023-04-17" {
+    description
+      "Add support for relative RED min-threshold and max-threshold values.";
+    reference "0.9.0";
+  }
+
+  revision "2023-02-17" {
+    description
+      "Add queue identifier.";
+    reference "0.8.0";
+  }
+
+  revision "2023-02-08" {
+    description
+      "Remove incorrect output placement of interface-ref";
+    reference "0.7.0";
+  }
+
+  revision "2023-01-28" {
+    description
+      "Split groupings in interfaces for better leaf reuse.";
+    reference "0.6.1";
+  }
+
+  revision "2022-09-13" {
+    description
+      "Add queue octet drop counter.";
+    reference "0.6.0";
+  }
+
+  revision "2021-08-28" {
+    description
+      "Revision updating memory management profile WRED and RED configuration.";
+    reference "0.5.0";
+  }
+
+  revision "2021-04-28" {
+    description
+      "Revision updating buffer management and queue management
+      configuration.";
+    reference "0.3.0";
+  }
+
+  revision "2019-11-28" {
+    description
+      "Fix xpaths in when statements";
+    reference "0.2.3";
+  }
+
+  revision "2019-08-20" {
+    description
+      "Fix typo in classifiers container name";
+    reference "0.2.2";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "0.2.1";
+  }
+
+  revision "2016-12-16" {
+    description
+      "Fix incorrect interface-ref placement";
+    reference "0.2.0";
+  }
+
+  revision "2016-06-03" {
+    description
+      "Initial revision";
+    reference "0.1.0";
+  }
+
+  grouping qos-classifier-term-config {
+    description
+      "Configuration data for list of match criteria in a QoS
+      classifier";
+
+    leaf id {
+      type string;
+      description
+        "Identifier for the match term";
+    }
+  }
+
+  grouping qos-classifier-term-state {
+    description
+      "Operational state data for list of match criteria in a QoS
+      classifier";
+  }
+
+  grouping qos-classifier-term-action-config {
+    description
+      "Configuration parameters for actions for a classifier term.";
+
+    leaf target-group {
+      type leafref {
+        // Current location:
+        // /qos/classifiers/classifier/terms/term/actions/config/target-group
+        path "../../../../../../../forwarding-groups/forwarding-group/" +
+          "config/name";
+      }
+      description
+        "References the forwarding group or class to which the
+        matched packets should be assigned";
+    }
+  }
+
+  grouping qos-classifier-terms-top {
+    description
+      "Top-level grouping for list of match criteria in a QoS
+      classifier";
+
+    container terms {
+      description
+        "Enclosing container for ths list of terms";
+
+      list term {
+        key "id";
+        description
+          "List of match terms used in the classifier";
+
+        leaf id {
+          type leafref {
+            path "../config/id";
+          }
+          description
+            "Reference to id list key.";
+        }
+
+        container config {
+          description
+            "Configuration data for list of match criteria in a QoS
+            classifier";
+
+          uses qos-classifier-term-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state data for list of match criteria in a
+            QoS classifier";
+
+          uses qos-classifier-term-config;
+          uses qos-classifier-term-state;
+        }
+
+        container conditions {
+          description
+            "Conditions for the classifier term. Packets must match all of
+            the criteria specified within the match condition to be considered
+            matching the term.";
+
+            // TODO(robjs): Consider whether we should have classifiers
+            // that can match >1 different value of a field, or whether
+            // this should require different match terms within the
+            // classifier.
+            uses oc-pkt-match:ethernet-header-top;
+            uses oc-pkt-match:ipv4-protocol-fields-top;
+            uses oc-pkt-match:ipv6-protocol-fields-top;
+            uses oc-pkt-match:transport-fields-top;
+            uses oc-pkt-match:mpls-header-top;
+        }
+
+        container actions {
+          description
+            "Actions to be applied for packets matching the specified
+            classification rules.";
+
+          container config {
+            description
+              "Actions to be applied to packets that match the classifier
+              term.";
+
+            uses qos-classifier-term-action-config;
+          }
+
+          container state {
+            config false;
+            description
+              "Operational state parameters associated with classifier term
+              actions";
+
+            uses qos-classifier-term-action-config;
+          }
+
+          container remark {
+            description
+              "Remark actions to be associated with packets that match the
+              classifier term. Where a packet matches these criteria, the
+              specified rewrite actions should be performed.";
+
+            uses qos-common-remark-actions;
+          }
+        }
+      }
+    }
+  }
+
+  grouping qos-classifier-config {
+    description
+      "Configuration data for classifiers";
+
+    leaf name {
+      type string;
+      description
+        "User-assigned name of the classifier";
+    }
+
+    leaf type {
+      type enumeration {
+        enum IPV4 {
+          description
+            "Classifier matches and operates
+            on packets with IPv4 headers.";
+        }
+        enum IPV6 {
+          description
+            "Classifier matches and operates
+            on packets with IPv6 headers.";
+        }
+        enum MPLS {
+          description
+            "Classifier matches and operates
+            on packets with MPLS headers.";
+        }
+        enum ETHERNET {
+          description
+            "Classifier matches and operates
+            on fields within the L2 ETHERNET
+            headers.";
+        }
+      }
+      description
+        "Type of classifier.";
+    }
+  }
+
+  grouping qos-classifier-state {
+    description
+      "Operational state data for classifiers";
+
+  }
+
+  grouping qos-classifier-top {
+    description
+      "Top-level grouping for classifier data";
+
+    container classifiers {
+      description
+        "Enclosing container for QoS classifiers";
+
+      list classifier {
+        key "name";
+        description
+          "List of classifier elements";
+
+        leaf name {
+          type leafref {
+            path "../config/name";
+          }
+          description
+            "Reference to list key name";
+        }
+
+        container config {
+          description
+            "Configuration data for classifers";
+
+          uses qos-classifier-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state data for classifiers";
+
+          uses qos-classifier-config;
+          uses qos-classifier-state;
+        }
+
+        uses qos-classifier-terms-top;
+      }
+    }
+  }
+
+  grouping qos-fabric-trace-config {
+    description
+      "Configuration data for fabric trace data";
+
+    leaf source {
+      type leafref {
+        path "/oc-platform:components/oc-platform:component" +
+          "/oc-platform:config/oc-platform:name";
+      }
+      description
+        "Source component for fabric trace data";
+    }
+
+    leaf dest {
+      type leafref {
+        path "/oc-platform:components/oc-platform:component" +
+          "/oc-platform:config/oc-platform:name";
+      }
+      description
+        "Destination component for fabric trace data";
+    }
+  }
+
+  grouping qos-forwarding-group-config {
+    description
+      "Configuration data for forwarding groups";
+
+    leaf name {
+      type string;
+      description
+        "Name of the forwarding group";
+    }
+
+    // TODO(robjs, Simon G): Discuss optionally moving
+    // this to a high/low priority indicator, if this
+    // is common across implementations.
+    leaf fabric-priority {
+      type uint8;
+      description
+        "Set the priority for the forwarding group for
+        local transmission through the device, e.g.,
+        across a switching fabric. Higher priorities
+        are considered to be better, such that traffic
+        with fabric priority 128 is considered to be
+        higher priority than that with fabric priority
+        0.";
+    }
+
+    leaf output-queue {
+      type leafref {
+        path "../../../../queues/queue/config/name";
+      }
+      description
+        "Output queue for packets in this forwarding group.
+        This leaf applies to both multicast and unicast
+        packets. Where a user or system requires separate
+        queueing for multicast and unicast the unicast-output-queue
+        and multicast-output-queue leaves should be specified.";
+    }
+
+    leaf unicast-output-queue {
+      type leafref {
+        path "../../../../queues/queue/config/name";
+      }
+      description
+        "Output queue for unicast packets within this
+        forwarding group. Where an operator or system does
+        not require separate queueing for multicast and
+        unicast this leaf is not specified.";
+    }
+
+    leaf multicast-output-queue {
+      type leafref {
+        path "../../../../queues/queue/config/name";
+      }
+      description
+        "Output queue for multicast packets within this
+        forwarding group. Where an operator or system does
+        not require separate queueing for multicast and
+        unicast this leaf is not specified.";
+    }
+  }
+
+  grouping qos-forwarding-group-state {
+    description
+      "Operational state data for forwarding groups";
+  }
+
+  grouping qos-forwarding-group-top {
+    description
+      "Top-level grouping for forwarding group data";
+
+    container forwarding-groups {
+      description
+        "Enclosing container for list of forwarding groups";
+
+      list forwarding-group {
+        key "name";
+        description
+          "List of forwarding groups.  Forwarding groups are
+          logical groups of traffic that will receive common
+          forwarding treatment.";
+
+        leaf name {
+          type leafref {
+            path "../config/name";
+          }
+          description
+            "Reference to name list key";
+        }
+
+        container config {
+          description
+            "Configuration data for forwarding groups";
+
+          uses qos-forwarding-group-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state data for forwarding groups";
+
+          uses qos-forwarding-group-config;
+          uses qos-forwarding-group-state;
+        }
+      }
+    }
+  }
+
+  grouping qos-queue-red-common-config {
+    description
+      "Common configuration parameters applicable to RED and
+      its variants";
+
+    leaf enable-ecn {
+      type boolean;
+      default false;
+      description
+        "When set to true, the device should mark packets that are
+        ECN-capable rather than dropping them.  The receiver is
+        expected to echo the congestion signal back to the sender
+        so that it may adjust its transmission rate accordingly.
+        When this leaf is false, the device drops packets according
+        to the RED/WRED probability, or all packets if the
+        average queue length is above the max threshold.";
+    }
+  }
+
+  grouping qos-queue-red-common-state {
+    description
+      "Common operational state data applicable to RED and
+      its variants";
+
+  }
+
+  grouping qos-queue-wred-config {
+    description
+      "Configuration data for WRED-managed queues";
+
+    // TODO(robjs, aashaikh): Add configuration for weighted RED
+    // within this grouping.
+  }
+
+  grouping qos-queue-wred-state {
+    description
+      "Operational state data for WRED-managed queues";
+  }
+
+  grouping qos-queue-wred-top {
+    description
+      "Top-level grouping for WRED-managed queues";
+
+    container wred {
+      description
+        "Top-level container for WRED data";
+
+      container config {
+        description
+          "Configuration data for WRED";
+
+        uses qos-queue-wred-config;
+      }
+
+      container state {
+        config false;
+        description
+          "Operational state data for WRED";
+
+        uses qos-queue-wred-config;
+        uses qos-queue-wred-state;
+      }
+    }
+  }
+
+  grouping qos-queue-red-config {
+    description
+      "Configuration data for queues managed with RED";
+
+    leaf minth {
+      type uint64;
+      units bytes;
+      description
+        "The mininum threshold parameter for a RED-managed queue.
+        When the average queue length is less than minth, all
+        packets are admitted to the queue.";
+    }
+
+    leaf maxth {
+      type uint64;
+      units bytes;
+      description
+        "The maximum threshold parameter for a RED-managed queue.
+        When the average queue length exceeds the maxth value, all
+        packets are dropped (or marked if ECN is enabled).";
+    }
+  }
+
+  grouping qos-queue-red-state {
+    description
+      "Operational state data for queues managed with RED";
+  }
+
+  grouping qos-queue-red-top {
+    description
+      "Top-level grouping for RED queues";
+
+    container red {
+      description
+        "Top-level container for data related to RED-managed
+        queues";
+
+      container config {
+        description
+          "Configuration data for RED queues";
+
+        uses qos-queue-red-config;
+      }
+
+      container state {
+        config false;
+        description
+          "Operational state data for RED queues";
+
+        uses qos-queue-red-config;
+        uses qos-queue-red-state;
+      }
+    }
+  }
+
+
+  grouping qos-queue-config {
+    description
+      "Configuration data for QoS egress queues";
+
+    leaf name {
+      type string;
+      description
+        "User-defined name of the queue";
+    }
+    leaf queue-id {
+      type uint8;
+      description
+        "An optional identifier which may be required by some hardware to map
+        the named queue to a hardware queue";
+    }
+  }
+
+  grouping qos-queue-state {
+    description
+      "Operational state data for egress queues";
+  }
+
+  grouping qos-queue-top {
+    description
+      "Top-level grouping for queue elements";
+
+    container queues {
+      description
+        "Enclosing container for the list of queues";
+
+      list queue {
+        key "name";
+        description
+          "List of defined queues";
+
+        leaf name {
+          type leafref {
+            path "../config/name";
+          }
+          description
+            "Reference to the queue name list key.";
+        }
+
+        container config {
+          description
+            "Configuration data for queues";
+
+          uses qos-queue-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state data for queues";
+
+          uses qos-queue-config;
+          uses qos-queue-state;
+        }
+      }
+    }
+  }
+
+  grouping qos-scheduler-output-config {
+    description
+      "Configuration data for scheduler output operations";
+
+    leaf output-type {
+      type enumeration {
+        enum SCHEDULER {
+          description
+            "Scheduler output is a child scheduler, e.g. to
+            implement hierarchical schedulers.";
+        }
+        enum FWD_GROUP {
+          description
+            "Scheduler output is a forwarding group, e.g., when
+            performing ingress scheduling before packets traverse
+            a fabric to be processed by an egress forwarding
+            complex.";
+        }
+        enum INTERFACE {
+          description
+            "Scheduler output is an interface for forwarding.";
+        }
+      }
+      description
+        "Describes the type of output sink for the scheduler.";
+    }
+
+    leaf child-scheduler {
+      when "../output-type = 'SCHEDULER'" {
+        description
+          "The child-scheduler leaf is valid only when
+          the output type of the scheduler is a child scheduler";
+      }
+      // TODO: consider whether both child (output) and parent
+      // (input) references are needed; consider whether child
+      // reference should separate in-profile and out-of-profile
+      type leafref {
+        // current loc:
+        // /qos/scheduler-policies/scheduler-policy/schedulers/scheduler/
+        // output/config/child-scheduler
+        path "../../../../../../../scheduler-policies/scheduler-policy/" +
+             "config/name";
+      }
+      description
+        "When the scheduler output type is a child scheduler,
+        this leaf provides a reference to the downstream
+        scheduler.";
+    }
+
+    leaf output-fwd-group {
+      when "../output-type = 'FWD_GROUP'" {
+        description
+          "The output-fwd-group leaf is valid only when
+          the output type of the scheduler is a forwarding group";
+      }
+      type leafref {
+        path "../../../../../../../forwarding-groups/forwarding-group" +
+          "/config/name";
+      }
+      description
+        "When the scheduler output type is a forwarding group,
+        this leaf provides a reference to the forwarding group.";
+    }
+  }
+
+  grouping qos-scheduler-output-state {
+    description
+      "Operational state data for scheduler output";
+  }
+
+  grouping qos-scheduler-output-top {
+    description
+      "Top-level grouping for data related to scheduler output";
+
+    container output {
+      description
+        "Top-level container for scheduler output data";
+
+      container config {
+        description
+          "Configuration data for scheduler output";
+
+        uses qos-scheduler-output-config;
+      }
+
+      container state {
+        config false;
+        description
+          "Operational state data for scheduler output";
+
+        uses qos-scheduler-output-config;
+        uses qos-scheduler-output-state;
+      }
+    }
+  }
+
+  grouping qos-scheduler-inputs-config {
+    description
+      "Configuration data for scheduler input sources";
+
+    leaf id {
+      type string;
+      description
+        "User-defined identifier for the scheduler input";
+    }
+
+    leaf input-type {
+      type enumeration {
+        enum QUEUE {
+          description
+            "Input is a defined queue.";
+        }
+        enum IN_PROFILE {
+          description
+            "Input is in-profile traffic from a parent scheduler/
+            shaper";
+        }
+        enum OUT_PROFILE {
+          description
+            "Input is out-of-profile traffic from a parent
+            scheduler/shaper";
+        }
+      }
+      description
+        "Describes the type of input source for the scheduler";
+    }
+
+    leaf queue {
+      when "../input-type = 'QUEUE'" {
+        description
+          "The queue leaf is valid only when
+          the input type of the scheduler is a queue";
+      }
+      type leafref {
+        // current loc: /qos/scheduler-policies/scheduler-policy/schedulers/
+        // scheduler/inputs/input/config/queue
+        path "../../../../../../../../queues/queue/name";
+      }
+      description
+        "Reference to a queue that is an input source for the
+        scheduler";
+    }
+
+    leaf weight {
+      type uint64;
+      description
+        "For priority schedulers, this indicates the priority of
+        the corresponding input.  Higher values indicate higher
+        priority.  For weighted round-robin schedulers, this leaf
+        indicates the weight of the corresponding input.";
+    }
+  }
+
+  grouping qos-scheduler-inputs-state {
+    description
+      "Operational state data for scheduler input sources";
+  }
+
+  grouping qos-scheduler-inputs-top {
+    description
+      "Top-level grouping for defining inputs to a scheduler.";
+
+    container inputs {
+      description
+        "Enclosing container ";
+
+      list input {
+        key "id";
+        description
+          "List of input sources for the scheduler.";
+
+        leaf id {
+          type leafref {
+            path "../config/id";
+          }
+          description
+            "Reference to list key";
+        }
+
+        container config {
+          description
+            "Configuration data for scheduler input sources";
+
+          uses qos-scheduler-inputs-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state data for scheduler input sources";
+
+          uses qos-scheduler-inputs-config;
+          uses qos-scheduler-inputs-state;
+        }
+      }
+    }
+  }
+
+  grouping qos-scheduler-1r2c-config {
+    description
+      "Configuration data for 1 rate, 2 color scheduler.";
+
+    leaf cir {
+      type uint64;
+      units bps;
+      description
+        "Committed information rate for the single-rate token
+        bucket scheduler.  This value represents the rate at which
+        tokens are added to the bucket.";
+    }
+
+    leaf cir-pct {
+      type oc-types:percentage;
+      description
+        "Committed information rate for the single-rate token
+        bucket scheduler. This value represents the rate at which
+        tokens are added to the bucket. It is expressed as a
+        percentage of the total bandwidth allocated to the
+        context in which the scheduler is referenced.";
+    }
+
+    leaf cir-pct-remaining {
+      type oc-types:percentage;
+      description
+        "Committed information rate for the single-rate token
+        bucket scheduler. This value represents the rate at which
+        tokens are added to the bucket. It is expressed as a
+        percentage of the unallocated bandwidth available in the
+        context in which the scheduled is referenced.";
+    }
+
+    leaf bc {
+      type uint32;
+      units bytes;
+      description
+        "Committed burst size for the single-rate token bucket
+        scheduler.  This value represents the depth of the token
+        bucket.";
+    }
+
+    leaf queuing-behavior {
+      type oc-qos-types:queue-behavior;
+      description
+        "The type of scheduler that is being configured.";
+    }
+
+    // TODO(robjs): Add when statements to these parameters when the
+    // types of scheduler are agreed through review.
+    leaf max-queue-depth-bytes {
+      type uint32;
+      units bytes;
+      description
+        "When the scheduler is specified to be a shaper - the
+        maximum depth of the queue in bytes is the value
+        specified by this leaf.";
+    }
+
+    leaf max-queue-depth-packets {
+      type uint32;
+      units packets;
+      description
+        "When the scheduler is specified to be a shaper - the
+        maximum depth of the queue in packets is the value
+        specified by this leaf.";
+    }
+
+    leaf max-queue-depth-percent {
+      type oc-types:percentage;
+      description
+        "The queue depth specified as a percentage of the total
+        available buffer that is avaialble.";
+    }
+  }
+
+  grouping qos-scheduler-1r2c-top {
+    description
+      "Top-level grouping for 1 rate, 2 color shapers";
+
+    container one-rate-two-color {
+      description
+        "Top-level container for data related to a 1 rate, 2 color
+        shaper.";
+
+      container config {
+        description
+          "Configuration data for 1 rate, 2 color shapers";
+
+        uses qos-scheduler-1r2c-config;
+      }
+
+      container state {
+        config false;
+        description
+          "Operational state data for 1 rate, 2 color shapers";
+
+        uses qos-scheduler-1r2c-config;
+      }
+
+      container conform-action {
+        description
+          "Action to be applied to packets that are scheduled within the
+          CIR of the one-rate, two-colour scheduler. Packets that receive
+          a token from the in-CIR bucket are said to be conforming and
+          have all of the specified actions applied.";
+
+        container config {
+          description
+            "Configuration parameters relating to conforming packets for the
+            1r2c scheduler.";
+
+          uses qos-common-remark-actions-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state parameters relating to conforming packets
+            for the 1r2c scheduler.";
+
+          uses qos-common-remark-actions-config;
+        }
+      }
+
+      container exceed-action {
+        description
+          "Action to be applied to packets that are scheduled above the CIR
+          of the one-rate, two-colour shaper. Packets that do not receive a
+          token from the in-CIR bucket are said to be exceeding, and have
+          all of the specified actions applied.";
+
+          container config {
+            description
+              "Configuration parameters relating to exceeding packets for
+              the 1r2c scheduler.";
+
+            uses qos-common-remark-actions-config;
+            uses qos-common-scheduler-actions-config;
+          }
+
+          container state {
+            config false;
+            description
+              "Operational state parameters relating to exceeding
+              packets for the 1r2c scheduler.";
+
+            uses qos-common-remark-actions-config;
+            uses qos-common-scheduler-actions-config;
+          }
+      }
+    }
+  }
+
+  grouping qos-scheduler-2r3c-config {
+    description
+      "Configuration data for 2 rate, 3 color policer";
+
+    leaf cir {
+      type uint64;
+      units bps;
+      description
+        "Committed information rate for the dual-rate token
+        bucket policer.  This value represents the rate at which
+        tokens are added to the primary bucket.";
+    }
+
+    leaf cir-pct {
+      type oc-types:percentage;
+      description
+        "Committed information rate for the dual-rate token bucket
+        policer. This value represents the rate at which tokens
+        are added to the primary bucket. It is expressed as a
+        percentage of the total bandwidth available within the
+        context the scheduler is instantiated.";
+    }
+
+    leaf cir-pct-remaining {
+      type oc-types:percentage;
+      description
+        "Committed information rate for the dual-rate token
+        bucket policer. This value represents the rate at which
+        tokens are added to the primary bucket. It is expressed
+        as a percentage of the remaining bandwidth within the
+        context the scheduler is instantiated.";
+    }
+
+    leaf pir {
+      type uint64;
+      units bps;
+      description
+        "Peak information rate for the dual-rate token bucket
+        policer.  This value represents the rate at which tokens
+        are added to the secondary bucket.";
+    }
+
+    leaf pir-pct {
+      type oc-types:percentage;
+      description
+        "Peak information rate for the dual-rate token bucket
+        policer. This value represents the rate at which tokens
+        are added to the secondary bucket. The value is expressed
+        as a percentage of the total bandwidth available in the
+        context in which the scheduler is instantiated.";
+    }
+
+    leaf pir-pct-remaining {
+      type oc-types:percentage;
+      description
+        "Peak information rate for the dual-rate token
+        bucket policer. This value represents the rate at which
+        tokens are added to the secondary bucket. It is expressed
+        as a percentage of the remaining bandwidth within the
+        context the scheduler is instantiated.";
+    }
+
+    leaf bc {
+      type uint32;
+      units bytes;
+      description
+        "Committed burst size for the dual-rate token bucket
+        policer.  This value represents the depth of the token
+        bucket.";
+    }
+
+    leaf be {
+      type uint32;
+      units bytes;
+      description
+        "Excess burst size for the dual-rate token bucket policer.
+        This value represents the depth of the secondary bucket.";
+    }
+  }
+
+  grouping qos-scheduler-2r3c-top {
+    description
+      "Top-level grouping for 2 rate, 3 color policers..";
+
+    container two-rate-three-color {
+      description
+        "Top-level container for data for a 2 rate, 3 color policer.";
+
+      container config {
+        description
+          "Configuration data for 2 rate, 3 color policers.";
+
+        uses qos-scheduler-2r3c-config;
+      }
+
+      container state {
+        config false;
+        description
+          "Operational state data for 2 rate, 3 color policers.";
+
+        uses qos-scheduler-2r3c-config;
+      }
+
+      container conform-action {
+        description
+          "Action to be applied to the packets that are scheduled
+          within the CIR of the policer. All packets that receive
+          a token from this bucket have all actions specified
+          applied to them";
+
+          container config {
+            description
+              "Configuration parameters for the conform action of a
+              2r3c policer.";
+            uses qos-common-remark-actions-config;
+          }
+
+          container state {
+            config false;
+            description
+              "Operational state parameters relating to the conform
+              action of a 2r3c policer.";
+            uses qos-common-remark-actions-config;
+          }
+      }
+
+      container exceed-action {
+        description
+          "Action to be applied to the packets that are scheduled
+          within the PIR of the policer. Packets that receive a
+          token from within the PIR allocation have all the
+          specified actions applied to them";
+
+        container config {
+          description
+            "Configuration parameters relating to the action
+            applied to exceeding packets.";
+
+          uses qos-common-remark-actions-config;
+          uses qos-common-scheduler-actions-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state parameters relating to the action
+            applied to exceeding packets.";
+
+          uses qos-common-remark-actions-config;
+          uses qos-common-scheduler-actions-config;
+        }
+      }
+
+      container violate-action {
+        description
+          "Action to be applied to the packets that are scheduled
+          above the PIR of the policer. Packets that do not receive
+          a token from either bucket have all specified actions
+          applied to them.";
+
+        container config {
+          description
+            "Configuration parameters relating to the action
+            applied to violating packets.";
+
+          uses qos-common-remark-actions-config;
+          uses qos-common-scheduler-actions-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state parameters relating to the action
+            applied to violating packets.";
+
+          uses qos-common-remark-actions-config;
+          uses qos-common-scheduler-actions-config;
+        }
+      }
+    }
+  }
+
+  grouping qos-scheduler-config {
+    description
+      "Configuration data for QoS schedulers";
+
+    leaf sequence {
+      type uint32;
+      description
+        "Sequence number for the scheduler within the scheduler
+        policy. Schedulers are processed from lowest sequence
+        to highest.";
+    }
+
+    leaf type {
+      type identityref {
+        base oc-qos-types:QOS_SCHEDULER_TYPE;
+      }
+      description
+        "Sets the type of scheduler, i.e. the scheduling algorithm
+        used to serve inputs.";
+    }
+
+    leaf priority {
+      type enumeration {
+        enum STRICT {
+          description
+            "This scheduler term is considered as a strict priority
+            term - such that packets that arrive in the queue are
+            immediately serviced.";
+        }
+      }
+      description
+        "Priority of the scheduler within the scheduler policy.";
+    }
+  }
+
+  grouping qos-scheduler-state {
+    description
+      "Operational state data for QoS schedulers";
+  }
+
+  grouping qos-scheduler-policy-config {
+    description
+      "Configuration parameters relating to a scheduler policy";
+
+    leaf name {
+      type string;
+      description
+        "Name for the scheduler policy.";
+    }
+  }
+
+  grouping qos-scheduler-top {
+    description
+      "Top-level grouping for the set of defined QoS schedulers";
+
+    container scheduler-policies {
+      description
+        "Enclosing container for the list of configured scheduler policies.";
+
+      list scheduler-policy {
+        key "name";
+
+        description
+          "List of scheduler policies. A scheduler policy is a set of schedulers
+          that are to be applied together. Each scheduler within a scheduler
+          policy takes an input, and outputs it according to a scheduling
+          discipline that is specified within it. The schedulers consume
+          resources according to the specification that is provided - which
+          may be absolute resource limits, or relative.";
+
+        leaf name {
+          type leafref {
+            path "../config/name";
+          }
+          description
+            "Reference to the name of the scheduler policy";
+        }
+
+        container config {
+          description
+            "Configuration parameters relating to a scheduler policy.";
+          uses qos-scheduler-policy-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state parameters relating to a scheduler policy.";
+          uses qos-scheduler-policy-config;
+        }
+
+        container schedulers {
+          description
+            "Schedulers within the scheduler policy.";
+
+          list scheduler {
+            key "sequence";
+            description
+              "List of defined QoS traffic schedulers.";
+
+            leaf sequence {
+              type leafref {
+                path "../config/sequence";
+              }
+              description
+                "Reference to the list key";
+            }
+
+            container config {
+              description
+                "Configuration data for QoS schedulers";
+
+              uses qos-scheduler-config;
+            }
+
+            container state {
+              config false;
+
+              description
+                "Operational state data for QoS schedulers";
+
+              uses qos-scheduler-config;
+              uses qos-scheduler-state;
+            }
+
+            uses qos-scheduler-inputs-top;
+            uses qos-scheduler-output-top;
+            uses qos-scheduler-1r2c-top;
+            uses qos-scheduler-2r3c-top;
+          }
+        }
+      }
+    }
+  }
+
+  grouping qos-common-remark-actions {
+    description
+      "Common grouping specifying actions related to re-marking
+      packets";
+
+    container config {
+      description
+        "Configuration parameters relating to remarking packets.";
+      uses qos-common-remark-actions-config;
+    }
+
+    container state {
+      config false;
+      description
+        "Operational state parameters relating to remarking packets.";
+      uses qos-common-remark-actions-config;
+    }
+  }
+
+  grouping qos-common-scheduler-actions-config {
+    description
+      "Configuration data for common actions of a QoS scheduler.";
+
+    leaf drop {
+      type boolean;
+      description
+        "If set to true, packets within this context are dropped.";
+    }
+  }
+
+  grouping qos-common-remark-actions-config {
+    description
+      "Configuration data for QoS re-marking actions";
+
+    leaf set-dscp {
+      type uint8;
+      description
+        "Sets the 6-bit DSCP (differentiated services code point)
+        value in the IP packet header.";
+      reference
+        "RFC 2474 - Definition of the Differentiated Services Field
+        (DS Field) in the IPv4 and IPv6 Headers";
+    }
+
+    leaf set-dot1p {
+      type uint8;
+      description
+        "Sets the 3-bit class-of-service value in the
+        Ethernet packet header for 802.1Q VLAN-tagged packets,
+        also known as PCP (priority code point).";
+      reference
+        "IEEE 802.1Q-2014 - IEEE Standard for Local and metropolitan
+        area networks--Bridges and Bridged Networks";
+    }
+
+    leaf set-mpls-tc {
+      type uint8;
+      description
+        "Sets the 3-bit traffic class value (also referred to as EXP
+        or CoS) in MPLS packets.";
+      reference
+        "RFC 3270 - Multi-Protocol Label Switching (MPLS) Support of
+        Differentiated Services";
+    }
+  }
+}

--- a/models/yang/common/openconfig-qos-interfaces.yang
+++ b/models/yang/common/openconfig-qos-interfaces.yang
@@ -1,0 +1,1025 @@
+submodule openconfig-qos-interfaces {
+
+  belongs-to openconfig-qos {
+    prefix "oc-qos";
+  }
+
+  // import openconfig-qos-elements { prefix oc-qos; }
+  import openconfig-extensions { prefix oc-ext; }
+  import openconfig-interfaces { prefix oc-if; }
+  import openconfig-yang-types { prefix oc-yang; }
+
+  include openconfig-qos-elements;
+  include openconfig-qos-mem-mgmt;
+
+  // meta
+  organization
+    "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+     www.openconfig.net";
+
+  description
+    "This submodule defines data related to quality-of-service
+    configuration and operational state associated with
+    interfaces.";
+
+  oc-ext:openconfig-version "0.11.2";
+
+  revision "2023-10-13" {
+    description
+      "Fix revision statement date";
+    reference "0.11.2";
+  }
+
+  revision "2023-10-08" {
+    description
+      "Clarification on WRED weight in case it is not present";
+    reference "0.11.1";
+  }
+
+  revision "2023-09-15" {
+    description
+      "Add support for ECN counters";
+    reference "0.11.0";
+  }
+
+  revision "2023-07-26" {
+    description
+      "Add buffer management parameters in time unts (microseconds).
+       Make profiles reusable across LAGs and PHY of different speed";
+    reference "0.10.0";
+  }
+
+  revision "2023-04-25" {
+    description
+      "Clarify interface-ref usage.";
+    reference "0.9.1";
+  }
+
+  revision "2023-04-17" {
+    description
+      "Add support for relative RED min-threshold and max-threshold values.";
+    reference "0.9.0";
+  }
+
+  revision "2023-02-17" {
+    description
+      "Add queue identifier.";
+    reference "0.8.0";
+  }
+
+  revision "2023-02-08" {
+    description
+      "Remove incorrect output placement of interface-ref";
+    reference "0.7.0";
+  }
+
+  revision "2023-01-28" {
+    description
+      "Split groupings in interfaces for better leaf reuse.";
+    reference "0.6.1";
+  }
+
+  revision "2022-09-13" {
+    description
+      "Add queue octet drop counter.";
+    reference "0.6.0";
+  }
+
+  revision "2021-08-28" {
+    description
+      "Revision updating memory management profile WRED and RED configuration.";
+    reference "0.5.0";
+  }
+
+  revision "2021-04-28" {
+    description
+      "Updating memory management profile to queue management profile.";
+    reference "0.4.0";
+  }
+
+  revision "2021-04-28" {
+    description
+      "Revision updating buffer management and queue management
+      configuration.";
+    reference "0.3.0";
+  }
+
+  revision "2019-11-28" {
+    description
+      "Fix xpaths in when statements";
+    reference "0.2.3";
+  }
+
+  revision "2019-08-20" {
+    description
+      "Fix typo in classifiers container name";
+    reference "0.2.2";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "0.2.1";
+  }
+
+  revision "2016-12-16" {
+    description
+      "Fix incorrect interface-ref placement";
+    reference "0.2.0";
+  }
+
+  revision "2016-06-03" {
+    description
+      "Initial revision";
+    reference "0.1.0";
+  }
+
+  grouping qos-interface-classifier-match-state {
+    description
+      "Operational state data for match terms in the classifier
+      associated with an interface";
+
+    leaf id {
+      type leafref {
+        // Current location:
+        // /qos/interfaces/interface/input/classifiers/classifier/
+        // terms/term/config/id
+        path "../../../../../../../../../classifiers/" +
+            "classifier[name=current()/../../../../config/name]/" +
+            "terms/term/config/id";
+
+      }
+      description
+        "Reference to match terms in the classifier";
+    }
+
+    uses qos-interface-classifier-match-counters-state;
+  }
+
+  grouping qos-interface-classifier-match-counters-state {
+    description
+      "Grouping for counters relating to QoS classifier match terms.";
+
+    leaf matched-packets {
+      type oc-yang:counter64;
+      description
+        "Count of the number of packets matching this classifier
+        match term on the interface.";
+    }
+
+    leaf matched-octets {
+      type oc-yang:counter64;
+      description
+        "Count of the number of octets (bytes) matching this
+        classifier match term on the interface.";
+    }
+
+  }
+
+  grouping qos-interface-classifier-match-top {
+    description
+      "Top-level grouping for match terms in the classifier
+      associated with an interface";
+
+    container terms {
+      description
+        "Enclosing container for the list of match terms in the
+        classifier";
+
+      list term {
+        key "id";
+        config false;
+
+        description
+          "List of match terms in the classifier associated with the
+          interface";
+
+        leaf id {
+          type leafref {
+            path "../state/id";
+          }
+          description
+            "Reference to match term id list key";
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state data for match terms in the classifier
+            associated with an interface";
+
+          uses qos-interface-classifier-match-state;
+        }
+      }
+    }
+  }
+
+  grouping qos-interface-classifier-top {
+    description
+      "Top-level grouping for a QoS classifier associated with an
+      interface";
+
+    container classifiers {
+      description
+        "Classifiers to be applied to the interface.";
+
+      list classifier {
+        key "type";
+
+        description
+          "A list of classifiers that should be applied to the interface";
+
+        leaf type {
+          type leafref {
+            path "../config/type";
+          }
+          description
+            "Reference to the classifier name.";
+        }
+
+        container config {
+          description
+            "Configuration parameters for the list of classifiers.";
+          uses qos-interface-classifiers-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state parameters for the list of classifiers.";
+          uses qos-interface-classifiers-config;
+        }
+
+        uses qos-interface-classifier-match-top;
+      }
+    }
+  }
+
+  grouping qos-interface-classifiers-config {
+    description
+      "Configuration parameters for the list of classifiers";
+
+    leaf name {
+      type leafref {
+        // current loc: /qos/interfaces/interface/input/classifiers/
+        // classifier/config/name
+        path "../../../../../../../classifiers/classifier/config/name";
+      }
+      description
+        "Reference to the classifier to be applied to ingress traffic on
+        the interface";
+    }
+
+    leaf type {
+      type enumeration {
+        enum IPV4 {
+          value 4;
+          description
+            "Classifier matches IPv4 Unicast packets.";
+        }
+        enum IPV6 {
+          value 6;
+          description
+            "Classifier matches IPv6 Unicast packets.";
+        }
+        enum MPLS {
+          description
+            "Classifier matches MPLS packets.";
+        }
+        enum IPV4_MULTICAST {
+          description
+            "Classifier matches IPv4 Multicast packets.";
+        }
+        enum IPV6_MULTICAST {
+          description
+            "Classifier matches IPv6 Multicast packets.";
+        }
+      }
+      description
+        "Type of packets matched by the classifier.";
+    }
+  }
+
+  grouping qos-interface-queue-config {
+    description
+      "Configuration data for queues associated with the
+      interface, this is re-used across input/output queues.";
+
+    leaf name {
+      // TODO(robjs): Previously we proposed that the queue name here is
+      // only a queue that has been configured. However, in some cases we
+      // may want to have queues that have not been configured exist.
+      //type leafref {
+      //  path "../../../../../../queues/queue/config/name";
+      //}
+      type string;
+      description
+        "Reference to the queue associated with this interface.
+        A queue may be explicitly configured, or implicitly created
+        by the system based on default queues that are instantiated
+        by a hardware component, or are assumed to be default on
+        the system.";
+    }
+  }
+
+  grouping qos-interface-queue-root-config {
+    description
+      "Configuration parameters for per-queue per-interface, applying
+      only to the root.";
+
+    leaf queue-management-profile {
+      type leafref {
+        // we are at /qos/interfaces/interface/{input,output}/queues/queue/config/queue-management-profile
+        path "../../../../../../../queue-management-profiles/" +
+             "queue-management-profile/config/name";
+      }
+      description
+        "The queue management profile that is to be used for the queue
+        on the interface.
+
+        For example, the system may use a profile which specifies that
+        WRED curves are used for setting an ECN mark in the IP header
+        instead of dropping a packet in order to signal impending
+        congestion and for determining when there is sufficient
+        congestion to tail drop packets.
+
+        A single profile is available per queue - which applies to all packets
+        that are enqueued to the specified queue, whether they are unicast or
+        multicast.";
+    }
+  }
+
+  grouping qos-interface-queue-state {
+    description
+      "Operational state data for the queue associated with the
+      interface";
+
+    leaf max-queue-len {
+      type oc-yang:counter64;
+      units bytes;
+      description
+        "Maximum observed queue length";
+    }
+
+    leaf avg-queue-len {
+      type oc-yang:counter64;
+      units bytes;
+      description
+        "Average observed queue length";
+
+    }
+
+    leaf transmit-pkts {
+      type oc-yang:counter64;
+      description
+        "Number of packets transmitted by this queue";
+    }
+
+    leaf transmit-octets {
+      type oc-yang:counter64;
+      description
+        "Number of octets trasmitted by this queue";
+    }
+
+    leaf dropped-pkts {
+      type oc-yang:counter64;
+      description
+        "Number of packets dropped by the queue due to overrun, that is tail-drop
+        or AMQ (RED, WRED, etc) induced drops as indicated by the attached
+        queue-management-profile";
+    }
+
+    leaf dropped-octets {
+      type oc-yang:counter64;
+      description
+        "Number of octets dropped by the queue due to overrun, that is tail-drop
+        or AMQ (RED, WRED, etc) induced drops as indicated by the attached
+        queue-management-profile";
+    }
+
+    leaf ecn-marked-pkts {
+      type oc-yang:counter64;
+      description
+        "number of packets for which ECN codepoint has been changed from ECT to CE";
+    }
+
+    leaf ecn-marked-octets {
+      type oc-yang:counter64;
+      description
+        "Number of octets for which ECN codepoint has been changed from ECT to CE";
+    }
+
+    leaf ecn-selected-pkts {
+      type oc-yang:counter64;
+      description
+        "Number of packets selected by AQM
+
+        For RED/WRED AQM this counter counts:
+        - all packets enqueued while queue utilization was greater then max-threshold
+        - packs enqueued while queue utilization was between min-threshold and max-threshold, with probability derived from RED/WRED slope
+
+        Packets are counted regardless of its ECN codepoint";
+    }
+
+    leaf ecn-selected-octets {
+      type oc-yang:counter64;
+      description
+        "Number of octets of packets selected by AQM
+
+        For RED/WRED AQM this counter counts:
+        - all octets enqueued while queue utilization was greater then max-threshold
+        - octets enqueued while queue utilization was between min-threshold and max-threshold, with probability derived from RED/WRED slope
+
+        Octets are counted regardless of its ECN codepoint";
+    }
+  }
+
+  grouping qos-interface-queue-top {
+    description
+      "Top-level grouping for the queue associated with the
+      interface";
+
+    container queues {
+      description
+        "Surrounding container for a list of queues that are
+        instantiated on an interface.";
+
+      list queue {
+        key "name";
+
+        description
+          "Top-level container for the queue associated with this
+          interface";
+
+        leaf name {
+          type leafref {
+            path "../config/name";
+          }
+          description
+            "Reference to the name of the queue
+            instantiated on the interface.";
+        }
+
+        container config {
+          description
+            "Configuration data for the queue associated with the
+            interface";
+
+          uses qos-interface-queue-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state data for the queue associated with the
+            interface";
+
+          uses qos-interface-queue-config;
+          uses qos-interface-queue-state;
+        }
+      }
+    }
+  }
+
+  grouping qos-interface-queue-root-top {
+    description
+      "Top-level grouping for the queue associated with the
+      interface - used only for /qos/interfaces/interface rather
+      than in multiple contexts.";
+
+    container queues {
+      description
+        "Surrounding container for a list of queues that are
+        instantiated on an interface.";
+
+      list queue {
+        key "name";
+
+        description
+          "Top-level container for the queue associated with this
+          interface";
+
+        leaf name {
+          type leafref {
+            path "../config/name";
+          }
+          description
+            "Reference to the name of the queue
+            instantiated on the interface.";
+        }
+
+        container config {
+          description
+            "Configuration data for the queue associated with the
+            interface";
+
+          uses qos-interface-queue-config;
+          uses qos-interface-queue-root-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state data for the queue associated with the
+            interface";
+
+          uses qos-interface-queue-config;
+          uses qos-interface-queue-root-config;
+          uses qos-interface-queue-state;
+        }
+      }
+    }
+  }
+
+  grouping qos-interface-voqs-top {
+    description
+      "Structural grouping of virtual-output-queue operational state
+      for an interface.";
+
+    container virtual-output-queues {
+      description
+        "Surrounding container for the list of egress interfaces
+        for which virtual output queues are instantiated on this
+        interface.";
+
+      list voq-interface {
+        key "name";
+
+        description
+          "List of egress interfaces for which a virtual output
+          queue is instantiated at this interface.";
+
+        leaf name {
+          type leafref {
+            path "../config/name";
+          }
+          description
+            "Name used to refer to the egress interface.";
+        }
+
+        container config {
+          description
+            "Configuration parameters relating to the interface
+            for which the VOQs are instantiated.";
+          uses qos-voqs-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state parameters relating to the interface
+            for which the VOQs are instantiated.";
+          uses qos-voqs-config;
+        }
+
+        uses qos-interface-queue-top;
+      }
+    }
+  }
+
+  grouping qos-voqs-config {
+    description
+      "Configuration parameters relating to an egress interface for which
+      VOQs are established on an interface.";
+
+    leaf name {
+        type string;
+        description
+          "Name used to refer to the egress interface.";
+    }
+  }
+
+  grouping qos-interface-scheduler-policy-config {
+    description
+      "Configuration data for schedulers associated with
+      the interface";
+
+    leaf name {
+      type leafref {
+        // current loc:
+        // /qos/interfaces/interface/input/schedulers/scheduler/config/name
+        path "../../../../../../scheduler-policies/scheduler-policy/" +
+             "config/name";
+      }
+      description
+        "The scheduler policy to be applied to traffic on this interface.";
+    }
+  }
+
+  grouping qos-interface-scheduler-state {
+    description
+      "Operational state data for a scheduler within
+      a scheduler group applied to an interface.";
+
+    leaf sequence {
+      type leafref {
+        // current loc: /qos/interfaces/interface/input/scheduler-policy/
+        // schedulers/scheduler/state/sequence
+        path "../../../../../../../../scheduler-policies/" +
+            "scheduler-policy[name=current()/../../../../config/name]" +
+            "/schedulers/scheduler/config/sequence";
+      }
+      description
+        "Reference to the sequence ID of the scheduler within
+        the current scheduler policy.";
+    }
+
+    uses qos-scheduler-common-state;
+  }
+
+  grouping qos-scheduler-common-state {
+    description
+      "Common definitions of counters used in schedulers.";
+
+    leaf conforming-pkts {
+      type oc-yang:counter64;
+      description
+        "The number of packets that were considered conforming by
+        the scheduler.";
+    }
+
+    leaf conforming-octets {
+      type oc-yang:counter64;
+      description
+        "The number of octets in packets that were considered
+        conforming by the scheduler.";
+    }
+
+    leaf exceeding-pkts {
+      type oc-yang:counter64;
+      description
+        "The number of packets that were considered exceeding by
+        the scheduler.";
+    }
+
+    leaf exceeding-octets {
+      type oc-yang:counter64;
+      description
+        "The number of octets in packets that were considered
+        exceeding by the scheduler.";
+    }
+
+    leaf violating-pkts {
+      type oc-yang:counter64;
+      description
+        "The number of packets that were considered violating by
+        the policer.";
+    }
+
+    leaf violating-octets {
+      type oc-yang:counter64;
+      description
+        "The number of octets in packets that were considered
+        violating by the policer.";
+    }
+  }
+
+  grouping qos-interface-scheduler-top {
+    description
+      "Top-level grouping ";
+
+    container scheduler-policy {
+      description
+        "Scheduler policy associated with the interface.";
+
+      container config {
+        description
+          "Configuration parameters relating to a scheduler policy on
+          an interface.";
+        uses qos-interface-scheduler-policy-config;
+      }
+
+      container state {
+        config false;
+        description
+          "Operational state parameters relating to a scheduler policy
+          on an interface.";
+        uses qos-interface-scheduler-policy-config;
+      }
+
+      container schedulers {
+        config false;
+        description
+          "Schedulers within the applied scheduler-policy.";
+
+        list scheduler {
+          key "sequence";
+          description
+            "List of the schedulers that are part of the scheduler-policy
+            specified.";
+
+          leaf sequence {
+            type leafref {
+              path "../state/sequence";
+            }
+            description
+              "Reference to the sequence ID for the scheduler.";
+          }
+
+          container state {
+            description
+              "Operational state parameters relating to the scheduler
+              policy.";
+
+            uses qos-interface-scheduler-state;
+          }
+        }
+      }
+    }
+  }
+
+  grouping qos-interfaces-config {
+    description
+      "Configuration data for interfaces referenced in the QoS
+      model";
+
+    leaf interface-id {
+      type string;
+      description
+        "Identifier for the interface.";
+    }
+  }
+
+  grouping qos-interfaces-state {
+    description
+      "Operational state data for interfaces referenced in the QoS
+      model";
+
+      // definitions per-interface counters for QoS
+  }
+
+  grouping qos-interface-input-config {
+    description
+      "Configuration data for QoS on ingress interface";
+
+    leaf buffer-allocation-profile {
+      type leafref {
+        // we are at
+        // /qos/interfaces/interface/input/config/buffer-allocation-profile
+        path "../../../../../buffer-allocation-profiles/"  +
+             "buffer-allocation-profile/config/name";
+      }
+      description
+        "The buffer allocation profile that is to be used for the interface.
+        This profile specifies how memory that is available to the interface
+        should be allocated amongst the queues that are instantiated on the
+        interface.
+
+        This reference specifies the policy that should be used for memory
+        allocated to the input (rx) queueing.
+
+        This leaf is used in deployment cases where the operator or system
+        requires common allocation profiles covering unicast and multicast
+        packets.";
+    }
+
+    leaf multicast-buffer-allocation-profile {
+      type leafref {
+        // we are at
+        // /qos/interfaces/interface/input/config/multicast-buffer-allocation-profile
+        path "../../../../../buffer-allocation-profiles/"  +
+             "buffer-allocation-profile/config/name";
+      }
+      description
+        "The buffer allocation profile that is to be used for the interface.
+        This profile specifies how memory that is available to the interface
+        should be allocated amongst the queues that are instantiated on the
+        interface.
+
+        This reference specifies the policy that should be used for memory
+        allocated to the output (tx) queueing.
+
+        This buffer allocation profile applies to only multicast packets on
+        the interface - if specified, the unicast-buffer-allocation-profile
+        governs the allocation profile used for memory dedicated to unicast.
+        If a system does not support, or an operator does not require separate
+        buffer-allocation-profiles, this is specified by use of the
+        buffer-allocation-profile leaf.";
+    }
+
+    leaf unicast-buffer-allocation-profile {
+      type leafref {
+        // we are at
+        // /qos/interfaces/interface/input/config/unicast-buffer-allocation-profile
+        path "../../../../../buffer-allocation-profiles/"  +
+             "buffer-allocation-profile/config/name";
+      }
+      description
+        "The buffer allocation profile that is to be used for the interface.
+        This profile specifies how memory that is available to the interface
+        should be allocated amongst the queues that are instantiated on the
+        interface.
+
+        This reference specifies the policy that should be used for memory
+        allocated to the output (tx) queueing.
+
+        This buffer allocation profile applies to only unicast packets on
+        the interface - if specified, the multicast-buffer-allocation-profile
+        governs the allocation profile used for memory dedicated to multicast.
+        If a system does not support, or an operator does not require separate
+        buffer-allocation-profiles, this is specified by use of the
+        buffer-allocation-profile leaf.";
+    }
+  }
+
+  grouping qos-interface-input-state {
+    description
+      "Operational state data for QoS on ingress interface";
+  }
+
+  grouping qos-interface-input-top {
+    description
+      "Top-level grouping for QoS on ingress interface";
+
+    container input {
+      description
+        "Top-level container for QoS data for the ingress
+        interface";
+
+      container config {
+        description
+          "Configuration data for QoS on ingress interface";
+
+        uses qos-interface-input-config;
+      }
+
+      container state {
+        config false;
+        description
+          "Operational state data for QoS on ingress interface";
+
+        uses qos-interface-input-config;
+        uses qos-interface-input-state;
+      }
+
+      uses qos-interface-classifier-top;
+      uses qos-interface-queue-root-top;
+      uses qos-interface-scheduler-top;
+      uses qos-interface-voqs-top;
+    }
+  }
+
+  grouping qos-interface-output-config {
+    description
+      "Configuration data for QoS on the egress interface";
+
+    leaf buffer-allocation-profile {
+      type leafref {
+        // we are at
+        // /qos/interfaces/interface/output/config/buffer-allocation-profile
+        path "../../../../../buffer-allocation-profiles/"  +
+             "buffer-allocation-profile/config/name";
+      }
+      description
+        "The buffer allocation profile that is to be used for the interface.
+        This profile specifies how memory that is available to the interface
+        should be allocated amongst the queues that are instantiated on the
+        interface.
+
+        This reference specifies the policy that should be used for memory
+        allocated to the output (tx) queueing.
+
+        This leaf is used in deployment cases where the operator or system
+        requires common allocation profiles covering unicast and multicast
+        packets.";
+    }
+
+    leaf multicast-buffer-allocation-profile {
+      type leafref {
+        // we are at
+        // /qos/interfaces/interface/output/config/buffer-allocation-profile
+        path "../../../../../buffer-allocation-profiles/"  +
+             "buffer-allocation-profile/config/name";
+      }
+      description
+        "The buffer allocation profile that is to be used for the interface.
+        This profile specifies how memory that is available to the interface
+        should be allocated amongst the queues that are instantiated on the
+        interface.
+
+        This reference specifies the policy that should be used for memory
+        allocated to the output (tx) queueing.
+
+        This buffer allocation profile applies to only multicast packets on
+        the interface - if specified, the unicast-buffer-allocation-profile
+        governs the allocation profile used for memory dedicated to unicast.
+        If a system does not support, or an operator does not require separate
+        buffer-allocation-profiles, this is specified by use of the
+        buffer-allocation-profile leaf.";
+    }
+
+    leaf unicast-buffer-allocation-profile {
+      type leafref {
+        // we are at
+        // /qos/interfaces/interface/output/config/buffer-allocation-profile
+        path "../../../../../buffer-allocation-profiles/"  +
+             "buffer-allocation-profile/config/name";
+      }
+      description
+        "The buffer allocation profile that is to be used for the interface.
+        This profile specifies how memory that is available to the interface
+        should be allocated amongst the queues that are instantiated on the
+        interface.
+
+        This reference specifies the policy that should be used for memory
+        allocated to the output (tx) queueing.
+
+        This buffer allocation profile applies to only unicast packets on
+        the interface - if specified, the multicast-buffer-allocation-profile
+        governs the allocation profile used for memory dedicated to multicast.
+        If a system does not support, or an operator does not require separate
+        buffer-allocation-profiles, this is specified by use of the
+        buffer-allocation-profile leaf.";
+    }
+  }
+
+  grouping qos-interface-output-state {
+    description
+      "Operational state data for QoS on the egress interface";
+  }
+
+  grouping qos-interface-output-top {
+    description
+      "Top-level grouping for QoS on the egress interface";
+
+    container output {
+      description
+        "Top-level container for QoS data related to the egress
+        interface.";
+
+      container config {
+        description
+          "Configuration data for QoS on the egress interface";
+
+        uses qos-interface-output-config;
+      }
+
+      container state {
+        config false;
+        description
+          "Operational state data for QoS on the egress interface";
+
+        uses qos-interface-output-config;
+        uses qos-interface-output-state;
+      }
+
+      uses qos-interface-classifier-top;
+      uses qos-interface-queue-root-top;
+      uses qos-interface-scheduler-top;
+    }
+  }
+
+  grouping qos-interfaces-top {
+    description
+      "Top-level grouping for interfaces referenced in the QoS
+      model";
+
+    container interfaces {
+      description
+        "Enclosing container for the list of interface references";
+
+      list interface {
+        key "interface-id";
+        description
+          "List of interfaces referenced by QoS entities.
+
+           The interface referenced is based on the interface and
+           subinterface leaves within the interface-ref container -
+           which reference an entry in the /interfaces/interface list -
+           and should not rely on the value of the list key.";
+
+        leaf interface-id {
+          type leafref {
+            path "../config/interface-id";
+          }
+          description
+            "Reference to the interface-id list key";
+        }
+
+        container config {
+          description
+            "Configuration data ";
+
+          uses qos-interfaces-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state data ";
+
+          uses qos-interfaces-config;
+          uses qos-interfaces-state;
+        }
+
+        uses oc-if:interface-ref;
+        uses qos-interface-input-top;
+        uses qos-interface-output-top;
+      }
+    }
+  }
+
+}

--- a/models/yang/common/openconfig-qos-mem-mgmt.yang
+++ b/models/yang/common/openconfig-qos-mem-mgmt.yang
@@ -1,0 +1,528 @@
+submodule openconfig-qos-mem-mgmt {
+
+  belongs-to openconfig-qos {
+    prefix "oc-qos";
+  }
+
+  import openconfig-extensions { prefix oc-ext; }
+  import openconfig-types { prefix oc-types; }
+
+  include openconfig-qos-elements;
+
+  organization
+    "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This submodule defines configuration and operational state
+    data associated related to queue management features of QoS
+    particularly:
+
+    - buffer-allocation-profiles: these profiles are applied on
+      a per-interface basis, and determine how memory is to be managed
+      across the queues that are instantiated on the system.
+
+    - queue-management-profiles: these profiles are applied on a per-interface
+      per-queue basis, and determine how packets are marked/dropped within
+      the queue instantiation.";
+
+  oc-ext:openconfig-version "0.11.2";
+
+  revision "2023-10-13" {
+    description
+      "Fix revision statement date";
+    reference "0.11.2";
+  }
+
+  revision "2023-10-08" {
+    description
+      "Clarification on WRED weight in case it is not present";
+    reference "0.11.1";
+  }
+
+  revision "2023-09-15" {
+    description
+      "Add support for ECN counters";
+    reference "0.11.0";
+  }
+
+revision "2023-07-26" {
+    description
+      "Add buffer management parameters in time unts (microseconds).
+       Make profiles reusable across LAGs and PHY of different speed";
+    reference "0.10.0";
+  }
+
+  revision "2023-04-25" {
+    description
+      "Clarify interface-ref usage.";
+    reference "0.9.1";
+  }
+
+  revision "2023-04-17" {
+    description
+      "Add support for relative RED min-threshold and max-threshold values.";
+    reference "0.9.0";
+  }
+
+  revision "2023-02-17" {
+    description
+      "Add queue identifier.";
+    reference "0.8.0";
+  }
+
+  revision "2023-02-08" {
+    description
+      "Remove incorrect output placement of interface-ref";
+    reference "0.7.0";
+  }
+
+  revision "2023-01-28" {
+    description
+      "Split groupings in interfaces for better leaf reuse.";
+    reference "0.6.1";
+  }
+
+  revision "2022-09-13" {
+    description
+      "Add queue octet drop counter.";
+    reference "0.6.0";
+  }
+
+  revision "2021-08-28" {
+    description
+      "Revision updating memory management profile WRED and RED configuration.";
+    reference "0.5.0";
+  }
+
+  revision "2021-06-28" {
+    description
+      "Adding buffer carving policies per interface per queue.";
+    reference "0.4.0";
+  }
+
+  revision "2021-04-28" {
+    description
+      "Revision updating buffer management and queue management
+      configuration.";
+    reference "0.3.0";
+  }
+
+  identity SHARED_BUFFER_LIMIT_TYPE {
+    description
+      "Base identity for supported shared buffer limit types.";
+  }
+
+  identity STATIC {
+    base SHARED_BUFFER_LIMIT_TYPE;
+    description
+      "The maximum buffer space that the queue is allowed to use from the shared
+       buffer is specified as a static-limit which is expressed in bytes.";
+  }
+
+  identity DYNAMIC_BASED_ON_SCALING_FACTOR {
+    base SHARED_BUFFER_LIMIT_TYPE;
+    description
+      "The maximum buffer space that the queue is allowed to use from the shared
+       buffer is dynamically determined based on the current usage pattern of the
+       shared buffer and a dynamic-limit which is expressed as a scaling factor
+       on the free space in the shared buffer.";
+  }
+
+  grouping qos-buffer-profile-top {
+    description
+      "Grouping containing buffer-allocation-profile structural definition";
+
+    container buffer-allocation-profiles {
+      description
+        "Surrounding container for buffer allocation profiles.";
+
+      list buffer-allocation-profile {
+        key "name";
+
+        description
+          "A buffer allocation profile describes a mapping between the queues
+          that are instantiated on an interface and the memory that is allocated
+          to them on the forwarding complex that they are instantiated. Profiles
+          (like queues) are defined in the abstract and instantiated by being
+          configured on a particular interface. Separate allocation profiles may
+          be used for ingress and egress traffic, with the profile being specified
+          within the /qos/interfaces/interface list.";
+
+        leaf name {
+          type leafref {
+            path "../config/name";
+          }
+          description
+            "Reference to the unique name used as a key for each buffer profile.";
+        }
+
+        container config {
+          description
+            "Configuration parameters for a buffer-allocation-profile.";
+          uses buffer-allocation-profile-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state parameters relating to a buffer-allocation-profile.";
+          uses buffer-allocation-profile-config;
+        }
+
+        container queues {
+          description
+            "Surrounding container for the queues that are referenced under a
+            buffer-allocation-policy.";
+
+          list queue {
+            key "name";
+
+            description
+              "Buffer allocation profile for a specific queue on the interface.";
+
+            leaf name {
+              type leafref {
+                path "../config/name";
+              }
+              description
+                "Reference to the name of the queue being referenced under the buffer
+                allocation profile.";
+            }
+
+            container config {
+              description
+                "Configuration parameters relating to a queue within a buffer allocation
+                profile.";
+              uses buffer-allocation-profile-q-config;
+            }
+
+            container state {
+              config false;
+              description
+                "Operational state parameters relating to a queue wtihin a buffer allocation
+                profile.";
+              uses buffer-allocation-profile-q-config;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  grouping buffer-allocation-profile-config {
+    description
+      "Configuration parameters relating to a buffer-allocation-profile.";
+
+    leaf name {
+      type string;
+      description
+        "Unique string identifying the buffer allocation profile, used to
+        reference to the profile on interfaces.";
+    }
+
+    // TODO(openconfig-ops): add any parameters that relate to overall allocation
+    // profile.
+  }
+
+  grouping buffer-allocation-profile-q-config {
+    description
+      "Configuration parameters relating to a queue within a buffer-allocation-profile.";
+
+    leaf name {
+      type leafref {
+        // @ /qos/buffer-allocation-profiles/buffer-allocation-profile/queues/queue/config/name
+        path "../../../../../../queues/queue/config/name";
+      }
+      description
+        "Reference to the queue being referenced within the buffer allocation profile.";
+    }
+
+    leaf dedicated-buffer {
+      type uint64;
+      units bytes;
+      description
+        "This is the dedicated buffer that is carved for the queue, this is the minimum
+        number of bytes reserved for this queue.
+        This leaf is mutualy exclusive with dedicated-buffer-temporal leaf";
+    }
+
+    leaf dedicated-buffer-temporal {
+      type uint64;
+      units microseconds;
+      description
+        "This is the dedicated buffer that is carved for the queue. The the minimum
+        number of bytes reserved for this queue is calculated by multiplying by interface speed
+        queue is attached to and queues minimum, guarantaed transmit share (derived
+        form WRR schedulers weights).
+        This leaf shouldbot be used for strict priority scheduled queues.
+        This leaf is mutualy exclusive with dedicated-buffer leaf";
+    }
+
+    leaf use-shared-buffer {
+      type boolean;
+      description
+        "If the flag is true, then the queue is allowed to use buffers from shared pool
+        in additional to the dedicated buffers assigned for this queue.";
+    }
+
+    leaf shared-buffer-limit-type {
+      type identityref {
+        base SHARED_BUFFER_LIMIT_TYPE;
+      }
+      description
+        "The type of limit used to specify the amount of buffer space that the queue
+        is allowed to use from the shared pool.";
+    }
+
+    leaf static-shared-buffer-limit {
+      type uint32;
+      units bytes;
+      description
+        "If the shared-buffer-limit-type is STATIC, then static-shared-buffer-limit is
+        the maximum number of bytes that the queue is allowed to use from the shared
+        pool.
+        This leaf is mutualy exclusive with static-shared-buffer-limit-temporal leaf.";
+    }
+
+    leaf static-shared-buffer-limit-temporal {
+      type uint32;
+      units microseconds;
+      description
+        "If the shared-buffer-limit-type is STATIC, then static-shared-buffer-limit-temporal is
+        the maximum number of bytes that the queue is allowed to use from the shared
+        pool.
+        The the number of bytes is calculated by multiplying static-shared-buffer-limit-temporal
+        by interface speed the queue is attached to and queues minimum, guarantaed transmit share
+        (derived form WRR schedulers weights).
+        This leaf shouldbot be used for strict priority scheduled queues.
+        This leaf is mutualy exclusive with static-shared-buffer-limit leaf.";
+    }
+
+    leaf dynamic-limit-scaling-factor {
+      type int32;
+      description
+        "If shared-buffer-limit-type is DYNAMIC_BASED_ON_SCALING_FACTOR, the scaling
+        factor and the current free space in the shared pool is used to determine the
+        maximum buffer sapce from the shared pool that the queue is allowed to use.
+
+        Example: If a queue is using 79MB and the other queues are using 11MB, the
+        free buffer is 10MB. If the configured scaling factor is 3 for the queue, the
+        maximum buffer space from the shared pool that the queue is allowed to use is
+        calculated as (free buffer * 2^scaling factor) ie. 10MB*2^3 = 80MB. Since the
+        current usage is 79MB which is < 80MB, the packet is queued.";
+    }
+  }
+
+  grouping qos-queue-management-profile-config {
+    description
+      "Configuration parameters for queue management profiles.";
+
+    leaf name {
+      type string;
+      description
+        "Unique string name used for the queue management profile.";
+    }
+  }
+
+  grouping qos-queue-management-profile-red-wred-common-config {
+    description
+      "Common configuration parameters for red and wred.";
+
+    leaf min-threshold {
+      type uint64;
+      units bytes;
+      description
+        "The mininum threshold parameter for a RED-managed queue in bytes.
+        When the average queue length is less than minth, all packets are admitted
+        to the queue.  Mututally exclusive with min-threshold-percent and
+        max-threshold-percent.";
+    }
+
+    leaf max-threshold {
+      type uint64;
+      units bytes;
+      description
+        "The maximum threshold parameter for a RED-managed queue in bytes.
+        When the average queue length exceeds the maxth value, all packets are
+        dropped (or marked if ECN is enabled).  Mutually exclusive with
+        min-threshold-percent and max-threshold-percent.";
+    }
+
+    leaf min-threshold-percent {
+      type uint64;
+      units oc-types:percentage;
+      description
+        "The mininum threshold parameter for a RED-managed queue in percent.
+        When the average queue length is less than minth, all packets are
+        admitted to the queue.  Mutually exclusive with min-threshold and
+        max-threshold.";
+    }
+
+    leaf max-threshold-percent {
+      type uint64;
+      units oc-types:percentage;
+      description
+        "The maximum threshold parameter for a RED-managed queue in percent.
+        When the average queue length exceeds the maxth value, all packets
+        are dropped (or marked if ECN is enabled).  Mutually exclusive with
+        min-threshold and max-threshold.";
+    }
+
+    leaf enable-ecn {
+      type boolean;
+      default false;
+      description
+        "When this leaf is true and the number of packets in the queue
+        is between the minimum threshold and the maximum threshold, if
+        the ECN field on the packet indicates that the endpoints are ECN
+        capable (that is, the ECT bit is set to 1 and the CE bit is set
+        to 0, or the ECT bit is set to 0 and the CE bit is set to 1) and
+        the WRED algorithm determines that the packet should have been
+        dropped based on the drop probability, the ECT and CE bits for
+        the packet are changed to 1, and the packet is transmitted.";
+    }
+
+    leaf drop {
+      type boolean;
+      default false;
+      description
+        "When this leaf is true and the packet and if the ECN field in
+        the packet indicates that the endpoints are not ECN capable and
+        the and the WRED algorithm determines that the packet should
+        have been dropped based on the drop probability, the packet
+        is dropped.";
+    }
+  }
+
+  grouping qos-queue-management-profile-wred-config {
+    description
+      "Configuration parameters for wred buffer allocation.";
+
+    leaf weight {
+      type uint32;
+      description
+        "The average queue size depends on the previous average as well as
+         the current size of the queue.
+
+        average queue size = (previous average queue size)*(1-2^{-n})+
+                             (current queue size)*(2^{-n})
+
+        where n is the user-configurable exponential weight factor.
+
+        The previous average is more important for high values of n. Peaks
+        and lows in queue size are smoothed by a high value. For low values
+        of n, the average queue size is close to the current queue size.
+
+        When this leaf is not present, implementation default value is
+        applied.";
+    }
+
+    leaf max-drop-probability-percent {
+      type oc-types:percentage;
+      description
+        "If the queue depth is between min and max threshold then this
+        the probability with which packets are dropped or marked.";
+    }
+  }
+
+  grouping qos-queue-mgmt-profile-top {
+    description
+      "Grouping containing queue management profiles for queues.";
+
+    container queue-management-profiles {
+      description
+        "Surrounding container for the list of configured
+        queue management profiles.";
+
+      list queue-management-profile {
+        key "name";
+
+        description
+          "A queue management profile within the OpenConfig QoS model
+          specifies how packets are ECN marked/dropped for a particular
+          instance of a queue on a particular interface. for example,
+          whether RED, or WRED is applied to manage the queue's occupancy.";
+
+        leaf name {
+          type leafref {
+            path "../config/name";
+          }
+          description
+            "Reference to the unique name used to reference the queue
+            management profile";
+        }
+
+        container config {
+          description
+            "Configuration parameters relating to the queue
+            management profile.";
+          uses qos-queue-management-profile-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state parameters relating to the queue
+            management profile.";
+          uses qos-queue-management-profile-config;
+        }
+
+        container wred {
+          description
+            "Configuration and operational state parameters relating to
+            Weighted Random Early Detection (WRED).";
+
+          container uniform {
+            description
+              "Uniform WRED parameters. These parameters are applied to all the
+              traffic coming into system.";
+
+            container config {
+              description
+                "Configuration parameters relating to the WRED.";
+              uses qos-queue-management-profile-red-wred-common-config;
+              uses qos-queue-management-profile-wred-config;
+            }
+
+            container state {
+              config false;
+              description
+                "Operational state parameters relating to the WRED.";
+              uses qos-queue-management-profile-red-wred-common-config;
+              uses qos-queue-management-profile-wred-config;
+            }
+          }
+        }
+
+        container red {
+          description
+            "Configuration and operational state parameters
+            relating to Random Early Detection (RED).";
+
+          container uniform {
+            description
+              "Uniform RED parameters. These parameters are applied to all
+              the traffic coming into system.";
+
+            container config {
+              description
+                "Configuration parameters relating to the RED.";
+              uses qos-queue-management-profile-red-wred-common-config;
+            }
+
+            container state {
+              config false;
+              description
+                "Operational state parameters relating to the RED.";
+              uses qos-queue-management-profile-red-wred-common-config;
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/models/yang/common/openconfig-qos-types.yang
+++ b/models/yang/common/openconfig-qos-types.yang
@@ -1,0 +1,159 @@
+module openconfig-qos-types {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/qos-types";
+
+  prefix "oc-qos-types";
+
+  // import some basic types
+  import openconfig-extensions { prefix oc-ext; }
+
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This module defines types and identities used in OpenConfig
+    models related to quality-of-service (QoS)";
+
+  oc-ext:openconfig-version "0.2.1";
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "0.2.1";
+  }
+
+  revision "2016-12-16" {
+    description
+      "Fix incorrect interface-ref placement";
+    reference "0.2.0";
+  }
+
+  revision "2016-08-08" {
+    description
+      "Initial revision";
+    reference "0.1.0";
+  }
+
+  // OpenConfig specific extensions for module metadata.
+  oc-ext:regexp-posix;
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  // extension statements
+
+  // feature statements
+
+  // identity statements
+
+  identity QOS_QUEUE_TYPE {
+    description
+      "Base identity for supported queue types, primarily
+      defined by their drop behavior / strategy";
+  }
+
+  identity DROP_TAIL {
+    base QOS_QUEUE_TYPE;
+    description
+      "When the queue is filled to capacity, newly arriving packets
+      are discarded until there is room in the queue to accept new
+      traffic.  Packets are not differentiated, i.e., all packets
+      are treated identically.";
+  }
+
+  identity RED {
+    base QOS_QUEUE_TYPE;
+    description
+      "Queue management based on Random Early Detection (RED).  RED
+      drops packets based on a drop probability that is based on the
+      average queue length, and settings of mininum and maximum
+      queue thresholds.  On ECN-capable devices, packets may be
+      marked instead of dropped to signal congestion to the
+      sender.";
+    reference
+      "IETF RFC 2309 - Recommendations on Queue Management and
+      Congestion Avoidance in the Internet
+      IETF RFC 7567 - IETF Recommendations Regarding Active Queue
+      Management";
+  }
+
+  identity WRED {
+    base QOS_QUEUE_TYPE;
+    description
+      "Queue management based on a variant of RED in which the packet
+      drop probability is based on its traffic class.";
+  }
+
+  identity QOS_SCHEDULER_TYPE {
+    description
+      "Base identity to describe supported QoS scheduler types.";
+  }
+
+  identity ONE_RATE_TWO_COLOR {
+    base QOS_SCHEDULER_TYPE;
+    description
+      "Token bucket scheduler with a single rate (committed information
+      rate) and two colors (conforming and exceeding).  The scheduler
+      behavior is governed by two parameters, the CIR which
+      determines the rate of token fill (bps) and the committed
+      burst size (depth of the token bucket in bytes).";
+  }
+
+  identity TWO_RATE_THREE_COLOR {
+    base QOS_SCHEDULER_TYPE;
+    description
+      "Token bucket scheduler with two buckets, one filled at the
+      committed information rate (CIR) in bps, and the second filled
+      at the peak information rate (PIR) in bps when the first
+      bucket is full.  The first bucket depth is
+      the committed burst size (bytes), and the second is the
+      excess burst size (bytes).  Traffic is categorized in three
+      colors as follows: traffic that falls within the
+      the CIR is conforming, traffic that is greater than the CIR
+      but less than the PIR is exceeding, and traffic that is
+      greater than PIR is violating.";
+  }
+
+  // typedef statements
+
+  typedef queue-behavior {
+    type enumeration {
+      enum SHAPE {
+        description
+          "Packets that exceed the CIR should be queued into a
+          buffer. The depth of the buffer is specified to be
+          max-queue-depth-bytes or max-queue-depth-packets.
+          Packets are subsequently scheduled from this queue
+          to the specified output. Only packets that overflow
+          the buffer have the exceed action applied to them.";
+      }
+      enum POLICE {
+        description
+          "Packets that exceed the CIR should be immediately
+          treated as exceeding the defined rate of the scheduler
+          and have the exceed action applied to them.";
+      }
+    }
+    description
+      "Type definition for different queueing behaviours that
+      are available to a scheduler.";
+  }
+
+  // grouping statements
+
+  // data definition statements
+
+  // augment statements
+
+  // rpc statements
+
+  // notification statements
+
+}

--- a/models/yang/common/openconfig-qos.yang
+++ b/models/yang/common/openconfig-qos.yang
@@ -1,0 +1,197 @@
+module openconfig-qos {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/qos";
+
+  prefix "oc-qos";
+
+  // import some basic types
+  import openconfig-extensions { prefix oc-ext; }
+
+  // include submodules
+  include openconfig-qos-interfaces;
+  include openconfig-qos-elements;
+  include openconfig-qos-mem-mgmt;
+
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This module defines configuration and operational state data
+    related to network quality-of-service.";
+
+  oc-ext:openconfig-version "0.11.2";
+
+  revision "2023-10-13" {
+    description
+      "Fix revision statement date";
+    reference "0.11.2";
+  }
+
+  revision "2023-10-08" {
+    description
+      "Clarification on WRED weight in case it is not present";
+    reference "0.11.1";
+  }
+
+  revision "2023-09-15" {
+    description
+      "Add support for ECN counters";
+    reference "0.11.0";
+  }
+
+revision "2023-07-26" {
+    description
+      "Add buffer management parameters in time unts (microseconds).
+       Make profiles reusable across LAGs and PHY of different speed";
+    reference "0.10.0";
+  }
+
+  revision "2023-04-25" {
+    description
+      "Clarify interface-ref usage.";
+    reference "0.9.1";
+  }
+
+  revision "2023-04-17" {
+    description
+      "Add support for relative RED min-threshold and max-threshold values.";
+    reference "0.9.0";
+  }
+
+  revision "2023-02-17" {
+    description
+      "Add queue identifier.";
+    reference "0.8.0";
+  }
+
+  revision "2023-02-08" {
+    description
+      "Remove incorrect output placement of interface-ref";
+    reference "0.7.0";
+  }
+
+  revision "2023-01-28" {
+    description
+      "Split groupings in interfaces for better leaf reuse.";
+    reference "0.6.1";
+  }
+
+  revision "2022-09-13" {
+    description
+      "Add queue octet drop counter.";
+    reference "0.6.0";
+  }
+
+  revision "2021-08-28" {
+    description
+      "Revision using latest revision of openconfig-qos-mem-mgmt submodule.";
+    reference "0.5.0";
+  }
+
+  revision "2021-06-28" {
+    description
+      "Revision to include buffer-allocation-profile-q-config
+      parameters in openconfig-qos-mem-mgmt submodule.";
+    reference "0.4.0";
+  }
+
+  revision "2021-04-28" {
+    description
+      "Revision updating buffer management and queue management
+      configuration.";
+    reference "0.3.0";
+  }
+
+  revision "2019-11-28" {
+    description
+      "Fix xpaths in when statements";
+    reference "0.2.3";
+  }
+
+  revision "2019-08-20" {
+    description
+      "Fix typo in classifiers container name";
+    reference "0.2.2";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "0.2.1";
+  }
+
+  revision "2016-12-16" {
+    description
+      "Fix incorrect interface-ref placement";
+    reference "0.2.0";
+  }
+
+  // OpenConfig specific extensions for module metadata.
+  oc-ext:regexp-posix;
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  // grouping statements
+  grouping qos-config {
+    description
+      "Configuration data for global QoS";
+  }
+
+  grouping qos-state {
+    description
+      "Operational state data for global QoS";
+  }
+
+  grouping qos-top {
+    description
+      "Top-level grouping for QoS model";
+
+    container qos {
+      description
+        "Top-level container for QoS data";
+
+      container config {
+        description
+          "Configuration data for global QoS";
+
+        uses qos-config;
+      }
+
+      container state {
+        config false;
+        description
+          "Operational state data for global QoS";
+
+        uses qos-config;
+        uses qos-state;
+      }
+
+      uses qos-interfaces-top;
+      uses qos-classifier-top;
+      uses qos-forwarding-group-top;
+      uses qos-queue-top;
+      uses qos-scheduler-top;
+      uses qos-buffer-profile-top;
+      uses qos-queue-mgmt-profile-top;
+    }
+  }
+
+  // data definition statements
+
+  uses qos-top;
+
+  // augment statements
+
+  // rpc statements
+
+  // notification statements
+
+}

--- a/models/yang/common/openconfig-rib-bgp-attributes.yang
+++ b/models/yang/common/openconfig-rib-bgp-attributes.yang
@@ -1,0 +1,991 @@
+submodule openconfig-rib-bgp-attributes {
+
+  belongs-to openconfig-rib-bgp {
+    prefix "oc-rib-bgp";
+  }
+
+
+  // import some basic types
+  import openconfig-bgp-types { prefix oc-bgpt; }
+  import openconfig-extensions { prefix oc-ext; }
+  import openconfig-rib-bgp-types { prefix oc-bgprt; }
+  import openconfig-segment-routing-types { prefix oc-srt; }
+  import openconfig-inet-types { prefix oc-inet; }
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This submodule contains common data definitions for BGP
+    attributes for use in BGP RIB tables.";
+
+
+  oc-ext:openconfig-version "0.9.0";
+
+  revision "2022-12-20" {
+    description
+      "Convert as-segment and as4-segment to keyed lists.";
+    reference "0.9.0";
+  }
+
+  revision "2022-06-06" {
+    description
+      "Revert IETF types in favor of oc-inet types";
+    reference "0.8.1";
+  }
+
+  revision "2021-06-21" {
+    description
+      "Add L2VPN-EVPN BGP RIB Support";
+    reference "0.8.0";
+  }
+
+  revision "2019-10-15" {
+    description
+      "Change imported segment-routing module.";
+    reference "0.7.0";
+  }
+
+  revision "2019-04-25" {
+    description
+      "Update last-modified timestamp to be expressed as nanoseconds
+      since the Unix epoch.";
+    reference "0.6.0";
+  }
+
+  revision "2019-04-16" {
+    description
+      "Rename the top-level BGP RIB container's name
+      to RIB.";
+    reference "0.5.0";
+  }
+
+  revision "2019-02-27" {
+    description
+      "Remove top-level BGP RIB container, and update list
+      names to be compatible with path compression.";
+    reference "0.4.0";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "0.3.1";
+  }
+
+  revision "2016-10-17" {
+    description
+      "OpenConfig BGP RIB refactor";
+    reference "0.3.0";
+  }
+
+  grouping bgp-as-path-attr-state {
+    description
+      "Data for representing BGP AS-PATH attribute";
+
+    leaf index {
+      type uint32;
+      description
+        "A unique ordering index starting from 0 identifying the position of
+        the AS-PATH segment in the list of segments.
+
+        The index MUST start from 0 and end at (length-1), where length is the
+        number of segments in the list of AS-PATH segments.";
+    }
+
+    leaf type {
+      type oc-bgpt:as-path-segment-type;
+      description
+        "The type of AS-PATH segment";
+    }
+
+    leaf-list member {
+      type oc-inet:as-number;
+      description
+        "List of the AS numbers in the AS-PATH segment";
+    }
+  }
+
+  grouping bgp-as-path-attr-top {
+    description
+      "Top-level grouping for AS-PATH attribute data";
+
+    container as-path {
+      oc-ext:telemetry-atomic;
+      description
+        "Enclosing container for the list of AS path segments.
+
+        In the Adj-RIB-In or Adj-RIB-Out, this list should show
+        the received or sent AS_PATH, respectively.  For
+        example, if the local router is not 4-byte capable, this
+        value should consist of 2-octet ASNs or the AS_TRANS
+        (AS 23456) values received or sent in route updates.
+
+        In the Loc-RIB, this list should reflect the effective
+        AS path for the route, e.g., a 4-octet value if the
+        local router is 4-octet capable.";
+      reference
+        "RFC 4271 - A Border Gateway Protocol 4 (BGP-4)
+        RFC 6793 - BGP Support for Four-octet AS Number Space
+        RFC 5065 - Autonomous System Confederations for BGP";
+
+      list as-segment {
+        key "index";
+
+        description
+          "List of AS-PATH segments";
+
+        leaf index {
+          type leafref {
+            path "../state/index";
+          }
+          description
+            "Reference to the unique ordering index starting from 0 identifying
+            the position of the AS-PATH segment in the list of segments.";
+        }
+
+        container state {
+          config false;
+          description
+            "Opstate data for AS-PATH segments";
+
+          uses bgp-as-path-attr-state;
+        }
+      }
+    }
+  }
+
+  grouping bgp-as4-path-attr-top {
+    description
+      "Top-level grouping for AS4-PATH attribute data";
+
+    container as4-path {
+      oc-ext:telemetry-atomic;
+      description
+        "This is the path encoded with 4-octet
+        AS numbers in the optional transitive AS4_PATH attribute.
+        This value is populated with the received or sent attribute
+        in Adj-RIB-In or Adj-RIB-Out, respectively.  It should not
+        be populated in Loc-RIB since the Loc-RIB is expected to
+        store the effective AS-Path in the as-path leaf regardless
+        of being 4-octet or 2-octet.";
+      reference
+          "RFC 6793 - BGP Support for Four-octet AS Number Space";
+
+      list as4-segment {
+        key "index";
+
+        description
+          "List of AS4-PATH segments";
+
+        leaf index {
+          type leafref {
+            path "../state/index";
+          }
+          description
+            "Reference to the unique ordering index starting from 0 identifying
+            the position of the AS4-PATH segment in the list of segments.";
+        }
+
+        container state {
+          config false;
+          description
+            "Opstate data for AS4-PATH segments";
+
+          uses bgp-as-path-attr-state;
+        }
+      }
+    }
+  }
+
+  grouping bgp-community-attr-state {
+    description
+      "Common definition of BGP community attributes";
+
+    leaf-list community {
+      type union {
+        type oc-bgpt:bgp-well-known-community-type;
+        type oc-bgpt:bgp-std-community-type;
+      }
+      description
+        "List of standard or well-known BGP community
+        attributes.";
+    }
+  }
+
+  grouping bgp-extended-community-attr-state {
+    description
+      "Common definition of BGP extended community attribute";
+
+    leaf-list ext-community {
+      type oc-bgpt:bgp-ext-community-recv-type;
+      description
+        "List of BGP extended community attributes.  The received
+        extended community may be an explicitly modeled
+        type or unknown, represented by an 8-octet value
+        formatted according to RFC 4360.";
+      reference
+        "RFC 4360 - BGP Extended Communities Attribute";
+    }
+
+  }
+
+  grouping bgp-aggregator-attr-state {
+    description
+      "Operational state data for the BGP aggregator
+      attribute";
+
+    leaf as {
+      type oc-inet:as-number;
+      description
+          "AS number of the autnonomous system that performed the
+          aggregation.";
+    }
+
+    leaf as4 {
+      type oc-inet:as-number;
+      description
+        "AS number of the autnonomous system that performed the
+        aggregation (4-octet representation).  This value is
+        populated if an upstream router is not 4-octet capable.
+        Its semantics are similar to the AS4_PATH optional
+        transitive attribute";
+      reference
+        "RFC 6793 - BGP Support for Four-octet AS Number Space";
+    }
+
+    leaf address {
+      type oc-inet:ipv4-address;
+      description
+        "IP address of the router that performed the
+        aggregation.";
+    }
+  }
+
+
+  grouping bgp-aggregator-attr-top {
+    description
+      "Common definition of the BGP aggregator attribute";
+
+    container aggregator {
+      description
+        "BGP attribute indicating the prefix has been aggregated by
+        the specified AS and router.";
+
+      container state {
+        config false;
+        description
+          "Operational state data for BGP aggregator attribute";
+
+        uses bgp-aggregator-attr-state;
+      }
+    }
+  }
+
+  grouping bgp-shared-common-attr-state {
+    description
+      "Route attributes shared across route table entries,
+      common to both LOC-Rib and Adj-RIB";
+
+
+    leaf origin {
+      type oc-bgpt:bgp-origin-attr-type;
+      description
+        "BGP attribute defining the origin of the path information.";
+    }
+
+    leaf atomic-aggregate {
+      type boolean;
+      description
+        "BGP attribute indicating that the prefix is an atomic
+        aggregate, i.e., the peer selected a less specific
+        route without selecting a more specific route that is
+        included in it.";
+    }
+
+    leaf next-hop {
+      type oc-inet:ip-address;
+      description
+        "BGP next hop attribute defining the IP address of the router
+        that should be used as the next hop to the destination";
+    }
+
+    leaf med {
+      type uint32;
+      description
+        "BGP multi-exit discriminator attribute used in BGP route
+        selection process";
+    }
+
+    leaf local-pref {
+      type uint32;
+      description
+        "BGP local preference attribute sent to internal peers to
+        indicate the degree of preference for externally learned
+        routes.  The route with the highest local preference value
+        is preferred.";
+    }
+
+    leaf originator-id {
+      type oc-inet:ipv4-address;
+      description
+        "BGP attribute that provides the id as an IPv4 address
+        of the originator of the announcement.";
+      reference
+        "RFC 4456 - BGP Route Reflection: An Alternative to Full
+        Mesh Internal BGP (IBGP)";
+    }
+
+    leaf-list cluster-list {
+      type oc-inet:ipv4-address;
+      description
+        "Represents the reflection path that the route has passed.";
+      reference
+        "RFC 4456 - BGP Route Reflection: An Alternative to Full
+        Mesh Internal BGP (IBGP)";
+    }
+
+    leaf aigp {
+      type uint64;
+      description
+        "BGP path attribute representing the accumulated IGP metric
+        for the path";
+      reference
+        "RFC 7311 - The Accumulated IGP Metric Attribute for BGP";
+    }
+  }
+
+  grouping bgp-unknown-attr-flags-state {
+    description
+      "Operational state data for path attribute flags";
+
+    leaf optional {
+      type boolean;
+      description
+        "Defines whether the attribute is optional (if
+         set to true) or well-known (if set to false).
+         Set in the high-order bit of the BGP attribute
+         flags octet.";
+      reference
+        "RFC 4271 - A Border Gateway Protocol 4 (BGP-4)";
+    }
+
+    leaf transitive {
+      type boolean;
+      description
+        "Defines whether an optional attribute is transitive
+        (if set to true) or non-transitive (if set to false).  For
+        well-known attributes, the transitive flag MUST be set to
+        true.  Set in the second high-order bit of the BGP attribute
+        flags octet.";
+      reference
+        "RFC 4271 - A Border Gateway Protocol 4 (BGP-4)";
+    }
+
+    leaf partial {
+      type boolean;
+      description
+        "Defines whether the information contained in the optional
+        transitive attribute is partial (if set to true) or complete
+        (if set to false).  For well-known attributes and for
+        optional non-transitive attributes, the partial flag
+        must be set to false.  Set in the third high-order bit of
+        the BGP attribute flags octet.";
+      reference
+        "RFC 4271 - A Border Gateway Protocol 4 (BGP-4)";
+    }
+
+    leaf extended {
+      type boolean;
+      description
+        "Defines whether the attribute length is one octet
+        (if set to false) or two octets (if set to true).  Set in
+        the fourth high-order bit of the BGP attribute flags
+        octet.";
+      reference
+        "RFC 4271 - A Border Gateway Protocol 4 (BGP-4)";
+    }
+  }
+
+  grouping bgp-unknown-attr-state {
+    description
+      "Operational state data for path attributes not shared
+      across route entries, common to LOC-RIB and Adj-RIB";
+
+    leaf attr-type {
+      type uint8;
+      description
+        "1-octet value encoding the attribute type code";
+      reference
+        "RFC 4271 - A Border Gateway Protocol 4 (BGP-4)";
+    }
+
+    leaf attr-len {
+      type uint16;
+      description
+        "One or two octet attribute length field indicating the
+        length of the attribute data in octets.  If the Extended
+        Length attribute flag is set, the length field is 2 octets,
+        otherwise it is 1 octet";
+      reference
+        "RFC 4271 - A Border Gateway Protocol 4 (BGP-4)";
+    }
+
+    leaf attr-value {
+      type binary {
+        length 1..65535;
+      }
+      description
+        "Raw attribute value, not including the attribute
+        flags, type, or length.  The maximum length
+        of the attribute value data is 2^16-1 per the max value
+        of the attr-len field (2 octets).";
+      reference
+        "RFC 4271 - A Border Gateway Protocol 4 (BGP-4)";
+    }
+  }
+
+  grouping bgp-unknown-attr-top {
+    description
+      "Unknown path attributes that are not expected to be shared
+      across route entries, common to LOC-RIB and Adj-RIB";
+
+    container unknown-attributes {
+      description
+        "Unknown path attributes that were received in the UPDATE
+        message which contained the prefix.";
+
+      list unknown-attribute {
+        key "attr-type";
+        description
+          "This list contains received attributes that are unrecognized
+          or unsupported by the local router.  The list may be empty.";
+
+        leaf attr-type {
+          type leafref {
+            path "../state/attr-type";
+          }
+          description
+            "Reference to the list key";
+        }
+
+        container state {
+          description
+            "Operational state for unknown route attributes";
+
+          uses bgp-unknown-attr-flags-state;
+          uses bgp-unknown-attr-state;
+        }
+      }
+    }
+  }
+
+  grouping bgp-loc-rib-attr-state {
+    description
+      "Path attributes that are not expected to be shared across
+      route entries, specific to LOC-RIB";
+
+  }
+
+  grouping bgp-adj-rib-attr-state {
+    description
+      "Path attributes that are not expected to be shared across
+      route entries, specific to Adj-RIB";
+
+    leaf path-id {
+      type uint32;
+      description
+        "When the BGP speaker supports advertisement of multiple
+        paths for a prefix, the path identifier is used to
+        uniquely identify a route based on the combination of the
+        prefix and path id.  In the Adj-RIB-In, the path-id value is
+        the value received in the update message.   In the Loc-RIB,
+        if used, it should represent a locally generated path-id
+        value for the corresponding route.  In Adj-RIB-Out, it
+        should be the value sent to a neighbor when add-paths is
+        used, i.e., the capability has been negotiated.";
+      reference
+        "draft-ietf-idr-add-paths - Advertisement of Multiple Paths
+        in BGP";
+    }
+  }
+
+  grouping bgp-tunnel-encapsulation-attr-top {
+    description
+      "Top-level definition of the BGP Tunnel encapsulation
+      attribute.";
+
+    container tunnel-encapsulation {
+      config false;
+      description
+        "The Tunnel Encapsulation attribute specifies a set of
+        tunnels to a remote destination. The attribute is TLV
+        based and allows description of a tunnel type, and the
+        relevant information to create the tunnel to the remote
+        destination.";
+
+      reference "RFC5512, draft-ietf-idr-tunnel-encaps";
+
+      container tunnels {
+        description
+          "Surrounding container for the set of tunnels included
+          within the tunnel encapsulation attribute.";
+
+        list tunnel {
+          key "type";
+          description
+            "List of the tunnels that are specified within the
+            attribute. Keyed on the type of tunnel that the
+            TLV describes.";
+
+          leaf type {
+            type leafref {
+              path "../state/type";
+            }
+            description
+              "Reference to the tunnel type specified within the
+              TLV's type field.";
+          }
+
+          container state {
+            config false;
+            description
+              "State parameters of the tunnel attribute";
+
+            uses bgp-tunnel-encapsulation-attr-tunnel-state;
+          }
+
+          container subtlvs {
+            description
+              "Surrounding container for the list of sub-TLVs within
+              the tunnel encapsulation attribute.";
+
+            list subtlv {
+              key "type";
+              description
+                "List of the subTLVs that are specified within the
+                TLV instance inside the tunnel encapsulation attribute.";
+
+              leaf type {
+                type leafref {
+                  path "../state/type";
+                }
+                description
+                  "Reference to the sub-TLV type that is included within
+                  the subTLV.";
+              }
+
+              container state {
+                config false;
+                description
+                  "State parameters of the subTLV of the tunnel attribute";
+
+                uses bgp-tunnel-encapsulation-attr-tunnel-subtlv-state;
+              }
+
+              container remote-endpoints {
+                when "../state/type = 'oc-bgprt:TUNNEL_REMOTE_ENDPOINT'" {
+                  description
+                    "Only allow the remote endpoint to be specified when the
+                    subTLV is specified to describe remote endpoints.";
+                }
+
+                description
+                  "The remote endpoints associated with the tunnel
+                  described by the attribute.";
+
+                list remote-endpoint {
+                  key "endpoint";
+                  description
+                    "List of the remote endpoints described within the TLV.";
+
+                  leaf endpoint {
+                    type leafref {
+                      path "../state/endpoint";
+                    }
+                    description
+                      "Reference to the IP address of the endpoint.";
+                  }
+
+                  container state {
+                    config false;
+                    description
+                      "State parameters of the remote endpoints described
+                      by the attribute.";
+
+                    uses bgp-tunnel-encapsulation-attr-tunnel-subtlv-endpoint-state;
+                  }
+                }
+              }
+
+              container segment-lists {
+                when "../state/type = 'oc-bgprt:SRTE_SEGMENT_LIST'" {
+                  description
+                    "Only allow the segment lists to be specified when the sub-TLV
+                    is of the relevant type.";
+                }
+
+                description
+                  "Surrounding container for the list of segment lists that are
+                  associated with a SR-TE Policy tunnel.";
+
+                list segment-list {
+                  key "instance-id";
+
+                  description
+                    "List of segment lists that are specified within the
+                    tunnel encapsulation attribute.";
+
+                  leaf instance-id {
+                    type leafref {
+                      path "../state/instance-id";
+                    }
+                    description
+                      "Reference to the instance identifier of the Segment List
+                      that is included within the tunnel encapsulation
+                      attribute.";
+                  }
+
+                  container state {
+                    config false;
+                    description
+                      "State parameters relating to the Segment List within the
+                      Tunnel Encapsulation attribute.";
+
+                    uses bgp-tunnel-encapsulation-attr-tunnel-subtlv-segment-list-state;
+                  }
+
+                  container segments {
+                    description
+                      "Surrounding container for the list of segments within the
+                      SR-TE segment list.";
+
+                    list segment {
+                      key "index";
+
+                      description
+                        "List of segments within the SR-TE segment list.";
+
+                      leaf index {
+                        type leafref {
+                          path "../state/index";
+                        }
+                        description
+                          "Reference to the index of the segment within the
+                          segment list.";
+                      }
+
+                      container state {
+                        config false;
+                        description
+                          "State parameters relating to the segment within
+                          the segment list.";
+
+                        uses bgp-tunnel-encapsulation-attr-tunnel-subtlv-segment-state;
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  grouping bgp-tunnel-encapsulation-attr-tunnel-state {
+    description
+      "State parameters of the tunnel encapsulation attribute";
+
+    leaf type {
+      type identityref {
+        base "oc-bgprt:TUNNEL_ENCAPSULATION_TYPE";
+      }
+      description
+        "Type of the tunnel described within the tunnel encapsulation
+        attribute.";
+    }
+  }
+
+  grouping bgp-tunnel-encapsulation-attr-tunnel-subtlv-state {
+    description
+      "State parameters relating to subTLVs of the tunnel encapsulation
+      attribute.";
+
+    leaf type {
+      type identityref {
+        base "oc-bgprt:TUNNEL_ENCAPSULATION_SUBTLV_TYPE";
+      }
+      description
+        "Type of the sub-TLV within the tunnel encapsulation attribute";
+    }
+
+    leaf-list colors {
+      when "../type = 'oc-bgprt:TUNNEL_COLOR'" {
+        description
+          "Only allow list of colours to be specified when the sub-TLV
+          specifies colours associated with the tunnel encapsulation
+          attribute.";
+      }
+      type uint32;
+      description
+        "The colours associated with the tunnel encapsulation attribute,
+        as described by RFC5512.";
+    }
+
+    leaf preference {
+      when "../type = 'oc-bgprt:SRTE_PREFERENCE'" {
+        description
+          "Only allow the preference to be specified when the sub-TLV
+          specifies the preference associated with the tunnel encapsulation
+          attribute.";
+      }
+      type uint32;
+      default 100;
+      description
+        "The preference of the SR-TE policy described by the tunnel
+        encapsulation attribute. If unspecified, the preference
+        defaults to 100.";
+    }
+
+    leaf binding-sid {
+      when "../type = 'oc-bgprt:SRTE_BINDING_SID'" {
+        description
+          "Only allow the binding SID to be specified when the sub-TLV
+          is specified to be the of the relevant type.";
+      }
+      type oc-srt:sr-sid-type;
+      description
+        "Binding SID associated with the SR-TE policy";
+    }
+  }
+
+  grouping bgp-tunnel-encapsulation-attr-tunnel-subtlv-endpoint-state {
+    description
+      "State parameters relating to the remote endpoint described by a
+      tunnel encapsulation attribute.";
+
+    leaf as {
+      type oc-inet:as-number;
+      description
+        "The remote AS to which the IP address of the remote endpoint
+        belongs.";
+    }
+
+    leaf endpoint {
+      type oc-inet:ip-address;
+      description
+        "IP address of the remote endpoint.";
+    }
+  }
+
+  grouping bgp-tunnel-encapsulation-attr-tunnel-subtlv-segment-list-state {
+    description
+      "State parameters relating to an entry within a segment list within
+      a SR-TE policy segment list.";
+
+    leaf instance-id {
+      type uint64;
+      description
+        "Instance of the segment list within the sub-TLV";
+    }
+
+    leaf weight {
+      type uint32;
+      description
+        "The weight given to the path within the set of segment
+        lists that are included in the tunnel attribute sub-TLV.";
+    }
+  }
+
+  grouping bgp-tunnel-encapsulation-attr-tunnel-subtlv-segment-state {
+    description
+      "State parameters relating to a segment within the segment list.";
+
+    leaf index {
+      type uint64;
+      description
+        "Index of the segment within the segment list. The segments are
+        ordered in ascending order, beginning at 0.";
+    }
+
+    leaf type {
+      type enumeration {
+        enum MPLS_SID {
+          description
+            "The segment is specified as an MPLS label.";
+          value 1;
+        }
+        enum IPV6_SID {
+          description
+            "The segment is specified as an IPv6 address.";
+          value 2;
+        }
+        enum IPV4_NODE_ADDRESS {
+          description
+            "The segment is specified as an IPv4 node address with
+            optional SID.";
+          value 3;
+        }
+        enum IPV6_NODE_ADDRESS {
+          description
+            "The segment is specified as an IPv6 node address with
+            optional SID.";
+          value 4;
+        }
+        enum IPV4_LOCAL_INTF_ID {
+          description
+            "The segment is specified as an IPv4 address with a
+            local interface identifier along with an .";
+          value 5;
+        }
+        enum IPV4_LOCAL_REMOTE_ADDR {
+          description
+            "The segment is specified as an IPv4 local and remote
+            address with an optional SID.";
+          value 6;
+        }
+        enum IPV6_LOCAL_INTF_ID {
+          description
+            "The segment is specified as an IPv6 address with an
+            index, along with an optional SID.";
+          value 7;
+        }
+        enum IPV6_LOCAL_REMOTE_ADDR {
+          description
+            "The segmetn is specified as an IPv6 local and remote
+            address with an optional SID.";
+          value 8;
+        }
+      }
+      description
+        "The type of segment specified within the segment entry.";
+    }
+
+    leaf sid {
+      type oc-srt:sr-sid-type;
+      description
+        "SID value for the segment entry, specified as an MPLS label
+        or IPv6 address.";
+    }
+
+    leaf mpls-tc {
+      when "../type = 'MPLS_SID'" {
+        description
+          "The MPLS TC bits can only be specified when the segment
+          time is an MPLS label.";
+      }
+      type uint8 {
+        range "0..7";
+      }
+      description
+        "The MPLS TC bits used when the SID is specified as an MPLS
+        label. If set to zero, the receiving system specifies the
+        value of the TC bits.";
+    }
+
+    leaf mpls-bos {
+      when "../type = 'MPLS_SID'" {
+        description
+          "The MPLS BoS bit can only be specified when the segment
+          type is an MPLS label.";
+      }
+      type boolean;
+      description
+        "When this leaf is set to true the MPLS bottom-of-stack
+        (BoS) bit is set in the MPLS segment. The BoS bit should
+        always be set to zero by the sender.";
+    }
+
+    leaf mpls-ttl {
+      when "../type = 'MPLS_SID'" {
+        description
+          "The MPLS TTL can only be set when the segment type is
+          an MPLS label.";
+      }
+      type uint8;
+      description
+        "The MPLS time to live (TTL) to be set for the MPLS
+        segment. If set to 255, the receiver specifies the
+        TTL value that is used for packets sent with this
+        segment in the stack.";
+    }
+
+    leaf remote-ipv4-address {
+      when "../type = 'IPV4_NODE_ADDRESS' or ../type='../IPV4_ADDRESS_INDEX'" +
+           "or ../type='IPV4_LOCAL_INTF_ID' or " +
+           "../type='IPV4_LOCAL_REMOTE_ADDR'" {
+        description
+          "An IPv4 address can only be associated with the segment entry
+          when the type of the SID is a node address, or an IPv6 address
+          with an index.";
+      }
+      type oc-inet:ipv4-address;
+      description
+        "An IPv4 address specified as the remote node address. When the type
+        of the segment specifies only the remote address, no other addresses
+        are specified. When the type of the segment requires a local address,
+        this leaf specifies the remote IPv4 address.";
+    }
+
+    leaf local-ipv4-address {
+      when "../type = 'IPV4_LOCAL_REMOTE_ADDR'" {
+        description
+          "A local IPv4 address can only be specified when the segment is
+          specified by the local and remote IPv4 interface addresses.";
+      }
+      type oc-inet:ipv4-address;
+      description
+        "An IPv4 address of a local adjacency that is used to identify
+        the segment.";
+    }
+
+    leaf remote-ipv6-address {
+      when "../type = 'IPV6_NODE_ADDRESS' or ../type='IPV6_ADDRESS_INDEX'" +
+           "or ../type='IPV6_LOCAL_INTF_ID' or " +
+           "../type='IPV6_LOCAL_REMOTE_ADDR'" {
+        description
+          "An IPv6 address can only be specified with a segment entry
+          when the type of the SID is a node address, or an IPv6 address
+          with an index.";
+      }
+      type oc-inet:ipv6-address;
+      description
+        "An IPv6 address specified as the remote node address. When the type
+        of the segment specifies only the remote address, no other addresses
+        are specified. When the type of the segment requires a local address,
+        this leaf specifies the remote IPv6 address.";
+    }
+
+    leaf local-ipv6-address {
+      when "../type = 'IPV6_LOCAL_REMOTE_ADDR'" {
+        description
+          "A local IPv6 address can only be speciifed when the segment
+          is specified by the local and remote IPv6 interface addresses.";
+      }
+      type oc-inet:ipv6-address;
+      description
+        "An IPv6 address of a local adjacency that is used to identify the
+        segment.";
+    }
+
+    leaf local-interface-id {
+      when "../type = 'IPV4_LOCAL_INTF_ID' or ../type='IPV6_LOCAL_INTF_ID'" {
+        description
+          "A local interface identifier can only be specified when the
+          type of the segment is an IPv4 address with local interface ID,
+          or IPv6 address with local interface ID.";
+      }
+      type uint32;
+      description
+        "The local interface identifier to be utilised for the segment.";
+      reference
+        "draft-ietf-pce-segment-routing";
+    }
+  }
+}

--- a/models/yang/common/openconfig-rib-bgp-ext.yang
+++ b/models/yang/common/openconfig-rib-bgp-ext.yang
@@ -1,0 +1,218 @@
+module openconfig-rib-bgp-ext {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/rib/bgp-ext";
+
+  prefix "oc-bgprib-ext";
+
+  import openconfig-extensions { prefix oc-ext; }
+  import openconfig-rib-bgp-types { prefix oc-bgpribt; }
+  import openconfig-network-instance { prefix oc-ni; }
+
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "Defines additional data nodes for the OpenConfig BGP RIB model.
+    These items reflect extensions that are desirable features but
+    are not currently supported in a majority of BGP
+    implementations.";
+
+  oc-ext:openconfig-version "0.6.0";
+
+  revision "2019-04-25" {
+    description
+      "Update last-modified timestamp to be expressed as nanoseconds
+      since the Unix epoch.";
+    reference "0.6.0";
+  }
+
+  revision "2019-04-16" {
+    description
+      "Rename the top-level BGP RIB container's name
+      to RIB.";
+    reference "0.5.0";
+  }
+
+  revision "2019-02-27" {
+    description
+      "Remove top-level BGP RIB container, and update list
+      names to be compatible with path compression.";
+    reference "0.4.0";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "0.3.1";
+  }
+
+  revision "2016-10-17" {
+    description
+      "OpenConfig BGP RIB refactor";
+    reference "0.3.0";
+  }
+
+  revision "2016-04-11" {
+    description
+      "OpenConfig public release";
+    reference "0.2.0";
+  }
+
+  // OpenConfig specific extensions for module metadata.
+  oc-ext:regexp-posix;
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  grouping rib-ext-route-annotations {
+    description
+      "Extended annotations for routes in the routing tables";
+
+    leaf reject-reason {
+      type union {
+        type identityref {
+          base oc-bgpribt:BGP_NOT_SELECTED_BESTPATH;
+        }
+        type identityref {
+          base oc-bgpribt:BGP_NOT_SELECTED_POLICY;
+        }
+      }
+      description
+        "Indicates the reason the route is not used, either due to
+        policy filtering or bestpath selection";
+    }
+  }
+
+  augment "/oc-ni:network-instances/oc-ni:network-instance/" +
+    "oc-ni:protocols/oc-ni:protocol/" +
+    "oc-ni:bgp/oc-ni:rib/oc-ni:afi-safis/" +
+    "oc-ni:afi-safi/oc-ni:ipv4-unicast/oc-ni:loc-rib/" +
+    "oc-ni:routes/oc-ni:route/oc-ni:state" {
+      description
+        "Add extended annotations to the Loc-RIB for IPv4";
+
+      uses rib-ext-route-annotations;
+  }
+
+  augment "/oc-ni:network-instances/oc-ni:network-instance/" +
+    "oc-ni:protocols/oc-ni:protocol" +
+    "/oc-ni:bgp/oc-ni:rib/oc-ni:afi-safis/" +
+    "oc-ni:afi-safi/oc-ni:ipv6-unicast/oc-ni:loc-rib/" +
+    "oc-ni:routes/oc-ni:route/oc-ni:state" {
+      description
+        "Add extended annotations to the Loc-RIB for IPv6";
+
+      uses rib-ext-route-annotations;
+  }
+
+  augment "/oc-ni:network-instances/oc-ni:network-instance/" +
+    "oc-ni:protocols/oc-ni:protocol" +
+    "/oc-ni:bgp/oc-ni:rib/oc-ni:afi-safis/" +
+    "oc-ni:afi-safi/oc-ni:ipv4-unicast/" +
+    "oc-ni:neighbors/oc-ni:neighbor/" +
+    "oc-ni:adj-rib-in-pre/oc-ni:routes/oc-ni:route" +
+    "/oc-ni:state" {
+      description
+        "Add extended annotations to Adj-RIB for IPv4";
+
+      uses rib-ext-route-annotations;
+  }
+
+  augment
+    "/oc-ni:network-instances/oc-ni:network-instance/" +
+    "oc-ni:protocols/oc-ni:protocol" +
+    "/oc-ni:bgp/oc-ni:rib/oc-ni:afi-safis/" +
+    "oc-ni:afi-safi/oc-ni:ipv4-unicast/" +
+    "oc-ni:neighbors/oc-ni:neighbor/" +
+    "oc-ni:adj-rib-in-post/oc-ni:routes/oc-ni:route" +
+    "/oc-ni:state"{
+      description
+        "Add extended annotations to Adj-RIB for IPv4";
+
+      uses rib-ext-route-annotations;
+  }
+
+  augment "/oc-ni:network-instances/oc-ni:network-instance/" +
+    "oc-ni:protocols/oc-ni:protocol" +
+    "/oc-ni:bgp/oc-ni:rib/oc-ni:afi-safis/" +
+    "oc-ni:afi-safi/oc-ni:ipv4-unicast/" +
+    "oc-ni:neighbors/oc-ni:neighbor/" +
+    "oc-ni:adj-rib-out-pre/oc-ni:routes/oc-ni:route" +
+    "/oc-ni:state"{
+      description
+        "Add extended annotations to Adj-RIB for IPv4";
+
+      uses rib-ext-route-annotations;
+  }
+
+  augment "/oc-ni:network-instances/oc-ni:network-instance/" +
+    "oc-ni:protocols/oc-ni:protocol" +
+    "/oc-ni:bgp/oc-ni:rib/oc-ni:afi-safis/" +
+    "oc-ni:afi-safi/oc-ni:ipv4-unicast/" +
+    "oc-ni:neighbors/oc-ni:neighbor/" +
+    "oc-ni:adj-rib-out-post/oc-ni:routes/oc-ni:route" +
+    "/oc-ni:state"{
+      description
+        "Add extended annotations to Adj-RIB for IPv4";
+
+      uses rib-ext-route-annotations;
+  }
+
+  augment "/oc-ni:network-instances/oc-ni:network-instance/" +
+    "oc-ni:protocols/oc-ni:protocol" +
+    "/oc-ni:bgp/oc-ni:rib/oc-ni:afi-safis/" +
+    "oc-ni:afi-safi/oc-ni:ipv6-unicast/" +
+    "oc-ni:neighbors/oc-ni:neighbor/" +
+    "oc-ni:adj-rib-in-pre/oc-ni:routes/oc-ni:route" +
+    "/oc-ni:state"{
+      description
+        "Add extended annotations to Adj-RIB for IPv6";
+
+      uses rib-ext-route-annotations;
+  }
+
+  augment "/oc-ni:network-instances/oc-ni:network-instance/" +
+    "oc-ni:protocols/oc-ni:protocol" +
+    "/oc-ni:bgp/oc-ni:rib/oc-ni:afi-safis/" +
+    "oc-ni:afi-safi/oc-ni:ipv6-unicast/" +
+    "oc-ni:neighbors/oc-ni:neighbor/" +
+    "oc-ni:adj-rib-in-post/oc-ni:routes/oc-ni:route" +
+    "/oc-ni:state"{
+      description
+        "Add extended annotations to Adj-RIB for IPv6";
+
+      uses rib-ext-route-annotations;
+  }
+
+  augment "/oc-ni:network-instances/oc-ni:network-instance/" +
+    "oc-ni:protocols/oc-ni:protocol" +
+    "/oc-ni:bgp/oc-ni:rib/oc-ni:afi-safis/" +
+    "oc-ni:afi-safi/oc-ni:ipv6-unicast/" +
+    "oc-ni:neighbors/oc-ni:neighbor/" +
+    "oc-ni:adj-rib-out-pre/oc-ni:routes/oc-ni:route" +
+    "/oc-ni:state"{
+      description
+        "Add extended annotations to Adj-RIB for IPv6";
+
+      uses rib-ext-route-annotations;
+  }
+
+  augment "/oc-ni:network-instances/oc-ni:network-instance/" +
+    "oc-ni:protocols/oc-ni:protocol" +
+    "/oc-ni:bgp/oc-ni:rib/oc-ni:afi-safis/" +
+    "oc-ni:afi-safi/oc-ni:ipv6-unicast/" +
+    "oc-ni:neighbors/oc-ni:neighbor/" +
+    "oc-ni:adj-rib-out-post/oc-ni:routes/oc-ni:route" +
+    "/oc-ni:state"{
+      description
+        "Add extended annotations to Adj-RIB for IPv6";
+
+      uses rib-ext-route-annotations;
+  }
+
+}

--- a/models/yang/common/openconfig-rib-bgp-shared-attributes.yang
+++ b/models/yang/common/openconfig-rib-bgp-shared-attributes.yang
@@ -1,0 +1,221 @@
+submodule openconfig-rib-bgp-shared-attributes {
+
+  belongs-to openconfig-rib-bgp {
+    prefix "oc-rib-bgp";
+  }
+
+
+  // import some basic types
+  import openconfig-extensions { prefix oc-ext; }
+
+  include openconfig-rib-bgp-attributes;
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This submodule contains structural data definitions for
+    attribute sets shared across routes.";
+
+  oc-ext:openconfig-version "0.9.0";
+
+  revision "2022-12-20" {
+    description
+      "Convert as-segment and as4-segment to keyed lists.";
+    reference "0.9.0";
+  }
+
+  revision "2022-06-06" {
+    description
+      "Revert IETF types in favor of oc-inet types";
+    reference "0.8.1";
+  }
+
+  revision "2021-06-21" {
+    description
+      "Add L2VPN-EVPN BGP RIB Support";
+    reference "0.8.0";
+  }
+
+  revision "2019-10-15" {
+    description
+      "Change imported segment-routing module.";
+    reference "0.7.0";
+  }
+
+  revision "2019-04-25" {
+    description
+      "Update last-modified timestamp to be expressed as nanoseconds
+      since the Unix epoch.";
+    reference "0.6.0";
+  }
+
+  revision "2019-04-16" {
+    description
+      "Rename the top-level BGP RIB container's name
+      to RIB.";
+    reference "0.5.0";
+  }
+
+  revision "2019-02-27" {
+    description
+      "Remove top-level BGP RIB container, and update list
+      names to be compatible with path compression.";
+    reference "0.4.0";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "0.3.1";
+  }
+
+  revision "2016-10-17" {
+    description
+      "OpenConfig BGP RIB refactor";
+    reference "0.3.0";
+  }
+
+
+  grouping attribute-sets-top {
+    description
+      "Top level grouping for list of common attribute sets";
+
+    container attr-sets {
+      description
+        "Enclosing container for the list of path attribute sets";
+
+      list attr-set {
+        key "index";
+
+        description
+          "List of path attributes that may be in use by multiple
+          routes in the table";
+
+        leaf index {
+          type leafref {
+            path "../state/index";
+          }
+          description
+            "Reference to list key";
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state for common path attributes";
+
+          leaf index {
+            type uint64;
+            description
+              "System generated index for each attribute set.  The
+              index is used to reference an attribute set from a
+              specific path.  Multiple paths may reference the same
+              attribute set.";
+          }
+
+          uses bgp-shared-common-attr-state;
+        }
+        uses bgp-aggregator-attr-top;
+        uses bgp-as-path-attr-top;
+        uses bgp-as4-path-attr-top;
+        uses bgp-tunnel-encapsulation-attr-top;
+      }
+    }
+  }
+
+  grouping community-sets-top {
+    description
+      "Top level grouping for list of shared community attribute
+      sets";
+
+    container communities {
+      description
+        "Enclosing container for the list of community attribute
+        sets";
+
+      list community {
+        key "index";
+
+        description
+          "List of path attributes that may be in use by multiple
+          routes in the table";
+
+        leaf index {
+          type leafref {
+            path "../state/index";
+          }
+          description
+            "Reference to the list key";
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state for shared BGP community attribute";
+
+          leaf index {
+            type uint64;
+            description
+              "System generated index for each attribute set.  The
+              index is used to reference an attribute set from a
+              specific path.  Multiple paths may reference the same
+              attribute set.";
+          }
+
+          uses bgp-community-attr-state;
+        }
+      }
+    }
+  }
+
+  grouping ext-community-sets-top {
+    description
+      "Top level grouping for list of extended community attribute
+      sets";
+
+    container ext-communities {
+      description
+        "Enclosing container for the list of extended community
+        attribute sets";
+
+      list ext-community {
+        key "index";
+
+        description
+          "List of path attributes that may be in use by multiple
+          routes in the table";
+
+        leaf index {
+          type leafref {
+            path "../state/index";
+          }
+          description
+            "Reference to the list key";
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state for shared BGP extended community
+            attribute";
+
+          leaf index {
+            type uint64;
+            description
+              "System generated index for each attribute set.  The
+              index is used to reference an attribute set from a
+              specific path.  Multiple paths may reference the same
+              attribute set.";
+          }
+
+          uses bgp-extended-community-attr-state;
+        }
+      }
+    }
+  }
+}

--- a/models/yang/common/openconfig-rib-bgp-table-attributes.yang
+++ b/models/yang/common/openconfig-rib-bgp-table-attributes.yang
@@ -1,0 +1,161 @@
+submodule openconfig-rib-bgp-table-attributes {
+
+  belongs-to openconfig-rib-bgp {
+    prefix "oc-rib-bgp";
+  }
+
+
+  // import some basic types
+  import openconfig-extensions { prefix oc-ext; }
+  import openconfig-types { prefix oc-types; }
+  import openconfig-rib-bgp-types { prefix oc-bgpribt; }
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This submodule contains common data definitions for data
+    related to a RIB entry, or RIB table.";
+
+  oc-ext:openconfig-version "0.9.0";
+
+  revision "2022-12-20" {
+    description
+      "Convert as-segment and as4-segment to keyed lists.";
+    reference "0.9.0";
+  }
+
+  revision "2022-06-06" {
+    description
+      "Revert IETF types in favor of oc-inet types";
+    reference "0.8.1";
+  }
+
+  revision "2021-06-21" {
+    description
+      "Add L2VPN-EVPN BGP RIB Support";
+    reference "0.8.0";
+  }
+
+  revision "2019-10-15" {
+    description
+      "Change imported segment-routing module.";
+    reference "0.7.0";
+  }
+
+  revision "2019-04-25" {
+    description
+      "Update last-modified timestamp to be expressed as nanoseconds
+      since the Unix epoch.";
+    reference "0.6.0";
+  }
+
+  revision "2019-04-16" {
+    description
+      "Rename the top-level BGP RIB container's name
+      to RIB.";
+    reference "0.5.0";
+  }
+
+  revision "2019-02-27" {
+    description
+      "Remove top-level BGP RIB container, and update list
+      names to be compatible with path compression.";
+    reference "0.4.0";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "0.3.1";
+  }
+
+  revision "2016-10-17" {
+    description
+      "OpenConfig BGP RIB refactor";
+    reference "0.3.0";
+  }
+
+  grouping bgp-common-route-annotations-state {
+    description
+      "Data definitions for flags and other information attached
+      to routes in both LOC-RIB and Adj-RIB";
+
+    leaf last-modified {
+      type oc-types:timeticks64;
+      description
+        "Timestamp when this path was last modified.
+
+        The value is the timestamp relative to
+        the Unix Epoch (Jan 1, 1970 00:00:00 UTC).";
+    }
+
+    leaf valid-route {
+      type boolean;
+      description
+        "Indicates that the route is considered valid by the
+        local router";
+    }
+
+    leaf invalid-reason {
+      type identityref {
+        base oc-bgpribt:INVALID_ROUTE_REASON;
+      }
+      description
+        "If the route is rejected as invalid, this indicates the
+        reason.";
+    }
+
+  }
+
+  grouping bgp-loc-rib-route-annotations-state {
+    description
+      "Data definitions for information attached to routes in the
+      LOC-RIB";
+
+    // placeholder for route metadata specific to the LOC-RIB
+
+  }
+
+  grouping bgp-adj-rib-in-post-route-annotations-state {
+    description
+      "Data definitions for information attached to routes in the
+      Adj-RIB-in post-policy table";
+
+    leaf best-path {
+      type boolean;
+      description
+        "Current path was selected as the best path.";
+    }
+  }
+
+  grouping bgp-common-table-attrs-state {
+    description
+      "Common attributes attached to all routing tables";
+
+    // placeholder for metadata associated with all tables
+  }
+
+  grouping bgp-common-table-attrs-top {
+    description
+      "Operational state data for common attributes attached to
+      all routing tables";
+    // no enclosing container as this data will fit under an
+    // existing LOC-RIB container
+
+    container state {
+      config false;
+      description
+        "Operational state data for data related to the entire
+        LOC-RIB";
+
+      uses bgp-common-table-attrs-state;
+    }
+  }
+
+
+}

--- a/models/yang/common/openconfig-rib-bgp-tables.yang
+++ b/models/yang/common/openconfig-rib-bgp-tables.yang
@@ -1,0 +1,1759 @@
+submodule openconfig-rib-bgp-tables {
+
+  belongs-to openconfig-rib-bgp {
+    prefix "oc-rib-bgp";
+  }
+
+
+  // import some basic types
+  import openconfig-inet-types { prefix oc-inet; }
+  import openconfig-yang-types { prefix oc-yang; }
+  import openconfig-extensions { prefix oc-ext; }
+  import openconfig-policy-types { prefix oc-pol-types; }
+
+  import openconfig-network-instance-types { prefix oc-ni-types; }
+  import openconfig-evpn-types { prefix oc-evpn-types; }
+  import openconfig-bgp-types { prefix oc-bgpt; }
+
+  include openconfig-rib-bgp-attributes;
+  include openconfig-rib-bgp-shared-attributes;
+  include openconfig-rib-bgp-table-attributes;
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This submodule contains structural data definitions for
+    BGP routing tables.";
+
+  oc-ext:openconfig-version "0.9.0";
+
+  revision "2022-12-20" {
+    description
+      "Convert as-segment and as4-segment to keyed lists.";
+    reference "0.9.0";
+  }
+
+  revision "2022-06-06" {
+    description
+      "Revert IETF types in favor of oc-inet types";
+    reference "0.8.1";
+  }
+
+  revision "2021-06-21" {
+    description
+      "Add L2VPN-EVPN BGP RIB Support";
+    reference "0.8.0";
+  }
+
+  revision "2019-10-15" {
+    description
+      "Change imported segment-routing module.";
+    reference "0.7.0";
+  }
+
+  revision "2019-04-25" {
+    description
+      "Update last-modified timestamp to be expressed as nanoseconds
+      since the Unix epoch.";
+    reference "0.6.0";
+  }
+
+  revision "2019-04-16" {
+    description
+      "Rename the top-level BGP RIB container's name
+      to RIB.";
+    reference "0.5.0";
+  }
+
+  revision "2019-02-27" {
+    description
+      "Remove top-level BGP RIB container, and update list
+      names to be compatible with path compression.";
+    reference "0.4.0";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "0.3.1";
+  }
+
+  revision "2016-10-17" {
+    description
+      "OpenConfig BGP RIB refactor";
+    reference "0.3.0";
+  }
+
+
+  grouping bgp-adj-rib-common-attr-refs {
+    description
+      "Definitions of common references to attribute sets for
+      multiple AFI-SAFIs for Adj-RIB tables";
+
+    leaf attr-index {
+      type leafref {
+        path "../../../../../../../../../../attr-sets/attr-set/" +
+          "state/index";
+      }
+      description
+        "Reference to the common attribute group for the
+        route";
+    }
+
+    leaf community-index {
+      type leafref {
+        path "../../../../../../../../../../communities/community/" +
+          "state/index";
+      }
+      description
+        "Reference to the community attribute for the route";
+    }
+
+    leaf ext-community-index {
+      type leafref {
+        path "../../../../../../../../../../ext-communities/" +
+          "ext-community/state/index";
+      }
+      description
+        "Reference to the extended community attribute for the
+        route";
+    }
+  }
+
+  grouping bgp-loc-rib-common-attr-refs {
+    description
+      "Definitions of common references to attribute sets for
+      multiple AFI-SAFIs for LOC-RIB tables";
+
+    leaf attr-index {
+      type leafref {
+        path "../../../../../../../../attr-sets/attr-set/" +
+          "state/index";
+      }
+      description
+        "Reference to the common attribute group for the
+        route";
+    }
+
+    leaf community-index {
+      type leafref {
+        path "../../../../../../../../communities/community/" +
+          "state/index";
+      }
+      description
+        "Reference to the community attribute for the route";
+    }
+
+    leaf ext-community-index {
+      type leafref {
+        path "../../../../../../../../ext-communities/" +
+          "ext-community/state/index";
+      }
+      description
+        "Reference to the extended community attribute for the
+        route";
+    }
+  }
+
+  grouping bgp-loc-rib-common-keys {
+    description
+      "Common references used in keys for IPv4 and IPv6
+      LOC-RIB entries";
+
+    leaf origin {
+      type union {
+        type oc-inet:ip-address;
+        type identityref {
+          base oc-pol-types:INSTALL_PROTOCOL_TYPE;
+        }
+      }
+      description
+        "Indicates the origin of the route.  If the route is learned
+        from a neighbor, this value is the neighbor address.  If
+        the route was injected or redistributed from another
+        protocol, the origin indicates the source protocol for the
+        route.";
+    }
+
+    leaf path-id {
+      type uint32;
+      default 0;
+      description
+        "If the route is learned from a neighbor, the path-id
+        corresponds to the path-id for the route in the
+        corresponding adj-rib-in-post table.  If the route is
+        injected from another protocol, or the neighbor does not
+        support BGP add-paths, the path-id should be set
+        to zero, also the default value.";
+    }
+  }
+
+  grouping bgp-loc-rib-key-refs {
+    description
+      "Key references to support operational state structure for
+      the BGP LOC-RIB table";
+
+    leaf prefix {
+      type leafref {
+        path "../state/prefix";
+      }
+      description
+        "Reference to the prefix list key";
+    }
+
+    leaf origin {
+      type leafref {
+        path "../state/origin";
+      }
+      description
+        "Reference to the origin list key";
+    }
+
+    leaf path-id {
+      type leafref {
+        path "../state/path-id";
+      }
+      description
+        "Reference to the path-id list key";
+    }
+  }
+
+  grouping ipv4-loc-rib-top {
+    description
+      "Top-level grouping for IPv4 routing tables";
+
+    container loc-rib {
+      config false;
+      description
+        "Container for the IPv4 BGP LOC-RIB data";
+
+      uses bgp-common-table-attrs-top;
+
+      container routes {
+        description
+          "Enclosing container for list of routes in the routing
+          table.";
+
+        list route {
+          key "prefix origin path-id";
+
+          description
+            "List of routes in the table, keyed by the route
+            prefix, the route origin, and path-id.  The route
+            origin can be either the neighbor address from which
+            the route was learned, or the source protocol that
+            injected the route.  The path-id distinguishes routes
+            for the same prefix received from a neighbor (e.g.,
+            if add-paths is eanbled).";
+
+          uses bgp-loc-rib-key-refs;
+
+          container state {
+            description
+              "Operational state data for route entries in the
+              BGP LOC-RIB";
+
+            leaf prefix {
+              type oc-inet:ipv4-prefix;
+              description
+                "The IPv4 prefix corresponding to the route";
+            }
+
+            uses bgp-loc-rib-common-keys;
+            uses bgp-loc-rib-common-attr-refs;
+            uses bgp-loc-rib-attr-state;
+            uses bgp-common-route-annotations-state;
+            uses bgp-loc-rib-route-annotations-state;
+
+           }
+
+           uses bgp-unknown-attr-top;
+
+        }
+      }
+    }
+  }
+
+  grouping ipv6-loc-rib-top {
+    description
+      "Top-level grouping for IPv6 routing tables";
+
+    container loc-rib {
+      config false;
+      description
+        "Container for the IPv6 BGP LOC-RIB data";
+
+      uses bgp-common-table-attrs-top;
+
+      container routes {
+        description
+          "Enclosing container for list of routes in the routing
+          table.";
+
+        list route {
+          key "prefix origin path-id";
+
+          description
+            "List of routes in the table, keyed by the route
+            prefix, the route origin, and path-id.  The route
+            origin can be either the neighbor address from which
+            the route was learned, or the source protocol that
+            injected the route.  The path-id distinguishes routes
+            for the same prefix received from a neighbor (e.g.,
+            if add-paths is eanbled).";
+
+          uses bgp-loc-rib-key-refs;
+
+          container state {
+            description
+              "Operational state data for route entries in the
+              BGP LOC-RIB";
+
+            leaf prefix {
+              type oc-inet:ipv6-prefix;
+              description
+                "The IPv6 prefix corresponding to the route";
+            }
+
+            uses bgp-loc-rib-common-keys;
+            uses bgp-loc-rib-common-attr-refs;
+            uses bgp-loc-rib-attr-state;
+            uses bgp-common-route-annotations-state;
+            uses bgp-loc-rib-route-annotations-state;
+
+          }
+
+          uses bgp-unknown-attr-top;
+        }
+      }
+    }
+  }
+
+  grouping l2vpn-evpn-loc-rib-top {
+    description
+      "Top-level grouping for L2VPN EVPN routing tables";
+
+    container loc-rib {
+      config false;
+      description
+        "Container for the L2VPN EVPN BGP LOC-RIB data";
+
+      uses bgp-common-table-attrs-top;
+
+      container routes {
+        description
+          "Enclosing container for list of routes in the routing
+          table.";
+
+        list route-distinguisher {
+          description "List of route distinguishers";
+          key "route-distinguisher";
+
+          leaf route-distinguisher {
+            type leafref {
+              path "../state/route-distinguisher";
+            }
+            description
+              "An EVPN instance requires a Route Distinguisher (RD) that is
+              unique per MAC-VRF";
+            reference "RFC7432: BGP MPLS-Based Ethernet VPN";
+          }
+
+          container state {
+            description "Top level container for L2VPN EVPN RDs";
+            leaf route-distinguisher {
+              type oc-ni-types:route-distinguisher;
+              description
+                "Route Distinguisher for all supported EVPN route types";
+            }
+          }
+          uses bgp-evpn-type-one-state;
+          uses bgp-evpn-type-two-state;
+          uses bgp-evpn-type-three-state;
+          uses bgp-evpn-type-four-state;
+          uses bgp-evpn-type-five-state;
+        }
+      }
+    }
+  }
+
+  grouping bgp-loc-rib-l2vpn-evpn-attr-refs {
+    description
+      "Definitions of common references to attribute sets for
+      multiple AFI-SAFIs for LOC-RIB tables";
+
+    leaf attr-index {
+      type leafref {
+        path "../../../../../../../../../../../../attr-sets/attr-set/" +
+          "state/index";
+      }
+      description
+        "Reference to the common attribute group for the
+        route";
+    }
+
+    leaf community-index {
+      type leafref {
+        path "../../../../../../../../../../../../communities/community/" +
+          "state/index";
+      }
+      description
+        "Reference to the community attribute for the route";
+    }
+
+    leaf ext-community-index {
+      type leafref {
+        path "../../../../../../../../../../../../ext-communities/" +
+          "ext-community/state/index";
+      }
+      description
+        "Reference to the extended community attribute for the
+        route";
+    }
+  }
+
+  grouping bgp-evpn-route-path-common-state {
+    description
+      "Grouping for BGP L2VPN EVPN route-type common path state information";
+
+    container paths {
+      description "List of BGP path attributes for this route";
+
+      list path {
+        description "List of paths";
+        key "peer-ip peer-path-id source-route-distinguisher source-address-family";
+
+        uses bgp-evpn-route-path-lefref-common;
+
+        container state {
+          description "BGP path attributes for this route";
+
+          uses bgp-evpn-route-path-keys-common;
+          uses bgp-evpn-route-path-attributes-common;
+        }
+
+        uses bgp-unknown-attr-top;
+
+      }
+    }
+  }
+
+  grouping bgp-evpn-route-path-type2-state {
+    description
+      "Grouping for BGP L2VPN EVPN route-type path state information for
+      route type 2";
+
+    container paths {
+      description "List of BGP path attributes for this route";
+
+      list path {
+        description "List of paths";
+        key "peer-ip peer-path-id source-route-distinguisher source-address-family";
+
+        uses bgp-evpn-route-path-lefref-common;
+
+        container state {
+          description "BGP path attributes for this route";
+
+          uses bgp-evpn-route-path-keys-common;
+
+          leaf esi {
+            type oc-evpn-types:esi;
+            description
+              "The Ethernet Segment Identifier (ESI) identifying the ethernet
+              segment for this route";
+          }
+
+          uses bgp-evpn-route-path-attributes-common;
+        }
+
+        uses bgp-unknown-attr-top;
+
+      }
+    }
+  }
+
+  grouping bgp-evpn-route-path-type5-state {
+    description
+      "Grouping for BGP L2VPN EVPN route-type path state information for
+      route type 5";
+
+    container paths {
+      description "List of BGP path attributes for this route";
+
+      list path {
+        description "List of paths";
+        key "peer-ip peer-path-id source-route-distinguisher source-address-family";
+
+        uses bgp-evpn-route-path-lefref-common;
+
+        container state {
+          description "BGP path attributes for this route";
+
+          leaf esi {
+            type oc-evpn-types:esi;
+            description
+              "The Ethernet Segment Identifier (ESI) identifying the ethernet
+              segment for this route";
+          }
+
+          leaf gateway-ip-address {
+            type oc-inet:ip-prefix;
+            description
+              "The gateway-ip-address for the route";
+          }
+
+          uses bgp-evpn-route-path-keys-common;
+          uses bgp-evpn-route-path-attributes-common;
+        }
+
+        uses bgp-unknown-attr-top;
+
+      }
+    }
+  }
+
+  grouping bgp-evpn-route-path-lefref-common {
+    description "Common BGP L2VPN EVPN Path Leaf References";
+
+    leaf peer-ip {
+      type leafref {
+        path "../state/peer-ip";
+      }
+      description "The source peer ip address of the imported route";
+    }
+
+    leaf peer-path-id {
+      type leafref {
+        path "../state/peer-path-id";
+      }
+      description "The source peer path id of the imported route";
+    }
+
+    leaf source-route-distinguisher {
+      type leafref {
+        path "../state/source-route-distinguisher";
+      }
+      description
+        "The source route distinguisher is the remote RD source of the
+        imported route";
+    }
+
+    leaf source-address-family {
+      type leafref {
+        path "../state/source-address-family";
+      }
+      description "The source address-family of the imported route";
+    }
+  }
+
+  grouping bgp-evpn-route-path-keys-common {
+    description "Common BGP L2VPN EVPN Path Keys";
+
+    leaf peer-ip {
+      type oc-inet:ip-address;
+      description
+        "The source peer ip address of the imported route";
+    }
+
+    leaf peer-path-id {
+      type uint32;
+      description "The source peer path id of the imported route";
+    }
+
+    leaf source-route-distinguisher {
+      type oc-ni-types:route-distinguisher;
+      description
+        "The source route distinguisher is the remote RD source of the
+        imported route";
+    }
+
+    leaf source-address-family {
+      type identityref {
+        base oc-bgpt:AFI_SAFI_TYPE;
+      }
+      description "The source address-family of the imported route";
+    }
+  }
+
+  grouping bgp-evpn-route-path-attributes-common {
+    description "Common BGP L2VPN EVPN Path Attributes";
+
+    leaf-list advertised-to-peer {
+      type oc-inet:ip-address;
+      description "List of peers to which this path is advertised";
+    }
+
+    leaf label {
+      type string;
+      description
+        "MPLS Label field used for route attributes";
+      reference "RFC7432: BGP MPLS-Based Ethernet VPN";
+    }
+
+    leaf label2 {
+      type string;
+      description "MPLS Label2 field used for route attributes";
+      reference "RFC7432: BGP MPLS-Based Ethernet VPN";
+    }
+
+    leaf bestpath {
+      type boolean;
+      description
+        "BGP can receive multiple paths to the same destination. This
+        parameter indicates that this path is the bestpath to install
+        in the IP routing table and use for traffic forwarding";
+    }
+
+    leaf multipath {
+      type boolean;
+      description
+        "BGP can use multiple paths to reach a destination allowing
+        BGP to load-balance traffic. This parameter indicates that this
+        path is marked as multipath";
+    }
+
+    leaf backup {
+      type boolean;
+      description "BGP path marked as a backup path";
+    }
+
+    uses bgp-common-route-annotations-state;
+    uses bgp-loc-rib-l2vpn-evpn-attr-refs;
+  }
+
+  grouping bgp-evpn-type-one-key-refs {
+    description
+      "Key references to support operational state structure for
+      BGP EVPN Ethernet Auto-discovery routes.
+
+      For the purpose of BGP route key processing, only the Ethernet Segment
+      Identifier and Ethernet Tag ID are considered to be part of the prefix in
+      the NLRI";
+    reference "RFC7432: BGP MPLS-Based Ethernet VPN";
+
+
+      leaf esi {
+        type leafref {
+          path "../state/esi";
+        }
+        description
+          "The Ethernet Segment Identifier (ESI) is a unique non-zero
+          identifier that identifies an Ethernet segment";
+        reference "RFC7432: BGP MPLS-Based Ethernet VPN";
+      }
+
+      leaf ethernet-tag {
+        type leafref {
+          path "../state/ethernet-tag";
+        }
+        description
+          "The Ethernet tag identifies a particular broadcast domain.  An EVPN
+          instance consists of one or more broadcast domains";
+        reference "RFC7432: BGP MPLS-Based Ethernet VPN";
+      }
+  }
+
+  grouping bgp-evpn-type-one-state {
+    description "Grouping for BGP EVPN Ethernet Auto-discovery routes";
+    container type-one-ethernet-auto-discovery {
+      description "Top level container BGP EVPN Ethernet Auto-discovery routes";
+      list type-one-route {
+        key "esi ethernet-tag";
+        description
+          "List of BGP EVPN Ethernet Auto-discovery routes
+
+          For the purpose of BGP route key processing, only the Ethernet Segment
+          Identifier and Ethernet Tag ID are considered to be part of the prefix in
+          the NLRI";
+        reference "RFC7432: BGP MPLS-Based Ethernet VPN";
+
+        uses bgp-evpn-type-one-key-refs;
+
+        container state {
+          description
+            "Operational state data for BGP EVPN Ethernet Auto-discovery route
+            entries in the BGP LOC-RIB";
+
+          leaf esi {
+            type oc-evpn-types:esi;
+            description
+              "The Ethernet Segment Identifier (ESI) identifying the ethernet
+              segment for this route";
+          }
+
+          leaf ethernet-tag {
+            type oc-evpn-types:ethernet-tag;
+            description
+              "The Ethernet tag identifying the broadcast domain for this
+              route";
+          }
+
+          uses bgp-loc-rib-attr-state;
+          uses bgp-loc-rib-route-annotations-state;
+        }
+
+         uses bgp-evpn-route-path-common-state;
+      }
+    }
+  }
+
+  grouping bgp-evpn-type-two-key-refs {
+    description
+      "Key references to support operational state structure for
+      MAC_IP Advertisement routes.
+
+      For the purpose of BGP route key processing, only the Ethernet Tag ID,
+      MAC Address Length, MAC Address, IP Address Length, and IP Address fields
+      are considered to be part of the prefix in the NLRI";
+    reference "RFC7432: BGP MPLS-Based Ethernet VPN";
+
+      leaf ethernet-tag {
+        type leafref {
+          path "../state/ethernet-tag";
+        }
+        description
+          "The Ethernet tag identifies a particular broadcast domain.  An EVPN
+          instance consists of one or more broadcast domains";
+        reference "RFC7432: BGP MPLS-Based Ethernet VPN";
+      }
+
+      leaf mac-address {
+        type leafref {
+          path "../state/mac-address";
+        }
+        description
+          "The PEs forward packets that they receive based on the destination
+          MAC address";
+        reference "RFC7432: BGP MPLS-Based Ethernet VPN";
+      }
+
+      leaf mac-length {
+        type leafref {
+          path "../state/mac-length";
+        }
+        description
+          "The MAC Address Length for the MAC address defined in mac-address";
+        reference "RFC7432: BGP MPLS-Based Ethernet VPN";
+      }
+
+      leaf ip-prefix {
+        type leafref {
+          path "../state/ip-prefix";
+        }
+        description
+          "The IPv4 or IPv6 address carried in a MAC_IP Advertisement route";
+      }
+
+      leaf ip-length {
+        type leafref {
+          path "../state/ip-length";
+        }
+        description
+          "The IPv4 or IPv6 address prefix length for the address defined in
+          ip-prefix";
+      }
+  }
+
+  grouping bgp-evpn-type-two-state {
+    description "Grouping for MAC_IP Advertisement L2VPN EVPN routes";
+    container type-two-mac-ip-advertisement {
+      description
+        "Top level container for MAC_IP Advertisement L2VPN EVPN routes";
+      list type-two-route {
+        key "ethernet-tag mac-address mac-length ip-prefix ip-length";
+        description
+          "List of MAC_IP Advertisement L2VPN EVPN routes
+
+          For the purpose of BGP route key processing, only the Ethernet Tag ID,
+          MAC Address Length, MAC Address, IP Address Length, and IP Address fields
+          are considered to be part of the prefix in the NLRI";
+        reference "RFC7432: BGP MPLS-Based Ethernet VPN";
+
+        uses bgp-evpn-type-two-key-refs;
+
+        container state {
+          description
+            "Operational state data MAC_IP Advertisement L2VPN EVPN route
+            entries in the BGP LOC-RIB";
+
+          leaf ethernet-tag {
+            type oc-evpn-types:ethernet-tag;
+            description
+              "The Ethernet tag identifying the broadcast domain for this
+              route";
+          }
+
+          leaf mac-address {
+            type oc-yang:mac-address;
+            description
+              "The MAC address that is learned on a PE from a CE that is
+              connected to it or learned from other PEs";
+          }
+
+          leaf mac-length {
+            type uint32;
+            description
+              "The MAC address length for the mac-address";
+          }
+
+          leaf ip-prefix {
+            type oc-inet:ip-prefix;
+            description
+              "The IP address for end-host reachability information";
+          }
+
+          leaf ip-length {
+            type uint32;
+            description
+              "The ip-prefix length for the IP address specified by ip-prefix";
+          }
+
+          uses bgp-loc-rib-attr-state;
+          uses bgp-loc-rib-route-annotations-state;
+        }
+
+         uses bgp-evpn-route-path-type2-state;
+      }
+    }
+  }
+
+  grouping bgp-evpn-type-three-key-refs {
+    description
+      "Key references to support operational state structure for Inclusive
+      Multicast Ethernet Tag routes.
+
+      For the purpose of BGP route key processing, only the Ethernet Tag ID,
+      IP Address Length, and Originating Router's IP Address fields are
+      considered to be part of the prefix in the NLRI";
+    reference "RFC7432: BGP MPLS-Based Ethernet VPN";
+
+      leaf ethernet-tag {
+        type leafref {
+          path "../state/ethernet-tag";
+        }
+        description
+          "The Ethernet tag identifies a particular broadcast domain.  An EVPN
+          instance consists of one or more broadcast domains";
+        reference "RFC7432: BGP MPLS-Based Ethernet VPN";
+      }
+
+      leaf originating-router-ip {
+        type leafref {
+          path "../state/originating-router-ip";
+        }
+        description
+          "Reference to the originating-router-ip list key";
+      }
+
+      leaf originator-ip-length {
+        type leafref {
+          path "../state/originator-ip-length";
+        }
+        description
+          "Reference to the originating router ip length list key";
+      }
+  }
+
+  grouping bgp-evpn-type-three-state {
+    description
+      "Grouping for Inclusive Multicast Ethernet Tag L2VPN EVPN routes";
+    container type-three-inclusive-multicast-ethernet-tag {
+      description
+        "Top level container for Inclusive Multicast Ethernet Tag L2VPN EVPN
+        routes";
+
+      list type-three-route {
+        key "ethernet-tag originating-router-ip originator-ip-length";
+        description
+          "List of Inclusive Multicast Ethernet Tag L2VPN EVPN routes
+
+          For the purpose of BGP route key processing, only the Ethernet Tag ID,
+          IP Address Length, and Originating Router's IP Address fields are
+          considered to be part of the prefix in the NLRI";
+        reference "RFC7432: BGP MPLS-Based Ethernet VPN";
+
+        uses bgp-evpn-type-three-key-refs;
+
+        container state {
+          description
+            "Operational state data for Inclusive Multicast Ethernet Tag L2VPN
+            EVPN entries in the BGP LOC-RIB";
+
+          leaf ethernet-tag {
+            type oc-evpn-types:ethernet-tag;
+            description
+              "The Ethernet tag identifying the broadcast domain for this
+              route";
+          }
+
+          leaf originating-router-ip {
+            type oc-inet:ip-prefix;
+            description
+              "The Originating Router's IP Address";
+            reference "RFC7432: BGP MPLS-Based Ethernet VPN";
+          }
+
+          leaf originator-ip-length {
+            type uint32;
+            description
+              "The ip-prefix length for the route";
+          }
+
+          uses bgp-loc-rib-attr-state;
+          uses bgp-loc-rib-route-annotations-state;
+        }
+
+         uses bgp-evpn-route-path-common-state;
+      }
+    }
+  }
+
+  grouping bgp-evpn-type-four-key-refs {
+    description
+      "Key references to support operational state structure for Ethernet
+      Segment routes.
+
+      For the purpose of BGP route key processing, only the Ethernet Segment ID,
+      IP Address Length, and Originating Router's IP Address fields are
+      considered to be part of the prefix in the NLRI";
+    reference "RFC7432: BGP MPLS-Based Ethernet VPN";
+
+      leaf esi {
+        type leafref {
+          path "../state/esi";
+        }
+        description
+          "The Ethernet Segment Identifier (ESI) is a unique non-zero
+          identifier that identifies an Ethernet segment";
+        reference "RFC7432: BGP MPLS-Based Ethernet VPN";
+      }
+
+      leaf originating-router-ip {
+        type leafref {
+          path "../state/originating-router-ip";
+        }
+        description
+          "Reference to the ip-prefix list key";
+      }
+
+      leaf originator-ip-length {
+        type leafref {
+          path "../state/originator-ip-length";
+        }
+        description
+          "Reference to the ip-length list key";
+      }
+  }
+
+  grouping bgp-evpn-type-four-state {
+    description "Grouping for Ethernet Segment L2VPN EVPN routes";
+    container type-four-ethernet-segment {
+      description "Top level container for Ethernet Segment L2VPN EVPN routes";
+
+      list type-four-route {
+        key "esi originating-router-ip originator-ip-length";
+        description
+          "List of Ethernet Segment L2VPN EVPN routes
+
+          For the purpose of BGP route key processing, only the Ethernet Segment ID,
+          IP Address Length, and Originating Router's IP Address fields are
+          considered to be part of the prefix in the NLRI";
+        reference "RFC7432: BGP MPLS-Based Ethernet VPN";
+
+        uses bgp-evpn-type-four-key-refs;
+
+        container state {
+          description
+            "Operational state data for Ethernet Segment L2VPN EVPN route
+            entries in the BGP LOC-RIB";
+
+          leaf esi {
+            type oc-evpn-types:esi;
+            description
+              "The Ethernet Segment Identifier (ESI) identifying the ethernet
+              segment for this route";
+          }
+
+          leaf originating-router-ip {
+            type oc-inet:ip-prefix;
+            description
+              "The originating router ip";
+          }
+
+          leaf originator-ip-length {
+            type uint32;
+            description
+              "The originating router ip length";
+          }
+
+          uses bgp-loc-rib-attr-state;
+          uses bgp-loc-rib-route-annotations-state;
+
+        }
+
+         uses bgp-evpn-route-path-common-state;
+      }
+    }
+  }
+
+  grouping bgp-evpn-type-five-key-refs {
+    description
+      "Key references to support operational state structure for IP Prefix
+      Advertisement routes.
+
+      For the purpose of BGP route key processing, only The RD, Ethernet Tag ID,
+      IP prefix length, and IP prefix are part of the route key used by BGP to
+      compare routes";
+    reference "RFC9136: IP Prefix Advertisement in Ethernet VPN (EVPN)";
+
+      leaf ethernet-tag {
+        type leafref {
+          path "../state/ethernet-tag";
+        }
+        description
+          "The Ethernet tag identifies a particular broadcast domain.  An EVPN
+          instance consists of one or more broadcast domains";
+        reference "RFC7432: BGP MPLS-Based Ethernet VPN";
+      }
+
+      leaf ip-prefix-length {
+        type leafref {
+          path "../state/ip-prefix-length";
+        }
+        description
+          "Reference to the ip-prefix-length list key";
+      }
+
+      leaf ip-prefix {
+        type leafref {
+          path "../state/ip-prefix";
+        }
+        description
+          "Reference to the ip-prefix list key";
+      }
+  }
+
+  grouping bgp-evpn-type-five-state {
+    description "Grouping for IP Prefix Advertisement L2VPN EVPN routes";
+    container type-five-ip-prefix {
+      description
+        "Top level container for IP Prefix Advertisement L2VPN EVPN routes";
+      list type-five-route {
+        key "ethernet-tag ip-prefix-length ip-prefix";
+        description
+          "List of IP Prefix Advertisement L2VPN EVPN routes
+
+          For the purpose of BGP route key processing, only The RD, Ethernet Tag ID,
+          IP prefix length, and IP prefix are part of the route key used by BGP to
+          compare routes";
+        reference "RFC9136: IP Prefix Advertisement in Ethernet VPN (EVPN)";
+
+        uses bgp-evpn-type-five-key-refs;
+
+        container state {
+          description
+            "Operational state data for IP Prefix Advertisement L2VPN EVPN
+            route entries in the BGP LOC-RIB";
+
+          leaf ethernet-tag {
+            type oc-evpn-types:ethernet-tag;
+            description
+              "The Ethernet tag identifying the broadcast domain for this
+              route";
+          }
+
+          leaf ip-prefix-length {
+            type string;
+            description
+              "The ip-prefix length for the route";
+          }
+
+          leaf ip-prefix {
+            type oc-inet:ip-prefix;
+            description
+              "The ip-prefix for the route";
+          }
+
+          uses bgp-loc-rib-attr-state;
+          uses bgp-loc-rib-route-annotations-state;
+        }
+
+         uses bgp-evpn-route-path-type5-state;
+      }
+    }
+  }
+
+  grouping l2vpn-evpn-adj-rib-top {
+    description
+      "Top-level grouping for L2VPN-EVPN Adj-RIB table";
+
+    container neighbors {
+      config false;
+      description
+        "Enclosing container for neighbor list";
+
+      list neighbor {
+        key "neighbor-address";
+        description
+          "List of neighbors (peers) of the local BGP speaker";
+
+        leaf neighbor-address {
+          type leafref {
+            path "../state/neighbor-address";
+          }
+          description
+            "Reference to the list key";
+        }
+
+        container state {
+          description
+            "Operational state for each neighbor BGP Adj-RIB";
+
+          leaf neighbor-address {
+            type oc-inet:ip-address;
+            description
+              "IP address of the BGP neighbor or peer";
+          }
+        }
+
+        container adj-rib-in-pre {
+          description
+            "Per-neighbor table containing the NLRI updates
+            received from the neighbor before any local input
+            policy rules or filters have been applied.  This can
+            be considered the 'raw' updates from the neighbor.";
+        }
+
+        container adj-rib-in-post {
+          description
+            "Per-neighbor table containing the paths received from
+            the neighbor that are eligible for best-path selection
+            after local input policy rules have been applied.";
+        }
+
+        container adj-rib-out-pre {
+          description
+            "Per-neighbor table containing paths eligble for
+            sending (advertising) to the neighbor before output
+            policy rules have been applied";
+        }
+
+        container adj-rib-out-post {
+          description
+            "Per-neighbor table containing paths eligble for
+            sending (advertising) to the neighbor after output
+            policy rules have been applied";
+        }
+      }
+    }
+  }
+
+  grouping bgp-adj-rib-key-refs {
+    description
+      "Key references to support operational state structure for
+      the BGP Adj-RIB tables";
+
+    leaf prefix {
+      type leafref {
+        path "../state/prefix";
+      }
+      description
+        "Reference to the prefix list key";
+    }
+
+    leaf path-id {
+      type leafref {
+        path "../state/path-id";
+      }
+      description
+        "Reference to the path-id list key";
+    }
+  }
+
+  grouping ipv4-adj-rib-common {
+    description
+      "Common structural grouping for each IPv4 adj-RIB table";
+
+    uses bgp-common-table-attrs-top;
+
+    container routes {
+      config false;
+      description
+        "Enclosing container for list of routes in the routing
+        table.";
+
+      list route {
+        key "prefix path-id";
+
+        description
+          "List of routes in the table, keyed by a combination of
+          the route prefix and path-id to distinguish multiple
+          routes received from a neighbor for the same prefix,
+          e.g., when BGP add-paths is enabled.";
+
+        uses bgp-adj-rib-key-refs;
+
+        container state {
+          description
+            "Operational state data for BGP Adj-RIB entries";
+
+          leaf prefix {
+            type oc-inet:ipv4-prefix;
+            description
+              "Prefix for the route";
+          }
+
+          uses bgp-adj-rib-attr-state;
+          uses bgp-adj-rib-common-attr-refs;
+          uses bgp-common-route-annotations-state;
+        }
+
+        uses bgp-unknown-attr-top;
+
+      }
+    }
+  }
+
+  grouping ipv4-adj-rib-in-post {
+    description
+      "Common structural grouping for the IPv4 adj-rib-in
+      post-policy table";
+
+    uses bgp-common-table-attrs-top;
+
+    container routes {
+      config false;
+      description
+        "Enclosing container for list of routes in the routing
+        table.";
+
+      list route {
+        key "prefix path-id";
+
+        description
+          "List of routes in the table, keyed by a combination of
+          the route prefix and path-id to distinguish multiple
+          routes received from a neighbor for the same prefix,
+          e.g., when BGP add-paths is enabled.";
+
+        uses bgp-adj-rib-key-refs;
+
+        container state {
+          description
+            "Operational state data for BGP Adj-RIB entries";
+
+          leaf prefix {
+            type oc-inet:ipv4-prefix;
+            description
+              "Prefix for the route";
+          }
+
+          uses bgp-adj-rib-attr-state;
+          uses bgp-adj-rib-common-attr-refs;
+          uses bgp-common-route-annotations-state;
+          uses bgp-adj-rib-in-post-route-annotations-state;
+        }
+
+        uses bgp-unknown-attr-top;
+      }
+    }
+  }
+
+
+  grouping ipv4-adj-rib-top {
+    description
+      "Top-level grouping for Adj-RIB table";
+
+    container neighbors {
+      config false;
+      description
+        "Enclosing container for neighbor list";
+
+      list neighbor {
+        key "neighbor-address";
+        description
+          "List of neighbors (peers) of the local BGP speaker";
+
+        leaf neighbor-address {
+          type leafref {
+            path "../state/neighbor-address";
+          }
+          description
+            "Reference to the list key";
+        }
+
+        container state {
+          description
+            "Operational state for each neighbor BGP Adj-RIB";
+
+          leaf neighbor-address {
+            type oc-inet:ip-address;
+            description
+              "IP address of the BGP neighbor or peer";
+          }
+        }
+
+        container adj-rib-in-pre {
+          description
+            "Per-neighbor table containing the NLRI updates
+            received from the neighbor before any local input
+            policy rules or filters have been applied.  This can
+            be considered the 'raw' updates from the neighbor.";
+
+          uses ipv4-adj-rib-common;
+
+        }
+
+        container adj-rib-in-post {
+          description
+            "Per-neighbor table containing the paths received from
+            the neighbor that are eligible for best-path selection
+            after local input policy rules have been applied.";
+
+          uses ipv4-adj-rib-in-post;
+        }
+
+        container adj-rib-out-pre {
+          description
+            "Per-neighbor table containing paths eligble for
+            sending (advertising) to the neighbor before output
+            policy rules have been applied";
+
+          uses ipv4-adj-rib-common;
+
+        }
+
+        container adj-rib-out-post {
+          description
+            "Per-neighbor table containing paths eligble for
+            sending (advertising) to the neighbor after output
+            policy rules have been applied";
+
+          uses ipv4-adj-rib-common;
+
+        }
+      }
+    }
+  }
+
+  grouping ipv6-adj-rib-common {
+    description
+      "Common structural grouping for each IPv6 adj-RIB table";
+
+    uses bgp-common-table-attrs-state;
+
+    container routes {
+      config false;
+      description
+        "Enclosing container for list of routes in the routing
+        table.";
+
+      list route {
+        key "prefix path-id";
+
+        description
+          "List of routes in the table";
+
+        uses bgp-adj-rib-key-refs;
+
+        container state {
+          description
+            "Operational state data for BGP Adj-RIB entries";
+
+          leaf prefix {
+            type oc-inet:ipv6-prefix;
+            description
+              "Prefix for the route";
+          }
+
+          uses bgp-adj-rib-attr-state;
+          uses bgp-adj-rib-common-attr-refs;
+          uses bgp-common-route-annotations-state;
+        }
+
+        uses bgp-unknown-attr-top;
+      }
+    }
+  }
+
+  grouping ipv6-adj-rib-in-post {
+    description
+      "Common structural grouping for the IPv6 adj-rib-in
+      post-policy table";
+
+    uses bgp-common-table-attrs-state;
+
+    container routes {
+      config false;
+      description
+        "Enclosing container for list of routes in the routing
+        table.";
+
+      list route {
+        key "prefix path-id";
+
+        description
+          "List of routes in the table";
+
+        uses bgp-adj-rib-key-refs;
+
+        container state {
+          description
+            "Operational state data for BGP Adj-RIB entries";
+
+          leaf prefix {
+            type oc-inet:ipv6-prefix;
+            description
+              "Prefix for the route";
+          }
+
+          uses bgp-adj-rib-attr-state;
+          uses bgp-adj-rib-common-attr-refs;
+          uses bgp-common-route-annotations-state;
+          uses bgp-adj-rib-in-post-route-annotations-state;
+        }
+
+        uses bgp-unknown-attr-top;
+      }
+    }
+  }
+
+  grouping ipv6-adj-rib-top {
+    description
+      "Top-level grouping for Adj-RIB table";
+
+    container neighbors {
+      config false;
+      description
+        "Enclosing container for neighbor list";
+
+      list neighbor {
+        key "neighbor-address";
+        description
+          "List of neighbors (peers) of the local BGP speaker";
+
+        leaf neighbor-address {
+          type leafref {
+            path "../state/neighbor-address";
+          }
+          description
+            "Reference to the list key";
+        }
+
+        container state {
+          description
+            "Operational state for each neighbor BGP Adj-RIB";
+
+          leaf neighbor-address {
+            type oc-inet:ip-address;
+            description
+              "IP address of the BGP neighbor or peer";
+          }
+        }
+
+        container adj-rib-in-pre {
+          description
+            "Per-neighbor table containing the NLRI updates
+            received from the neighbor before any local input
+            policy rules or filters have been applied.  This can
+            be considered the 'raw' updates from the neighbor.";
+
+          uses ipv6-adj-rib-common;
+
+        }
+
+        container adj-rib-in-post {
+          description
+            "Per-neighbor table containing the paths received from
+            the neighbor that are eligible for best-path selection
+            after local input policy rules have been applied.";
+
+          uses ipv6-adj-rib-in-post;
+        }
+
+        container adj-rib-out-pre {
+          description
+            "Per-neighbor table containing paths eligble for
+            sending (advertising) to the neighbor before output
+            policy rules have been applied";
+
+          uses ipv6-adj-rib-common;
+
+        }
+
+        container adj-rib-out-post {
+          description
+            "Per-neighbor table containing paths eligble for
+            sending (advertising) to the neighbor after output
+            policy rules have been applied";
+
+          uses ipv6-adj-rib-common;
+
+        }
+      }
+    }
+  }
+
+  grouping ipvX-srte-policy-adjrib-top {
+    description
+      "Top-level grouping for the IPv4 and IPv6 AFI, SR-TE Policy SAFI
+      Adj-RIBs.";
+
+    container neighbors {
+      description
+        "Surrounding container for the list of neighbours that are
+        enabled for the IPv4 and IPv6 AFI, SR-TE Policy SAFI address
+        family.";
+
+      list neighbor {
+        key "neighbor-address";
+
+        description
+          "An individual neighbour that is enabled for the SR-TE
+          Policy SAFI.";
+
+        leaf neighbor-address {
+          type leafref {
+            path "../state/neighbor-address";
+          }
+          description
+            "Reference to the address of the neighbour for which the
+            Adj-RIBs specified are maintained.";
+        }
+
+        container state {
+          description
+            "Operational state parameters of the BGP neighbour for
+            which the SR-TE Policy SAFI is enabled.";
+          uses ipvX-srte-policy-adjrib-neighbor-state;
+        }
+
+        container adj-rib-in-pre {
+          description
+            "The Adj-RIB-In for the SR-TE Policy SAFI for the neighbour,
+            prior to any inbound policy constraints or modifications
+            having been applied.";
+          uses ipvX-srte-policy-adjrib-common;
+        }
+
+        container adj-rib-in-post {
+          description
+            "The Adj-RIB-In for the SR-TE Policy SAFI for the neighbour,
+            following any inbound policy constraints or modifications
+            being made.";
+          uses ipvX-srte-policy-adjrib-in-post;
+        }
+
+        container adj-rib-out-pre {
+          description
+            "The Adj-RIB-Out for the SR-TE Policy SAFI for the neighbour,
+            prior to any outgoing policy modifications or constraints
+            having been applied.";
+          uses ipvX-srte-policy-adjrib-common;
+        }
+
+        container adj-rib-out-post {
+          description
+            "The Adj-RIB-Out for the SR-TE Policy SAFI for the neighbour,
+            follow any outbound policy constraints or modifications being
+            made.";
+          uses ipvX-srte-policy-adjrib-common;
+        }
+      }
+    }
+  }
+
+  grouping ipvX-srte-policy-adjrib-neighbor-state {
+    description
+      "Common attributes for each neighbour for which the SR-TE
+      Policy SAFI RIBs are being maintained.";
+
+    leaf neighbor-address {
+      description
+        "The address of the neighbour for which the SR-TE policy
+        SAFI has been negotiated.";
+      type oc-inet:ip-address;
+    }
+  }
+
+  grouping ipvX-srte-policy-adjrib-common {
+    description
+      "Common structure containing the routes that are learnt via
+      the IPv4 or IPv6 SR-TE Policy SAFI.";
+
+    container routes {
+      description
+        "Surrounding container for the list of routes within the
+        SR-TE Policy SAFI.";
+
+      list route {
+        key "path-id endpoint color";
+
+        description
+          "The routes within the SR-TE Policy SAFI Adj-RIB. The
+          routes are keyed on the path-id - set to a non-zero
+          value only if ADD-PATHS is being used; the color; and
+          the endpoint. The colour and endpoint are extracted from
+          the NLRI.";
+
+        uses ipvX-srte-policy-common-keys;
+
+        container state {
+          description
+            "State parameters for entries within the Adj-RIB used
+            to store SR-TE Policy SAFI routes.";
+
+          uses ipvX-srte-policy-common-route-state;
+          uses bgp-adj-rib-common-attr-refs;
+          uses bgp-common-route-annotations-state;
+        }
+
+        uses bgp-unknown-attr-top;
+      }
+    }
+  }
+
+  grouping ipvX-srte-policy-common-route-state {
+    description
+      "Common attributes used SR-TE Policy SAFI routes.";
+
+    leaf path-id {
+      type uint32;
+      default 0;
+      description
+        "Identifier for the path when using BGP ADD-PATHS for the SR-TE
+        policy SAFI.";
+    }
+
+    leaf endpoint {
+      type oc-inet:ip-address;
+      description
+        "A unique identifier for the remote set of nodes. When the address
+        family is IPv4, the value is a 4-octet IPv4 address. When the
+        address family is IPv6, the value is a 16-octet IPv6 address.";
+    }
+
+    leaf color {
+      type uint32;
+      description
+        "A 4-octet value identifying the policy. Combined with the endpoint
+        the endpoint and colour represent the unique policy.";
+    }
+  }
+
+  grouping ipvX-srte-policy-common-keys {
+    description
+      "Common grouping of the keys used for lists of SR-TE policy
+      SAFI routes.";
+
+    leaf path-id {
+      type leafref {
+        path "../state/path-id";
+      }
+      description
+        "Reference to the path identifier for the SR-TE Policy SAFI
+        route. The value is only non-zero if ADD-PATHS is not being
+        used.";
+    }
+
+    leaf endpoint {
+      type leafref {
+        path "../state/endpoint";
+      }
+      description
+        "Reference to the endpoint used for the SR-TE Policy SAFI
+        route within the NLRI.";
+    }
+
+    leaf color {
+      type leafref {
+        path "../state/color";
+      }
+      description
+        "Reference to the colour used for the SR-TE policy SAFI
+        route within the NLRI.";
+    }
+  }
+
+  grouping ipvX-srte-policy-adjrib-in-post {
+    description
+      "Grouping for the post-policy Adj-RIB-In for SR-TE Policy SAFI routes";
+
+    container routes {
+      description
+        "The set of routes that are within the Adj-RIB-Out for the
+        neighbour.";
+
+      list route {
+        key "path-id endpoint color";
+
+        description
+          "The routes that are in the Adj-RIB-In-Post for the specified
+          BGP neighbour within the SR-TE Policy SAFI for the specified
+          address family.";
+
+        uses ipvX-srte-policy-common-keys;
+
+        container state {
+          description
+            "Operational state attributes related to the route within
+            the SR-TE Policy SAFI Adj-RIB-In-Post for the specified
+            neighbour.";
+
+          uses ipvX-srte-policy-common-route-state;
+          uses bgp-adj-rib-common-attr-refs;
+          uses bgp-common-route-annotations-state;
+          uses bgp-adj-rib-in-post-route-annotations-state;
+        }
+
+        uses bgp-unknown-attr-top;
+      }
+    }
+  }
+
+  grouping ipvX-srte-policy-locrib-top {
+    description
+      "Top-level grouping for the Loc-RIB for IPv4 or IPv6 Adj-RIB
+      for SR-TE Policy SAFI.";
+
+    container loc-rib {
+      description
+        "The Loc-RIB for the SR-TE Policy SAFI for IPv4 or IPv6 Unicast
+        AFIs.";
+
+      container routes {
+        description
+          "List of routes within the SR-TE Policy SAFI, for the IPv4 or
+          IPv6 AFI.";
+
+        list route {
+          key "path-id endpoint color";
+
+          description
+            "Route within the specified address family for the SR-TE
+            Policy SAFI.";
+
+          uses ipvX-srte-policy-common-keys;
+
+          container state {
+            description
+              "Operational state attributes for each route within the
+              IPv4 or IPv6 Unicast SR-TE Policy SAFI.";
+
+            uses ipvX-srte-policy-common-route-state;
+            uses bgp-loc-rib-common-attr-refs;
+            uses bgp-common-route-annotations-state;
+          }
+
+          uses bgp-unknown-attr-top;
+        }
+      }
+    }
+  }
+}

--- a/models/yang/common/openconfig-rib-bgp-types.yang
+++ b/models/yang/common/openconfig-rib-bgp-types.yang
@@ -1,0 +1,269 @@
+module openconfig-rib-bgp-types {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/rib/bgp-types";
+
+  prefix "oc-bgprib-types";
+
+  import openconfig-extensions { prefix oc-ext; }
+
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "Defines identity and type defintions associated with
+    the OpenConfig BGP RIB modules";
+
+  oc-ext:openconfig-version "0.5.0";
+
+  revision "2019-03-14" {
+    description
+      "Update last-modified timestamp to be expressed as nanoseconds
+      since the Unix epoch.";
+    reference "0.5.0";
+  }
+
+  revision "2019-02-27" {
+    description
+      "Remove top-level BGP RIB container, and update list
+      names to be compatible with path compression.";
+    reference "0.4.0";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "0.3.1";
+  }
+
+  revision "2016-10-17" {
+    description
+      "OpenConfig BGP RIB refactor";
+    reference "0.3.0";
+  }
+
+  revision "2016-04-11" {
+    description
+      "OpenConfig public release";
+    reference "0.2.0";
+  }
+
+  // OpenConfig specific extensions for module metadata.
+  oc-ext:regexp-posix;
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  identity INVALID_ROUTE_REASON {
+    description
+      "Base identity for reason code for routes that are rejected as
+      invalid.  Some derived entities are based on BMP v3";
+    reference "BGP Monitoring Protocol (draft-ietf-grow-bmp-07)";
+  }
+
+  identity INVALID_CLUSTER_LOOP {
+    base INVALID_ROUTE_REASON;
+    description
+      "Route was invalid due to CLUSTER_LIST loop";
+  }
+
+  identity INVALID_AS_LOOP {
+    base INVALID_ROUTE_REASON;
+    description
+      "Route was invalid due to AS_PATH loop";
+  }
+
+  identity INVALID_ORIGINATOR {
+    base INVALID_ROUTE_REASON;
+    description
+      "Route was invalid due to ORIGINATOR_ID, e.g., update has
+      local router as originator";
+  }
+
+  identity INVALID_CONFED {
+    base INVALID_ROUTE_REASON;
+    description
+      "Route was invalid due to a loop in the AS_CONFED_SEQUENCE or
+      AS_CONFED_SET attributes";
+  }
+
+  identity BGP_NOT_SELECTED_BESTPATH {
+    description
+      "Base identity for indicating reason a route was was not
+      selected by BGP route selection algorithm";
+    reference
+      "RFC 4271 - Section 9.1";
+  }
+
+  identity LOCAL_PREF_LOWER {
+    base BGP_NOT_SELECTED_BESTPATH;
+    description
+      "Route has a lower localpref attribute than current best path";
+    reference
+      "RFC 4271 - Section 9.1.2";
+  }
+
+  identity AS_PATH_LONGER {
+    base BGP_NOT_SELECTED_BESTPATH;
+    description
+      "Route has a longer AS path attribute than current best path";
+    reference
+      "RFC 4271 - Section 9.1.2.2 (a)";
+  }
+
+  identity ORIGIN_TYPE_HIGHER {
+    base BGP_NOT_SELECTED_BESTPATH;
+    description
+      "Route has a higher origin type, i.e., IGP origin is preferred
+      over EGP or incomplete";
+    reference
+      "RFC 4271 - Section 9.1.2.2 (b)";
+  }
+
+  identity MED_HIGHER {
+    base BGP_NOT_SELECTED_BESTPATH;
+    description
+      "Route has a higher MED, or metric, attribute than the current
+      best path";
+    reference
+      "RFC 4271 - Section 9.1.2.2 (c)";
+  }
+
+  identity PREFER_EXTERNAL {
+    base BGP_NOT_SELECTED_BESTPATH;
+    description
+      "Route source is via IGP, rather than EGP.";
+    reference
+      "RFC 4271 - Section 9.1.2.2 (d)";
+  }
+
+  identity NEXTHOP_COST_HIGHER {
+    base BGP_NOT_SELECTED_BESTPATH;
+    description
+      "Route has a higher interior cost to the next hop.";
+    reference
+      "RFC 4271 - Section 9.1.2.2 (e)";
+  }
+
+  identity HIGHER_ROUTER_ID {
+    base BGP_NOT_SELECTED_BESTPATH;
+    description
+      "Route was sent by a peer with a higher BGP Identifier value,
+      or router id";
+    reference
+      "RFC 4271 - Section 9.1.2.2 (f)";
+  }
+
+  identity HIGHER_PEER_ADDRESS {
+    base BGP_NOT_SELECTED_BESTPATH;
+    description
+      "Route was sent by a peer with a higher IP address";
+    reference
+      "RFC 4271 - Section 9.1.2.2 (g)";
+  }
+
+  identity BGP_NOT_SELECTED_POLICY {
+    description
+      "Base identity for reason code for routes that are rejected
+      due to policy";
+  }
+
+  identity REJECTED_IMPORT_POLICY {
+    base BGP_NOT_SELECTED_POLICY;
+    description
+      "Route was rejected after apply import policies";
+  }
+
+  identity TUNNEL_ENCAPSULATION_TYPE {
+    description
+      "Types of tunnel encapsulation, as described by the Tunnel
+      Encapsulation attribute";
+    reference
+      "RFC5512";
+    }
+
+    identity SRTE_POLICY_TUNNEL {
+      base TUNNEL_ENCAPSULATION_TYPE;
+      description
+        "Segment Routing Traffic Engineering Policy tunnel.";
+      reference
+        "draft-previdi-idr-segment-routing-te-policy";
+    }
+
+    identity TUNNEL_ENCAPSULATION_SUBTLV_TYPE {
+      description
+        "SubTLVs of the Tunnel Encapsulation attribute";
+      reference
+        "RFC5512";
+    }
+
+    identity TUNNEL_REMOTE_ENDPOINT {
+      base TUNNEL_ENCAPSULATION_SUBTLV_TYPE;
+      description
+        "Remote endpoint of the tunnel.";
+      reference
+        "RFC5512";
+    }
+
+    identity TUNNEL_COLOR {
+      base TUNNEL_ENCAPSULATION_SUBTLV_TYPE;
+      description
+        "Colour of the tunnel";
+      reference
+        "RFC5512";
+    }
+
+    identity SRTE_PREFERENCE {
+      base TUNNEL_ENCAPSULATION_SUBTLV_TYPE;
+      description
+        "Preference of the SR-TE policy entry described by
+        the tunnel encapsulation attribute.";
+      reference
+        "draft-previdi-idr-segment-routing-te-policy";
+    }
+
+    identity SRTE_BINDING_SID {
+      base TUNNEL_ENCAPSULATION_SUBTLV_TYPE;
+      description
+        "Binding SID to be used by the SR-TE policy described
+        by the tunnel encapsulation attribute.";
+      reference
+        "draft-previdi-idr-segment-routing-te-policy";
+    }
+
+    identity SRTE_SEGMENT_LIST {
+      base TUNNEL_ENCAPSULATION_SUBTLV_TYPE;
+      description
+        "Segment lists to be used by the SR-TE policy described
+        by the tunnel encapsulation attribute.";
+      reference
+        "draft-previdi-idr-segment-routing-te-policy";
+    }
+
+    identity SRTE_SEGMENT_LIST_SUBTLV {
+      description
+        "SubTLVs of the SR-TE Policy Segment List sub-TLV of the
+        Tunnel Encapsulation attribute.";
+      reference
+        "draft-previdi-idr-segment-routing-te-policy";
+    }
+
+    identity SRTE_SEGMENT_LIST_WEIGHT {
+      base SRTE_SEGMENT_LIST_SUBTLV;
+      description
+        "Weight of the segment list within the SR-TE policy";
+      reference
+        "draft-previdi-idr-segment-routing-te-policy";
+    }
+
+    identity SRTE_SEGMENT_LIST_SEGMENT {
+      base SRTE_SEGMENT_LIST_SUBTLV;
+      description
+        "An individual element within the SR-TE Policy Segment
+        List.";
+    }
+}

--- a/models/yang/common/openconfig-rib-bgp.yang
+++ b/models/yang/common/openconfig-rib-bgp.yang
@@ -1,0 +1,270 @@
+module openconfig-rib-bgp {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/rib/bgp";
+
+  prefix "oc-rib-bgp";
+
+  // import some basic types
+  import openconfig-bgp-types { prefix oc-bgpt; }
+  import openconfig-extensions { prefix oc-ext; }
+
+  // include RIB submodules
+
+  // structure for LOC-RIB and Adj-RIB tables
+  include openconfig-rib-bgp-tables;
+
+  // structure of shared attribute groups
+  include openconfig-rib-bgp-shared-attributes;
+
+  // groupings of attributes in three categories:
+  //  - shared across multiple routes
+  //  - common to LOC-RIB and Adj-RIB, but not shared across routes
+  //  - specific to LOC-RIB or Adj-RIB
+  include openconfig-rib-bgp-attributes;
+
+  // groupings of annotations for each route or table
+  include openconfig-rib-bgp-table-attributes;
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "Defines a data model for representing BGP routing table (RIB)
+    contents.  The model supports 5 logical RIBs per address family:
+
+    loc-rib: This is the main BGP routing table for the local routing
+    instance, containing best-path selections for each prefix. The
+    loc-rib table may contain multiple routes for a given prefix,
+    with an attribute to indicate which was selected as the best
+    path.  Note that multiple paths may be used or advertised even if
+    only one path is marked as best, e.g., when using BGP
+    add-paths.  An implementation may choose to mark multiple
+    paths in the RIB as best path by setting the flag to true for
+    multiple entries.
+
+    adj-rib-in-pre: This is a per-neighbor table containing the NLRI
+    updates received from the neighbor before any local input policy
+    rules or filters have been applied.  This can be considered the
+    'raw' updates from a given neighbor.
+
+    adj-rib-in-post: This is a per-neighbor table containing the
+    routes received from the neighbor that are eligible for
+    best-path selection after local input policy rules have been
+    applied.
+
+    adj-rib-out-pre: This is a per-neighbor table containing routes
+    eligible for sending (advertising) to the neighbor before output
+    policy rules have been applied.
+
+    adj-rib-out-post: This is a per-neighbor table containing routes
+    eligible for sending (advertising) to the neighbor after output
+    policy rules have been applied.";
+
+  oc-ext:openconfig-version "0.9.0";
+
+  revision "2022-12-20" {
+    description
+      "Convert as-segment and as4-segment to keyed lists.";
+    reference "0.9.0";
+  }
+
+  revision "2022-06-06" {
+    description
+      "Revert IETF types in favor of oc-inet types";
+    reference "0.8.1";
+  }
+
+  revision "2021-06-21" {
+    description
+      "Add L2VPN-EVPN BGP RIB Support";
+    reference "0.8.0";
+  }
+
+  revision "2019-10-15" {
+    description
+      "Change imported segment-routing module.";
+    reference "0.7.0";
+  }
+
+  revision "2019-04-25" {
+    description
+      "Update last-modified timestamp to be expressed as nanoseconds
+      since the Unix epoch.";
+    reference "0.6.0";
+  }
+
+  revision "2019-04-16" {
+    description
+      "Rename the top-level BGP RIB container's name
+      to RIB.";
+    reference "0.5.0";
+  }
+
+  revision "2019-02-27" {
+    description
+      "Remove top-level BGP RIB container, and update list
+      names to be compatible with path compression.";
+    reference "0.4.0";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "0.3.1";
+  }
+
+  revision "2016-10-17" {
+    description
+      "OpenConfig BGP RIB refactor";
+    reference "0.3.0";
+  }
+
+  revision "2016-04-11" {
+    description
+      "OpenConfig public release";
+    reference "0.2.0";
+  }
+
+
+
+  // grouping statements
+
+
+
+  grouping bgp-rib-state {
+    description
+      "Operational state data for the top level BGP RIB";
+
+    leaf afi-safi-name {
+      type identityref {
+        base oc-bgpt:AFI_SAFI_TYPE;
+      }
+      description "AFI,SAFI";
+    }
+  }
+
+  grouping bgp-rib-top {
+    description
+      "Top-level grouping for the BGP RIB";
+
+    container rib {
+      config false;
+      description
+        "Top level container for BGP RIBs";
+
+      uses attribute-sets-top;
+      uses community-sets-top;
+      uses ext-community-sets-top;
+
+      container afi-safis {
+        config false;
+        description
+          "Enclosing container for address family list";
+
+        list afi-safi {
+          key "afi-safi-name";
+          description
+            "list of afi-safi types";
+
+          leaf afi-safi-name {
+            type leafref {
+              path "../state/afi-safi-name";
+            }
+            description
+              "Reference to the list key";
+          }
+
+          container state {
+            config false;
+            description
+              "Operational state data for the BGP list";
+
+            uses bgp-rib-state;
+          }
+
+          container ipv4-unicast {
+            when "../afi-safi-name = 'oc-bgpt:IPV4_UNICAST'" {
+              description
+                "Include this container for IPv4 unicast RIB";
+            }
+            description
+              "Routing tables for IPv4 unicast -- active when the
+              afi-safi name is ipv4-unicast";
+
+            uses ipv4-loc-rib-top;
+            uses ipv4-adj-rib-top;
+          }
+
+          container ipv6-unicast {
+            when "../afi-safi-name = 'oc-bgpt:IPV6_UNICAST'" {
+              description
+                "Include this container for IPv6 unicast RIB";
+            }
+            description
+              "Routing tables for IPv6 unicast -- active when the
+              afi-safi name is ipv6-unicast";
+
+            uses ipv6-loc-rib-top;
+            uses ipv6-adj-rib-top;
+          }
+
+          container ipv4-srte-policy {
+            when "../afi-safi-name = 'oc-bgpt:SRTE_POLICY_IPV4'" {
+              description
+                "Include this container only for the IPv4 AFI, SR-TE Policy
+                SAFI.";
+            }
+            description
+              "Routing tables for the IPv4 Unicast, SR-TE Policy SAFI.";
+
+            uses ipvX-srte-policy-locrib-top;
+            uses ipvX-srte-policy-adjrib-top;
+          }
+
+          container ipv6-srte-policy {
+            when "../afi-safi-name = 'oc-bgpt:SRTE_POLICY_IPV6'" {
+              description
+                "Include this container only for the IPv6 AFI, SR-TE Policy
+                SAFI.";
+            }
+            description
+              "Routing tables for the IPv6 Unicast, SR-TE Policy SAFI.";
+
+            uses ipvX-srte-policy-locrib-top;
+            uses ipvX-srte-policy-adjrib-top;
+          }
+
+          container l2vpn-evpn {
+            when "../afi-safi-name = 'oc-bgpt:L2VPN_EVPN'" {
+              description
+                "Include this container for l2vpn evpn route-types";
+            }
+            description
+              "Routing tables for l2vpn evpn -- active when the
+              afi-safi name is l2vpn-evpn";
+
+            uses l2vpn-evpn-loc-rib-top;
+            uses l2vpn-evpn-adj-rib-top;
+          }
+        }
+      }
+    }
+  }
+
+
+  // data definition statements
+  // augment statements
+
+
+  // rpc statements
+
+  // notification statements
+
+}

--- a/models/yang/common/openconfig-routing-policy.yang
+++ b/models/yang/common/openconfig-routing-policy.yang
@@ -1,0 +1,1368 @@
+module openconfig-routing-policy {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/routing-policy";
+
+  prefix "oc-rpol";
+
+  // import some basic types
+  import openconfig-inet-types { prefix oc-inet; }
+  import openconfig-interfaces { prefix oc-if; }
+  import openconfig-policy-types { prefix oc-pol-types; }
+  import openconfig-extensions { prefix oc-ext; }
+
+  // meta
+  organization
+    "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    netopenconfig@googlegroups.com";
+
+  description
+    "This module describes a YANG model for routing policy
+    configuration. It is a limited subset of all of the policy
+    configuration parameters available in the variety of vendor
+    implementations, but supports widely used constructs for managing
+    how routes are imported, exported, and modified across different
+    routing protocols.  This module is intended to be used in
+    conjunction with routing protocol configuration models (e.g.,
+    BGP) defined in other modules.
+
+    Route policy expression:
+
+    Policies are expressed as a set of top-level policy definitions,
+    each of which consists of a sequence of policy statements. Policy
+    statements consist of simple condition-action tuples. Conditions
+    may include mutiple match or comparison operations, and similarly
+    actions may be multitude of changes to route attributes or a
+    final disposition of accepting or rejecting the route.
+
+    Route policy evaluation:
+
+    Policy definitions are referenced in routing protocol
+    configurations using import and export configuration statements.
+    The arguments are members of an ordered list of named policy
+    definitions which comprise a policy chain, and optionally, an
+    explicit default policy action (i.e., reject or accept).
+
+    Evaluation of each policy definition proceeds by evaluating its
+    corresponding individual policy statements in order.  When a
+    condition statement in a policy statement is satisfied, the
+    corresponding action statement is executed.  If the action
+    statement has a final disposition configured as policy result, either
+    accept-route or reject-route, evaluation of the current policy definition
+    stops, and no further policy statements are evaluated. In case there is a
+    policy chain, no further policy definitions in the chain are evaluated.
+
+    If the action statement has the NEXT_STATEMENT policy result, all the
+    defined actions are executed and policy evaluation proceeds to the next
+    statement.  The NEXT_STATEMENT is the default policy result action.
+
+    If the condition is not satisfied, then evaluation proceeds to
+    the next policy statement.  If none of the policy statement
+    conditions are satisfied, then evaluation of the current policy
+    definition stops, and the next policy definition in the chain is
+    evaluated.  When the end of the policy chain is reached, the
+    default route disposition action is performed (i.e., reject-route
+    unless an an alternate default action is specified for the
+    chain).
+
+    Policy 'subroutines' (or nested policies) are supported by
+    allowing policy statement conditions to reference another policy
+    definition which applies conditions and actions from the
+    referenced policy before returning to the calling policy
+    statement and resuming evaluation.  If the called policy
+    results in an accept-route (either explicit or by default), then
+    the subroutine returns an effective true value to the calling
+    policy.  Similarly, a reject-route action returns false.  If the
+    subroutine returns true, the calling policy continues to evaluate
+    the remaining conditions (using a modified route if the
+    subroutine performed any changes to the route).
+
+    If a routing protocol is defined and the related
+    apply-policy/default-(import|export)-policy leaf is not set, the
+    default value for the default-(import|export)-policy leaf must be
+    applied.  See RFC6020 7.6.1 which applies to this model.";
+
+  oc-ext:openconfig-version "3.4.2";
+
+  revision "2023-11-01" {
+    description
+      "Refactor apply policy to separate default policy in it's own common
+      set of groupings";
+    reference "3.4.2";
+  }
+
+  revision "2023-10-24" {
+    description
+      "Clarify the use of default-(import|export)-policy when no policy
+      is applied to a protocol.";
+    reference "3.4.1";
+  }
+
+  revision "2023-10-11" {
+    description
+      "Add NEXT_STATEMENT policy-result-type enum value.";
+    reference "3.4.0";
+  }
+
+  revision "2022-05-24" {
+    description
+      "Remove module extension oc-ext:regexp-posix by making pattern regexes
+      conform to RFC6020/7950.
+
+      Types impacted:
+      - masklength-range";
+    reference "3.3.0";
+  }
+
+  revision "2020-08-18" {
+    description
+      "Fix regex anchors for masklength-range's pattern statement.";
+    reference "3.2.2";
+  }
+
+  revision "2020-06-30" {
+    description
+      "Add OpenConfig POSIX pattern extensions.";
+    reference "3.2.1";
+  }
+
+  revision "2020-04-02" {
+    description
+      "Add generic set-tag operation back to support local and IGP
+      tagged routes.";
+    reference "3.2.0";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "3.1.1";
+  }
+
+  revision "2018-06-05" {
+    description
+      "Add PIM, IGMP to INSTALL_PROTOCOL_TYPES identity";
+    reference "3.1.0";
+  }
+
+  revision "2017-07-14" {
+    description
+      "Replace policy choice node/type with policy-result
+      enumeration;simplified defined set naming;removed generic
+      IGP actions; migrate to OpenConfig types; added mode for
+      prefix sets";
+    reference "3.0.0";
+  }
+
+  revision "2016-05-12" {
+    description
+      "OpenConfig public release";
+    reference "2.0.1";
+  }
+
+  // OpenConfig specific extensions for module metadata.
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  // typedef statements
+
+  typedef default-policy-type {
+    // this typedef retained for name compatibiity with default
+    // import and export policy
+    type enumeration {
+      enum ACCEPT_ROUTE {
+        description
+          "Default policy to accept the route";
+      }
+      enum REJECT_ROUTE {
+        description
+          "Default policy to reject the route";
+      }
+    }
+    description
+      "Type used to specify route disposition in
+      a policy chain";
+  }
+
+  typedef policy-result-type {
+    type enumeration {
+      enum ACCEPT_ROUTE {
+        description "Policy accepts the route and evaluation of the
+        current policy definition stops.";
+      }
+      enum REJECT_ROUTE {
+        description "Policy rejects the route and evaluation of the
+        current policy definition stops.";
+      }
+      enum NEXT_STATEMENT {
+        description "Any modifications of the route are preserved and the evaluation of the policy will continue to the
+        next statement.";
+      }
+    }
+    default NEXT_STATEMENT;
+    description
+      "Type used to specify route disposition in
+      a policy chain";
+  }
+
+
+  // grouping statements
+
+  grouping prefix-set-config {
+    description
+      "Configuration data for prefix sets used in policy
+      definitions.";
+
+    leaf name {
+      type string;
+      description
+        "name / label of the prefix set -- this is used to
+        reference the set in match conditions";
+    }
+
+    leaf mode {
+      type enumeration {
+        enum IPV4 {
+          description
+            "Prefix set contains IPv4 prefixes only";
+        }
+        enum IPV6 {
+          description
+            "Prefix set contains IPv6 prefixes only";
+        }
+        enum MIXED {
+          description
+            "Prefix set contains mixed IPv4 and IPv6 prefixes";
+        }
+      }
+      description
+        "Indicates the mode of the prefix set, in terms of which
+        address families (IPv4, IPv6, or both) are present.  The
+        mode provides a hint, but the device must validate that all
+        prefixes are of the indicated type, and is expected to
+        reject the configuration if there is a discrepancy.  The
+        MIXED mode may not be supported on devices that require
+        prefix sets to be of only one address family.";
+    }
+
+  }
+
+  grouping prefix-set-state {
+    description
+      "Operational state data for prefix sets";
+  }
+
+  grouping prefix-set-top {
+    description
+      "Top-level data definitions for a list of IPv4 or IPv6
+      prefixes which are matched as part of a policy";
+
+    container prefix-sets {
+      description
+        "Enclosing container ";
+
+      list prefix-set {
+        key "name";
+        description
+          "List of the defined prefix sets";
+
+        leaf name {
+          type leafref {
+            path "../config/name";
+          }
+          description
+            "Reference to prefix name list key";
+        }
+
+        container config {
+          description
+            "Configuration data for prefix sets";
+
+          uses prefix-set-config;
+        }
+
+        container state {
+
+          config false;
+
+          description
+            "Operational state data ";
+
+          uses prefix-set-config;
+          uses prefix-set-state;
+        }
+
+        uses prefix-top;
+      }
+    }
+  }
+
+  grouping prefix-config {
+    description
+      "Configuration data for a prefix definition";
+
+    leaf ip-prefix {
+      type oc-inet:ip-prefix;
+      mandatory true;
+      description
+        "The prefix member in CIDR notation -- while the
+        prefix may be either IPv4 or IPv6, most
+        implementations require all members of the prefix set
+        to be the same address family.  Mixing address types in
+        the same prefix set is likely to cause an error.";
+    }
+
+    leaf masklength-range {
+      type string {
+        pattern '(([0-9]+\.\.[0-9]+)|exact)';
+        oc-ext:posix-pattern '^(([0-9]+\.\.[0-9]+)|exact)$';
+      }
+      description
+        "Defines a range for the masklength, or 'exact' if
+        the prefix has an exact length.
+
+        Example: 10.3.192.0/21 through 10.3.192.0/24 would be
+        expressed as prefix: 10.3.192.0/21,
+        masklength-range: 21..24.
+
+        Example: 10.3.192.0/21 would be expressed as
+        prefix: 10.3.192.0/21,
+        masklength-range: exact";
+    }
+  }
+
+  grouping prefix-state {
+    description
+      "Operational state data for prefix definitions";
+  }
+
+  grouping prefix-top {
+    description
+      "Top-level grouping for prefixes in a prefix list";
+
+    container prefixes {
+      description
+        "Enclosing container for the list of prefixes in a policy
+        prefix list";
+
+      list prefix {
+        key "ip-prefix masklength-range";
+        description
+          "List of prefixes in the prefix set";
+
+        leaf ip-prefix {
+          type leafref {
+            path "../config/ip-prefix";
+          }
+          description
+            "Reference to the ip-prefix list key.";
+        }
+
+        leaf masklength-range {
+          type leafref {
+            path "../config/masklength-range";
+          }
+          description
+            "Reference to the masklength-range list key";
+        }
+
+        container config {
+          description
+            "Configuration data for prefix definition";
+
+          uses prefix-config;
+        }
+
+        container state {
+
+          config false;
+
+          description
+            "Operational state data for prefix definition";
+
+          uses prefix-config;
+          uses prefix-state;
+        }
+      }
+    }
+  }
+
+  grouping neighbor-set-config {
+    description
+      "Configuration data for neighbor set definitions";
+
+    leaf name {
+      type string;
+      description
+          "name / label of the neighbor set -- this is used to
+          reference the set in match conditions";
+    }
+
+    leaf-list address {
+      type oc-inet:ip-address;
+      description
+        "List of IP addresses in the neighbor set";
+    }
+  }
+
+  grouping neighbor-set-state {
+    description
+      "Operational state data for neighbor set definitions";
+  }
+
+  grouping neighbor-set-top {
+    description
+      "Top-level data definition for a list of IPv4 or IPv6
+      neighbors which can be matched in a routing policy";
+
+    container neighbor-sets {
+      description
+        "Enclosing container for the list of neighbor set
+        definitions";
+
+      list neighbor-set {
+        key "name";
+        description
+          "List of defined neighbor sets for use in policies.";
+
+        leaf name {
+          type leafref {
+            path "../config/name";
+          }
+          description
+            "Reference to the neighbor set name list key.";
+        }
+
+        container config {
+          description
+            "Configuration data for neighbor sets.";
+
+          uses neighbor-set-config;
+        }
+
+        container state {
+
+          config false;
+
+          description
+            "Operational state data for neighbor sets.";
+
+          uses neighbor-set-config;
+          uses neighbor-set-state;
+        }
+      }
+    }
+  }
+
+  grouping tag-set-config {
+    description
+      "Configuration data for tag set definitions.";
+
+    leaf name {
+      type string;
+      description
+        "name / label of the tag set -- this is used to reference
+        the set in match conditions";
+    }
+
+    leaf-list tag-value {
+      type oc-pol-types:tag-type;
+      description
+        "Value of the tag set member";
+    }
+  }
+
+  grouping tag-set-state {
+    description
+      "Operational state data for tag set definitions.";
+  }
+
+  grouping tag-set-top {
+    description
+      "Top-level data definitions for a list of tags which can
+      be matched in policies";
+
+    container tag-sets {
+      description
+        "Enclosing container for the list of tag sets.";
+
+      list tag-set {
+        key "name";
+        description
+          "List of tag set definitions.";
+
+        leaf name {
+          type leafref {
+            path "../config/name";
+          }
+          description
+            "Reference to the tag set name list key";
+        }
+
+        container config {
+          description
+            "Configuration data for tag sets";
+
+          uses tag-set-config;
+        }
+
+        container state {
+
+          config false;
+
+          description
+            "Operational state data for tag sets";
+
+          uses tag-set-config;
+          uses tag-set-state;
+        }
+      }
+    }
+  }
+
+  grouping generic-defined-sets {
+    description
+      "Data definitions for pre-defined sets of attributes used in
+      policy match conditions.  These sets are generic and can
+      be used in matching conditions in different routing
+      protocols.";
+
+    uses prefix-set-top;
+    uses neighbor-set-top;
+    uses tag-set-top;
+  }
+
+  grouping match-set-options-group {
+    description
+      "Grouping containing options relating to how a particular set
+      should be matched";
+
+    leaf match-set-options {
+      type oc-pol-types:match-set-options-type;
+      description
+        "Optional parameter that governs the behaviour of the
+        match operation";
+    }
+  }
+
+  grouping match-set-options-restricted-group {
+    description
+      "Grouping for a restricted set of match operation modifiers";
+
+    leaf match-set-options {
+      type oc-pol-types:match-set-options-restricted-type;
+      description
+        "Optional parameter that governs the behaviour of the
+        match operation.  This leaf only supports matching on ANY
+        member of the set or inverting the match.  Matching on ALL is
+        not supported";
+    }
+  }
+
+  grouping match-interface-condition-config {
+    description
+      "Configuration data for interface match condition";
+
+    uses oc-if:interface-ref-common;
+  }
+
+  grouping match-interface-condition-state {
+    description
+      "Operational state data for interface match condition";
+  }
+
+  grouping match-interface-condition-top {
+    description
+      "Top-level grouping for the interface match condition";
+
+    container match-interface {
+      description
+        "Top-level container for interface match conditions";
+
+      container config {
+        description
+          "Configuration data for interface match conditions";
+
+        uses match-interface-condition-config;
+      }
+
+      container state {
+
+        config false;
+
+        description
+          "Operational state data for interface match conditions";
+
+        uses match-interface-condition-config;
+        uses match-interface-condition-state;
+      }
+
+    }
+  }
+
+  grouping prefix-set-condition-config {
+    description
+      "Configuration data for prefix-set conditions";
+
+    leaf prefix-set {
+        type leafref {
+          path "../../../../../../../../defined-sets/" +
+            "prefix-sets/prefix-set/config/name";
+        }
+        description "References a defined prefix set";
+      }
+      uses match-set-options-restricted-group;
+  }
+
+
+  grouping prefix-set-condition-state {
+    description
+      "Operational state data for prefix-set conditions";
+  }
+
+  grouping prefix-set-condition-top {
+    description
+      "Top-level grouping for prefix-set conditions";
+
+    container match-prefix-set {
+      description
+        "Match a referenced prefix-set according to the logic
+        defined in the match-set-options leaf";
+
+      container config {
+        description
+          "Configuration data for a prefix-set condition";
+
+        uses prefix-set-condition-config;
+      }
+
+      container state {
+
+        config false;
+
+        description
+          "Operational state data for a prefix-set condition";
+
+        uses prefix-set-condition-config;
+        uses prefix-set-condition-state;
+      }
+    }
+  }
+
+  grouping neighbor-set-condition-config {
+    description
+      "Configuration data for neighbor-set conditions";
+
+    leaf neighbor-set {
+      type leafref {
+        path "../../../../../../../../defined-sets/neighbor-sets/" +
+        "neighbor-set/name";
+        //TODO: require-instance should be added when it's
+        //supported in YANG 1.1
+        //require-instance true;
+      }
+      description "References a defined neighbor set";
+    }
+
+    uses match-set-options-restricted-group;
+  }
+
+  grouping neighbor-set-condition-state {
+    description
+      "Operational state data for neighbor-set conditions";
+  }
+
+  grouping neighbor-set-condition-top {
+    description
+      "Top-level grouping for neighbor-set conditions";
+
+    container match-neighbor-set {
+      description
+        "Match a referenced neighbor set according to the logic
+        defined in the match-set-options-leaf";
+
+      container config {
+        description
+          "Configuration data ";
+
+        uses neighbor-set-condition-config;
+      }
+
+      container state {
+
+        config false;
+
+        description
+          "Operational state data ";
+
+        uses neighbor-set-condition-config;
+        uses neighbor-set-condition-state;
+      }
+    }
+  }
+
+  grouping tag-set-condition-config {
+    description
+      "Configuration data for tag-set condition statements";
+
+    leaf tag-set {
+      type leafref {
+        path "../../../../../../../../defined-sets/tag-sets/tag-set" +
+        "/name";
+        //TODO: require-instance should be added when it's
+        //supported in YANG 1.1
+        //require-instance true;
+      }
+      description "References a defined tag set";
+    }
+    uses match-set-options-restricted-group;
+  }
+
+  grouping tag-set-condition-state {
+    description
+      "Operational state data for tag-set condition statements";
+  }
+
+  grouping tag-set-condition-top {
+    description
+      "Top-level grouping for tag-set conditions";
+
+    container match-tag-set {
+      description
+        "Match a referenced tag set according to the logic defined
+        in the match-options-set leaf";
+
+      container config {
+        description
+          "Configuration data for tag-set conditions";
+
+        uses tag-set-condition-config;
+      }
+
+      container state {
+
+        config false;
+
+        description
+          "Operational state data tag-set conditions";
+
+        uses tag-set-condition-config;
+        uses tag-set-condition-state;
+      }
+    }
+  }
+
+  grouping generic-conditions {
+    description "Condition statement definitions for checking
+    membership in a generic defined set";
+
+    uses match-interface-condition-top;
+    uses prefix-set-condition-top;
+    uses neighbor-set-condition-top;
+    uses tag-set-condition-top;
+
+  }
+
+  grouping generic-actions {
+    description
+      "Definitions for common set of policy action statements that
+      manage the disposition or control flow of the policy";
+
+    leaf policy-result {
+      type policy-result-type;
+      description
+        "Select the final disposition for the route, either
+        accept or reject.";
+    }
+  }
+
+
+  grouping policy-conditions-config {
+    description
+      "Configuration data for general policy conditions, i.e., those
+      not related to match-sets";
+
+      leaf call-policy {
+        type leafref {
+          path "../../../../../../../" +
+            "oc-rpol:policy-definitions/" +
+            "oc-rpol:policy-definition/oc-rpol:name";
+          //TODO: require-instance should be added when
+          //it is supported in YANG 1.1
+          //require-instance true;
+        }
+        description
+          "Applies the statements from the specified policy
+          definition and then returns control the current
+          policy statement. Note that the called policy may
+          itself call other policies (subject to
+          implementation limitations). This is intended to
+          provide a policy 'subroutine' capability.  The
+          called policy should contain an explicit or a
+          default route disposition that returns an
+          effective true (accept-route) or false
+          (reject-route), otherwise the behavior may be
+          ambiguous and implementation dependent";
+      }
+
+      leaf install-protocol-eq {
+        type identityref {
+          base oc-pol-types:INSTALL_PROTOCOL_TYPE;
+        }
+        description
+          "Condition to check the protocol / method used to install
+          the route into the local routing table";
+      }
+  }
+
+  grouping policy-conditions-state {
+    description
+      "Operational state data for policy conditions";
+  }
+
+  grouping policy-conditions-top {
+    description
+      "Top-level grouping for policy conditions";
+
+    container conditions {
+      description
+        "Condition statements for the current policy statement";
+
+      container config {
+        description
+          "Configuration data for policy conditions";
+
+        uses policy-conditions-config;
+      }
+
+      container state {
+
+        config false;
+
+        description
+          "Operational state data for policy conditions";
+
+        uses policy-conditions-config;
+        uses policy-conditions-state;
+      }
+      uses generic-conditions;
+    }
+  }
+
+  grouping policy-statements-config {
+    description
+      "Configuration data for policy statements";
+
+    leaf name {
+      type string;
+      description
+        "name of the policy statement";
+    }
+  }
+
+  grouping policy-statements-state {
+    description
+      "Operational state data for policy statements";
+  }
+
+  grouping policy-actions-config {
+    description
+      "Configuration data for policy actions";
+
+    uses generic-actions;
+  }
+
+  grouping policy-actions-state {
+    description
+      "Operational state data for policy actions";
+  }
+
+  grouping policy-actions-tag-set {
+    description
+      "Protocol agnostic tag specification.";
+
+    container set-tag {
+      description
+        "Policy actions associated with setting tags for a particular
+        route. A tag is an abstract entity which can be mapped to underlying
+        protocol attributes where applicable.";
+
+      container config {
+        description
+          "Configuration of tag application";
+        uses action-tag-set-config;
+      }
+
+      container state {
+        description
+          "Operational state related to tag application.";
+        config false;
+        uses action-tag-set-config;
+      }
+
+      container inline {
+        description
+          "The tags specified in this container are set on a route using
+          the values directly. It is applicable when the mode of application
+          is explicitly specified as INLINE.";
+
+        when "../config/mode = 'INLINE'" {
+          description
+            "In-line configuration is only relevant when the action's set-tag
+            mode is specified explicitly to be INLINE.";
+        }
+
+        container config {
+          description
+            "Configuration values related to in-line tag specification.";
+          uses action-tag-set-inline-config;
+        }
+
+        container state {
+          description
+            "Operational state related to in-line tag specification.";
+          config false;
+          uses action-tag-set-inline-config;
+        }
+      }
+
+      container reference {
+        description
+          "This container is applicable when the mode of application is explicitly
+          specified to as REFERENCE. The tags set on a route are those that are
+          specified within the tag-set";
+
+        when "../config/mode = 'REFERENCE'" {
+          description
+            "Reference configuration is only relevant when the action's set-tag
+            mode is specified explicitly to be REFERENCE.";
+        }
+
+        container config {
+          description
+            "Configuration values related to specifying a tag-set to be applied to
+            a route.";
+          uses action-tag-set-reference-config;
+        }
+
+        container state {
+          description
+            "Operational state related to specifying a tag-set to be applied to a
+            route.";
+          config false;
+          uses action-tag-set-reference-config;
+        }
+      }
+    }
+  }
+
+  grouping action-tag-set-config {
+    description
+      "Configuration leaves for setting a tag applicable to both inline and
+      reference modes.";
+
+    leaf mode {
+      type enumeration {
+        enum INLINE {
+          description
+            "Use an in-line specified list of tags";
+        }
+        enum REFERENCE {
+          description
+            "Use a reference to a defined tag-set.";
+        }
+      }
+      description
+        "This leaf controls the source of the tags that are set as a result
+        of the action. In the case that the INLINE value is specified, the
+        list of tags specified within the action is applied to matching prefixes.
+        In the case that the REFERENCE value is specified, a pre-defined set of
+        tags is utilised.";
+    }
+  }
+
+  grouping action-tag-set-inline-config {
+    description
+      "Configuration leaves for setting a tag within an action using an in-line
+      specified set of tags.";
+
+    leaf-list tag {
+      type oc-pol-types:tag-type;
+      description
+        "Set one or more tags for prefixes that match the specified condition(s)
+        using the specified tag values. When a tag is set it MUST be possible to
+        match the value set in subsequent policies on the local device. Where the
+        protocol that is carrying the prefix has a tag field (OSPF, and IS-IS in
+        particular) the tag MUST be set in the corresponding protocol advertisements
+        of the prefix.";
+    }
+  }
+
+  grouping action-tag-set-reference-config {
+    description
+      "Configuration leaves for setting a tag within an action using a set of
+      tags that is specified in a defined-set.";
+
+    leaf tag-set {
+      type leafref {
+        // we are at
+        // /routing-policy/policy-definitions/policy-definition/statements/statements/statement/action/set-tag/reference/config/tag-set
+        path "../../../../../../../../../defined-sets/tag-sets/tag-set/config/name";
+      }
+      description
+        "Use the referenced tag-set to set tags on the prefixes that match the
+        specified conditions. When a tag is set it MUST be possible to match the
+        value set in subsequent policies on the local device. where the protocol that
+        is carrying the prefix has a tag field (OSPF, and IS-IS for in particular)
+        the tag MUST be set in the corresponding protocol advertisements of the
+        prefix.";
+    }
+  }
+
+  grouping policy-actions-top {
+    description
+      "Top-level grouping for policy actions";
+
+    container actions {
+      description
+        "Top-level container for policy action statements";
+
+      container config {
+        description
+          "Configuration data for policy actions";
+
+        uses policy-actions-config;
+      }
+
+      container state {
+
+        config false;
+
+        description
+          "Operational state data for policy actions";
+
+        uses policy-actions-config;
+        uses policy-actions-state;
+      }
+
+      uses policy-actions-tag-set;
+    }
+  }
+
+  grouping policy-statements-top {
+    description
+      "Top-level grouping for the policy statements list";
+
+    container statements {
+      description
+        "Enclosing container for policy statements";
+
+      list statement {
+        key "name";
+        // TODO: names of policy statements within a policy
+        // definition should probably be optional, however, YANG
+        // requires a unique id for lists
+        ordered-by user;
+        description
+          "Policy statements group conditions and actions
+          within a policy definition.  They are evaluated in
+          the order specified (see the description of policy
+          evaluation at the top of this module.";
+
+        leaf name {
+          type leafref {
+            path "../config/name";
+          }
+          description
+            "Reference to list key";
+        }
+
+        container config {
+          description
+            "Configuration data for policy statements";
+
+          uses policy-statements-config;
+        }
+
+        container state {
+
+          config false;
+
+          description
+            "Operational state data for policy statements";
+
+          uses policy-statements-config;
+          uses policy-statements-state;
+        }
+
+        uses policy-conditions-top;
+        uses policy-actions-top;
+      }
+    }
+  }
+
+  grouping defined-sets-top {
+    description
+      "Top-level grouping for defined set definitions";
+
+    container defined-sets {
+      description
+        "Predefined sets of attributes used in policy match
+        statements";
+
+      uses generic-defined-sets;
+    }
+  }
+
+  grouping policy-definitions-config {
+    description
+      "Configuration data for policy definitions";
+
+    leaf name {
+      type string;
+      description
+        "Name of the top-level policy definition -- this name
+        is used in references to the current policy";
+    }
+  }
+
+  grouping policy-definitions-state {
+    description
+      "Operational state data for policy definitions";
+  }
+
+  grouping policy-definitions-top {
+    description
+      "Top-level grouping for the policy definition list";
+
+    container policy-definitions {
+      description
+        "Enclosing container for the list of top-level policy
+          definitions";
+
+      list policy-definition {
+        key "name";
+        description
+          "List of top-level policy definitions, keyed by unique
+          name.  These policy definitions are expected to be
+          referenced (by name) in policy chains specified in import
+          or export configuration statements.";
+
+        leaf name {
+          type leafref {
+            path "../config/name";
+          }
+          description
+            "Reference to the list key";
+        }
+
+        container config {
+          description
+            "Configuration data for policy defintions";
+
+          uses policy-definitions-config;
+        }
+
+        container state {
+
+          config false;
+
+          description
+            "Operational state data for policy definitions";
+
+          uses policy-definitions-config;
+          uses policy-definitions-state;
+        }
+
+        uses policy-statements-top;
+      }
+    }
+  }
+
+  grouping routing-policy-top {
+    description
+      "Top level container for OpenConfig routing policy";
+
+    container routing-policy {
+      description
+        "Top-level container for all routing policy configuration";
+
+
+      uses defined-sets-top;
+
+      uses policy-definitions-top;
+    }
+  }
+
+  grouping apply-policy-import-config {
+    description
+      "Configuration data for applying import policies";
+
+    leaf-list import-policy {
+      type leafref {
+        path "/oc-rpol:routing-policy/oc-rpol:policy-definitions/" +
+          "oc-rpol:policy-definition/oc-rpol:name";
+        //TODO: require-instance should be added when it's
+        //supported in YANG 1.1
+        //require-instance true;
+      }
+      ordered-by user;
+      description
+        "list of policy names in sequence to be applied on
+        receiving a routing update in the current context, e.g.,
+        for the current peer group, neighbor, address family,
+        etc.";
+    }
+  }
+
+  grouping default-policy-import-config {
+    description
+      "Configuration data for default import policy";
+
+    leaf default-import-policy {
+      type default-policy-type;
+      default REJECT_ROUTE;
+      description
+        "explicitly set a default policy if no policy definition
+        in the import policy chain is satisfied.";
+    }
+  }
+
+  grouping apply-policy-export-config {
+    description
+      "Configuration data for applying export policies";
+
+    leaf-list export-policy {
+      type leafref {
+        path "/oc-rpol:routing-policy/oc-rpol:policy-definitions/" +
+          "oc-rpol:policy-definition/oc-rpol:name";
+        //TODO: require-instance should be added when it's
+        //supported in YANG 1.1
+        //require-instance true;
+      }
+      ordered-by user;
+      description
+        "list of policy names in sequence to be applied on
+        sending a routing update in the current context, e.g.,
+        for the current peer group, neighbor, address family,
+        etc.";
+    }
+  }
+
+  grouping default-policy-export-config {
+    description
+      "Configuration data for default export policy";
+
+    leaf default-export-policy {
+      type default-policy-type;
+      default REJECT_ROUTE;
+      description
+        "explicitly set a default policy if no policy definition
+        in the export policy chain is satisfied.";
+    }
+  }
+
+  grouping apply-policy-config {
+    description
+      "Configuration data for routing policies";
+
+    uses apply-policy-import-config;
+    uses apply-policy-export-config;
+    uses default-policy-config;
+  }
+
+  grouping default-policy-config {
+    description
+      "Configuration data for default routing policies";
+
+    uses default-policy-import-config;
+    uses default-policy-export-config;
+  }
+
+  grouping apply-policy-state {
+    description
+      "Operational state associated with routing policy";
+
+    uses default-policy-state;
+
+    //TODO: identify additional state data beyond the intended
+    //policy configuration.
+  }
+
+  grouping default-policy-state {
+    description
+      "Operational state associated with routing policy";
+
+    //TODO: identify additional state data beyond the intended
+    //policy configuration.
+  }
+
+  grouping apply-policy-group {
+    description
+      "Top level container for routing policy applications. This
+      grouping is intended to be used in routing models where
+      needed.";
+
+    container apply-policy {
+      description
+        "Anchor point for routing policies in the model.
+        Import and export policies are with respect to the local
+        routing table, i.e., export (send) and import (receive),
+        depending on the context.";
+
+      container config {
+        description
+          "Policy configuration data.";
+
+        uses apply-policy-config;
+      }
+
+      container state {
+
+        config false;
+        description
+          "Operational state for routing policy";
+
+        uses apply-policy-config;
+        uses apply-policy-state;
+      }
+    }
+  }
+
+  grouping default-policy-group {
+     description
+      "Top level container for default routing policy applications.";
+
+    container apply-policy {
+      description
+        "Anchor point for routing policies in the model.
+        Import and export policies are with respect to the local
+        routing table, i.e., export (send) and import (receive),
+        depending on the context.";
+
+      container config {
+        description
+          "Policy configuration data.";
+
+        uses default-policy-config;
+      }
+
+      container state {
+        config false;
+        description
+          "Operational state for routing policy";
+
+        uses default-policy-config;
+        uses default-policy-state;
+      }
+    }
+  }
+
+  uses routing-policy-top;
+
+}

--- a/models/yang/common/openconfig-rsvp-sr-ext.yang
+++ b/models/yang/common/openconfig-rsvp-sr-ext.yang
@@ -1,0 +1,418 @@
+module openconfig-rsvp-sr-ext {
+  yang-version "1";
+
+  namespace "http://openconfig.net/yang/rsvp-sr-ext";
+  prefix "oc-sr-rsvp-ext";
+
+  import openconfig-extensions { prefix "oc-ext"; }
+  import openconfig-types { prefix "oc-types"; }
+  import openconfig-network-instance { prefix "oc-ni"; }
+
+  organization
+    "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This module adds extensions to the OpenConfig MPLS models to
+    provide extensions which allow the coexistence of RSVP-TE and
+    Segment Routing (SR) within the same network. It augments the
+    existing OpenConfig segment routing (SR) and RSVP-TE models
+    where required.";
+
+  oc-ext:openconfig-version "0.3.0";
+
+  revision "2019-07-09" {
+    description
+      "Clarify the base for measurements using timeticks64.";
+    reference "0.3.0";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "0.2.1";
+  }
+
+  revision 2018-04-13 {
+    description
+      "Replace boolean with modes for measure-sr-traffic.";
+    reference "0.2.0";
+  }
+
+  revision 2017-03-06 {
+    description
+      "Initial revision.";
+    reference "0.1.0";
+  }
+
+  // OpenConfig specific extensions for module metadata.
+  oc-ext:regexp-posix;
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  grouping bandwidth-measurement-global-state {
+    description
+      "Operational state parameters for bandwidth measurement which
+      apply globally to the device.";
+
+    leaf effective-adjustment-interval {
+      type uint32;
+      units "seconds";
+      description
+        "The effective adjustment interval that is being used by
+        the system. In the case that the adjustment-interval leaf
+        is set to a non-integer multiple of the collection-interval,
+        and the system does not support this, the value of this leaf
+        should reflect the effective value of the adjustment interval
+        that it has selected. In the case where no rounding of the
+        adjustment interval has occurred, this value should have the
+        same value as the adjustment-inerval leaf.";
+    }
+  }
+
+  grouping bandwidth-measurement-global-config {
+    description
+      "Configuration parameters for bandwidth measurement which apply
+      globally to the device.";
+
+    leaf measure-sr-traffic {
+      type enumeration {
+         enum MEASURE_ONLY {
+           description
+             "Only measure the SR traffic being sent via an interface,
+             and do not flood it into the IGP.";
+         }
+         enum MEASURE_AND_FLOOD {
+            description
+              "Measure the SR traffic being sent via an interface and
+              flood it into the IGP.";
+         }
+      }
+      description
+        "Parameter enabling SR traffic measurement
+        and optional flooding into IGP.";
+      reference
+        "draft-sitaraman-sr-rsvp-coexistence-rec-01";
+    }
+
+    // TODO(robjs): For future extension, traffic accounting for
+    // non-SR, non-RSVP traffic could be added here. e.g., LDP,
+    // BGP-LU etc.
+
+    leaf collection-interval {
+      type uint32;
+      units "seconds";
+      description
+        "The interval at which the collection of interface
+        statistics relating to non-RSVP-TE traffic should be
+        performed";
+      reference
+        "draft-sitaraman-sr-rsvp-coexistence-rec-01";
+    }
+
+    leaf adjustment-interval {
+      type uint32;
+      units "seconds";
+      description
+        "The interval after which an adjustment to the utilised
+        bandwidth on the interface is made. This value must be
+        greater than, or equal to, the collection interval for
+        statistics.  This value is referred to as N in
+        draft-sitaraman-sr-rsvp-coexistence-rec-01.
+
+        After N seconds have expired, the
+        arithmetic mean of the samples is taken, and this is
+        considered as the non-RSVP-TE utilisation of the
+        interface. In the case that the adjustment interval is
+        an integer >1 multiple of the collection interval, this
+        serves to provide smoothing of the collected bandwidth
+        statistics.";
+      reference
+        "draft-sitaraman-sr-rsvp-coexistence-rec-01";
+    }
+
+    leaf bandwidth-multiplier {
+      type decimal64 {
+        fraction-digits 4;
+      }
+      default 1.0000;
+      description
+        "A multiplier applied to the sampled bandwidth which
+        determines the value that is propagated to the IGP TED.
+        By default this value is 1.0000, and hence the actual
+        sampled value is flooded.";
+    }
+  }
+
+  grouping bandwidth-measurement-update-config {
+    description
+      "Configuration parameters related to when the bandwidth
+      measurement information is used to update the IGP TED.";
+
+    leaf update-trigger {
+      type enumeration {
+        enum ADJUSTED_MAX_RESERVABLE_PCT {
+          description
+            "Update of a new maximum reservable bandwidth IGP
+            TLV is based on the value changing >= X% of
+            the currently flooded adjusted-absolute-subscription-bw.
+            The percentage of this value that is used is specified
+            by the adjusted-max-reservable-bw-pct leaf.";
+        }
+        enum SR_TRAFFIC_PCT {
+          description
+            "Update of the new maximum reservable bandwidth IGP
+            TLV is based on the value changing >= X% of the last
+            calculated segment routing traffic utilisation for the
+            interface. The percentage delta of this value is
+            specified by the sr-traffic-pct leaf.";
+        }
+      }
+      description
+        "The trigger that should be used to determine when the IGP
+        TED is updated with new information as to the effective
+        maximum reservable bandwidth
+        (adjusted-absolute-subscription-bw)";
+    }
+
+    leaf adjusted-max-reservable-bw-pct {
+      when "../update-trigger = 'ADJUSTED_MAX_RESERVABLE_PCT'" {
+        description
+          "Only allow the adjusted-max-reservable-bw update trigger
+          to be specified when the update-trigger mode is specified
+          to be a percentage of the currently flooded value.";
+      }
+      type oc-types:percentage;
+      description
+        "The delta in the adjusted-max-reservable-bandwidth that
+        should trigger an update in the value which is flooded
+        through the IGP TED.
+        The delta is measured as a percentage of the
+        current adjusted value of the maximum reservable bandwidth
+        of the interface, as specified by the
+        adjusted-absolute-subscription-bw RSVP-TE leaf.";
+      reference
+        "draft-sitaraman-sr-rsvp-coexistence-rec-01";
+    }
+
+    leaf sr-traffic-pct {
+      when "../update-trigger = 'SR_TRAFFIC_PCT'" {
+        description
+          "Only allow the SR traffic percentage trigger to be
+          specified when the update trigger is defined to be a
+          percentage of the last calculated SR traffic value.";
+      }
+      type oc-types:percentage;
+      description
+        "The change in the calculated SR traffic on the interface
+        that should trigger an update in the value of the
+        maximum reservable bandwidth flooded through the IGP TED.
+        The value is specified as a percentage of the
+        last-calculated-sr-traffic state leaf.";
+    }
+  }
+
+  grouping bandwidth-measurement-global-structural {
+    description
+      "Structural grouping for the measurement of segment routing
+      traffic, and its advertisement into the IGP TED.";
+
+    container bandwidth-measurement {
+      description
+        "Configuration and operational state parameters related to
+        how bandwidth utilisation is measured and flooded into the
+        IGP.";
+
+      container config {
+        description
+          "Configuration parameters relating to bandwidth
+          measurement.";
+
+        uses bandwidth-measurement-global-config;
+      }
+
+      container state {
+        config false;
+        description
+          "Operational state parameters relating to bandwidth
+          measurement";
+
+        uses bandwidth-measurement-global-config;
+        uses bandwidth-measurement-global-state;
+      }
+
+      container update-trigger {
+        description
+          "Configuration and operational state parameters related
+          to the update trigger for flooding new bandwidth
+          information into the IGP.";
+
+        container config {
+          description
+            "Configuration parameters related to the bandwidth
+            measurement update trigger.";
+
+          uses bandwidth-measurement-update-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state parameters related to the bandwidth
+            measurement update trigger.";
+
+          uses bandwidth-measurement-update-config;
+        }
+      }
+    }
+  }
+
+  augment "/oc-ni:network-instances/oc-ni:network-instance/" +
+          "oc-ni:mpls/oc-ni:te-global-attributes" {
+    description
+      "Add the bandwidth measurement parameters to MPLS global
+      traffic engineering hierarchy.";
+
+    uses bandwidth-measurement-global-structural;
+  }
+
+  grouping bandwidth-measurement-rsvp-te-adjusted-state {
+    description
+      "Logical grouping augmented into the RSVP-TE hierarchy to
+      provide an operational state value which reflects the
+      adjusted RSVP-TE available bandwidth.";
+
+    leaf adjusted-absolute-subscription-bw {
+      type uint64;
+      units "kbps";
+      description
+        "The adjusted absolute value (in kbps) of the
+        bandwidth which is reservable to RSVP-TE on the
+        local system. In the case that the bandwidth-measurement
+        configuration does not account for non-RSVP-TE traffic
+        then this value is equal to the
+        calculated-absolute-subscription-bw, in the case that
+        non-RSVP-TE traffic is being accounted for, it is lower
+        such that calculated-absolute-subscription-bw -
+        adjusted-absolute-subscription-bw = the current calculated
+        non-RSVP-TE traffic.
+
+        This value reflects the last flooded value of the maximum
+        reservable bandwidth, or subscription.";
+    }
+  }
+
+  augment "/oc-ni:network-instances/oc-ni:network-instance/" +
+    "oc-ni:mpls/oc-ni:signaling-protocols/oc-ni:rsvp-te/" +
+    "oc-ni:interface-attributes/oc-ni:interface/" +
+    "oc-ni:subscription/oc-ni:state" {
+
+    description
+      "Augmentation to add the adjusted RSVP-TE available bandwidth
+      state to the RSVP-TE signaling protocol.";
+
+    uses bandwidth-measurement-rsvp-te-adjusted-state;
+  }
+
+  grouping bandwidth-measurement-intf-structural {
+    description
+      "Structural grouping containing interface bandwidth
+      measurement configuration and operational state
+      parameters.";
+
+    container bandwidth-measurement {
+      description
+        "Configuration and operational state parameters relating to
+        per-interface bandwidth measurement. These parameters are
+        used in the case that RSVP-TE coexists with other MPLS
+        signaling protocols on an interface.";
+
+      container state {
+        config false;
+        description
+          "Operational state parameters relating to the containing
+          interface's bandwidth measurement.";
+
+        uses bandwidth-measurement-intf-state;
+      }
+    }
+  }
+
+  grouping bandwidth-measurement-intf-state {
+    description
+      "Operational state parameters per-interface for the measured
+      bandwidth on an interface";
+
+    leaf last-sample-time {
+      type oc-types:timeticks64;
+      description
+        "The time at which the last sample of bandwidth utilisation
+        for both RSVP-TE and non-RSVP-TE traffic was taken. This value
+        is relative to the Unix Epoch (Jan 1, 1970 00:00:00 UTC).";
+    }
+
+    leaf last-sample-measured-rsvp-util {
+      type uint64;
+      units "kbps";
+      description
+        "The measured RSVP-TE bandwidth utilisation at the last sample
+        (whose time is indicated in last-sample-time). This value is
+        expressed as a 64-bit unsigned integer representing the number
+        of kilobits per second that RSVP-TE traffic is consuming on
+        the interface.";
+    }
+
+    leaf last-sample-measured-sr-util {
+      type uint64;
+      units "kbps";
+      description
+        "The measured Segment Routing bandwidth utilisation at the
+        last sample (whose time is indicated in last-sample-time).
+        This value is expressed as a 64-bit unsigned integer
+        representing the number of kilobits per second that Segment
+        Routing traffic is consuming on the interface.";
+    }
+
+    leaf last-calculated-time {
+      type oc-types:timeticks64;
+      description
+        "The time at which the last calculated value for bandwidth
+        utilisation was performed. The value is expressed relative
+        to the Unix Epoch (Jan 1, 1970 00:00:00 UTC).";
+    }
+
+    leaf last-calculated-sr-utilisation {
+      type uint64;
+      description
+        "The last calculated value of the Segment Routing  utilisation
+        (taken post any averaging or adjustment that occurs). This
+        value is updated regardless of whether the value was flooded
+        or not.";
+    }
+
+    leaf last-flooded-time {
+      type oc-types:timeticks64;
+      description
+        "The time, relative to the Unix Epoch (Jan 1 1970 00:00:00 UTC),
+        at which the bandwidth utilisation of non-RSVP-TE traffic resulted
+        in the value being flooded in the IGP. If the configuration of the
+        local system specifies a 0% change requires flooding, this leaf
+        will always reflect the value of the last-calculated-time. In
+        systems that have suppression due to a >0% delta being required
+        then it indicates the last time that the percentage threshold
+        was exceeded.";
+    }
+  }
+
+  augment "/oc-ni:network-instances/oc-ni:network-instance/oc-ni:mpls" +
+          "/oc-ni:te-interface-attributes/oc-ni:interface" {
+    description
+      "Augment the per-interface bandwidth measurement parameters into the
+      MPLS hierarchy of network instance.";
+
+    uses bandwidth-measurement-intf-structural;
+  }
+}

--- a/models/yang/common/openconfig-segment-routing-types.yang
+++ b/models/yang/common/openconfig-segment-routing-types.yang
@@ -1,0 +1,158 @@
+module openconfig-segment-routing-types {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/segment-routing-types";
+
+  prefix "oc-srt";
+
+  // import some basic types
+  import openconfig-extensions { prefix "oc-ext"; }
+  import openconfig-mpls-types { prefix "oc-mplst"; }
+  import openconfig-inet-types { prefix "oc-inet"; }
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "Types associated with a network instance";
+
+  oc-ext:openconfig-version "0.2.0";
+
+  revision "2020-02-04" {
+    description
+      "Consistent prefix for openconfig-mpls-types.";
+    reference "0.2.0";
+  }
+
+  revision "2019-09-24" {
+    description
+      "Initial revision of the SR types.";
+    reference "0.1.0";
+  }
+
+  typedef sr-dataplane-type {
+    type enumeration {
+      enum MPLS {
+        description
+          "The entity uses MPLS labels as Segment Identifiers.";
+      }
+      enum IPV6 {
+        description
+          "The entity uses IPv6 prefixes as Segment Identifiers.";
+      }
+    }
+    description
+      "Types of data plane that can be used to instantiate a Segment
+      Routing block of SIDs.";
+  }
+
+  typedef sr-sid-type {
+    type union {
+      type oc-mplst:mpls-label;
+      type oc-inet:ipv6-address;
+    }
+    description
+      "The defined value of a segment identifier.";
+  }
+
+  typedef srte-protocol-type {
+    type enumeration {
+      enum PCEP {
+        value 10;
+        description
+          "Path Computation Element Protocol.";
+      }
+      enum BGP {
+        value 20;
+        description
+          "BGP SR policy.";
+      }
+      enum CONFIG {
+        value 30;
+        description
+          "Local configuration.";
+      }
+    }
+    description
+      "The component or protocol that originates or signals the
+      candidate path.";
+    reference
+      "Section 2.3 of draft-ietf-spring-segment-routing-policy.";
+  }
+
+  typedef srte-endpoint-type {
+    type oc-inet:ip-address;
+    description
+      "SR-TE endpoint is the policy destination which can be either an
+      IPv4 or IPv6 address.";
+    reference
+      "draft-ietf-spring-segment-routing-policy";
+  }
+
+  typedef srte-invalid-sl-reason {
+    type enumeration {
+      enum EMPTY_SL {
+        description
+          "Segment-list is empty.";
+      }
+      enum ZERO_WEIGHT {
+        description
+          "Segment-list weight is 0.";
+      }
+      enum FIRST_SID_UNRESOLVABLE {
+        description
+          "The headend is unable to perform path resolution for the
+          first SID into one or more outgoing interface(s) and
+          next-hop(s).";
+      }
+      enum OTHER_SID_UNRESOLVABLE {
+        description
+          "The headend is unable to perform SID resolution for any
+          non-first SID of type 3-through-11 into an MPLS label or
+          an SRv6 SID.";
+      }
+      enum VERIFICATION_FAIL {
+        description
+          "The headend verification fails for any SID for which
+          verification has been explicitly requested.";
+      }
+    }
+    description
+      "The list of segment-list invalid reasons.";
+    reference "draft-ietf-spring-segment-routing-policy";
+  }
+
+  typedef enlp-type {
+    type enumeration {
+      enum PUSH_IPV4_EXPLICIT_NULL {
+        description
+          "Push an IPv4 Explicit NULL label on an unlabeled IPv4
+          packet but not IPv6 one.";
+      }
+      enum PUSH_IPV6_EXPLICIT_NULL {
+        description
+          "Push an IPv6 Explicit NULL label on an unlabeled IPv4
+          packet but not IPv4 one.";
+      }
+      enum PUSH_IPV46_EXPLICIT_NULL {
+        description
+          "Push an IPv4 Explicit NULL label on both unlabeled IPv4
+          packet and IPv6 packet.";
+      }
+      enum NO_EXPLICIT_NULL {
+        description
+          "Do not push an Explicit NULL label.";
+      }
+    }
+    description
+      "The list of possible ENLP(Explicit NULL Label Policy) values.";
+    reference "draft-ietf-idr-segment-routing-te-policy";
+  }
+
+}

--- a/models/yang/common/openconfig-segment-routing.yang
+++ b/models/yang/common/openconfig-segment-routing.yang
@@ -1,0 +1,945 @@
+module openconfig-segment-routing {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/sr";
+  prefix "oc-sr";
+
+  // import some basic types
+  import openconfig-extensions { prefix "oc-ext"; }
+  import openconfig-mpls-types { prefix "oc-mplst"; }
+  import openconfig-interfaces { prefix "oc-if"; }
+  import ietf-inet-types { prefix "inet"; }
+  import ietf-yang-types { prefix "yang"; }
+  import openconfig-segment-routing-types { prefix "oc-srt"; }
+  import openconfig-srte-policy { prefix "oc-srte"; }
+  import openconfig-isis-types { prefix "oc-isis-types"; }
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    netopenconfig@googlegroups.com";
+
+  description
+    "Configuration and operational state parameters relating to the
+    segment routing. This module defines a number of elements which are
+    instantiated in multiple places throughout the OpenConfig collection
+    of models.
+
+    Particularly:
+      - SRGB+LB dataplane instances - directly instantied by SR.
+      - SRGB+LB dataplane reservations - instantiated within MPLS and future SR
+                                      dataplanes.
+      - SR SID advertisements - instantiated within the relevant IGP.
+      - SR-specific counters - instantied within the relevant dataplane.";
+
+  oc-ext:openconfig-version "0.4.1";
+
+  revision "2023-08-09" {
+    description
+      "Update interface key to use interface-id type";
+    reference "0.4.1";
+  }
+
+  revision "2023-05-24" {
+    description
+      "Add flex-algo model";
+    reference "0.4.0";
+  }
+
+  revision "2023-02-06" {
+    description
+      "Clarify use of interface-ref.";
+    reference "0.3.2";
+  }
+
+  revision "2021-07-28" {
+    description
+      "Add qualify to when statements.";
+    reference "0.3.1";
+  }
+
+  revision "2020-03-31" {
+    description
+      "Move segment-list to the te-policies container.";
+    reference "0.3.0";
+  }
+
+  revision "2020-02-04" {
+    description
+      "Consistent prefix for openconfig-mpls-types.";
+    reference "0.2.0";
+  }
+
+  revision "2019-09-24" {
+    description
+      "Move SR types to a separate module and add a SR-TE policy module.";
+    reference "0.1.0";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "0.0.4";
+  }
+
+  revision "2017-01-12" {
+    description
+      "Minor compliance fixes.";
+    reference "0.0.3";
+  }
+
+  revision "2016-12-15" {
+    description
+      "Updated revision of SR module.";
+    reference "0.0.2";
+  }
+
+  revision "2016-07-28" {
+    description
+      "Initial revision of SR module.";
+    reference "0.0.1";
+  }
+
+  // OpenConfig specific extensions for module metadata.
+  oc-ext:regexp-posix;
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  grouping srgb-config {
+    description
+      "Configuration parameters relating to the SRGB.";
+
+    leaf local-id {
+      type string;
+      description
+        "Unique identifier for the segment routing global block on
+        the local system.";
+    }
+
+    leaf dataplane-type {
+      type oc-srt:sr-dataplane-type;
+      description
+        "The dataplane being used to instantiate the SRGB. When MPLS is specified
+        the set of MPLS label blocks that are defined in the mpls-label-blocks
+        list are used to make up the SRGB. When IPv6 is specified, the set of IPv6
+        prefixes specified in the ipv6-prefixes list are used.";
+    }
+
+    leaf-list mpls-label-blocks {
+      when "../dataplane-type = 'oc-srt:MPLS'" {
+        description
+          "Allow the MPLS label block to be specified only for SRGBs that are
+          using the MPLS dataplane.";
+      }
+      type leafref {
+        // We are at /network-instances/network-instance/segment-routing/
+        // srgbs/srgb/config/mpls-label-blocks
+        path "../../../../../mpls/global/reserved-label-blocks/" +
+             "reserved-label-block/config/local-id";
+      }
+      description
+        "A list of refences to the label blocks that are used to make
+        up the SRGB.";
+    }
+
+    leaf-list ipv6-prefixes {
+      when "../dataplane-type = 'oc-srt:IPV6'" {
+        description
+          "Allow IPv6 prefixes to be specified only when the dataplane
+          realisation of the SRGB is IPv6.";
+      }
+      type inet:ipv6-prefix;
+      description
+        "A list of IPv6 prefixes which are to be used for segment routing using
+        the IPv6 dataplane.";
+    }
+  }
+
+  grouping srgb-state {
+    description
+      "Operational state parameters relating to the SRGB.";
+
+    leaf size {
+      type uint32;
+      description
+        "The total number of SRGB entries that are available within the SRGB.";
+    }
+
+    leaf used {
+      type uint32;
+      description
+        "The total number of SRGB entries that have already been alocated by
+        protocols referencing the SRGB.";
+    }
+  }
+
+  grouping srlb-config {
+    description
+      "Configuration parameters relating to an SRLB.";
+
+    leaf local-id {
+      type string;
+      description
+        "A unique local identifier used for the Segment Routing Local Block.
+        The identifier is used when referencing the SRLB within other
+        contexts.";
+    }
+
+    leaf dataplane-type {
+      type oc-srt:sr-dataplane-type;
+      description
+        "The dataplane that is to be used for the Segment Routing Local Block.
+        When MPLS is specified, the local block corresponds to a block of MPLS
+        labels; when IPv6 is specified it corresponds to an IPv6 prefix.";
+    }
+
+    leaf mpls-label-block {
+      when "../dataplane-type = 'oc-srt:MPLS'" {
+        description
+          "Allow the MPLS label block to be specified only for SRLBs that are
+          using the MPLS dataplane.";
+      }
+      type leafref {
+        path "../../../../../mpls/global/reserved-label-blocks/" +
+             "reserved-label-block/config/local-id";
+      }
+      description
+        "A reference to the MPLS label block that is used to contain the
+        SIDs of the SRLB.";
+    }
+
+    leaf ipv6-prefix {
+      when "../dataplane-type = 'oc-srt:IPV6'" {
+        description
+          "Allow IPv6 prefixes to be specified only when the dataplane
+          realisation of the SRGB is IPv6.";
+      }
+      type inet:ipv6-prefix;
+      description
+        "The IPv6 prefix that is used for the SRLB.";
+    }
+  }
+
+  grouping sr-structural {
+    description
+      "Top-level structural grouping defining Segment Routing Global Blocks.";
+
+    container srgbs {
+      description
+        "Configuration and operational state parameters relating to the
+        SRGBs defined for the system.";
+
+      list srgb {
+        key "local-id";
+
+        description
+          "A single definition of an SRGB which may comprise of multiple
+          sets of dataplane addresses (IPv6 addresses, or MPLS labels).";
+
+        leaf local-id {
+          type leafref {
+            path "../config/local-id";
+          }
+          description
+            "A reference to the identifier for the SRGB.";
+        }
+
+        container config {
+          description
+            "Configuration parameters relating to the SRGB.";
+          uses srgb-config;
+        }
+
+        container state {
+          config false;
+          description
+            "State parameters relating to the SRGB.";
+          uses srgb-config;
+          uses srgb-state;
+        }
+      }
+    }
+
+    container srlbs {
+      description
+        "Configuration and operational state parameters relating to the
+        Segment Routing Local Blocks (SRLBs) defined for the system.";
+
+      list srlb {
+        key "local-id";
+
+        description
+          "A definition of a Segment Routing Local Block, defined to be
+          a set of Segment Identifiers (specified as MPLS labels or
+          IPv6 addreses) that are defined for local allocation by the
+          system. A block may optionally be advertised into an IGP.";
+
+        leaf local-id {
+          type leafref {
+            path "../config/local-id";
+          }
+          description
+            "Reference to the local identifier used for the SRLB.";
+        }
+
+        container config {
+          description
+            "Configuration parameters relating to the SRLB.";
+          uses srlb-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state parmeters relating to the SRLB.";
+          uses srlb-config;
+        }
+      }
+    }
+  }
+
+  grouping sr-mpls-top {
+    description
+      "Structural grouping defining SR definition within MPLS.";
+
+    container segment-routing {
+      description
+        "MPLS-specific Segment Routing configuration and operational state
+        parameters";
+
+      container aggregate-sid-counters {
+        description
+          "Per-SID counters aggregated across all interfaces on the local system";
+
+        list aggregate-sid-counter {
+          key "mpls-label";
+          config false;
+
+          description
+            "Counters aggregated across all of the interfaces of the local
+            system corresponding to traffic received or forwarded with a
+            particular SID";
+
+          leaf mpls-label {
+            type leafref {
+              path "../state/mpls-label";
+            }
+            description
+              "The MPLS label representing the segment identifier";
+          }
+
+          container state {
+            config false;
+            description
+              "State parameters for per-SID statistics";
+            uses sr-mpls-sid-counters-state;
+            uses sr-mpls-common-counters;
+          }
+        }
+      }
+
+      container interfaces {
+        description
+          "Interface related Segment Routing parameters.";
+
+        list interface {
+          key "interface-id";
+
+          description
+            "Parameters and MPLS-specific configuration relating to Segment
+            Routing on an interface.
+
+            The interface referenced is based on the interface and
+            subinterface leaves within the interface-ref container -
+            which reference an entry in the /interfaces/interface list -
+            and should not rely on the value of the list key.";
+
+          leaf interface-id {
+            type leafref {
+              path "../config/interface-id";
+            }
+            description
+              "A reference to the ID for the interface for which SR is
+              configured";
+          }
+
+          container config {
+            description
+              "MPLS-specific Segment Routing configuration parameters
+              related to an interface.";
+            uses sr-mpls-interface-config;
+          }
+
+          container state {
+            config false;
+            description
+              "MPLS-specific Segment Routing operational state parameters
+              related to an interface.";
+            uses sr-mpls-interface-config;
+            uses sr-mpls-interface-state;
+          }
+
+          container sid-counters {
+            description
+              "Per-SID statistics for MPLS";
+
+            list sid-counter {
+              key "mpls-label";
+              config false;
+
+              description
+                "Per segment identifier counters for the MPLS dataplane.";
+
+              leaf mpls-label {
+                type leafref {
+                  path "../state/mpls-label";
+                }
+                description
+                  "The MPLS label representing the segment identifier";
+              }
+
+              container state {
+                config false;
+                description
+                  "State parameters for per-SID statistics";
+                uses sr-mpls-sid-counters-state;
+                uses sr-mpls-common-counters;
+              }
+
+              container forwarding-classes {
+                description
+                  "Per-SID per-forwarding class counters for Segment Routing.";
+
+                list forwarding-class {
+                  key "exp";
+                  config false;
+
+                  description
+                    "SID entries for the forwarding class associated with the
+                    referenced MPLS EXP.";
+
+                  leaf exp {
+                    type leafref {
+                      path "../state/exp";
+                    }
+                    description
+                      "Reference to the value of the EXP bits of the segment
+                      identifier.";
+                  }
+
+                  container state {
+                    config false;
+                    description
+                      "Per-SID, per forwarding class counters for Segment Routing
+                      with the MPLS dataplane";
+
+                    uses sr-mpls-interface-sid-fc-state;
+                    uses sr-mpls-common-counters;
+                  }
+                }
+              }
+            }
+          }
+          uses oc-if:interface-ref;
+        }
+      }
+    }
+  }
+
+  grouping sr-mpls-interface-config {
+    description
+      "MPLS-specific Segment Routing configuration for an interface";
+
+    leaf interface-id {
+      type oc-if:interface-id;
+      description
+        "A unique identifier for the interface.";
+    }
+  }
+
+  grouping sr-mpls-interface-state {
+    description
+      "MPLS-specific Segment Routing operational state parameters for an
+      interface";
+
+    uses sr-mpls-common-counters;
+  }
+
+  grouping sr-mpls-interface-sid-fc-state {
+    description
+      "Per-SID per forwarding class statistics for SR with the MPLS dataplane";
+
+    leaf exp {
+      type uint8 {
+        range "0..7";
+      }
+      description
+        "The value of the MPLS EXP (experimental) or Traffic Class bits that the
+        SID statistics relate to. Packets received with a MPLS label value
+        equal to the SID's MPLS label and EXP bits equal to the this value
+        should be counted towards the associated ingress statistics. Packets
+        that are forwarded to the destination MPLS label corresponding to the
+        SID should be counted towards this value. In the egress direction, where
+        forwarding follows a SID value that requires PHP at the local node,
+        packets should still be counted towards the egress counters.";
+    }
+  }
+
+  grouping sr-mpls-sid-counters-state {
+    description
+      "Per-SID statistics leaves";
+
+    leaf mpls-label {
+      type oc-mplst:mpls-label;
+      description
+        "The MPLS label used for the segment identifier";
+    }
+  }
+
+  grouping sr-mpls-common-counters {
+    description
+      "Per segment identifier counters used in the model";
+
+      leaf in-pkts {
+        type yang:counter64;
+        description
+          "A cumulative counter of the packets received within the context
+          which have matched a label corresponding to an SR Segment Identifier.";
+      }
+
+      leaf in-octets {
+        type yang:counter64;
+        description
+          "The cumulative counter of the total bytes received within the context
+          which have matched a label corresponding to an SR Segment Identifier";
+      }
+
+      leaf out-pkts {
+        type yang:counter64;
+        description
+          "A cumulative counter of the total number of packets transmitted by
+          the local system within the context which have a label imposed that
+          corresponds to an Segment Identifier.";
+      }
+
+      leaf out-octets {
+        type yang:counter64;
+        description
+          "A cumulative counter of the total bytes transmitted by the local
+          system within the context which have a label imported that
+          corresponds to an SR Segment Identifier.";
+      }
+  }
+
+  grouping sr-igp-config {
+    description
+      "Configuration parameters relating to segment routing within an
+      IGP.";
+
+    leaf enabled {
+      type boolean;
+      description
+        "When this leaf is set to true, the segment routing extensions are
+        utilised within the IGP.";
+    }
+
+    leaf srgb {
+      type leafref {
+        path "../../../../../../../segment-routing/srgbs/srgb/config/local-id";
+      }
+      description
+        "A reference to the Segment Routing Global Block (SRGB) that is
+        to be used by this IGP instance.";
+    }
+
+    leaf srlb {
+      // Leaf is defined at
+      // /network-instances/network-instance/protocols/protocol/<igp>/global/
+      // segment-routing/config
+      type leafref {
+        path "../../../../../../../segment-routing/srlbs/srlb/config/local-id";
+      }
+      description
+        "A reference to the Segment Routing Local Block (SRLB) that is to
+        be advertised by the IGP instance.";
+    }
+  }
+
+  grouping flex-algo-binding-attributes {
+    description
+      "Attributes for Flexible Algorithm bindings";
+    leaf flex-algo-id {
+      type uint8 {
+	range "128..255";
+      }
+      description
+        "Flexible Algorithm identifier";
+    }
+    leaf isis-level {
+      type oc-isis-types:level-type;
+      default "LEVEL_1_2";
+      description
+        "IS-IS Level associated with this Flex Algorithm";
+    }
+    leaf advertised {
+      type boolean;
+      default "false";
+      description
+        "Indicates if the Flex Algorithm definition is advertised by this node";
+    }
+    leaf participate {
+      type boolean;
+      default "false";
+      description
+        "Indicates if the node participates in this Flex Algorithm";
+    }
+  }
+
+  grouping sr-igp-top {
+    description
+      "Per-instance configuration and state parameters for Segment Routing
+      in an IGP.";
+
+    container segment-routing {
+      description
+        "Configuration and operational state relating to segment routing.";
+
+      container config {
+        description
+          "Configuration parameters relating to the configuration of segment
+          routing for the IGP instance.";
+        uses sr-igp-config;
+      }
+
+      container state {
+        config false;
+        description
+          "Operational state parameters relating to segment routing for the
+          IGP instance.";
+        uses sr-igp-config;
+      }
+
+      container flex-algorithm-bindings {
+        description
+          "Flex Algorithm bindings";
+        list flex-algorithm-binding {
+          key "flex-algo-id";
+          description
+            "Flex Algorithm binding";
+          leaf flex-algo-id {
+            type leafref {
+              path "../config/flex-algo-id";
+            }
+            description
+              "Flex Algorithm identifier used by IGP";
+          }
+          container config {
+            description
+              "Attributes of a FAD binding";
+            uses flex-algo-binding-attributes;
+          }
+          container state {
+            config false;
+            description
+              "Attributes of a FAD binding";
+            uses flex-algo-binding-attributes;
+          }
+        }
+      }
+    }
+  }
+
+  grouping sr-igp-interface-prefix-sid-config {
+    description
+      "Configuration parameters relating to an IGP prefix SID advertisement";
+
+    leaf prefix {
+      type inet:ip-prefix;
+      description
+        "The IP prefix for which the IGP prefix SID should be advertised. The
+        value specified is a local prefix on the interface which is advertised
+        into the IGP.";
+    }
+
+    leaf sid-id {
+      type oc-srt:sr-sid-type;
+      description
+        "The Segment Identifier to be used when advertising the IGP Prefix SID.";
+    }
+
+    leaf label-options {
+      type enumeration {
+        enum NO_PHP {
+          description
+            "When this value is specified, the penultimate hop must not pop
+            the Prefix-SID label before forwarding it to the local system.";
+        }
+        enum EXPLICIT_NULL {
+          description
+            "When set, the penultimate hop must swap the prefix SID for the
+            relevant explicit null label before forwarding the packet.";
+        }
+      }
+      description
+        "The options associated with the IGP prefix SID for MPLS. The value
+        of this leaf specifies the option that the SID should be advertised
+        into the IGP with.";
+    }
+  }
+
+  grouping sr-igp-interface-adjsid-config {
+    description
+      "Configuration parameters relating to an Adj-SID on an interface";
+
+    leaf sid-id {
+      type union {
+        type oc-srt:sr-sid-type;
+        type enumeration {
+            enum DYNAMIC {
+              description
+                "The SID chosen for the Adjacency SID should be dynamically
+                allocated from the system's dynamic range of Segment
+                Identifiers. For MPLS, this range should be considered to be
+                those labels that do not fall within a reserved label block.";
+            }
+        }
+      }
+      description
+        "The value of the Adj-SID to be advertised. Where a static SID
+        identifier is specified, this should be advertised directly by the
+        system. Where the DYNAMIC value is specified, this should be treated
+        as a dynamically allocated value. When the MPLS data plane is in use
+        the dynamic value should not fall within a reserved-label-block.";
+    }
+
+    leaf protection-eligible {
+      type boolean;
+      default true;
+      description
+        "Whether the Adj-SID should be considered to be eligible for protection
+        using IP or MPLS FRR during a network failure. When this value is set to
+        true, the B-flag of the Adj-SID is set to 1, and the local system should
+        provide FRR paths for the associated label forwarding entry. When it is
+        set to false, the local system must not provide FRR for the specified
+        LFIB entry.";
+    }
+
+    leaf group {
+      type boolean;
+      default false;
+      description
+        "When set to true, the Adj-SID is indicated to be part of a group, and
+        the G flag is set to 1 in the corresponding advertisement in the IGP.";
+    }
+
+    leaf neighbor {
+      type inet:ip-address;
+      description
+        "The remote system on the interface with which the Adj-SID is
+        associated.";
+    }
+  }
+
+  grouping sr-igp-interface-adjsid-state {
+    description
+      "Operational state parameters relating to the adjacency SID for an
+      interface";
+
+    leaf allocated-dynamic-local {
+      type oc-srt:sr-sid-type;
+      description
+        "Where an Adjacency SID with a dynamic value is to be allocated by
+        the system, this leaf reports to the value of the Adj-SID allocated
+        to this interface.";
+    }
+  }
+
+  grouping sr-igp-interface-flex-algo-prefix-sid-config {
+    description
+      "Configuration parameters relating to an IGP prefix SID advertisement for
+       Flexible Algorithms";
+    leaf prefix {
+      type inet:ip-prefix;
+      description
+        "The IP prefix for which the IGP prefix SID should be advertised. The
+         value specified is a local prefix on the interface which is advertised
+         into the IGP.";
+    }
+    leaf flex-algo-id {
+      type uint8 {
+	range "128..255";
+      }
+      description
+        "Flexible Algorithm identifier for the prefix segment.";
+    }
+    leaf sid-id {
+      type oc-srt:sr-sid-type;
+      description
+        "The Segment Identifier to be used when advertising the IGP Prefix SID for
+         the Flexible Algorithm.";
+    }
+  }
+
+  grouping sr-igp-interface-top {
+    description
+      "Per-interface configuration and operational state relating to an
+      interface within the IGP.";
+
+    container segment-routing {
+      description
+        "Configuration and operatioanl state parameters relating to segment
+        routing for an interface within the IGP.";
+
+      container prefix-sids {
+        description
+          "Configuration and operational state parameters relating to
+          the advertisement of a segment routing IGP-Prefix SID for this
+          interface.";
+
+        list prefix-sid {
+          key "prefix";
+
+          description
+            "An IGP prefix that should have a segment routing IGP-Prefix SID
+            allocated to it. The value of the SID is specified by the SID ID,
+            as an absolute value. If the absolute value falls within the SRGB,
+            the Global flag should be advertised by the system.";
+
+          leaf prefix {
+            type leafref {
+              path "../config/prefix";
+            }
+            description
+              "Reference to the prefix for which the IGP-Prefix SID is to be
+              advertised";
+          }
+
+          container config {
+            description
+              "Configuration parameters for the IGP Prefix SID.";
+            uses sr-igp-interface-prefix-sid-config;
+          }
+
+          container state {
+            config false;
+            description
+              "Operational state parameters for the IGP-Prefix SID.";
+            uses sr-igp-interface-prefix-sid-config;
+          }
+        }
+      }
+
+      container flex-algo-prefix-sids {
+        description
+           "Configuration and operational state parameters relating to segment
+           routing flexible algorithm for an interface within the IGP.";
+
+        list flex-algo-prefix-sid {
+          key "prefix flex-algo-id";
+
+          description
+            "IGP prefix segments allocated for Flexible Algorithms";
+
+          leaf prefix {
+            type leafref {
+              path "../config/prefix";
+            }
+            description
+              "Reference to the prefix for which Flexible Algorithm Prefix SID is to be
+              advertised.";
+          }
+
+          leaf flex-algo-id {
+            type leafref {
+              path "../config/flex-algo-id";
+            }
+            description
+              "Reference to the Flexible Algorithm for which Flexible Algorithm Prefix
+              SID is to be advertised.";
+          }
+
+          container config {
+            description
+              "Configuration parameters for the IGP Flexible Algorithm Prefix SID.";
+            uses sr-igp-interface-flex-algo-prefix-sid-config;
+          }
+
+          container state {
+            config false;
+            description
+              "Operational state parameters for the IGP Flexible Algorithm Prefix SID.";
+            uses sr-igp-interface-flex-algo-prefix-sid-config;
+          }
+        }
+      }
+
+      container adjacency-sids {
+        description
+          "Configuration and operational state parameters relating to
+          the advertisement of a segment routing adjacency SID for this
+          interface.";
+
+        list adjacency-sid {
+          key "neighbor sid-id";
+
+          description
+            "An Adjacency SID to be advertised for the specified interface.
+            The Adj-SID's identifier (the SID ID) must be unique, with flags
+            specified indicating the parameters that should be set for the SID.
+            Where a SID value is specified that is allocated from the SRGB, the
+            global flag must be set by the system.";
+
+          leaf sid-id {
+            type leafref {
+              path "../config/sid-id";
+            }
+            description
+              "Reference to the segment identifier to be used by the local
+              system.";
+          }
+
+          leaf neighbor {
+            type leafref {
+              path "../config/neighbor";
+            }
+            description
+              "Reference to the neighbor with which the Adjacency SID is
+              associated.";
+          }
+
+          container config {
+            description
+              "Configuraton parameters relating to the AdjSID.";
+            uses sr-igp-interface-adjsid-config;
+          }
+
+          container state {
+            config false;
+            description
+              "Operational state parameters relating to the AdjSID.";
+            uses sr-igp-interface-adjsid-config;
+            uses sr-igp-interface-adjsid-state;
+          }
+        }
+      }
+    }
+  }
+
+  grouping sr-top {
+    description
+      "Top level grouping for Segment Routing";
+
+    container segment-routing {
+      description
+        "Configuration and operational state parameters relating to
+        segment routing.";
+
+      uses sr-structural;
+      uses oc-srte:oc-srte-policy-top;
+    }
+  }
+}

--- a/models/yang/common/openconfig-srte-policy.yang
+++ b/models/yang/common/openconfig-srte-policy.yang
@@ -1,0 +1,675 @@
+module openconfig-srte-policy {
+  yang-version "1";
+  namespace "http://openconfig.net/yang/segment-routing/srte-policy";
+  prefix "oc-srte";
+
+  import openconfig-types { prefix "oc-types"; }
+  import openconfig-extensions { prefix "oc-ext"; }
+  import openconfig-interfaces { prefix "oc-if"; }
+  import openconfig-inet-types { prefix "oc-inet"; }
+  import openconfig-yang-types { prefix "oc-yang"; }
+  import openconfig-aft { prefix "oc-aft"; }
+  import openconfig-segment-routing-types { prefix "oc-srt"; }
+
+  organization
+    "OpenConfig working group";
+
+  contact
+    "OpenConfig Working group
+    www.openconfig.net";
+
+  description
+    "This module defines a collection of segment routing traffic
+    engineering policy operational states.
+
+    Each policy, identified by a combination of color and endpoint,
+    has one or more candidate paths learned from one or more sources.
+    The best valid/usable path is marked as active and programmed in
+    forwarding plane.
+
+    A candidate path, identified by protocol-origin, originator and
+    discriminator, can have one and more segment-list defining the
+    path traffic should take. Each segment-list is associated with a
+    weight for weighted load balancing.
+
+    Traffic counters related to SR policies are also defined in this
+    module.";
+
+  reference
+    "draft-ietf-spring-segment-routing-policy";
+
+  oc-ext:openconfig-version "0.2.3";
+
+  revision "2021-07-28" {
+    description
+      "Add qualify to when statements.";
+    reference "0.2.3";
+  }
+
+  revision "2020-11-06" {
+    description
+      "Update segment-lists nexthop state container to use index leaf
+      from aft-common-entry-nexthop-state.";
+    reference "0.2.2";
+  }
+
+  revision "2020-05-01" {
+    description
+      "Fix consistency of per-policy counters.";
+    reference "0.2.1";
+  }
+
+  revision "2020-03-31" {
+    description
+      "Updated traffic counters on policy and segment-list levels.";
+    reference "0.2.0";
+  }
+
+  revision "2019-09-24" {
+    description
+      "Initial revision of the SR-TE policy model.";
+    reference "0.1.0";
+  }
+
+  // OpenConfig specific extensions for module metadata.
+  oc-ext:regexp-posix;
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  grouping oc-srte-policy-top {
+    description
+      "Top-level grouping used for SR-TE policy operational states.";
+
+    container te-policies {
+      config false;
+      description
+        "A collection of SR-TE policies in the system.";
+
+      list te-policy {
+        key "color endpoint";
+        description
+          "An individual SR-TE policy is identified by a combination
+          of color and endpoint.";
+
+        leaf color {
+          type leafref {
+            path "../state/color";
+          }
+          description
+            "A reference to the srte color in the state.";
+        }
+
+        leaf endpoint {
+          type leafref {
+            path "../state/endpoint";
+          }
+          description
+            "A reference to the srte endpoint in the state.";
+        }
+
+        container state {
+          config false;
+          description
+            "The operational state of parameters associated with
+            SR-TE policies.";
+
+          uses oc-srte-policy-state;
+
+          container counters {
+            description
+              "A collection of counters on the policy level. They
+              count the total traffic forwarded by the policy,
+              regardless of its installation source. The counters
+              should be persistent across policy state changes and
+              switches between active protocols.";
+
+              uses oc-srte-policy-counters;
+          }
+        }
+
+        uses oc-srte-candidate-path;
+      }
+    }
+  }
+
+  grouping oc-srte-policy-keys {
+    description
+      "Keys to identify a SR-TE policy.";
+
+    leaf color {
+      type uint32;
+      description
+        "When the policy is used for RIB resolution to a specific
+        Segment Routing Traffic Engineering path, the policy is used
+        when the color required in the policy (which may be specified
+        based on the value of a BGP extended colour community) matches
+        the value of this leaf. The color being set to 0 indicates
+        that the colour is a wildcard in the policy resolution.";
+    }
+
+    leaf endpoint {
+      type oc-srt:srte-endpoint-type;
+      description
+        "When the policy is used for RIB resolution to a Segment
+        Routing Traffic Engineering path, the policy is used when the
+        required endpoint (which may be the protocol next-hop) matches
+        the endpoint address specified in this leaf. When the leaf is
+        set to all zeros (0.0.0.0 or ::), the endpoint acts as a
+        wildcard in the policy resolution.";
+    }
+  }
+
+  grouping oc-srte-policy-state {
+    description
+      "Operational states specific to a SR-TE policy.";
+
+    uses oc-srte-policy-keys;
+
+    leaf name {
+      type string;
+      description
+        "The user friendly SR-TE policy name.";
+    }
+
+    leaf bsid {
+      type oc-srt:sr-sid-type;
+      description
+        "The Binding SID (BSID) assigned to the SR-TE policy,
+        expressed as an MPLS label or IPv6 address. Packets that are
+        ingress to the system with active segment matching the SID
+        value specified in this leaf should be forwarded according
+        to the policy. The specified Binding SID must be removed
+        from the segment list by the system.";
+    }
+
+    leaf active {
+      type boolean;
+      description
+        "A SR-TE policy is marked as active when at least one of its
+        candidate paths is valid/active and the policy has been
+        instantiated in the forwarding plane.";
+    }
+
+    leaf active-since {
+      type oc-types:timeticks64;
+      description
+        "Indication of the time the policy transitioned to the active
+        state.
+
+        The value is the timestamp in nanoseconds relative to the Unix
+        Epoch (Jan 1, 1970 00:00:00 UTC).";
+    }
+
+    leaf active-transitions {
+      type oc-yang:counter64;
+      description
+        "The number of transitions to active state for the policy.";
+    }
+
+  }
+
+  grouping oc-srte-policy-counters {
+    description
+      "A collection of traffic counters on the SR-TE policy level.";
+
+    leaf in-pkts {
+      type oc-yang:counter64;
+      description
+        "A cumulative counter of the incoming packets steered to
+        the SR-TE policy. It includes both labeled and unlabeled
+        steered traffic.";
+    }
+
+    leaf in-octets {
+      type oc-yang:counter64;
+      description
+        "The cumulative counter of the total incoming bytes steered
+        to the SR-TE policy. It includes both labeled and unlabeled
+        steered traffic.";
+    }
+
+    leaf in-labeled-pkts {
+      type oc-yang:counter64;
+      description
+        "A cumulative counter of the incoming labeled packets steered
+        to the SR-TE policy. Labeled packets carries an active SID
+        (top-most SID in the stack) that matches the BSID associated
+        to this policy.";
+    }
+
+    leaf in-labeled-octets {
+      type oc-yang:counter64;
+      description
+        "A cumulative counter of the total bytes of incoming labeled
+        traffic steered to the SR-TE policy. Labeled traffic carries
+        an active SID (top-most SID in the stack) that matches the
+        BSID associated to this policy.";
+    }
+
+    leaf out-pkts {
+      type oc-yang:counter64;
+      description
+        "A cumulative counter of the outgoing packets after being
+        steered to the SR-TE policy. It includes both labeled and
+        unlabeled steered traffic.";
+    }
+
+    leaf out-octets {
+      type oc-yang:counter64;
+      description
+        "The cumulative counter of the total outgoing bytes after
+        being steered to the SR-TE policy. It includes both labeled
+        and unlabeled steered traffic. The counter should include the
+        segments pushed to packets.";
+    }
+
+    leaf out-labeled-pkts {
+      type oc-yang:counter64;
+      description
+        "A cumulative counter of the outgoing labeled packets after
+        being steered to the SR-TE policy. Labeled packets carries
+        an active SID (top-most SID in the stack) that matches the
+        BSID associated to this policy.";
+    }
+
+    leaf out-labeled-octets {
+      type oc-yang:counter64;
+      description
+        "A cumulative counter of the total bytes of outgoing labeled
+        traffic after being steered to the SR-TE policy. Labeled
+        traffic carries an active SID (top-most SID in the stack) that
+        matches the BSID associated to this policy. The counter should
+        include the segments pushed to packets.";
+    }
+  }
+
+  grouping oc-srte-candidate-path {
+    description
+      "A collection of candidate paths associated with the SR-TE
+      policy.";
+
+    container candidate-paths {
+      description
+        "One or more candidate paths may be associated to a SR-TE
+        policy. The best and usable one should be used as forwarding
+        next-hops.";
+
+      list candidate-path {
+        key "protocol-origin originator-asn originator-addr discriminator";
+        description
+          "An individual candidate path within the list of candidate
+          paths associated with this SR-TE policy. It is uniquely
+          identified by the combination of protocol-origin,
+          originator and discriminator";
+
+        leaf protocol-origin {
+          type leafref {
+            path "../state/protocol-origin";
+          }
+          description
+            "A reference to the component or protocol that originates
+            or signals the candidate path";
+        }
+
+        leaf originator-asn {
+          type leafref {
+            path "../state/originator-asn";
+          }
+          description
+            "A reference to the autonomous system that the node
+            originating the candidate path locates.";
+        }
+
+        leaf originator-addr {
+          type leafref {
+            path "../state/originator-addr";
+          }
+          description
+            "A reference to the address of the node originating the
+            candidate path.";
+        }
+
+        leaf discriminator {
+          type leafref {
+            path "../state/discriminator";
+          }
+          description
+            "A reference to the ID uniquely identifying the path
+            within the context of a policy learnt from a protocol.";
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state parameters associated with SR-TE
+            candidate paths.";
+
+          uses oc-srte-candidate-path-state;
+        }
+
+        container segment-lists {
+          description
+            "A collection of segment lists associated with the policy
+            candidate path.";
+
+          list segment-list {
+            key "id";
+            description
+              "An individual segment list within the list of segment
+              lists associated with this candidate path.";
+
+            leaf id {
+              type leafref {
+                path "../state/id";
+              }
+              description
+                "A reference to the segment-list that in use for the
+                candidate path.";
+            }
+
+            container state {
+              config false;
+              description
+                "Operational state parameters associated with a
+                segment-list in a SR-TE candidate paths.";
+
+              uses oc-srte-segment-list-state;
+
+              container counters {
+                description
+                  "The counters of traffic steered to the segment-list.";
+
+                uses oc-srte-segment-list-common-counters;
+              }
+            }
+
+            container sids {
+              description
+                "The list of SIDs that make up the segment list. The
+                order of the SIDs is specified by ordering the list
+                according to index, in ascending order. The network
+                device should consider the top-most SID the entry with
+                the lowest index.";
+
+              list sid {
+                key "index";
+
+                description
+                  "List of SIDs that make up the segment list. The segment
+                  list is formed by ordering the set of SIDs that are
+                  specified by their index in ascending numerical order.";
+
+                leaf index {
+                  type leafref {
+                    path "../state/index";
+                  }
+                  description
+                    "Reference to the SID's index within the segment list
+                    which acts as the key of the list.";
+                }
+
+                container state {
+                  config false;
+                  description
+                    "Operational state parameters relating to the SID within
+                    the segment list.";
+                  uses oc-srte-segment-list-sids-state;
+                }
+              }
+            }
+
+            container next-hops {
+              description
+                "The set of next-hops which the segment-list is resolved to.
+                Traffic steered to the segment-list should be forwarded over
+                them.";
+
+              list next-hop {
+                key "index";
+                description
+                  "A next-hop the segment list is resolved to.";
+
+                leaf index {
+                  type leafref {
+                    path "../state/index";
+                  }
+                  description
+                    "A reference to the nexthop index in the state.";
+                }
+
+                container state {
+                  config false;
+                  description "State parameters for the nexthop.";
+
+                  uses oc-aft:aft-common-entry-nexthop-state;
+
+                  container counters {
+                    description
+                      "The counters of traffic steered to the segment-list on
+                      per next-hop basis.";
+                    uses oc-srte-segment-list-common-counters;
+                  }
+                }
+
+                uses oc-if:interface-ref-state;
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  grouping oc-srte-segment-list-state {
+    description
+      "Operational state specific to a segment-list in a
+      candidate-path.";
+
+    leaf id {
+      type uint32;
+      description
+        "A unique id identifying the segment-list.";
+    }
+
+    leaf valid {
+      type boolean;
+      description
+        "The validity of a segment-list should marked as true
+        when it is usable.";
+      reference
+        "draft-ietf-spring-segment-routing-policy.";
+    }
+
+    leaf invalid-reason {
+      type oc-srt:srte-invalid-sl-reason;
+      description
+        "If a segment-list is marked as invalid, this leaf should
+        indicate the reason.";
+    }
+
+    leaf weight {
+      type uint32;
+      description
+        "The weight of the segment list within the set of
+        segment lists specified for the candidate path. The
+        traffic that is forwarded according to the policy is
+        distributed across the set of segment-lists such that
+        each list receives weight/(sum of all weights) traffic.";
+    }
+
+  }
+
+  grouping oc-srte-candidate-path-state {
+    description
+      "Operational state specific to a SR-TE policy candidate path.";
+
+    leaf name {
+      type string;
+      description
+        "The user friendly SR-TE candidate path name.";
+    }
+
+    leaf protocol-origin {
+      type oc-srt:srte-protocol-type;
+      description
+        "The component or protocol that originates or signals the
+        candidate path.";
+    }
+
+    leaf originator-asn {
+      type uint32;
+      description
+        "The autonomous system that node originating the candidate
+        path locates.";
+      reference
+        "Section 2.4 of draft-ietf-spring-segment-routing-policy.";
+    }
+
+    leaf originator-addr {
+      type oc-inet:ipv6-address;
+      description
+        "The address of the node originating the candidate path.
+        Address in IPv4 can be represented as IPv6-encoded-IPv4 e.g.
+        ::FFFF:192.168.1.2 or a normal IPv6 address with the lowest
+        32 bits carrying the actual IPv4 address.";
+      reference
+        "Section 2.4 of draft-ietf-spring-segment-routing-policy.";
+    }
+
+    leaf discriminator {
+      type uint32;
+      description
+        "A 32 bit value uniquely identifying the path within the
+        context of a policy learnt from a protocol.";
+    }
+
+    leaf preference {
+      type uint32;
+      description
+        "When there are multiple candidate paths specified a
+        particular SR-TE policy. The preference is used to resolve
+        between them. And the one with higher preference is
+        preferred.
+        These paths may be learnt from a dynamic routing protocol,
+        or interface to the device, or from other static entries
+        configured on the system.";
+    }
+
+    leaf enlp {
+      type oc-srt:enlp-type;
+      description
+        "ENLP (Explicit NULL Label Policy) indicates whether Explicit
+        NULL labels are to be pushed on unlabeled IP packets that are
+        being steered into a given SR policy.";
+      reference "draft-ietf-idr-segment-routing-te-policy";
+    }
+
+    leaf valid {
+      type boolean;
+      description
+        "A path should be marked as valid when it is usable e.g. the
+        at least one segment-list is valid even though the path may
+        not be the best.";
+    }
+
+    leaf active {
+      type boolean;
+      description
+        "A candidate path is active when it is valid and it is
+        determined to be the best path of the SR-TE Policy.";
+    }
+
+    leaf active-since {
+      type oc-types:timeticks64;
+      description
+        "Indication of the time the path transitioned to the active
+        state.
+
+        The value is the timestamp in nanoseconds relative to the
+        Unix Epoch (Jan 1, 1970 00:00:00 UTC).";
+    }
+
+    leaf active-transitions {
+      type oc-yang:counter64;
+      description
+        "The number of transitions to active state for the candidate
+        path.";
+    }
+  }
+
+  grouping oc-srte-segment-list-common-counters {
+    description
+      "A collection of traffic counters on the segment-list level.";
+
+    leaf out-pkts {
+      type oc-yang:counter64;
+      description
+        "A cumulative counter of the outgoing packets steered to the
+        segment list. The counter includes both labeled and unlabeled
+        steered traffic.";
+    }
+
+    leaf out-octets {
+      type oc-yang:counter64;
+      description
+        "The cumulative counter of the total outgoing bytes steered
+        to the segment list. The counter includes both labeled and
+        unlabeled steerted traffic.";
+    }
+
+    leaf out-labeled-pkts {
+      type oc-yang:counter64;
+      description
+        "A cumulative counter of the incoming labeled packets steered
+        to the segment list.";
+    }
+
+    leaf out-labeled-octets {
+      type oc-yang:counter64;
+      description
+        "A cumulative counter of the total bytes of incoming labeled
+        traffic steered to the segment list.";
+    }
+  }
+
+  grouping oc-srte-segment-list-sids-state {
+    description
+      "Operational state relating to a SID within an SR-TE segment
+      list";
+
+    leaf index {
+      type uint64;
+      description
+        "The index of the SID within the segment list. The segment list is
+        applied by ordering the SID entries in ascending numerical order
+        beginning at 0.";
+    }
+
+    leaf value {
+      type oc-srt:sr-sid-type;
+      description
+        "The value of the SID that is to be used. Specified as an MPLS
+        label or IPv6 address.";
+    }
+
+    leaf mpls-ttl {
+      type uint8;
+      default 0;
+      description
+        "The TTL to be set if the type of the SID is an MPLS label. If the
+        value of the TTL is set to be 0, the value is picked by the local
+        implementation.";
+    }
+
+    leaf mpls-tc {
+      type uint8 {
+        range "0..7";
+      }
+      default 0;
+      description
+        "The value of the MPLS Traffic Class (TC) bits to be used if the
+        value of the SID is an MPLS label. In the case that the value is
+        set to 0, then the local implementation should choose the value.";
+    }
+  }
+}

--- a/models/yang/common/openconfig-system-bootz.yang
+++ b/models/yang/common/openconfig-system-bootz.yang
@@ -1,0 +1,115 @@
+module openconfig-system-bootz {
+  yang-version "1";
+
+  namespace "http://openconfig.net/yang/system-bootz";
+  prefix "oc-sys-bootz";
+
+  import openconfig-extensions { prefix oc-ext; }
+  import openconfig-system { prefix oc-sys; }
+  import openconfig-types { prefix oc-types; }
+  import openconfig-yang-types { prefix oc-yang; }
+
+  organization
+    "OpenConfig working group";
+  contact
+    "www.openconfig.net";
+
+  description
+    "This module adds configuration and operational state relating to bootz
+    service running on a network device.";
+
+
+  oc-ext:openconfig-version "1.0.0";
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  revision "2023-06-16" {
+    description
+      "Creation of bootz state paths needed for the service.";
+    reference "1.0.0";
+  }
+
+  grouping bootz-service-structural {
+    description
+      "Structural grouping for bootz service that can be enabled on
+      the system.";
+
+    container bootz {
+      description
+        "Bootz protocol container for management of bootz protocol state.";
+
+      container state {
+        config false;
+        description
+          "Operational state relating to the bootz service.";
+        uses bootz-state;
+      }
+    }
+  }
+
+  grouping bootz-state {
+    description
+      "State parameters required to monitor bootz service.";
+
+    leaf checksum {
+      type string;
+      default "";
+      description
+        "The current checksum of the bootz protocol buffer.
+
+        This value should refect the current sha-512 of the bootz
+        protocol buffer message BootstrapDataSigned. The protocol
+        buffer serialization must be done by tag value for each field
+        in the bootz protocol buffer. This will produce a
+        determintistic marshalled value which can be
+        checksummed.";
+    }
+
+    leaf error-count {
+      type oc-yang:counter64;
+      description
+        "Total count of all bootz errors.";
+    }
+
+    leaf status {
+      type enumeration {
+        enum BOOTZ_UNSPECIFIED;
+        enum BOOTZ_SENT;
+        enum BOOTZ_RECEIVED;
+        enum BOOTZ_CONFIGURATION_APPLIED;
+        enum BOOTZ_OK;
+        enum BOOTZ_OV_INVALID;
+        enum BOOTZ_OS_UPGRADE_IN_PROGRESS;
+        enum BOOTZ_OS_UPGRADE_COMPLETE;
+        enum BOOTZ_OS_INVALID_IMAGE;
+        enum BOOTZ_CONFIGURATION_INVALID;
+      }
+      description
+        "The status of the bootz service.
+
+        The general sequence for the flow would be:
+        BOOTZ_UNSPECIFIED            <- system initial state
+        BOOTZ_SENT                   <- bootz request sent
+        BOOTZ_RECEIVED               <- bootz response received
+        BOOTZ_OS_UPGRADE_IN_PROGRESS <- (if needed)
+        BOOTZ_OS_UPGRADE_COMPLETE    <- (if needed)
+        BOOTZ_CONFIGURATION_APPLIED  <- bootz configuration applied
+        BOOTZ_OK                     <- bootz process successful
+
+        If any error is encounter an error ENUM will be returned.";
+    }
+
+    leaf last-boot-attempt {
+      type oc-types:timeticks64;
+      description
+        "The timestamp of the last bootz attempt.";
+    }
+  }
+
+  augment "/oc-sys:system" {
+    description
+      "Add bootz service configuration to the openconfig-system model.";
+
+    uses bootz-service-structural;
+  }
+}

--- a/models/yang/common/openconfig-system-controlplane.yang
+++ b/models/yang/common/openconfig-system-controlplane.yang
@@ -1,0 +1,374 @@
+module openconfig-system-controlplane {
+    yang-version "1";
+
+    namespace "http://openconfig.net/yang/system-controlplane";
+    prefix "oc-sys-copp";
+
+    import openconfig-extensions {
+        prefix oc-ext;
+    }
+    import openconfig-system {
+        prefix oc-sys;
+    }
+    import openconfig-acl {
+        prefix oc-acl;
+    }
+    import openconfig-qos {
+        prefix oc-qos;
+    }
+
+    organization
+      "OpenConfig working group";
+    contact
+      "www.openconfig.net";
+
+    description
+      "This module adds configuration and operational state relating to
+       policies for traffic destined to the system's control-plane.
+       Particularly, it allows for mechanisms to:
+        - apply an ACL that forwards or drops traffic towards the control-plane.
+        - classify traffic that is destined to the control-plane according to
+          a QoS classifier.
+        - schedule traffic that has been forwarded towards the control-plane,
+          to allow for policies such as rate limits to be applied.
+       The configured policies apply generically to all control-planes that
+       exist within the system, and should be mapped to the internal interfaces
+       via which packets are forwarded to control-plane modules.
+       When a packet is received at an input interface - it is classified into a
+       forwarding group which drains to a specific queue. If this input mapping
+       is sufficient, the CPU-facing interface uses the specified scheduler
+       to determine how to drain queues. If more granular remapping is required
+       (e.g., to classify control-plane traffic more granularly), a user specifies
+       an alternate classifier that is used to reclassify traffic into
+       a new set of forwarding-groups (and hence queues) that can subsequently
+       be scheduled by the specified scheduler.
+       The specified control-plane ACL is applied to traffic received by the
+       control-plane of the system.";
+
+    oc-ext:openconfig-version "0.2.0";
+    oc-ext:catalog-organization "openconfig";
+    oc-ext:origin "openconfig";
+
+    revision "2023-03-03" {
+      description
+        "Add missing state container to ACL.";
+      reference "0.2.0";
+    }
+
+    revision "2021-08-02" {
+      description
+        "Initial revision.";
+      reference "0.1.0";
+    }
+
+    grouping system-controlplane-top {
+      description
+        "Top-level structural grouping for control-plane traffic policies.";
+
+      container control-plane-traffic {
+        description
+          "Policies and configuration relating to the traffic destined towards
+            the system control-plane.";
+
+        container ingress {
+          description
+            "Control-plane traffic parameters relating to ingress traffic.
+            This refers to traffic that is being received by the system's
+            control plane from external-to-the-controlplane sources.";
+
+          uses system-controlplane-acl-common-top;
+
+          container qos {
+            description
+              "Configuration and operational state relating to QoS policies
+              that are applied to control-plane traffic.";
+
+            container classifier {
+              description
+                "Configuration and state parameters relating to the QoS
+                classifier that is applied to control plane traffic. A QoS
+                classifier - defined in /qos/classifiers specifies how traffic
+                is mapped to QoS queues. The classifier specified in this
+                container and corresponding state allows for traffic towards
+                the control-plane to be classified.";
+
+              container config {
+                description
+                  "Configuration parameters relating to QoS classifier
+                  applied to match control plane traffic.";
+                uses system-controlplane-qos-classifier-config;
+              }
+
+              container state {
+                config false;
+                description
+                  "Operational state parameters relating to the QoS classifier
+                  applied to match control plane traffic.";
+                uses system-controlplane-qos-classifier-config;
+              }
+
+              container terms {
+                config false;
+                description
+                  "Operational state and counters relating to the classifier
+                  applied to control-plane traffic.";
+
+                list term {
+                  key "id";
+
+                  description
+                    "A list of the terms within the QoS classifier being
+                    applied for control-plane traffic. Each term has
+                    corresponding operational state parameters.";
+
+                  leaf id {
+                    type leafref {
+                      path "../state/id";
+                    }
+                    description
+                      "Reference to the identifier for the classifier term.";
+                  }
+
+                  container state {
+                    config false;
+                    description
+                      "Operational state parameters relating to a term within
+                      the applied control-plane classifier";
+
+                    uses system-controlplane-qos-classifier-term-state;
+                    uses oc-qos:qos-interface-classifier-match-counters-state;
+                  }
+                }
+              }
+            }
+
+            container scheduler-policy {
+              description
+                "Configuration and operational state relating to the QoS
+                scheduler policy that is applied to control-plane traffic.
+                The scheduler policy determines how traffic, classified by
+                the specified control-plane classifier is rate-limited towards
+                the control-plane. The scheduler policy is defined in
+                /qos/scheduler-policies.";
+
+              container config {
+                description
+                  "Configuration parameters relating to the scheduler-policy
+                  that is to be applied control-plane traffic.";
+
+                uses system-controlplane-qos-scheduler-config;
+              }
+
+              container state {
+                config false;
+                description
+                  "Operational state parameters relating to the scheduler policy
+                  applied to the control-plane traffic.";
+
+                uses system-controlplane-qos-scheduler-config;
+              }
+
+              container scheduler-statistics {
+                config false;
+                description
+                  "Operational state and counters relating to the
+                  scheduler-policy applied to control plane traffic.";
+
+                list scheduler {
+                  key "sequence";
+                  description
+                    "List of the schedulers that are part of the scheduler-policy
+                    specified.";
+
+                  leaf sequence {
+                    type leafref {
+                      path "../state/sequence";
+                    }
+                    description
+                      "Reference to the sequence ID for the scheduler.";
+                  }
+
+                  container state {
+                    description
+                      "Operational state parameters relating to the scheduler
+                      policy.";
+
+                    uses system-controlplane-qos-scheduler-seq-state;
+                  }
+                }
+              }
+            }
+          }
+        }
+
+        container egress {
+          description
+            "Control-plane traffic parameters relating to egress traffic.
+            This refers to traffic that is sent by the system's control
+            plane to external-to-the-controlplane destinations.";
+
+          uses system-controlplane-acl-common-top;
+        }
+      }
+    }
+
+    grouping system-controlplane-acl-common-top {
+      description
+        "Common structural grouping for ACL configuration and state for
+        control plane traffic.";
+
+      container acl {
+        description
+          "Configuration and operational state parameters relating to the
+          access control list applied to control-plane traffic.";
+
+        list acl-set {
+          key "set-name type";
+
+          description
+            "List of the ACL that is to be applied in the specific ingress
+            or egress context. The key of the list specifies the type of
+            traffic to be matched, along with a reference to an ACL
+            configured in the OpenConfig ACL model within the /acl hierarchy.";
+
+          leaf set-name {
+            type leafref {
+              path "../config/set-name";
+            }
+            description
+              "Reference to the name of the ACL-set to be applied.";
+          }
+
+          leaf type {
+            type leafref {
+              path "../config/type";
+            }
+            description
+              "Reference to the type of the ACL-set to be applied.";
+          }
+
+          container config {
+            description
+              "Configuration parameters relating to the ACL to be applied.";
+
+            uses system-controlplane-common-acl-config;
+          }
+
+          container state {
+            config false;
+            description
+              "Operational state parameters relating to the ACL to be applied.";
+            uses system-controlplane-common-acl-config;
+          }
+
+          uses oc-acl:interface-acl-entries-top;
+        }
+      }
+    }
+
+    grouping system-controlplane-common-acl-config {
+      description
+        "Grouping for ACL parameters relating to the system control-plane.";
+
+      leaf set-name {
+        type leafref {
+            path "/oc-acl:acl/oc-acl:acl-sets/oc-acl:acl-set/" +
+                  "oc-acl:config/oc-acl:name";
+        }
+        description
+          "Reference to the ACL to be applied to traffic
+          in the specified context (ingress or egress).";
+      }
+
+      leaf type {
+        type leafref {
+          path "/oc-acl:acl/oc-acl:acl-sets/oc-acl:acl-set" +
+              "[oc-acl:name=current()/../set-name]" +
+              "/oc-acl:config/oc-acl:type";
+        }
+        description
+          "Reference to the ACL set type applied to traffic
+          in the specified context (ingress or egress).";
+      }
+    }
+
+    grouping system-controlplane-qos-classifier-config {
+      description
+        "Grouping for configuration parameters relating to QoS classifiers
+        for the system control-plane.";
+
+      leaf name {
+          type leafref {
+              path "/oc-qos:qos/oc-qos:classifiers/oc-qos:classifier/" +
+              "oc-qos:config/oc-qos:name";
+          }
+          description
+            "Reference to a classifier that is used to classify traffic
+              destined to the control-plane of the system.
+              This classifier determines how packets that match each terms
+              are classified into forwarding groups, and subsequently into
+              queues to be forwarded.";
+      }
+    }
+
+    grouping system-controlplane-qos-classifier-term-state {
+      description
+        "Grouping for control-plane traffic specific leaves required for
+        each configuration term.";
+
+      leaf id {
+        // Current location /system/control-plane/ingress/qos/classifier/
+        // terms/term/state/id
+        type leafref {
+          path "/oc-qos:qos/oc-qos:classifiers/" +
+              "oc-qos:classifier[oc-qos:name=current()/../../../../config/name]" +
+              "/oc-qos:terms/oc-qos:term/oc-qos:config/oc-qos:id";
+        }
+        description
+          "Reference to a term identifier within the configured control-plane
+          classifier.";
+      }
+    }
+
+    grouping system-controlplane-qos-scheduler-config {
+      description
+        "Grouping for configuration parameters relating to the QoS scheduler
+        policy for control-plane traffic.";
+
+      leaf name {
+          type leafref {
+              path "/oc-qos:qos/oc-qos:scheduler-policies/oc-qos:scheduler-policy/" +
+              "oc-qos:config/oc-qos:name";
+          }
+          description
+            "Reference to a scheduler policy that determines rate limits, or
+            shaping of packets towards the control-plane.";
+      }
+    }
+
+    grouping system-controlplane-qos-scheduler-seq-state {
+      description
+        "Grouping for operational state parameters relating to indivual
+        schedulers within the applied scheduler policy.";
+
+      leaf sequence {
+        type leafref {
+          path "/oc-qos:qos/oc-qos:scheduler-policies/oc-qos:scheduler-policy" +
+             "[oc-qos:name=current()/../../../../config/name]" +
+             "/oc-qos:schedulers/oc-qos:scheduler/oc-qos:config/" +
+             "oc-qos:sequence";
+        }
+        description
+          "Reference to a scheduler within the configured scheduler policy.";
+      }
+
+      uses oc-qos:qos-scheduler-common-state;
+    }
+
+    augment "/oc-sys:system" {
+        description
+          "Add control-plane configuration and state to the system model.";
+
+        uses system-controlplane-top;
+    }
+}

--- a/models/yang/common/openconfig-system-grpc.yang
+++ b/models/yang/common/openconfig-system-grpc.yang
@@ -1,0 +1,310 @@
+module openconfig-system-grpc {
+  yang-version "1";
+
+  namespace "http://openconfig.net/yang/system-grpc";
+  prefix "oc-sys-grpc";
+
+  import openconfig-extensions { prefix oc-ext; }
+  import openconfig-system { prefix oc-sys; }
+  import openconfig-inet-types { prefix oc-inet; }
+  import openconfig-network-instance { prefix oc-ni; }
+  import openconfig-yang-types { prefix oc-yang; }
+
+  organization
+    "OpenConfig working group";
+  contact
+    "www.openconfig.net";
+
+  description
+    "This module adds configuration and operational state relating to gRPC
+    services running on a network device. The GRPC_SERVICE identity is used
+    to create an extensible list of services that can be instantiated, with
+    a base set defined in this module. New services can extend the identity
+    to be included in the list.";
+
+
+  oc-ext:openconfig-version "1.1.0";
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  revision "2024-05-29" {
+    description
+      "Add support for gRPC connections.";
+    reference "1.1.0";
+  }
+
+  revision "2022-04-19" {
+    description
+      "Description and default value updates for grpc-server
+      implementation guidance.";
+    reference "1.0.0";
+  }
+
+  revision "2021-06-16" {
+    description
+      "Remove trailing whitespace";
+    reference "0.1.1";
+  }
+
+  revision 2021-03-30 {
+    description
+      "Initial revision.";
+    reference "0.1.0";
+  }
+
+  identity GRPC_SERVICE {
+    description
+      "Base identity for a gRPC-based service.";
+  }
+
+  identity GNMI {
+    base GRPC_SERVICE;
+    description
+      "gNMI: gRPC Network Management Interface";
+  }
+
+  grouping grpc-service-structural {
+    description
+      "Structural grouping for gRPC services that can be enabled on
+      the system.";
+
+    container grpc-servers {
+      description
+        "List of gRPC servers that can be configured on the device.";
+
+      list grpc-server {
+        key "name";
+
+        description
+          "The list of gRPC servers that are running on the device. Each
+          instance within this list corresponds to an individual gRPC listener
+          that listens on a single TCP port on the specified addresses.
+          Where there are multiple services that run on a single port, these
+          are enabled through the service leaf-list which uses the GRPC_SERVICE
+          identity to list the supported service types.";
+
+        leaf name {
+          type leafref {
+            path "../config/name";
+          }
+          description
+            "Reference to the name of the service that is to be enabled.";
+        }
+
+        container config {
+          description
+            "Configuration parameters relating to the gRPC service.";
+
+          uses grpc-server-config;
+          }
+
+        container state {
+          config false;
+          description
+            "Operational state relating to the gRPC service.";
+          uses grpc-server-config;
+        }
+        uses connections-top;
+      }
+    }
+  }
+
+  grouping grpc-server-config {
+    description
+      "Configuration parameters corresponding to an individual gRPC
+      server.";
+
+    leaf name {
+      type string;
+      default "DEFAULT";
+      description
+        "The name of the gRPC server instance that is running on
+        the local system.
+
+        If the operator does not designate a name for the protocol
+        instance (e.g. config), the implementation should use the
+        name of 'DEFAULT' (e.g. state).  In addition, for
+        implementations that support a single gRPC server instance,
+        the default value is recommended for consistency.";
+    }
+
+    leaf-list services {
+      type identityref {
+        base GRPC_SERVICE;
+      }
+      description
+        "The gRPC service definitions that should be enabled for the
+        specified server. A target may support only specific
+        sets of services being enabled on the same server (e.g.,
+        it may be possible to run gNMI and gNOI services on the same
+        port, but not to run gRIBI and gNMI on the same port).
+
+        The set of gRPC services that are available to be configured is
+        defined through the GRPC_SERVICE identity, which can be extended
+        for each protocol that is based on gRPC that is available on the
+        device.";
+    }
+
+    leaf enable {
+      type boolean;
+      description
+        "When set to true, the gRPC server is enabled and runs on the
+        local device.";
+    }
+
+    leaf port {
+      type oc-inet:port-number;
+      description
+        "TCP port on which the gRPC server should listen.";
+    }
+
+    leaf transport-security {
+      type boolean;
+      default true;
+      description
+        "Use gRPC transport security (e.g., SSL or TLS). Enabled by default.
+        This leaf allows transport security to be disabled for use cases that
+        are not supported, such as lab testing.";
+    }
+
+    leaf certificate-id {
+      type string;
+      description
+        "Name of the certificate that is associated with the gRPC service. The
+        certificate ID is provisioned through other interfaces to the device, such
+        as the gNOI certificate management service.";
+    }
+
+    leaf metadata-authentication {
+      type boolean;
+      description
+        "When set to true, metadata authentication is enabled for the gRPC server.
+        In this mode of operation, gRPC metadata is used to carry authentication
+        credentials as per the specification in
+        https://github.com/openconfig/reference/blob/master/rpc/gnmi/gnmi-authentication.md#credentials-and-authentication.";
+    }
+
+    leaf-list listen-addresses {
+      type union {
+        type oc-inet:ip-address;
+        type enumeration {
+          enum ANY {
+            description
+              "The gRPC server should listen on any address bound to an interface
+              of the system.";
+          }
+        }
+      }
+      description
+        "The IP addresses that the gRPC server should listen on. This may be
+        an IPv4 or an IPv6 address (or both).";
+    }
+
+    leaf network-instance {
+      type oc-ni:network-instance-ref;
+      description
+        "The network instance within which the gRPC server is listening.
+        When unspecified, the DEFAULT_INSTANCE should be used.";
+    }
+  }
+
+  grouping grpc-counters {
+    description
+      "Top-level container for gRPC counters.";
+    container counters {
+      description
+        "Operational data for gRPC counters.";
+      uses grpc-counters-top;
+    }
+  }
+
+  grouping grpc-counters-top {
+    description
+      "Top-level container of operational data for gRPC counters.";
+
+    leaf bytes-sent {
+      type oc-yang:counter64;
+      description
+        "The total number of bytes sent to the client.";
+    }
+
+    leaf packets-sent {
+      type oc-yang:counter64;
+      description
+        "The total number of packets sent to the client.";
+    }
+
+    leaf data-send-error {
+      type oc-yang:counter64;
+      description
+        "A count of errors the gRPC server encountered when
+        sending data to a grpc client.";
+    }
+  }
+
+  grouping grpc-server-connections-state {
+    description
+      "Operational data for gRPC server connections.";
+
+    leaf address {
+      type oc-inet:ip-address;
+      description
+        "IPv4/IPv6 address of the gRPC server connection.";
+    }
+
+    leaf port {
+      type oc-inet:port-number;
+      description
+        "TCP/UDP port number for the gRPC server connection.";
+    }
+  }
+
+  grouping connections-top {
+    description
+      "Top-level grouping for data related to gRPC connections.";
+
+    container connections {
+      config false;
+      description
+        "Enclosing container for list of gRPC connections.";
+
+      list connection {
+        key "address port";
+        description
+          "List of gRPC connections";
+
+        leaf address {
+          type leafref {
+            path "../state/address";
+          }
+          description
+            "Reference to address list key.";
+        }
+
+        leaf port {
+          type leafref {
+            path "../state/port";
+          }
+          description
+            "Reference to port list key.";
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state data for gRPC connections.";
+
+          uses grpc-server-connections-state;
+          uses grpc-counters;
+        }
+      }
+    }
+  }
+
+  augment "/oc-sys:system" {
+    description
+      "Add gRPC service configuration to the openconfig-system model.";
+
+    uses grpc-service-structural;
+  }
+}

--- a/models/yang/common/openconfig-system-logging.yang
+++ b/models/yang/common/openconfig-system-logging.yang
@@ -10,7 +10,7 @@ module openconfig-system-logging {
   // import some basic types
   import openconfig-extensions { prefix oc-ext; }
   import openconfig-inet-types { prefix oc-inet; }
-
+  import openconfig-network-instance { prefix oc-ni; }
 
   // meta
   organization "OpenConfig working group";
@@ -23,7 +23,25 @@ module openconfig-system-logging {
     "This module defines configuration and operational state data
     for common logging facilities on network systems.";
 
-  oc-ext:openconfig-version "0.3.1";
+  oc-ext:openconfig-version "0.6.0";
+
+revision "2023-07-20" {
+    description
+      "adding VTY and local files as logging destinations";
+    reference "0.6.0";
+  }
+
+  revision "2023-05-04" {
+    description
+      "removing LOG_DESTINATION_TYPE identities";
+    reference "0.5.0";
+  }
+
+  revision "2022-12-29" {
+    description
+      "Add network-instance for remote logging servers";
+    reference "0.4.1";
+  }
 
   revision "2018-11-21" {
     description
@@ -220,35 +238,6 @@ module openconfig-system-logging {
       "IETF RFC 5424 - The Syslog Protocol";
   }
 
-  identity LOG_DESTINATION_TYPE {
-    description
-      "Base identity for destination for logging messages";
-  }
-
-  identity DEST_CONSOLE {
-    base LOG_DESTINATION_TYPE;
-    description
-      "Directs log messages to the console";
-  }
-
-  identity DEST_BUFFER {
-    base LOG_DESTINATION_TYPE;
-    description
-      "Directs log messages to and in-memory circular buffer";
-  }
-
-  identity DEST_FILE {
-    base LOG_DESTINATION_TYPE;
-    description
-      "Directs log messages to a local file";
-  }
-
-  identity DEST_REMOTE {
-    base LOG_DESTINATION_TYPE;
-    description
-      "Directs log messages to a remote syslog server";
-  }
-
   // typedef statements
 
     typedef syslog-severity {
@@ -371,12 +360,12 @@ module openconfig-system-logging {
 
   grouping logging-console-config {
     description
-      "Configuration data for console logging";
+      "Configuration data for console and vty logging";
   }
 
   grouping logging-console-state {
     description
-      "Operational state data for console logging";
+      "Operational state data for console and vty logging";
   }
 
   grouping logging-console-top {
@@ -426,6 +415,13 @@ module openconfig-system-logging {
         "Source IP address for packets to the log server";
     }
 
+    leaf network-instance {
+      type oc-ni:network-instance-ref;
+      description
+        "The network instance used to reach the log server.  If no
+        instance is specified, DEFAULT_INSTANCE is used.";
+    }
+
     leaf remote-port {
       type oc-inet:port-number;
       default 514;
@@ -446,7 +442,8 @@ module openconfig-system-logging {
 
     container remote-servers {
       description
-        "Enclosing container for the list of remote log servers";
+        "Enclosing container for the list of remote log
+         servers";
 
       list remote-server {
         key "host";
@@ -483,6 +480,154 @@ module openconfig-system-logging {
     }
   }
 
+  grouping logging-file-config {
+    description
+      "Configuration data for logfile";
+
+    leaf filename-prefix {
+      type string {
+        length 0..255;
+      }
+      description
+        "A name used for the file.  It is expected that an
+        implementation may append timestamp, serial-number or
+        other identifier to the filename.";
+    }
+
+    leaf path {
+      type string {
+        length 0..255;
+      }
+      description
+        "The fully specified path of the folder where the
+        logfile is stored.  The path is implementation specific
+        and may include attributes such as a drive identifier.";
+    }
+
+    leaf rotate {
+      type uint32;
+      default 0;
+      description
+        "Used for logfile rotation.
+         Log files are rotated the number of times defined by
+         this leaf.
+         The default value of 1 indicates that there will be one
+         rotation file and one active file.  A 0 value indicates
+         old versions are removed rather than rotated.";
+    }
+
+    leaf max-size {
+      type uint32;
+      default 1000;
+      description
+        "Used for logfile rotation.
+        Maximum size in Bytes, logfile may grow to. When logfile
+        reach this size it triggers log rotation. The log file need to
+        be save, closed, and new file open or future log storage.
+        If needed oldest logfile of same prefix shall be deleted to";
+    }
+
+    leaf max-open-time {
+      type uint32;
+      default 1440;
+      description
+        "Used for logfile rotation.
+        Maximum time, in minutes, the logfile can be open. When expires,
+        it triggers log rotation.
+        Actions are same ans when log file reaches its max-size.
+        it need to be closed, save, and new file open or future log
+        storage. If needed oldest logfile of same prefix shall be
+        deleted to ";
+    }
+  }
+
+  grouping logging-file-state {
+    description
+      "Operational state data for logfile";
+    leaf open-logfile {
+      type string{
+        length 0..511;
+      }
+      description
+        "the currently active/open filename prepended by folder path
+        and including suffix appended to filename-prefix by system";
+    }
+  }
+
+  grouping logging-files-top {
+    description
+      "Top-level grouping for local log files";
+
+    container files {
+      description
+        "Enclosing container for the list of log files";
+
+      list file {
+        key "path filename-prefix";
+        description
+          "List of logfiles";
+
+        leaf filename-prefix {
+          type leafref {
+            path "../config/filename-prefix";
+          }
+          description
+            "Reference to the logfiles list key";
+        }
+
+        leaf path {
+          type leafref {
+            path "../config/path";
+          }
+          description
+            "Reference to the logfiles list key";
+        }
+
+        container config {
+          description
+            "Configuration data for logfile";
+          uses logging-file-config;
+        }
+
+        container state {
+          config false;
+          description
+            "Operational state data for logfile servers";
+          uses logging-file-config;
+          uses logging-file-state;
+        }
+        uses logging-selectors-top;
+      }
+    }
+  }
+
+  grouping logging-vty-top {
+    description
+      "Top-level grouping for vty logging data";
+
+    container vty {
+      description
+        "Top-level container for data related to vty-based
+        logging (active sessions of ssh, telnet, etc )";
+
+      container config {
+        description
+          "Configuration data for vty logging";
+
+        uses logging-console-config;
+      }
+
+      container state {
+        config false;
+        description
+          "Operational state data for console logging";
+        uses logging-console-config;
+        uses logging-console-state;
+      }
+      uses logging-selectors-top;
+    }
+  }
+
   grouping logging-top {
     description
       "Top-level grouping for logging data";
@@ -493,6 +638,9 @@ module openconfig-system-logging {
 
       uses logging-console-top;
       uses logging-remote-top;
+      uses logging-files-top;
+      uses logging-vty-top;
+
     }
   }
   // data definition statements

--- a/models/yang/common/openconfig-system-utilization.yang
+++ b/models/yang/common/openconfig-system-utilization.yang
@@ -1,0 +1,115 @@
+module openconfig-system-utilization {
+  yang-version "1";
+
+  namespace "http://openconfig.net/yang/system-utilization";
+  prefix "oc-sys-util";
+
+  import openconfig-extensions { prefix oc-ext; }
+  import openconfig-system { prefix oc-sys; }
+  import openconfig-platform { prefix oc-platform; }
+
+  organization
+    "OpenConfig working group";
+  contact
+    "www.openconfig.net";
+
+  description
+    "This module adds configuration and operational state for
+    system wide resource utilization thresholds.";
+
+  oc-ext:openconfig-version "0.1.0";
+
+  revision "2023-02-13" {
+      description
+        "Add system wide utilization thresholds.";
+      reference
+        "0.1.0";
+  }
+
+  grouping system-resource-utilization-config {
+    description
+      "Configuration data for resource utilization. The configuration added here should
+      apply across all of the components that matches the respective resource.
+      /components/component/*/utilization/resources/resource/name";
+
+
+    leaf name {
+      type string;
+      description
+        "Resource name within the system.";
+    }
+
+    uses oc-platform:resource-utilization-threshold-common;
+  }
+
+  grouping system-resource-utilization-state {
+    description
+      "State data for resource utilization.";
+
+    leaf-list active-component-list {
+      type leafref {
+        path "/oc-platform:components/oc-platform:component/oc-platform:config/oc-platform:name";
+      }
+
+      description
+        "List of references to each component which has this resource.";
+    }
+  }
+
+  grouping system-resource-utilization-top {
+    description
+      "Top level grouping for system wide configuration of resources for
+      all components.";
+
+    container "utilization" {
+      description
+        "System wide resource utilization configuration.";
+
+      container "resources" {
+        description
+          "Enclosing container for the resources in the entire system. The system
+          resource names should be aggregated from the following collections:
+
+          * /components/component/chassis/utilization/resources/resource
+          * /components/component/integrate-circuit/utilization/resources/resource
+          * /components/component/linecard/utilization/resources/resource.";
+
+        list "resource" {
+          key "name";
+          description
+            "The list of all resources across all platform components keyed by
+            resource name.";
+
+          leaf name {
+            type leafref {
+              path "../config/name";
+            }
+            description
+              "References the resource name.";
+          }
+
+          container "config" {
+            description
+              "Configuration data for resource utilization.";
+            uses system-resource-utilization-config;
+          }
+
+          container "state" {
+            config false;
+            description
+              "Operational state data for resource utilization.";
+
+            uses system-resource-utilization-config;
+            uses system-resource-utilization-state;
+          }
+        }
+      }
+    }
+  }
+
+  augment "/oc-sys:system" {
+    description
+      "Add system resource utilization.";
+    uses system-resource-utilization-top;
+  }
+}

--- a/models/yang/common/openconfig-transport-types.yang
+++ b/models/yang/common/openconfig-transport-types.yang
@@ -1,0 +1,1906 @@
+module openconfig-transport-types {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/transport-types";
+
+  prefix "oc-opt-types";
+
+  import openconfig-platform-types { prefix oc-platform-types; }
+  import openconfig-extensions { prefix oc-ext; }
+  import openconfig-types { prefix oc-types; }
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This module contains general type definitions and identities
+    for optical transport models.";
+
+  oc-ext:openconfig-version "0.25.0";
+
+  revision "2024-06-28" {
+    description
+      "Add ETH_25GBASE_LR and ETH_25GBASE_SR PMD types.";
+    reference "0.25.0";
+  }
+
+  revision "2024-05-13" {
+    description
+      "Fix the QSFP56_DD description as it is meant to be generic.";
+     reference "0.24.1";
+  }
+
+  revision "2024-03-20" {
+    description
+      "FlexO support, 800G trib protocol, and OSFP
+       description update for 800G.";
+     reference "0.24.0";
+  }
+
+  revision "2024-03-12" {
+    description
+      "Add TRIBUTARY_RATE_CLASS_TYPE's up to 3200G to support
+       mating of two 1600G line rates.";
+     reference "0.23.0";
+  }
+
+  revision "2024-01-17" {
+    description
+      "Update loopback-mode types.";
+    reference "0.22.0";
+  }
+
+  revision "2024-01-16" {
+    description
+      "Added form factors QSFP28_DD and CSFP.
+       Added new PMDs: ETH_100GBASE_ER4L (MSA 100GBASE-ER4 Lite),
+       ETH_1GBASE_LX10.
+       Added References for 100GBASE-CR4 and 40GGBASE-CR4 for DACs";
+     reference "0.21.0";
+  }
+
+  revision "2023-08-03" {
+    description
+      "Add QSFP56 and QSFP56_DD form factor identities and
+      deprecated QSFP56_DD_TYPE1 and QSFP56_DD_TYPE2 form factor identities.";
+    reference "0.20.0";
+  }
+
+  revision "2023-07-24" {
+    description
+      "Add SFP_DD and DSFP form factor identities.";
+    reference "0.19.0";
+  }
+
+  revision "2023-02-08" {
+    description
+      "Add ETH_100GBASE_DR PMD type";
+    reference "0.18.1";
+  }
+
+  revision "2022-12-05" {
+    description
+      "Fix trailing whitespace";
+    reference "0.17.1";
+  }
+
+  revision "2022-10-18" {
+    description
+      "Add ETH_400GMSA_PSM4 PMD type";
+    reference "0.17.0";
+  }
+
+  revision "2022-09-26" {
+    description
+      "Add SFP28 and SFP56 form factor identities.";
+    reference "0.16.0";
+  }
+
+  revision "2021-07-29" {
+    description
+      "Add several avg-min-max-instant-stats groupings";
+    reference "0.15.0";
+  }
+
+  revision "2021-03-22" {
+    description
+      "Add client mapping mode identityref.";
+    reference "0.14.0";
+  }
+
+  revision "2021-02-26" {
+    description
+      "Additional PMD types, form factors, and protocol types.";
+    reference "0.13.0";
+  }
+
+  revision "2020-08-12" {
+    description
+      "Additional tributary rates.";
+    reference "0.12.0";
+  }
+
+  revision "2020-04-24" {
+    description
+      "Add 400G protocol and additional tributary half rates.";
+    reference "0.11.0";
+  }
+
+  revision "2020-04-22" {
+    description
+      "Add AOC and DAC connector identities.";
+    reference "0.10.0";
+  }
+
+  revision "2019-06-27" {
+    description
+      "Add FIBER_JUMPER_TYPE identityref.";
+    reference "0.9.0";
+  }
+
+  revision "2019-06-21" {
+    description
+      "Generalize and rename optical port type identity";
+    reference "0.8.0";
+  }
+
+  revision "2018-11-21" {
+    description
+      "Add OpenConfig module metadata extensions.";
+    reference "0.7.1";
+  }
+
+  revision "2018-10-23" {
+    description
+      "Added frame mapping protocols for logical channels assignments
+      and tributary slot granularity for OTN logical channels";
+    reference "0.7.0";
+  }
+
+  revision "2018-05-16" {
+    description
+      "Added interval,min,max time to interval stats.";
+    reference "0.6.0";
+  }
+
+  revision "2017-08-16" {
+    description
+      "Added ODU Cn protocol type";
+    reference "0.5.0";
+  }
+
+  revision "2016-12-22" {
+    description
+      "Fixes and additions for terminal optics model";
+    reference "0.4.0";
+  }
+
+  // OpenConfig specific extensions for module metadata.
+  oc-ext:regexp-posix;
+  oc-ext:catalog-organization "openconfig";
+  oc-ext:origin "openconfig";
+
+  // typedef statements
+
+  typedef frequency-type {
+    type uint64;
+    units "MHz";
+    description
+      "Type for optical spectrum frequency values";
+  }
+
+  typedef admin-state-type {
+    type enumeration {
+      enum ENABLED {
+        description
+        "Sets the channel admin state to enabled";
+      }
+      enum DISABLED {
+        description
+        "Sets the channel admin state to disabled";
+      }
+      enum MAINT {
+        description
+        "Sets the channel to maintenance / diagnostic mode";
+      }
+    }
+    description "Administrative state modes for
+    logical channels in the transponder model.";
+  }
+
+  typedef loopback-mode-type {
+    type enumeration {
+      enum NONE {
+        description
+          "No loopback is applied";
+      }
+      enum FACILITY {
+        description
+          "A port internal loopback at ASIC level. The loopback directs
+          traffic normally transmitted on the port back to the device as
+          if received on the same port from an external source. Note this
+          mode is used when internal loopback does NOT specify MAC or PHY.";
+      }
+      enum TERMINAL {
+        description
+          "A port external loopback at ASIC level. The loopback which
+          directs traffic received from an external source on the port
+          back out the transmit side of the same port. Note this mode is
+          used when external loopback does NOT specify MAC or PHY";
+      }
+      enum ASIC_PHY_LOCAL {
+        description
+          "A port internal loopback at PHY module. The loopback directs
+          traffic normally transmitted on the port back to the device as
+          if received on the same port from an external source.";
+      }
+      enum ASIC_PHY_REMOTE {
+        description
+          "A port external loopback at PHY module. The loopback which
+          directs traffic received from an external source on the port
+          back out the transmit side of the same port.";
+      }
+      enum ASIC_MAC_LOCAL {
+        description
+          "A port internal loopback at MAC module. The loopback directs
+          traffic normally transmitted on the port back to the device as
+          if received on the same port from an external source.";
+      }
+      enum ASIC_MAC_REMOTE {
+        description
+          "A port external loopback at MAC module. The loopback which
+          directs traffic received from an external source on the port
+          back out the transmit side of the same port.";
+      }
+    }
+    default NONE;
+    description
+      "Loopback modes for transponder logical channels";
+  }
+
+  identity FRAME_MAPPING_PROTOCOL {
+    description
+      "Base identity for frame mapping protocols that can be used
+      when mapping Ethernet, OTN or other client signals to OTN
+      logical channels.";
+  }
+
+  identity AMP {
+    base FRAME_MAPPING_PROTOCOL;
+    description "Asynchronous Mapping Procedure";
+  }
+
+  identity GMP {
+    base FRAME_MAPPING_PROTOCOL;
+    description "Generic Mapping Procedure";
+  }
+
+  identity BMP {
+    base FRAME_MAPPING_PROTOCOL;
+    description "Bit-synchronous Mapping Procedure";
+  }
+
+  identity CBR {
+    base FRAME_MAPPING_PROTOCOL;
+    description "Constant Bit Rate Mapping Procedure";
+  }
+
+  identity GFP_T {
+    base FRAME_MAPPING_PROTOCOL;
+    description "Transparent Generic Framing Protocol";
+  }
+
+  identity GFP_F {
+    base FRAME_MAPPING_PROTOCOL;
+    description "Framed-Mapped Generic Framing Protocol";
+  }
+
+  identity TRIBUTARY_SLOT_GRANULARITY {
+    description
+      "Base identity for tributary slot granularity for OTN
+      logical channels.";
+  }
+
+  identity TRIB_SLOT_1.25G {
+    base TRIBUTARY_SLOT_GRANULARITY;
+    description
+      "The tributary slot with a bandwidth of approximately 1.25 Gb/s
+      as defined in ITU-T G.709 standard.";
+  }
+
+  identity TRIB_SLOT_2.5G {
+    base TRIBUTARY_SLOT_GRANULARITY;
+    description
+      "The tributary slot with a bandwidth of approximately 2.5 Gb/s
+      as defined in ITU-T G.709 standard.";
+  }
+
+  identity TRIB_SLOT_5G {
+    base TRIBUTARY_SLOT_GRANULARITY;
+    description
+      "The tributary slot with a bandwidth of approximately 5 Gb/s
+      as defined in ITU-T G.709 standard.";
+  }
+
+  // grouping statements
+
+  grouping avg-min-max-instant-stats-precision2-ps-nm {
+    description
+      "Common grouping for recording picosecond per nanometer
+      values with 2 decimal precision. Values include the
+      instantaneous, average, minimum, and maximum statistics.
+      Statistics are computed and reported based on a moving time
+      interval (e.g., the last 30s).  If supported by the device,
+      the time interval over which the statistics are computed, and
+      the times at which the minimum and maximum values occurred,
+      are also reported.";
+
+    leaf instant {
+      type decimal64 {
+        fraction-digits 2;
+      }
+      units ps-nm;
+      description
+        "The instantaneous value of the statistic.";
+    }
+
+    leaf avg {
+      type decimal64 {
+        fraction-digits 2;
+      }
+      units ps-nm;
+      description
+        "The arithmetic mean value of the statistic over the
+        time interval.";
+    }
+
+    leaf min {
+      type decimal64 {
+        fraction-digits 2;
+      }
+      units ps-nm;
+      description
+        "The minimum value of the statistic over the time interval.";
+    }
+
+    leaf max {
+      type decimal64 {
+        fraction-digits 2;
+      }
+      units ps-nm;
+      description
+        "The maximum value of the statistic over the time interval.";
+    }
+
+    uses oc-types:stat-interval-state;
+    uses oc-types:min-max-time;
+  }
+
+  grouping avg-min-max-instant-stats-precision2-ps {
+    description
+      "Common grouping for recording picosecond values with
+      2 decimal precision. Values include the
+      instantaneous, average, minimum, and maximum statistics.
+      Statistics are computed and reported based on a moving time
+      interval (e.g., the last 30s).  If supported by the device,
+      the time interval over which the statistics are computed, and
+      the times at which the minimum and maximum values occurred,
+      are also reported.";
+
+    leaf instant {
+      type decimal64 {
+        fraction-digits 2;
+      }
+      units ps;
+      description
+        "The instantaneous value of the statistic.";
+    }
+
+    leaf avg {
+      type decimal64 {
+        fraction-digits 2;
+      }
+      units ps;
+      description
+        "The arithmetic mean value of the statistic over the
+        time interval.";
+    }
+
+    leaf min {
+      type decimal64 {
+        fraction-digits 2;
+      }
+      units ps;
+      description
+        "The minimum value of the statistic over the time interval.";
+    }
+
+    leaf max {
+      type decimal64 {
+        fraction-digits 2;
+      }
+      units ps;
+      description
+        "The maximum value of the statistic over the time interval.";
+    }
+
+    uses oc-types:stat-interval-state;
+    uses oc-types:min-max-time;
+  }
+
+  grouping avg-min-max-instant-stats-precision2-ps2 {
+    description
+      "Common grouping for recording picosecond^2 values with
+      2 decimal precision. Values include the
+      instantaneous, average, minimum, and maximum statistics.
+      Statistics are computed and reported based on a moving time
+      interval (e.g., the last 30s).  If supported by the device,
+      the time interval over which the statistics are computed, and
+      the times at which the minimum and maximum values occurred,
+      are also reported.";
+
+    leaf instant {
+      type decimal64 {
+        fraction-digits 2;
+      }
+      units ps^2;
+      description
+        "The instantaneous value of the statistic.";
+    }
+
+    leaf avg {
+      type decimal64 {
+        fraction-digits 2;
+      }
+      units ps^2;
+      description
+        "The arithmetic mean value of the statistic over the
+        time interval.";
+    }
+
+    leaf min {
+      type decimal64 {
+        fraction-digits 2;
+      }
+      units ps^2;
+      description
+        "The minimum value of the statistic over the time interval.";
+    }
+
+    leaf max {
+      type decimal64 {
+        fraction-digits 2;
+      }
+      units ps^2;
+      description
+        "The maximum value of the statistic over the time
+        interval.";
+    }
+
+    uses oc-types:stat-interval-state;
+    uses oc-types:min-max-time;
+  }
+
+  grouping avg-min-max-instant-stats-precision18-ber {
+    description
+      "Common grouping for recording bit error rate (BER) values
+      with 18 decimal precision. Note that decimal64 supports
+      values as small as i x 10^-18 where i is an integer. Values
+      smaller than this should be reported as 0 to inidicate error
+      free or near error free performance. Values include the
+      instantaneous, average, minimum, and maximum statistics.
+      Statistics are computed and reported based on a moving time
+      interval (e.g., the last 30s).  If supported by the device,
+      the time interval over which the statistics are computed, and
+      the times at which the minimum and maximum values occurred,
+      are also reported.";
+
+    leaf instant {
+      type decimal64 {
+        fraction-digits 18;
+      }
+      units bit-errors-per-second;
+      description
+        "The instantaneous value of the statistic.";
+    }
+
+    leaf avg {
+      type decimal64 {
+        fraction-digits 18;
+      }
+      units bit-errors-per-second;
+      description
+        "The arithmetic mean value of the statistic over the
+        time interval.";
+    }
+
+    leaf min {
+      type decimal64 {
+        fraction-digits 18;
+      }
+      units bit-errors-per-second;
+      description
+        "The minimum value of the statistic over the time
+        interval.";
+    }
+
+    leaf max {
+      type decimal64 {
+        fraction-digits 18;
+      }
+      units bit-errors-per-second;
+      description
+        "The maximum value of the statistic over the time
+        interval.";
+    }
+
+    uses oc-types:stat-interval-state;
+    uses oc-types:min-max-time;
+  }
+
+  grouping avg-min-max-instant-stats-precision1-mhz {
+    description
+      "Common grouping for recording frequency values in MHz with
+      1 decimal precision. Values include the instantaneous, average,
+      minimum, and maximum statistics. Statistics are computed and
+      reported based on a moving time interval (e.g., the last 30s).
+      If supported by the device, the time interval over which the
+      statistics are computed, and the times at which the minimum and
+      maximum values occurred, are also reported.";
+
+    leaf instant {
+      type decimal64 {
+        fraction-digits 1;
+      }
+      units MHz;
+      description
+        "The instantaneous value of the statistic.";
+    }
+
+    leaf avg {
+      type decimal64 {
+        fraction-digits 1;
+      }
+      units MHz;
+      description
+        "The arithmetic mean value of the statistic over the
+        time interval.";
+    }
+
+    leaf min {
+      type decimal64 {
+        fraction-digits 1;
+      }
+      units MHz;
+      description
+        "The minimum value of the statistic over the time interval.";
+    }
+
+    leaf max {
+      type decimal64 {
+        fraction-digits 1;
+      }
+      units MHz;
+      description
+        "The maximum value of the statistic over the time interval.";
+    }
+
+    uses oc-types:stat-interval-state;
+    uses oc-types:min-max-time;
+  }
+
+  grouping avg-min-max-instant-stats-precision1-krads {
+    description
+      "Common grouping for recording kiloradian per second (krad/s) values
+      with 1 decimal precision. Values include the instantaneous,
+      average, minimum, and maximum statistics. Statistics are computed
+      and reported based on a moving time interval (e.g., the last 30s).
+      If supported by the device, the time interval over which the
+      statistics are computed, and the times at which the minimum and
+      maximum values occurred, are also reported.";
+
+    leaf instant {
+      type decimal64 {
+        fraction-digits 1;
+      }
+      units "krad/s";
+      description
+        "The instantaneous value of the statistic.";
+    }
+
+    leaf avg {
+      type decimal64 {
+        fraction-digits 1;
+      }
+      units "krad/s";
+      description
+        "The arithmetic mean value of the statistic over the
+        time interval.";
+    }
+
+    leaf min {
+      type decimal64 {
+        fraction-digits 1;
+      }
+      units "krad/s";
+      description
+        "The minimum value of the statistic over the time interval.";
+    }
+
+    leaf max {
+      type decimal64 {
+        fraction-digits 1;
+      }
+      units "krad/s";
+      description
+        "The maximum value of the statistic over the time interval.";
+    }
+
+    uses oc-types:stat-interval-state;
+    uses oc-types:min-max-time;
+  }
+
+  grouping avg-min-max-instant-stats-precision2-pct {
+    description
+      "Common grouping for percentage statistics with 2 decimal precision.
+      Values include the instantaneous, average, minimum, and maximum
+      statistics. Statistics are computed and reported based on a moving
+      time interval (e.g., the last 30s). If supported by the device,
+      the time interval over which the statistics are computed, and the
+      times at which the minimum and maximum values occurred, are also
+      reported.";
+
+    leaf instant {
+      type decimal64 {
+        fraction-digits 2;
+      }
+      units percentage;
+      description
+        "The instantaneous value of the statistic.";
+    }
+
+    leaf avg {
+      type decimal64 {
+        fraction-digits 2;
+      }
+      units percentage;
+      description
+        "The arithmetic mean value of the statistic over the
+        time interval.";
+    }
+
+    leaf min {
+      type decimal64 {
+        fraction-digits 2;
+      }
+      units percentage;
+      description
+        "The minimum value of the statistic over the time interval.";
+    }
+
+    leaf max {
+      type decimal64 {
+        fraction-digits 2;
+      }
+      units percentage;
+      description
+        "The maximum value of the statistic over the time interval.";
+    }
+
+    uses oc-types:stat-interval-state;
+    uses oc-types:min-max-time;
+  }
+
+
+  // identity statements
+
+  identity TRIBUTARY_PROTOCOL_TYPE {
+    description
+      "Base identity for protocol framing used by tributary
+      signals.";
+  }
+
+  identity PROT_1GE {
+    base TRIBUTARY_PROTOCOL_TYPE;
+    description "1G Ethernet protocol";
+  }
+
+  identity PROT_OC48 {
+    base TRIBUTARY_PROTOCOL_TYPE;
+    description "OC48 protocol";
+  }
+
+  identity PROT_STM16 {
+    base TRIBUTARY_PROTOCOL_TYPE;
+    description "STM 16 protocol";
+  }
+
+  identity PROT_10GE_LAN {
+    base TRIBUTARY_PROTOCOL_TYPE;
+    description "10G Ethernet LAN protocol";
+  }
+
+  identity PROT_10GE_WAN {
+    base TRIBUTARY_PROTOCOL_TYPE;
+    description "10G Ethernet WAN protocol";
+  }
+
+  identity PROT_OC192 {
+    base TRIBUTARY_PROTOCOL_TYPE;
+    description "OC 192 (9.6GB) port protocol";
+  }
+
+  identity PROT_STM64 {
+    base TRIBUTARY_PROTOCOL_TYPE;
+    description "STM 64 protocol";
+  }
+
+  identity PROT_OTU2 {
+    base TRIBUTARY_PROTOCOL_TYPE;
+    description "OTU 2 protocol";
+  }
+
+  identity PROT_OTU2E {
+    base TRIBUTARY_PROTOCOL_TYPE;
+    description "OTU 2e protocol";
+  }
+
+  identity PROT_OTU1E {
+    base TRIBUTARY_PROTOCOL_TYPE;
+    description "OTU 1e protocol";
+  }
+
+  identity PROT_ODU2 {
+    base TRIBUTARY_PROTOCOL_TYPE;
+    description "ODU 2 protocol";
+  }
+
+  identity PROT_ODU2E {
+    base TRIBUTARY_PROTOCOL_TYPE;
+    description "ODU 2e protocol";
+  }
+
+  identity PROT_40GE {
+    base TRIBUTARY_PROTOCOL_TYPE;
+    description "40G Ethernet port protocol";
+  }
+
+  identity PROT_OC768 {
+    base TRIBUTARY_PROTOCOL_TYPE;
+    description "OC 768 protocol";
+  }
+
+  identity PROT_STM256 {
+    base TRIBUTARY_PROTOCOL_TYPE;
+    description "STM 256 protocol";
+  }
+
+  identity PROT_OTU3 {
+    base TRIBUTARY_PROTOCOL_TYPE;
+    description "OTU 3 protocol";
+  }
+
+  identity PROT_ODU3 {
+    base TRIBUTARY_PROTOCOL_TYPE;
+    description "ODU 3 protocol";
+  }
+
+  identity PROT_100GE {
+    base TRIBUTARY_PROTOCOL_TYPE;
+    description "100G Ethernet protocol";
+  }
+
+  identity PROT_100G_MLG {
+    base TRIBUTARY_PROTOCOL_TYPE;
+    description "100G MLG protocol";
+  }
+
+  identity PROT_OTU4 {
+    base TRIBUTARY_PROTOCOL_TYPE;
+    description "OTU4 signal protocol (112G) for transporting
+    100GE signal";
+  }
+
+  identity PROT_OTUCN {
+    base TRIBUTARY_PROTOCOL_TYPE;
+    description "OTU Cn protocol";
+  }
+
+  identity PROT_ODUCN {
+    base TRIBUTARY_PROTOCOL_TYPE;
+    description "ODU Cn protocol";
+  }
+
+  identity PROT_ODU4 {
+    base TRIBUTARY_PROTOCOL_TYPE;
+    description "ODU 4 protocol";
+  }
+
+  identity PROT_400GE {
+    base TRIBUTARY_PROTOCOL_TYPE;
+    description "400G Ethernet protocol";
+  }
+
+  identity PROT_800GE {
+    base TRIBUTARY_PROTOCOL_TYPE;
+    description "800G Ethernet protocol";
+  }
+
+  identity PROT_OTSIG {
+    base TRIBUTARY_PROTOCOL_TYPE;
+    description "Optical tributary signal group protocol";
+  }
+
+  identity PROT_ODUFLEX_CBR {
+    base TRIBUTARY_PROTOCOL_TYPE;
+    description "ODU Flex with CBR protocol";
+  }
+
+  identity PROT_FLEXO {
+    base TRIBUTARY_PROTOCOL_TYPE;
+    description
+      "FlexO protocol as defined in ITU-T G.709.1 and ITU-T G.709.3";
+  }
+
+  identity PROT_ODUFLEX_GFP {
+    base TRIBUTARY_PROTOCOL_TYPE;
+    description "ODU Flex with GFP protocol";
+  }
+
+  identity TRANSCEIVER_FORM_FACTOR_TYPE {
+    description
+      "Base identity for identifying the type of pluggable optic
+      transceiver (i.e,. form factor) used in a port.";
+  }
+
+  identity CFP {
+    base TRANSCEIVER_FORM_FACTOR_TYPE;
+    description
+      "C form-factor pluggable, that can support up to a
+      100 Gb/s signal with 10x10G or 4x25G physical channels";
+  }
+
+  identity CFP2 {
+    base TRANSCEIVER_FORM_FACTOR_TYPE;
+    description
+      "1/2 C form-factor pluggable, that can support up to a
+      200 Gb/s signal with 10x10G, 4x25G, or 8x25G physical
+      channels";
+  }
+
+  identity CFP2_ACO {
+    base TRANSCEIVER_FORM_FACTOR_TYPE;
+    description
+      "CFP2 analog coherent optics transceiver, supporting
+      100 Gb, 200Gb, and 250 Gb/s signal.";
+  }
+
+  identity CFP4 {
+    base TRANSCEIVER_FORM_FACTOR_TYPE;
+    description
+      "1/4 C form-factor pluggable, that can support up to a
+      100 Gb/s signal with 10x10G or 4x25G physical channels";
+  }
+
+  identity QSFP {
+    base TRANSCEIVER_FORM_FACTOR_TYPE;
+    description
+      "OriginalQuad Small Form-factor Pluggable transceiver that can
+      support 4x1G physical channels.  Not commonly used.";
+  }
+
+  identity QSFP_PLUS {
+    base TRANSCEIVER_FORM_FACTOR_TYPE;
+    description
+      "Quad Small Form-factor Pluggable transceiver that can support
+      up to 4x10G physical channels.";
+  }
+
+  identity QSFP28 {
+    base TRANSCEIVER_FORM_FACTOR_TYPE;
+    description
+      "QSFP pluggable optic with support for up to 4x28G physical
+      channels";
+  }
+
+  identity QSFP28_DD {
+    base TRANSCEIVER_FORM_FACTOR_TYPE;
+    description
+      "QSFP-DD with electrical interfaces consisting of 8 lanes that operate at up to
+      25 Gbps with NRZ modulation";
+    reference "http://qsfp-dd.com";
+  }
+
+  identity QSFP56 {
+    base TRANSCEIVER_FORM_FACTOR_TYPE;
+    description
+      "QSFP pluggable optic with support for up to 4x56G physical
+      channels";
+  }
+
+  identity QSFP56_DD {
+    base TRANSCEIVER_FORM_FACTOR_TYPE;
+    description
+      "QSFP-DD quad small form factor pluggable double density
+      optic providing an 8 lane electrical interface";
+    reference "http://qsfp-dd.com";
+  }
+
+  identity QSFP56_DD_TYPE1 {
+    base TRANSCEIVER_FORM_FACTOR_TYPE;
+    status deprecated;
+    description
+      "QSFP DD pluggable optic with support for up to 8x56G physical
+      channels. Type 1 uses eight optical and electrical signals.";
+  }
+
+  identity QSFP56_DD_TYPE2 {
+    base TRANSCEIVER_FORM_FACTOR_TYPE;
+    status deprecated;
+    description
+      "QSFP DD pluggable optic with support for up to 4x112G physical
+      channels. Type 2 uses four optical and eight electrical
+      signals.";
+  }
+
+  identity CPAK {
+    base TRANSCEIVER_FORM_FACTOR_TYPE;
+    description
+      "Cisco CPAK transceiver supporting 100 Gb/s.";
+  }
+
+  identity SFP {
+    base TRANSCEIVER_FORM_FACTOR_TYPE;
+    description
+      "Small form-factor pluggable transceiver supporting up to
+      10 Gb/s signal";
+  }
+
+  identity SFP_PLUS {
+    base TRANSCEIVER_FORM_FACTOR_TYPE;
+    description
+      "Enhanced small form-factor pluggable transceiver supporting
+      up to 16 Gb/s signals, including 10 GbE and OTU2";
+  }
+
+  identity CSFP {
+    base TRANSCEIVER_FORM_FACTOR_TYPE;
+    description
+      "Compact Small form-factor pluggable transceiver. It is a version
+      of SFP with the same mechanical form factor allowing two independent
+      bidirectional channels per port.";
+  }
+
+
+
+  identity SFP28 {
+    base TRANSCEIVER_FORM_FACTOR_TYPE;
+    description
+      "Small form-factor pluggable transceiver supporting up to
+      25 Gb/s signal";
+  }
+
+  identity SFP56 {
+    base TRANSCEIVER_FORM_FACTOR_TYPE;
+    description
+      "Small form-factor pluggable transceiver supporting up to
+      50 Gb/s signal";
+  }
+
+  identity SFP_DD {
+    base TRANSCEIVER_FORM_FACTOR_TYPE;
+    description
+      "SFP-DD electrical interfaces will employ 2 lanes that operate up to
+      25 Gbps NRZ modulation or 56 Gbps PAM4 modulation, providing
+      solutions up to 50 Gbps or 112 Gbps PAM4 aggregate";
+    reference "http://sfp-dd.com";
+  }
+
+  identity DSFP {
+    base TRANSCEIVER_FORM_FACTOR_TYPE;
+    description
+      "A transceiver implementing the DSFP Transceiver specification";
+    reference "https://dsfpmsa.org/";
+  }
+
+  identity XFP {
+    base TRANSCEIVER_FORM_FACTOR_TYPE;
+    description
+      "10 Gigabit small form factor pluggable transceiver supporting
+      10 GbE and OTU2";
+  }
+
+  identity X2 {
+    base TRANSCEIVER_FORM_FACTOR_TYPE;
+    description
+      "10 Gigabit small form factor pluggable transceiver supporting
+      10 GbE using a XAUI inerface and 4 data channels.";
+  }
+
+  identity OSFP {
+    base TRANSCEIVER_FORM_FACTOR_TYPE;
+    description
+      "Octal small form factor pluggable transceiver supporting
+      400 Gb/s or 800 Gb/s.";
+  }
+
+  identity NON_PLUGGABLE {
+    base TRANSCEIVER_FORM_FACTOR_TYPE;
+    description
+      "Represents a port that does not require a pluggable optic,
+      e.g., with on-board optics like COBO";
+  }
+
+  identity OTHER {
+    base TRANSCEIVER_FORM_FACTOR_TYPE;
+    description
+      "Represents a transceiver form factor not otherwise listed";
+  }
+
+  identity FIBER_CONNECTOR_TYPE {
+    description
+      "Type of optical fiber connector";
+  }
+
+  identity SC_CONNECTOR {
+    base FIBER_CONNECTOR_TYPE;
+    description
+      "SC type fiber connector";
+  }
+
+  identity LC_CONNECTOR {
+    base FIBER_CONNECTOR_TYPE;
+    description
+      "LC type fiber connector";
+  }
+
+  identity MPO_CONNECTOR {
+    base FIBER_CONNECTOR_TYPE;
+    description
+      "MPO (multi-fiber push-on/pull-off) type fiber connector
+      1x12 fibers";
+  }
+
+  identity AOC_CONNECTOR {
+    base FIBER_CONNECTOR_TYPE;
+    description
+      "AOC (active optical cable) type fiber connector";
+  }
+
+  identity DAC_CONNECTOR {
+    base FIBER_CONNECTOR_TYPE;
+    description
+      "DAC (direct attach copper) type fiber connector";
+  }
+
+  identity ETHERNET_PMD_TYPE {
+    description
+      "Ethernet compliance codes (PMD) supported by transceivers";
+  }
+
+  identity ETH_1000BASE_LX10 {
+    base ETHERNET_PMD_TYPE;
+    description "Ethernet compliance code: ETH_1000BASE_LX10";
+    reference "802.3ah-2004(CL59)";
+  }
+
+  identity ETH_10GBASE_LRM {
+    base ETHERNET_PMD_TYPE;
+    description "Ethernet compliance code: 10GBASE_LRM";
+  }
+
+  identity ETH_10GBASE_LR {
+    base ETHERNET_PMD_TYPE;
+    description "Ethernet compliance code: 10GBASE_LR";
+  }
+
+  identity ETH_10GBASE_ZR {
+    base ETHERNET_PMD_TYPE;
+    description "Ethernet compliance code: 10GBASE_ZR";
+  }
+
+  identity ETH_10GBASE_ER {
+    base ETHERNET_PMD_TYPE;
+    description "Ethernet compliance code: 10GBASE_ER";
+  }
+
+  identity ETH_10GBASE_SR {
+    base ETHERNET_PMD_TYPE;
+    description "Ethernet compliance code: 10GBASE_SR";
+  }
+
+  identity ETH_25GBASE_LR {
+    base ETHERNET_PMD_TYPE;
+    description "Ethernet compliance code: 25GBASE_LR";
+    reference "IEEE 802.3cc-2022 (CL114)";
+  }
+
+  identity ETH_25GBASE_SR {
+    base ETHERNET_PMD_TYPE;
+    description "Ethernet compliance code: 25GBASE_SR";
+    reference "IEEE 802.3by-2022 (CL112)";
+  }
+
+  identity ETH_40GBASE_CR4 {
+    base ETHERNET_PMD_TYPE;
+    description "Ethernet compliance code: 40GBASE_CR4.
+    This PMD is used in Direct Attach Cables (DAC)
+    and Active Optical Cables (AOC)";
+    reference "IEEE 802.3ba 40GBASE-CR4";
+  }
+
+  identity ETH_40GBASE_SR4 {
+    base ETHERNET_PMD_TYPE;
+    description "Ethernet compliance code: 40GBASE_SR4";
+  }
+
+  identity ETH_40GBASE_LR4 {
+    base ETHERNET_PMD_TYPE;
+    description "Ethernet compliance code: 40GBASE_LR4";
+  }
+
+  identity ETH_40GBASE_ER4 {
+    base ETHERNET_PMD_TYPE;
+    description "Ethernet compliance code: 40GBASE_ER4";
+  }
+
+  identity ETH_40GBASE_PSM4 {
+    base ETHERNET_PMD_TYPE;
+    description "Ethernet compliance code: 40GBASE_PSM4";
+  }
+
+  identity ETH_4X10GBASE_LR {
+    base ETHERNET_PMD_TYPE;
+    description "Ethernet compliance code: 4x10GBASE_LR";
+  }
+
+  identity ETH_4X10GBASE_SR {
+    base ETHERNET_PMD_TYPE;
+    description "Ethernet compliance code: 4x10GBASE_SR";
+  }
+
+  identity ETH_100G_AOC {
+    base ETHERNET_PMD_TYPE;
+    description "Ethernet compliance code: 100G_AOC";
+  }
+
+  identity ETH_100G_ACC {
+    base ETHERNET_PMD_TYPE;
+    description "Ethernet compliance code: 100G_ACC";
+  }
+
+  identity ETH_100GBASE_SR10 {
+    base ETHERNET_PMD_TYPE;
+    description "Ethernet compliance code: 100GBASE_SR10";
+  }
+
+  identity ETH_100GBASE_SR4 {
+    base ETHERNET_PMD_TYPE;
+    description "Ethernet compliance code: 100GBASE_SR4";
+  }
+
+  identity ETH_100GBASE_LR4 {
+    base ETHERNET_PMD_TYPE;
+    description "Ethernet compliance code: 100GBASE_LR4";
+  }
+
+  identity ETH_100GBASE_ER4L {
+    base ETHERNET_PMD_TYPE;
+    description "Ethernet compliance code: 100GBASE_ER4L";
+  }
+
+  identity ETH_100GBASE_ER4 {
+    base ETHERNET_PMD_TYPE;
+    description "Ethernet compliance code: 100GBASE_ER4";
+  }
+
+  identity ETH_100GBASE_CWDM4 {
+    base ETHERNET_PMD_TYPE;
+    description "Ethernet compliance code: 100GBASE_CWDM4";
+  }
+
+  identity ETH_100GBASE_CLR4 {
+    base ETHERNET_PMD_TYPE;
+    description "Ethernet compliance code: 100GBASE_CLR4";
+  }
+
+  identity ETH_100GBASE_PSM4 {
+    base ETHERNET_PMD_TYPE;
+    description "Ethernet compliance code: 100GBASE_PSM4";
+  }
+
+  identity ETH_100GBASE_CR4 {
+    base ETHERNET_PMD_TYPE;
+    description "Ethernet compliance code: 100GBASE_CR4.
+      This PMD is used in Direct Attach Cables (DAC)
+      and Active Optical Cables (AOC)";
+    reference "IEEE 802.3bj 100GBASE-CR4";
+  }
+
+  identity ETH_100GBASE_FR {
+    base ETHERNET_PMD_TYPE;
+    description "Ethernet compliance code: 100GBASE_FR";
+  }
+
+  identity ETH_100GBASE_DR {
+    base ETHERNET_PMD_TYPE;
+    description "Ethernet compliance code: 100GBASE_DR";
+  }
+
+  identity ETH_400GBASE_ZR {
+    base ETHERNET_PMD_TYPE;
+    description "Ethernet compliance code: 400GBASE_ZR";
+  }
+
+  identity ETH_400GBASE_LR4 {
+    base ETHERNET_PMD_TYPE;
+    description "Ethernet compliance code: 400GBASE_LR4";
+  }
+
+  identity ETH_400GBASE_FR4 {
+    base ETHERNET_PMD_TYPE;
+    description "Ethernet compliance code: 400GBASE_FR4";
+  }
+
+  identity ETH_400GBASE_LR8 {
+    base ETHERNET_PMD_TYPE;
+    description "Ethernet compliance code: 400GBASE_LR8";
+  }
+
+  identity ETH_400GBASE_DR4 {
+    base ETHERNET_PMD_TYPE;
+    description "Ethernet compliance code: 400GBASE_DR4";
+  }
+
+  identity ETH_400GMSA_PSM4 {
+    base ETHERNET_PMD_TYPE;
+    description "Ethernet compliance code: 400GMSA_PSM4";
+  }
+
+  identity ETH_UNDEFINED {
+    base ETHERNET_PMD_TYPE;
+    description "Ethernet compliance code: undefined";
+  }
+
+  identity SONET_APPLICATION_CODE {
+    description
+      "Supported SONET/SDH application codes";
+  }
+
+  identity VSR2000_3R2 {
+    base SONET_APPLICATION_CODE;
+    description
+      "SONET/SDH application code: VSR2000_3R2";
+  }
+
+  identity VSR2000_3R3 {
+    base SONET_APPLICATION_CODE;
+    description
+      "SONET/SDH application code: VSR2000_3R3";
+  }
+
+  identity VSR2000_3R5 {
+    base SONET_APPLICATION_CODE;
+    description
+      "SONET/SDH application code: VSR2000_3R5";
+  }
+
+  identity SONET_UNDEFINED {
+    base SONET_APPLICATION_CODE;
+    description
+      "SONET/SDH application code: undefined";
+  }
+
+  identity OTN_APPLICATION_CODE {
+    description
+      "Supported OTN application codes";
+  }
+
+  identity P1L1_2D1 {
+    base OTN_APPLICATION_CODE;
+    description
+      "OTN application code: P1L1_2D1";
+  }
+
+  identity P1S1_2D2 {
+    base OTN_APPLICATION_CODE;
+    description
+      "OTN application code: P1S1_2D2";
+  }
+
+  identity P1L1_2D2 {
+    base OTN_APPLICATION_CODE;
+    description
+      "OTN application code: P1L1_2D2";
+  }
+
+  identity OTN_UNDEFINED {
+    base OTN_APPLICATION_CODE;
+    description
+      "OTN application code: undefined";
+  }
+
+  identity TRIBUTARY_RATE_CLASS_TYPE {
+    description
+      "Rate of tributary signal _- identities will typically reflect
+      rounded bit rate.";
+  }
+
+  identity TRIB_RATE_1G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "1G tributary signal rate";
+  }
+
+  identity TRIB_RATE_2.5G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "2.5G tributary signal rate";
+  }
+
+  identity TRIB_RATE_10G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "10G tributary signal rate";
+  }
+
+  identity TRIB_RATE_40G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "40G tributary signal rate";
+  }
+
+  identity TRIB_RATE_100G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "100G tributary signal rate";
+  }
+
+  identity TRIB_RATE_150G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "150G tributary signal rate";
+  }
+
+  identity TRIB_RATE_200G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "200G tributary signal rate";
+  }
+
+  identity TRIB_RATE_250G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "250G tributary signal rate";
+  }
+
+  identity TRIB_RATE_300G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "300G tributary signal rate";
+  }
+
+  identity TRIB_RATE_350G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "350G tributary signal rate";
+  }
+
+  identity TRIB_RATE_400G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "400G tributary signal rate";
+  }
+
+  identity TRIB_RATE_450G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "450G tributary signal rate";
+  }
+
+  identity TRIB_RATE_500G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "500G tributary signal rate";
+  }
+
+  identity TRIB_RATE_550G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "550G tributary signal rate";
+  }
+
+  identity TRIB_RATE_600G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "600G tributary signal rate";
+  }
+
+  identity TRIB_RATE_650G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "650G tributary signal rate";
+  }
+
+  identity TRIB_RATE_700G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "700G tributary signal rate";
+  }
+
+  identity TRIB_RATE_750G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "750G tributary signal rate";
+  }
+
+  identity TRIB_RATE_800G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "800G tributary signal rate";
+  }
+
+  identity TRIB_RATE_850G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "850G tributary signal rate";
+  }
+
+  identity TRIB_RATE_900G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "900G tributary signal rate";
+  }
+
+  identity TRIB_RATE_950G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "950G tributary signal rate";
+  }
+
+  identity TRIB_RATE_1000G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "1000G tributary signal rate";
+  }
+
+  identity TRIB_RATE_1050G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "1050G tributary signal rate";
+  }
+
+  identity TRIB_RATE_1100G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "1100G tributary signal rate";
+  }
+
+  identity TRIB_RATE_1150G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "1150G tributary signal rate";
+  }
+
+  identity TRIB_RATE_1200G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "1200G tributary signal rate";
+  }
+
+  identity TRIB_RATE_1250G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "1250G tributary signal rate";
+  }
+
+  identity TRIB_RATE_1300G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "1300G tributary signal rate";
+  }
+
+  identity TRIB_RATE_1350G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "1350G tributary signal rate";
+  }
+
+  identity TRIB_RATE_1400G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "1400G tributary signal rate";
+  }
+
+  identity TRIB_RATE_1450G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "1450G tributary signal rate";
+  }
+
+  identity TRIB_RATE_1500G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "1500G tributary signal rate";
+  }
+
+  identity TRIB_RATE_1550G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "1550G tributary signal rate";
+  }
+
+  identity TRIB_RATE_1600G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "1600G tributary signal rate";
+  }
+
+  identity TRIB_RATE_1650G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "1650G tributary signal rate";
+  }
+
+  identity TRIB_RATE_1700G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "1700G tributary signal rate";
+  }
+
+  identity TRIB_RATE_1750G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "1750G tributary signal rate";
+  }
+
+  identity TRIB_RATE_1800G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "1800G tributary signal rate";
+  }
+
+  identity TRIB_RATE_1850G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "1850G tributary signal rate";
+  }
+
+  identity TRIB_RATE_1900G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "1900G tributary signal rate";
+  }
+
+  identity TRIB_RATE_1950G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "1950G tributary signal rate";
+  }
+
+  identity TRIB_RATE_2000G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "2000G tributary signal rate";
+  }
+
+  identity TRIB_RATE_2050G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "2050G tributary signal rate";
+  }
+
+  identity TRIB_RATE_2100G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "2100G tributary signal rate";
+  }
+
+  identity TRIB_RATE_2150G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "2150G tributary signal rate";
+  }
+
+  identity TRIB_RATE_2200G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "2200G tributary signal rate";
+  }
+
+  identity TRIB_RATE_2250G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "2250G tributary signal rate";
+  }
+
+  identity TRIB_RATE_2300G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "2300G tributary signal rate";
+  }
+
+  identity TRIB_RATE_2350G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "2350G tributary signal rate";
+  }
+
+  identity TRIB_RATE_2400G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "2400G tributary signal rate";
+  }
+
+  identity TRIB_RATE_2450G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "2450G tributary signal rate";
+  }
+
+  identity TRIB_RATE_2500G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "2500G tributary signal rate";
+  }
+
+  identity TRIB_RATE_2550G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "2550G tributary signal rate";
+  }
+
+  identity TRIB_RATE_2600G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "2600G tributary signal rate";
+  }
+
+  identity TRIB_RATE_2650G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "2650G tributary signal rate";
+  }
+
+  identity TRIB_RATE_2700G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "2700G tributary signal rate";
+  }
+
+  identity TRIB_RATE_2750G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "2750G tributary signal rate";
+  }
+
+  identity TRIB_RATE_2800G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "2800G tributary signal rate";
+  }
+
+  identity TRIB_RATE_2850G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "2850G tributary signal rate";
+  }
+
+  identity TRIB_RATE_2900G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "2900G tributary signal rate";
+  }
+
+  identity TRIB_RATE_2950G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "2950G tributary signal rate";
+  }
+
+  identity TRIB_RATE_3000G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "3000G tributary signal rate";
+  }
+
+  identity TRIB_RATE_3050G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "3050G tributary signal rate";
+  }
+
+  identity TRIB_RATE_3100G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "3100G tributary signal rate";
+  }
+
+  identity TRIB_RATE_3150G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "3150G tributary signal rate";
+  }
+
+  identity TRIB_RATE_3200G {
+    base TRIBUTARY_RATE_CLASS_TYPE;
+    description
+      "3200G tributary signal rate";
+  }
+
+  identity LOGICAL_ELEMENT_PROTOCOL_TYPE {
+    description
+      "Type of protocol framing used on the logical channel or
+      tributary";
+  }
+
+  identity PROT_ETHERNET {
+    base LOGICAL_ELEMENT_PROTOCOL_TYPE;
+    description
+      "Ethernet protocol framing";
+  }
+
+  identity PROT_OTN {
+    base LOGICAL_ELEMENT_PROTOCOL_TYPE;
+    description
+      "OTN protocol framing";
+  }
+
+  identity OPTICAL_CHANNEL {
+    base oc-platform-types:OPENCONFIG_HARDWARE_COMPONENT;
+    description
+      "Optical channels act as carriers for transport traffic
+      directed over a line system.  They are represented as
+      physical components in the physical inventory model.";
+  }
+
+  identity FIBER_JUMPER_TYPE {
+    description
+      "Types of fiber jumpers used for connecting device ports";
+  }
+
+  identity FIBER_JUMPER_SIMPLEX {
+    base FIBER_JUMPER_TYPE;
+    description
+      "Simplex fiber jumper";
+  }
+
+  identity FIBER_JUMPER_MULTI_FIBER_STRAND {
+    base FIBER_JUMPER_TYPE;
+    description
+      "One strand of a fiber jumper which contains multiple fibers
+      within it, such as an MPO based fiber jumper";
+  }
+
+  identity OPTICAL_PORT_TYPE {
+    description
+      "Type definition for optical transport port types";
+  }
+
+  identity INGRESS {
+    base OPTICAL_PORT_TYPE;
+    description
+      "Ingress port, corresponding to a signal entering
+      a line system device such as an amplifier or wavelength
+      router.";
+  }
+
+  identity EGRESS {
+    base OPTICAL_PORT_TYPE;
+    description
+      "Egress port, corresponding to a signal exiting
+      a line system device such as an amplifier or wavelength
+      router.";
+  }
+
+  identity ADD {
+    base OPTICAL_PORT_TYPE;
+    description
+      "Add port, corresponding to a signal injected
+      at a wavelength router.";
+  }
+
+  identity DROP {
+    base OPTICAL_PORT_TYPE;
+    description
+      "Drop port, corresponding to a signal dropped
+      at a wavelength router.";
+  }
+
+  identity MONITOR {
+    base OPTICAL_PORT_TYPE;
+    description
+      "Monitor port, corresponding to a signal used by an optical
+      channel monitor. This is used to represent the connection
+      that a channel monitor port is connected to, typically on a
+      line system device. This  connection may be via physical cable
+      and faceplate ports or internal to the device";
+  }
+
+  identity TERMINAL_CLIENT {
+    base OPTICAL_PORT_TYPE;
+    description
+      "Client-facing port on a terminal optics device (e.g.,
+      transponder or muxponder).";
+  }
+
+  identity TERMINAL_LINE {
+    base OPTICAL_PORT_TYPE;
+    description
+      "Line-facing port on a terminal optics device (e.g.,
+      transponder or muxponder).";
+  }
+
+  identity CLIENT_MAPPING_MODE {
+    description
+      "Type definition for optical transport client mapping modes.";
+  }
+
+  identity MODE_1X100G {
+    base CLIENT_MAPPING_MODE;
+    description
+      "1 x 100G client mapping mode.";
+  }
+
+  identity MODE_1X200G {
+    base CLIENT_MAPPING_MODE;
+    description
+      "1 x 200G client mapping mode.";
+  }
+
+  identity MODE_1X400G {
+    base CLIENT_MAPPING_MODE;
+    description
+      "1 x 400G client mapping mode.";
+  }
+
+  identity MODE_2X100G {
+    base CLIENT_MAPPING_MODE;
+    description
+      "2 x 100G client mapping mode.";
+  }
+
+  identity MODE_2X200G {
+    base CLIENT_MAPPING_MODE;
+    description
+      "2 x 200G client mapping mode.";
+  }
+
+  identity MODE_3X100G {
+    base CLIENT_MAPPING_MODE;
+    description
+      "3 x 100G client mapping mode.";
+  }
+
+  identity MODE_4X100G {
+    base CLIENT_MAPPING_MODE;
+    description
+      "4 x 100G client mapping mode.";
+  }
+
+  identity TRANSCEIVER_MODULE_FUNCTIONAL_TYPE {
+    description
+      "Type definition for transceiver module functional types.";
+  }
+
+  identity TYPE_STANDARD_OPTIC {
+    base TRANSCEIVER_MODULE_FUNCTIONAL_TYPE;
+    description
+      "Standard optic using a grey wavelength (i.e. 1310, 1550, etc.)
+      and on-off-keying (OOK) modulation.";
+  }
+
+  identity TYPE_DIGITAL_COHERENT_OPTIC {
+    base TRANSCEIVER_MODULE_FUNCTIONAL_TYPE;
+    description
+      "Digital coherent module which transmits a phase / amplitude
+      modulated signal and uses a digital signal processor to receive
+      and decode the received signal.";
+  }
+}

--- a/models/yang/common/openconfig-types.yang
+++ b/models/yang/common/openconfig-types.yang
@@ -21,7 +21,19 @@ module openconfig-types {
     are used across OpenConfig models. It can be imported by modules
     that make use of these types.";
 
-  oc-ext:openconfig-version "0.5.1";
+  oc-ext:openconfig-version "1.0.0";
+
+  revision "2024-01-31" {
+    description
+      "Add posix-eregexp type and promote model to version 1.0.0.";
+    reference "1.0.0";
+  }
+
+  revision "2019-04-16" {
+    description
+      "Clarify definition of timeticks64.";
+    reference "0.6.0";
+  }
 
   revision "2018-11-21" {
     description
@@ -95,14 +107,21 @@ module openconfig-types {
       supported. An initial proposal is POSIX compatible.";
   }
 
+  typedef posix-eregexp {
+    type string;
+    description
+      "This is a string which represents an extended POSIX
+      regular expression.";
+    reference "IEEE Std 1003.1-2017";
+  }
+
   typedef timeticks64 {
     type uint64;
+    units "nanoseconds";
     description
-     "This type is based on the timeticks type defined in
-     RFC 6991, but with 64-bit width.  It represents the time,
-     modulo 2^64, in hundredths of a second between two epochs.";
-    reference
-      "RFC 6991 - Common YANG Data Types";
+     "The timeticks64 represents the time, modulo 2^64 in
+     nanoseconds between two epochs. The leaf using this
+     type must define the epochs that tests are relative to.";
   }
 
   typedef ieeefloat32 {

--- a/models/yang/common/openconfig-yang-types.yang
+++ b/models/yang/common/openconfig-yang-types.yang
@@ -32,7 +32,38 @@ module openconfig-yang-types {
     Section 4.c of the IETF Trust's Legal Provisions Relating
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
-  oc-ext:openconfig-version "0.2.1";
+  oc-ext:openconfig-version "1.0.0";
+
+  revision "2024-05-30" {
+    description
+      "Add hex-string-prefixed typedef";
+    reference "1.0.0";
+  }
+
+  revision "2021-07-14" {
+    description
+      "Use auto-generated regex for certain pattern statements:
+      - dotted-quad
+      - date-and-time
+      - date
+
+      For date-and-time, allow lowercase z and t in the pattern.";
+    reference "0.3.1";
+  }
+
+  revision "2021-03-02" {
+    description
+      "Fix date-and-time and date's pattern statement, and remove the
+      regexp-posix extension, which makes pattern statements conform to the
+      YANG standard.";
+    reference "0.3.0";
+  }
+
+  revision "2020-06-30" {
+    description
+      "Add OpenConfig POSIX pattern extensions.";
+    reference "0.2.2";
+  }
 
   revision "2018-11-21" {
     description
@@ -65,15 +96,17 @@ module openconfig-yang-types {
   }
 
   // OpenConfig specific extensions for module metadata.
-  oc-ext:regexp-posix;
   oc-ext:catalog-organization "openconfig";
   oc-ext:origin "openconfig";
 
   typedef dotted-quad {
     type string {
-      pattern '^(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|'       +
-              '25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4]' +
-              '[0-9]|25[0-5])$';
+      pattern
+        '([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\.([0-9]|'
+        + '[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])){3}';
+      oc-ext:posix-pattern
+        '^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\.([0-9]|'
+        + '[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])){3})$';
     }
     description
       "An unsigned 32-bit integer expressed as a dotted quad. The
@@ -82,11 +115,26 @@ module openconfig-yang-types {
   }
 
   typedef hex-string {
+    status deprecated;
     type string {
-      pattern '^[0-9a-fA-F]*$';
+      pattern '[0-9a-fA-F]*';
+      oc-ext:posix-pattern '^[0-9a-fA-F]*$';
     }
     description
-      "A string consisting of a hexadecimal characters.";
+      "A string consisting of a hexadecimal characters.  This leaf is
+      deprecated and will removed in a future version of this model.
+      The type hex-string-prefixed should be used instead.";
+  }
+
+  typedef hex-string-prefixed {
+    type string {
+      pattern '(0x)([0-9a-fA-F]{2})*';
+      oc-ext:posix-pattern '^(0x)([0-9a-fA-F]{2})*$';
+      length "3..max";
+    }
+    description
+      "A string encoding a hexadecimal number with a prefix of '0x' followed
+      by a list of bytes.";
   }
 
   typedef counter32 {
@@ -105,7 +153,6 @@ module openconfig-yang-types {
   typedef counter64 {
     type uint64;
     description
-
       "A 64-bit counter. A counter value is a monotonically increasing
       value which is used to express a count of a number of
       occurrences of a particular event or entity. When a counter64
@@ -118,8 +165,15 @@ module openconfig-yang-types {
   typedef date-and-time {
     type string {
       pattern
-        '^[0-9]{4}\-[0-9]{2}\-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}' +
-        '(\.[0-9]+)?Z[+-][0-9]{2}:[0-9]{2}$';
+        '[0-9]{4}\-(0[1-9]|1[0-2])\-(0[1-9]|[12][0-9]|3[01])[Tt](0[0-9]|'
+        + '1[0-9]|2[0-3]):(0[0-9]|[1-5][0-9]):(0[0-9]|[1-5][0-9]|'
+        + '60)(\.[0-9]+)?([Zz]|([+-](0[0-9]|1[0-9]|2[0-3]):(0[0-9]|'
+        + '[1-5][0-9])))';
+      oc-ext:posix-pattern
+        '^([0-9]{4}\-(0[1-9]|1[0-2])\-(0[1-9]|[12][0-9]|3[01])[Tt](0[0-9]|'
+        + '1[0-9]|2[0-3]):(0[0-9]|[1-5][0-9]):(0[0-9]|[1-5][0-9]|'
+        + '60)(\.[0-9]+)?([Zz]|([+-](0[0-9]|1[0-9]|2[0-3]):(0[0-9]|'
+        + '[1-5][0-9]))))$';
     }
     description
       "A date and time, expressed in the format described in RFC3339.
@@ -147,7 +201,10 @@ module openconfig-yang-types {
 
   typedef date {
     type string {
-      pattern '^[0-9]{4}\-[0-9]{2}\-[0-9]{2}$';
+      pattern
+        '[0-9]{4}\-(0[1-9]|1[0-2])\-(0[1-9]|[12][0-9]|3[01])';
+      oc-ext:posix-pattern
+        '^([0-9]{4}\-(0[1-9]|1[0-2])\-(0[1-9]|[12][0-9]|3[01]))$';
     }
     description
       "A full UTC date, expressed in the format described in RFC3339.
@@ -174,7 +231,8 @@ module openconfig-yang-types {
 
   typedef phys-address {
     type string {
-      pattern '^([0-9a-fA-F]{2}(:[0-9a-fA-F]{2})*)?$';
+      pattern '([0-9a-fA-F]{2}(:[0-9a-fA-F]{2})*)?';
+      oc-ext:posix-pattern '^([0-9a-fA-F]{2}(:[0-9a-fA-F]{2})*)?$';
     }
     description
       "A physical layer address, expressed as a series of pairs of
@@ -183,7 +241,8 @@ module openconfig-yang-types {
 
   typedef mac-address {
     type string {
-      pattern '^[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}$';
+      pattern '[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}';
+      oc-ext:posix-pattern '^[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}$';
     }
     description
       "An IEEE 802 MAC address";

--- a/models/yang/openconfig-platform.yang
+++ b/models/yang/openconfig-platform.yang
@@ -11,7 +11,9 @@ module openconfig-platform {
   import openconfig-extensions { prefix oc-ext; }
   import openconfig-alarm-types { prefix oc-alarm-types; }
   import openconfig-yang-types { prefix oc-yang; }
+  import openconfig-types { prefix oc-types; }
 
+  include openconfig-platform-common;
 
   // meta
   organization "OpenConfig working group";
@@ -63,7 +65,108 @@ module openconfig-platform {
     (presence or absence of a component) and state (physical
     attributes or status).";
 
-  oc-ext:openconfig-version "0.12.2";
+  oc-ext:openconfig-version "0.27.0";
+
+  revision "2024-05-29" {
+    description
+      "Change install-position from leaf-ref to string.";
+    reference "0.27.0";
+  }
+
+  revision "2024-04-12" {
+    description
+      "Add install-position, install-component and deprecate location and
+      slot-id.";
+    reference "0.26.0";
+  }
+
+  revision "2024-01-30" {
+    description
+      "Add rules for controller-card power-off
+       Also introduces last-poweroff-reason container
+       and last-poweroff-time leaf";
+    reference "0.25.0";
+  }
+
+  revision "2023-11-28" {
+    description
+      "Add model-name";
+    reference "0.24.0";
+  }
+
+  revision "2023-02-13" {
+    description
+      "Refactor resource utilization threshold config into a separate grouping.
+      Update 'utilization resource' to 'resource utilization'.";
+    reference "0.23.0";
+  }
+
+  revision "2022-12-20" {
+     description
+        "Add threshold and threshold-exceeded for resource usage.";
+      reference "0.22.0";
+   }
+
+  revision "2022-12-19" {
+    description
+      "Update last-high-watermark timestamp documentation.";
+    reference "0.21.1";
+  }
+
+  revision "2022-09-26" {
+    description
+      "Add state data for base-mac-address.";
+    reference "0.21.0";
+  }
+
+  revision "2022-08-31" {
+    description
+      "Add new state data for component CLEI code.";
+    reference "0.20.0";
+  }
+
+  revision "2022-07-28" {
+    description
+      "Add container for controller card component";
+    reference "0.19.0";
+  }
+
+  revision "2022-07-11" {
+    description
+      "Add switchover ready";
+    reference "0.18.0";
+  }
+
+  revision "2022-06-10" {
+    description
+      "Specify units and epoch for switchover and reboot times.";
+    reference "0.17.0";
+  }
+
+  revision "2022-04-21" {
+    description
+      "Add platform utilization.";
+    reference "0.16.0";
+  }
+
+  revision "2022-02-02" {
+    description
+      "Add new state data for component reboot and
+      switchover.";
+    reference "0.15.0";
+  }
+
+  revision "2021-08-13" {
+    description
+      "Add container for PCIe error statistics";
+    reference "0.14.0";
+  }
+
+  revision "2021-01-18" {
+    description
+      "Add container for software module component";
+    reference "0.13.0";
+  }
 
   revision "2019-04-16" {
     description
@@ -321,12 +424,61 @@ module openconfig-platform {
 
     leaf location {
       type string;
+      status deprecated;
       description
         "System-supplied description of the location of the
         component within the system. This could be a bay position,
         slot number, socket location, etc. For component types that
         have an explicit slot-id attribute, such as linecards, the
-        system should populate the more specific slot-id.";
+        system should populate the more specific slot-id.
+
+        This leaf is deprecated and replaced by install-position and
+        install-component.";
+    }
+
+    leaf install-position {
+      type string;
+      description
+        "System-supplied index to a position where this component is
+        installed.  The position may be referred in device documenation
+        as a port, slot, bay, socket, etc.  This string must only
+        indicate the name of the position, and not any indication of
+        the name of the parent component within the system.  Instead,
+        parent component name should be present in the 'parent' leaf.
+
+        Typically the install-position is a number, but it is observed
+        that some devices may use letters or alphanumerics.  The
+        position name should be the same name used to physically
+        identify the position in documentation or printed on the
+        device.
+
+        Any component which is removable is expected to have
+        an install-position and an install-component which points to
+        an ancestor component where the connection occurs.
+
+        For component types that have an explicit slot-id attribute,
+        such as LINECARD, the system should populate slot-id,
+        install-position and install-component.  This will facilitate a
+        transition to deprecate slot-id.";
+    }
+
+    leaf install-component {
+      type leafref {
+        path "../name";
+      }
+      description
+        "This leaf contains the name of the ancestor component which
+        contains the 'install-position'.  This creates a distinct
+        mapping between a removable component and the target component
+        it is installed into.  Note there may be zero or more
+        intermediate components between the removable component and
+        the install-component.
+
+        For example, consider the component tree
+        PORT ['eth1/2']-> INTEGRATED_CIRCUIT ['npu1']-> LINECARD ['lc1'].
+        The PORT has an install-position of '2' and install-component named
+        'lc1'.  The intermediate INTEGRATED-CIRCUIT component is not
+        present in either install-position or install-component leaves.";
     }
 
     leaf description {
@@ -387,6 +539,22 @@ module openconfig-platform {
         (field replaceable unit)";
     }
 
+    leaf model-name {
+      type string;
+      description
+        "A human readable string describing the model of a component.
+        This string is optional and should only be populated if part-no
+        is also populated.";
+    }
+
+    leaf clei-code {
+      type string;
+      description
+        "Common Language Equipment Identifier (CLEI) code of the
+        component.  This should be present in particular if the
+        component is also an FRU (field replaceable unit)";
+    }
+
     leaf removable {
       type boolean;
       description
@@ -424,6 +592,98 @@ module openconfig-platform {
         corresponding subcomponent reference from the parent
         component.";
     }
+
+    leaf redundant-role {
+      type oc-platform-types:component-redundant-role;
+      description
+        "For components that have redundant roles (e.g. two
+        supervisors in a device, one as primary the other as secondary),
+        this reports the role of the component.";
+    }
+
+    container last-poweroff-reason {
+      description
+        "Records last power-off reason for a component.";
+
+      uses oc-platform-types:component-last-poweroff-reason;
+    }
+
+    leaf last-poweroff-time {
+      type oc-types:timeticks64;
+      units "nanoseconds";
+      description
+        "This records the last time a component was directly powered
+         down. The value is a Unix Epoch timestamp (nanoseconds since
+         Jan 1, 1970 00:00:00 UTC). Component power-off can be:
+         - USER_INITIATED
+         - SYSTEM_INITIATED
+         - POWER_FAILURE
+         This field is not updated during reboots; those are tracked
+         in the 'last-reboot-time' leaf.";
+    }
+
+    container last-switchover-reason {
+      description
+        "For components that have redundant roles (e.g. two
+        supervisors in a device, one as primary the other as secondary),
+        this reports the reason of the last change of the
+        component's role.";
+
+      uses oc-platform-types:component-redundant-role-switchover-reason;
+    }
+
+    leaf last-switchover-time {
+      type oc-types:timeticks64;
+      units "nanoseconds";
+      description
+        "For components that have redundant roles (e.g. two
+        supervisors in a device, one as primary the other as
+        secondary), this reports the time of the last change of
+        the component's role. The value is the timestamp in
+        nanoseconds relative to the Unix Epoch (Jan 1, 1970 00:00:00 UTC).";
+
+    }
+
+    leaf last-reboot-reason {
+      type identityref {
+        base oc-platform-types:COMPONENT_REBOOT_REASON;
+      }
+      description
+        "This reports the reason of the last reboot of the component.";
+    }
+
+    leaf last-reboot-time {
+      type oc-types:timeticks64;
+      units "nanoseconds";
+      description
+        "This reports the time of the last reboot of the component. The
+        value is the timestamp in nanoseconds relative to the Unix Epoch
+        (Jan 1, 1970 00:00:00 UTC). This timer is not updated during
+        power shutdowns; those are tracked in 'last-poweroff-time' leaf.";
+    }
+
+    leaf switchover-ready {
+      type boolean;
+      description
+        "For components that have redundant roles, this reports a value
+        that indicates if the component is ready to support failover.
+
+        The components with a redundant-role should reflect the overall
+        system's switchover status.  For example, two supervisors in a
+        device, one as primary and the other as secondary, should both
+        report the same value.";
+    }
+
+    leaf base-mac-address {
+      type oc-yang:mac-address;
+      description
+        "This is a MAC address representing the root or primary MAC
+        address for a component.  Components such as CHASSIS and
+        CONTROLLER_CARD are expected to provide a base-mac-address.  The
+        base mac-address for CHASSIS and a PRIMARY CONTROLLER_CARD may
+        contain the same value.";
+    }
+
   }
 
   grouping platform-component-temp-alarm-state {
@@ -522,6 +782,235 @@ module openconfig-platform {
     }
   }
 
+  grouping pcie-uncorrectable-errors {
+    description
+      "PCIe uncorrectable error statistics.";
+
+    leaf total-errors {
+      type oc-yang:counter64;
+      description
+        "Total number of uncorrectable errors detected by PCIe device
+        since the system booted, according to PCIe AER driver.";
+    }
+
+    leaf undefined-errors {
+      type oc-yang:counter64;
+      description
+        "Number of undefined errors detected by PCIe device since the
+        system booted, according to PCIe AER driver.";
+    }
+
+    leaf data-link-errors {
+      type oc-yang:counter64;
+      description
+        "Number of data-link errors detected by PCIe device since the
+        system booted, according to PCIe AER driver.";
+    }
+
+    leaf surprise-down-errors {
+      type oc-yang:counter64;
+      description
+        "Number of unexpected link down errors detected by PCIe device
+        since the system booted, according to PCIe AER driver.";
+    }
+
+    leaf poisoned-tlp-errors {
+      type oc-yang:counter64;
+      description
+        "Number of poisoned TLP errors detected by PCIe device since the
+        system booted, according to PCIe AER driver.";
+    }
+
+    leaf flow-control-protocol-errors {
+      type oc-yang:counter64;
+      description
+        "Number of flow control protocol errors detected by PCIe device
+        since the system booted, according to PCIe AER driver.";
+    }
+
+    leaf completion-timeout-errors {
+      type oc-yang:counter64;
+      description
+        "Number of completion timeout errors detected by PCIe device
+        since the system booted, according to PCIe AER driver.";
+    }
+
+    leaf completion-abort-errors {
+      type oc-yang:counter64;
+      description
+        "Number of completion abort errors detected by PCIe device
+        since the system booted, according to PCIe AER driver.";
+    }
+
+    leaf unexpected-completion-errors {
+      type oc-yang:counter64;
+      description
+        "Number of unexpected completion errors detected by PCIe device
+        since the system booted, according to PCIe AER driver.";
+    }
+
+    leaf receiver-overflow-errors  {
+      type oc-yang:counter64;
+      description
+        "Number of receiver overflow errors detected by PCIe device
+        since the system booted, according to PCIe AER driver.";
+    }
+
+    leaf malformed-tlp-errors  {
+      type oc-yang:counter64;
+      description
+        "Number of malformed TLP errors detected by PCIe device since the
+        system booted, according to PCIe AER driver.";
+    }
+
+    leaf ecrc-errors  {
+      type oc-yang:counter64;
+      description
+        "Number of ECRC errors detected by PCIe device since the system
+        booted, according to PCIe AER driver.";
+    }
+
+    leaf unsupported-request-errors {
+      type oc-yang:counter64;
+      description
+        "Number of unsupported request errors detected by PCIe device
+        since the system booted, according to PCIe AER driver.";
+    }
+
+    leaf acs-violation-errors {
+      type oc-yang:counter64;
+      description
+        "Number of access control errors detected by PCIe device since
+        the system booted, according to PCIe AER driver.";
+    }
+
+    leaf internal-errors {
+      type oc-yang:counter64;
+      description
+        "Number of internal errors detected by PCIe device since the
+        system booted, according to PCIe AER driver.";
+    }
+
+    leaf blocked-tlp-errors {
+      type oc-yang:counter64;
+      description
+        "Number of blocked TLP errors detected by PCIe device since
+        the system booted, according to PCIe AER driver.";
+    }
+
+    leaf atomic-op-blocked-errors {
+      type oc-yang:counter64;
+      description
+        "Number of atomic operation blocked errors detected by PCIe
+        device since the system booted, according to PCIe AER driver.";
+    }
+
+    leaf tlp-prefix-blocked-errors {
+      type oc-yang:counter64;
+      description
+        "Number of TLP prefix blocked errors detected by PCIe device
+        since the system booted, according to PCIe AER driver.";
+    }
+  }
+
+  grouping pcie-correctable-errors {
+    description
+      "PCIe correctable error statistics.";
+
+    leaf total-errors {
+      type oc-yang:counter64;
+      description
+        "Total number of correctable errors detected by PCIe device
+        since the system booted, according to PCIe AER driver.";
+    }
+
+    leaf receiver-errors {
+      type oc-yang:counter64;
+      description
+        "Number of receiver errors detected by PCIe device since the
+        system booted, according to PCIe AER driver.";
+    }
+
+    leaf bad-tlp-errors {
+      type oc-yang:counter64;
+      description
+        "Number of TLPs with bad LCRC detected by PCIe device since the
+        system booted, according to PCIe AER driver.";
+    }
+
+    leaf bad-dllp-errors {
+      type oc-yang:counter64;
+      description
+        "Number of DLLPs with bad LCRC detected by PCIe device since the
+        system booted, according to PCIe AER driver.";
+    }
+
+    leaf relay-rollover-errors {
+      type oc-yang:counter64;
+      description
+        "Number of relay rollover errors detected by PCIe device since the
+        system booted, according to PCIe AER driver.";
+    }
+
+    leaf replay-timeout-errors {
+      type oc-yang:counter64;
+      description
+        "Number of replay timeout errors detected by PCIe device since the
+        system booted, according to PCIe AER driver.";
+    }
+
+    leaf advisory-non-fatal-errors {
+      type oc-yang:counter64;
+      description
+        "Number of advisory non fatal errors detected by PCIe device since
+        the system booted, according to PCIe AER driver.";
+    }
+
+    leaf internal-errors {
+      type oc-yang:counter64;
+      description
+        "Number of internal errors detected by PCIe device since the system
+        booted, according to PCIe AER driver.";
+    }
+
+    leaf hdr-log-overflow-errors {
+      type oc-yang:counter64;
+      description
+        "Number of header log overflow errors detected by PCIe device since
+        the system booted, according to PCIe AER driver.";
+    }
+  }
+
+  grouping platform-component-pcie-state {
+    description
+      "Per-component PCIe error statistics";
+
+    container pcie {
+      description
+        "Components that are connected to the system over the Peripheral
+        Component Interconnect Express (PCIe), report the fatal, non-fatal
+        and correctable PCIe error counts.";
+
+      container fatal-errors {
+        description
+          "The count of the fatal PCIe errors.";
+        uses pcie-uncorrectable-errors;
+      }
+
+      container non-fatal-errors {
+        description
+          "The count of the non-fatal PCIe errors.";
+        uses pcie-uncorrectable-errors;
+      }
+
+      container correctable-errors {
+        description
+          "The count of the correctable PCIe errors.";
+        uses pcie-correctable-errors;
+      }
+    }
+  }
+
   grouping platform-anchors-top {
     description
       "This grouping is used to add containers for components that
@@ -545,6 +1034,8 @@ module openconfig-platform {
         description
           "Operational state data for chassis components";
       }
+
+      uses platform-resource-utilization-top;
     }
 
 // TODO(aashaikh): linecard container is already defined in
@@ -699,6 +1190,8 @@ module openconfig-platform {
         description
           "Operational state data for chip components";
       }
+
+      uses platform-resource-utilization-top;
     }
 
     container backplane {
@@ -714,6 +1207,40 @@ module openconfig-platform {
         config false;
         description
           "Operational state data for backplane components";
+      }
+    }
+
+    container software-module {
+      description
+        "Data for software module components, i.e., for components
+        with type=SOFTWARE_MODULE";
+
+      container config {
+        description
+          "Configuration data for software module components";
+      }
+
+      container state {
+        config false;
+        description
+          "Operational state data for software module components";
+      }
+    }
+
+    container controller-card {
+      description
+        "Data for controller card components, i.e., for components
+        with type=CONTROLLER_CARD";
+
+      container config {
+        description
+          "Configuration data for controller card components.";
+      }
+
+      container state {
+        config false;
+        description
+          "Operational state data for controller card components";
       }
     }
   }
@@ -758,6 +1285,11 @@ module openconfig-platform {
           uses platform-component-temp-state;
           uses platform-component-memory-state;
           uses platform-component-power-state;
+          uses platform-component-pcie-state {
+            when "./type = 'oc-platform-types:STORAGE' or " +
+              "'oc-platform-types:INTEGRATED_CIRCUIT' or " +
+              "'oc-platform-types:FRU'";
+          }
         }
 
         uses platform-component-properties-top;

--- a/models/yang/openconfig-system.yang
+++ b/models/yang/openconfig-system.yang
@@ -14,11 +14,13 @@ module openconfig-system {
   import openconfig-extensions { prefix oc-ext; }
   import openconfig-aaa { prefix oc-aaa; }
   import openconfig-system-logging { prefix oc-log; }
-  import openconfig-system-management { prefix oc-sys-mgmt; }
   import openconfig-system-terminal { prefix oc-sys-term; }
   import openconfig-procmon { prefix oc-proc; }
+  import openconfig-platform { prefix oc-platform; }
   import openconfig-alarms { prefix oc-alarms; }
   import openconfig-messages { prefix oc-messages; }
+  import openconfig-license { prefix oc-license; }
+  import openconfig-network-instance { prefix oc-ni; }
 
   // meta
   organization "OpenConfig working group";
@@ -45,7 +47,119 @@ module openconfig-system {
     Section 4.c of the IETF Trust's Legal Provisions Relating
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
-  oc-ext:openconfig-version "0.7.0";
+  oc-ext:openconfig-version "2.1.0";
+
+  revision "2024-07-15" {
+    description
+      "Added auth key reference in ntp server configuration.";
+    reference "2.1.0";
+  }
+
+  revision "2023-12-20" {
+    description
+      "Change NTP offset, root-delay, and root-dispersion to int64 nanoseconds,
+      and update their descriptions for accuracy and clarity.";
+    reference "2.0.0";
+  }
+
+  revision "2023-10-26" {
+    description
+      "Add up-time leaf and promote module to version 1.0.";
+    reference "1.0.0";
+  }
+
+  revision "2023-06-16" {
+    description
+      "Reordered imports to be alphabetical.";
+    reference "0.17.1";
+  }
+
+  revision "2022-12-20" {
+    description
+      "Added network instance leaf to ntp client, and dropped
+      ntp-source-address from global to individual config. Removed ntp prefix.";
+    reference "0.17.0";
+  }
+
+  revision "2022-12-19" {
+    description
+      "Update last configuration timestamp documentation.";
+    reference "0.16.1";
+  }
+
+  revision "2022-09-28" {
+    description
+      "Add last configuration timestamp leaf.";
+    reference "0.16.0";
+  }
+
+  revision "2022-07-25" {
+    description
+      "Add system software version.";
+    reference "0.15.0";
+  }
+
+  revision "2022-07-20" {
+    description
+      "Added routing-mac system MAC address.";
+    reference "0.14.0";
+  }
+
+  revision "2022-07-12" {
+    description
+      "Modify ntp enabled description to reflect true and false case.";
+    reference "0.13.1";
+  }
+
+  revision "2021-07-20" {
+    description
+      "Adding list of mount points.";
+    reference "0.13.0";
+  }
+
+  revision "2021-07-14" {
+    description
+      "Support for additional RAM usage counters.";
+    reference "0.12.0";
+  }
+
+  revision "2021-06-28" {
+    description
+      "Adding system memory error counters.";
+    reference "0.11.1";
+  }
+
+  revision "2021-06-16" {
+    description
+      "Remove trailing whitespace";
+    reference "0.10.1";
+  }
+
+  revision "2020-04-13" {
+    description
+      "Remove the existing grpc-service, and add a new list
+      of the gRPC servers in a new module.";
+    reference "0.10.0";
+  }
+
+  revision "2020-03-25" {
+    description
+      "Fix typo in description statement for ipv4-address
+      list.";
+    reference "0.9.1";
+  }
+
+  revision "2020-01-07" {
+    description
+      "Add import of license management model.";
+    reference "0.9.0";
+  }
+
+  revision "2019-03-15" {
+    description
+      "Update boot time to be nanoseconds since epoch.";
+    reference "0.8.0";
+  }
 
   revision "2019-01-29" {
     description
@@ -217,6 +331,55 @@ module openconfig-system {
     }
   }
 
+  grouping mount-point-state {
+    description
+      "Operational state data for the mount point.";
+
+    leaf name {
+      type string;
+      description
+        "Mount point name.";
+    }
+
+    leaf storage-component {
+      type leafref {
+        path "/oc-platform:components/oc-platform:component/" +
+          "oc-platform:name";
+      }
+
+      description
+        "In the case that the filesystem that is mounted corresponds to a
+        physical or logical component within the system, this leaf provides
+        a reference to the hosting component within the /components
+        hierarchy.
+
+        The reference should be to the most specific component (e.g., if an
+        entry for /dev/sda1 exists, then this should be referred to,
+        otherwise a reference to /dev/sda may be provided.";
+    }
+
+    leaf size {
+      type uint64;
+      units megabytes;
+      description
+        "The total size of the initialised filesystem.";
+    }
+
+    leaf available {
+      type uint64;
+      units megabytes;
+      description
+        "The amount of unused space on the filesystem.";
+    }
+
+    leaf utilized {
+      type uint64;
+      units megabytes;
+      description
+        "The amount of space currently in use on the filesystem.";
+    }
+  }
+
   grouping system-global-state {
     description
       "Global operational state data for the system";
@@ -227,14 +390,77 @@ module openconfig-system {
           "The current system date and time.";
     }
 
+    leaf up-time {
+        type oc-types:timeticks64;
+        units "nanoseconds";
+        description
+          "The amount of time since the network operating system was
+          initialized.";
+    }
+
     leaf boot-time {
         type oc-types:timeticks64;
+        units "nanoseconds";
         description
           "This timestamp indicates the time that the system was last
-          restarted.  The value is the timestamp in seconds relative
+          restarted.  The value is the timestamp in nanoseconds relative
           to the Unix Epoch (Jan 1, 1970 00:00:00 UTC).";
     }
 
+    leaf software-version {
+        type string;
+        description
+          "Operating system version of the currently active controller
+          of the device.  It is required that this value matches the
+          value of the state/software-version leaf in the component
+          of type OPERATING_SYSTEM.";
+    }
+
+    leaf last-configuration-timestamp {
+      type oc-types:timeticks64;
+      units "nanoseconds";
+      description
+        "Indicates the monotonically increasing timestamp at which the
+        last configuration change was made. This may may be through CLI,
+        gNMI or some other mechanism. The value is the timestamp in
+        nanoseconds relative to the Unix Epoch (Jan 1, 1970 00:00:00 UTC).";
+    }
+  }
+
+  grouping mount-points-top {
+    description
+      "Top-level grouping for mount points data.";
+
+    container mount-points {
+      config false;
+      description
+        "When a system has a set of filesystems that are attached to a
+        directory (i.e., mounted on the system) they are expected to be
+        present in this list. If the system has the concept of mounting
+        physical or virtual resources to a mount point within the root
+        filesystem (/) they should also be included in this list.";
+
+      list mount-point {
+        key "name";
+        description
+          "List of mount points in the system.";
+
+        leaf name {
+          type leafref {
+            path "../state/name";
+          }
+          description
+            "Reference to the key for list of mount points.";
+        }
+
+        container state {
+          config false;
+          description
+            "State of system mount point.";
+          uses mount-point-state;
+        }
+      }
+    }
   }
 
   grouping system-dns-config {
@@ -252,7 +478,6 @@ module openconfig-system {
   grouping system-dns-state {
     description
       "Operational state data for system DNS resolver";
-
   }
 
   grouping system-dns-servers-config {
@@ -302,7 +527,7 @@ module openconfig-system {
     leaf-list ipv4-address {
       type oc-inet:ipv4-address;
       description
-        "List of IPv4 addressses for the host entry";
+        "List of IPv4 addresses for the host entry";
     }
 
     leaf-list ipv6-address {
@@ -346,9 +571,7 @@ module openconfig-system {
         }
 
         container state {
-
           config false;
-
           description
             "Operational state data for static host entries";
 
@@ -408,9 +631,7 @@ module openconfig-system {
         }
 
         container state {
-
           config false;
-
           description
             "Operational state data for each DNS resolver";
 
@@ -440,9 +661,7 @@ module openconfig-system {
       }
 
       container state {
-
         config false;
-
         description
           "Operational state data for the DNS resolver";
 
@@ -523,6 +742,26 @@ module openconfig-system {
         "Indicates whether this server should be preferred
         or not.";
     }
+
+    leaf network-instance {
+      type oc-ni:network-instance-ref;
+      description
+        "The network instance used to find this server.";
+    }
+
+    leaf source-address {
+      type oc-inet:ip-address;
+      description
+        "Source address to use on outgoing NTP packets";
+    }
+
+    leaf key-id {
+      type leafref {
+        path "../../../../ntp-keys/ntp-key/key-id";
+      }
+      description
+        "Reference to NTP authentication key for this server.";
+    }
   }
 
   grouping system-ntp-server-state {
@@ -549,39 +788,35 @@ module openconfig-system {
     }
 
     leaf root-delay {
-      type uint32;
-      // TODO: reconsider units for these values -- the spec defines
-      // rootdelay and rootdisperson as 2 16-bit integers for seconds
-      // and fractional seconds, respectively.  This gives a
-      // precision of ~15 us (2^-16).  Using milliseconds here based
-      // on what implementations typically provide and likely lack
-      // of utility for less than millisecond precision with NTP
-      // time sync.
-      units "milliseconds";
+      type int64;
+      units "nanoseconds";
       description
-        "The round-trip delay to the server, in milliseconds.";
+        "The total round-trip delay to the reference clock, in nanoseconds.";
       reference
         "RFC 5905 - Network Time Protocol Version 4: Protocol and
-        Algorithms Specification";
+        Algorithms Specification, Section 7.3";
     }
 
     leaf root-dispersion {
-      type uint64;
-      units "milliseconds";
+      type int64;
+      units "nanoseconds";
       description
-        "Dispersion (epsilon) represents the maximum error inherent
-        in the measurement";
+        "The maximum error inherent in the measurement, accumulated over the
+        stratum levels from the reference clock.";
       reference
         "RFC 5905 - Network Time Protocol Version 4: Protocol and
-        Algorithms Specification";
+        Algorithms Specification, Section 4";
     }
 
     leaf offset {
-      type uint64;
-      units "milliseconds";
+      type int64;
+      units "nanoseconds";
       description
         "Estimate of the current time offset from the peer.  This is
-        the time difference between the local and reference clock.";
+        the time difference of the peer's clock minus the local clock.";
+      reference
+        "RFC 5905 - Network Time Protocol Version 4: Protocol and
+        Algorithms Specification, Section 8";
     }
 
     leaf poll-interval {
@@ -625,16 +860,13 @@ module openconfig-system {
         }
 
         container state {
-
           config false;
-
           description
             "Operational state data for an NTP server.";
 
           uses system-ntp-server-config;
           uses system-ntp-server-state;
         }
-
       }
     }
   }
@@ -721,15 +953,9 @@ module openconfig-system {
       type boolean;
       default false;
       description
-        "Enables the NTP protocol and indicates that the system should
+        "Enables and disables the NTP protocol and indicates that the system should
         attempt to synchronize the system clock with an NTP server
         from the servers defined in the 'ntp/server' list.";
-    }
-
-    leaf ntp-source-address {
-      type oc-inet:ip-address;
-      description
-        "Source address to use on outgoing NTP packets";
     }
 
     leaf enable-ntp-auth {
@@ -782,6 +1008,52 @@ module openconfig-system {
     }
   }
 
+  grouping system-routing-macaddr-config {
+    description
+      "Configuration data for system's routing MAC addresses.";
+
+    leaf routing-mac {
+      type oc-yang:mac-address;
+      description
+        "Any packets destined to this MAC address must be sent through the
+        routing pipeline by the system. This MAC address is used to identify
+        routed packets in addition to any other MAC addresses that the system
+        may already have been using to perform routing.
+
+        It is not expected that this MAC address will be used as the
+        source MAC address of any routed packet, as the source MAC address of
+        any packets generated by the system, or a MAC address used in ARP
+        response. This MAC address may not be allocated from the block of
+        MAC address that system owns. For instance, it's allocation could
+        be managed by an external controller.";
+    }
+  }
+
+  grouping system-macaddr-top {
+    description
+      "Top-level grouping for configuration and state of system's MAC addresses.";
+
+    container mac-address {
+      description
+        "Top-level container for system's MAC address configuration and state";
+
+      container config {
+        description
+          "Configuration data for routing MAC address.";
+
+        uses system-routing-macaddr-config;
+      }
+
+      container state {
+        config false;
+        description
+          "Operational state data for routing MAC address.";
+
+        uses system-routing-macaddr-config;
+      }
+    }
+  }
+
   grouping system-memory-config {
     description
       "Configuration data for system memory";
@@ -806,6 +1078,47 @@ module openconfig-system {
       description
         "Memory reserved for system use";
     }
+
+    leaf used {
+      type uint64;
+      units bytes;
+      description
+        "Memory that has been used and not available for allocation.";
+    }
+
+    leaf free {
+      type uint64;
+      units bytes;
+      description
+        "Memory that is not used and is available for allocation.";
+    }
+  }
+
+  grouping system-memory-error-counters {
+    description
+      "Counters for system memory errors.";
+
+    leaf correctable-ecc-errors {
+      type uint64;
+      description
+        "Count of correctable ECC errors. Systems with ECC memory
+        are capable of correcting Single-bit ECC errors.";
+    }
+
+    leaf uncorrectable-ecc-errors {
+      type uint64;
+      description
+        "Count of uncorrectable ECC errors. Systems with ECC
+        memory are capable of detecting multi-bit ECC errors,
+        but cannot correct them.";
+    }
+
+    leaf total-ecc-errors {
+      type uint64;
+      description
+        "Count of total ECC errors, this includes both correctable
+        and uncorrectable ECC errors.";
+    }
   }
 
   grouping system-memory-top {
@@ -827,6 +1140,12 @@ module openconfig-system {
         config false;
         description
           "Operational state data for system memory";
+
+        container counters {
+          description
+            "Counters for tracking system memory errors";
+            uses system-memory-error-counters;
+        }
 
         uses system-memory-config;
         uses system-memory-state;
@@ -940,7 +1259,6 @@ module openconfig-system {
         }
 
         container state {
-
           description
             "Operational state data for the system CPU(s)";
 
@@ -963,7 +1281,6 @@ module openconfig-system {
         description "Global configuration data for the system";
 
         uses system-global-config;
-
       }
 
       container state {
@@ -974,24 +1291,24 @@ module openconfig-system {
         uses system-global-state;
       }
 
-      uses system-clock-top;
-      uses system-dns-top;
-      uses system-ntp-top;
-      uses oc-sys-mgmt:system-grpc-server-top;
+      uses mount-points-top;
+      uses oc-aaa:aaa-top;
+      uses oc-alarms:alarms-top;
+      uses oc-log:logging-top;
+      uses oc-proc:procmon-processes-top;
+      uses oc-messages:messages-top;
+      uses oc-license:license-top;
       uses oc-sys-term:system-ssh-server-top;
       uses oc-sys-term:system-telnet-server-top;
-      uses oc-log:logging-top;
-      uses oc-aaa:aaa-top;
-      uses system-memory-top;
+      uses system-clock-top;
       uses system-cpu-top;
-      uses oc-proc:procmon-processes-top;
-      uses oc-alarms:alarms-top;
-      uses oc-messages:messages-top;
+      uses system-dns-top;
+      uses system-macaddr-top;
+      uses system-memory-top;
+      uses system-ntp-top;
     }
   }
 
   // data definition statements
-
   uses system-top;
-
 }


### PR DESCRIPTION
Feature wise major changes -
system/state → uptime, software-version, last-configuration-timestamp nodes are added 
ntp → source-address moved to per server list from global container. Also network-instance is included per server.
            ntp key reference added for ntp servers
grpc-server → Restructured completely, multiple server provision is added. 
logging → For remote-server, network-instance support is added. Files & VTY containers are added newly 
memory → used and free leaves are added.
process → uptime leaf is removed

New features added in recent version -
license
mac-address
hashing
bootz
control-plane-traffic (copp)
resource utilization

Testing
======
Ensured no yang related error introduced, with pyang lint