### PR TITLE
CVL custom validation example and test case

### DIFF
--- a/cvl/testdata/schema/sonic-spanning-tree.yang
+++ b/cvl/testdata/schema/sonic-spanning-tree.yang
@@ -95,7 +95,8 @@ module sonic-spanning-tree {
 
         container STP {
             list STP_LIST {
-		max-elements 1;
+                sonic-ext:custom-validation ValidateStpFeatureEnabled;
+                max-elements 1;
                 key "keyleaf";
 
                 leaf keyleaf {


### PR DESCRIPTION
This commit includes an example cvl custom validation to demonstrate its capability to allow/deny configuration based on other db data. CVL test schema for the STP table now includes a custom validation callback ValidateStpFeatureEnabled(), which accepts the config only if stp_supported=true in the APPL_DB table "SWITCH_TABLE:switch". This function is compiled & run only during cvl gotest execution. Not used in the production REST or telemetry server.