### PR TITLE
[CVL] Add support for YANG map-list

### DIFF
--- a/cvl/internal/yparser/yparser.go
+++ b/cvl/internal/yparser/yparser.go
@@ -975,6 +975,8 @@ func GetModelListInfo(module *YParserModule) []*YParserListInfo {
 						l.DependentOnTable = argVal
 					case "tbl-key":
 						l.Key = argVal
+					case "map-leaf":
+						l.MapLeaf = strings.Split(argVal, " ")
 					}
 				}
 


### PR DESCRIPTION
This change adds support for YANG `map-list` and `map-leaf` extensions. This support was removed in #110 and without it,  tables defined using `map-list` and `map-leaf` do not work.