### PR TITLE
Fix dropped OnChange notifications for paths with composite fields

### DIFF
--- a/translib/subscribe_notify.go
+++ b/translib/subscribe_notify.go
@@ -482,6 +482,10 @@ func (ne *notificationEvent) createYangPathInfos(nInfo *notificationInfo, fields
 					leafName:     leaf,
 					deleted:      isDelete,
 				})
+				// If nInfo is for a leaf path, do not add multiple updates.
+				if nInfo.flags.Has(niLeafPath) {
+					return yInfos
+				}
 				continue
 			}
 			// DB field mapped to multiple leaf nodes -- a comma separated value


### PR DESCRIPTION
Paths that have composite fields defined can react to changes for any of those DB fields. If more than one of those fields changes when processing an OnChange event, the framework will generate two updates to process. This leads to an error because the framework handles multiple updates differently.

Handling multiple updates occurs [here](https://github.com/sonic-net/sonic-mgmt-common/blob/b91a4df3bd0e4be97e67ab3f27b1826b1713afc5/translib/subscribe_notify.go#L748C3-L749C84). Eventually, [mergeYgotAtPath](https://github.com/sonic-net/sonic-mgmt-common/blob/b91a4df3bd0e4be97e67ab3f27b1826b1713afc5/translib/subscribe_notify.go#L751) is called and that function tries to cast the GoStruct for the leaf path to a ValidatedGoStruct. This returns an error.

The fix is to only generate 1 update for leaf paths, even if multiple fields changed. A leaf path can never have more than 1 update because it is a single path.