### PR TITLE
sonic-mgmt-common: port to libyang3

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -78,7 +78,8 @@ stages:
         sudo dpkg -i ../target/debs/trixie/libpcre3-dev_*.deb
 
         # LIBYANG
-        sudo dpkg -i ../target/debs/trixie/libyang*1.0.73*.deb
+        sudo dpkg -i ../target/debs/trixie/libyang3_*.deb \
+                     ../target/debs/trixie/libyang-dev_3*.deb
       displayName: "Install dependency"
 
     - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -78,8 +78,7 @@ stages:
         sudo dpkg -i ../target/debs/trixie/libpcre3-dev_*.deb
 
         # LIBYANG
-        sudo dpkg -i ../target/debs/trixie/libyang3_*.deb \
-                     ../target/debs/trixie/libyang-dev_3*.deb
+        sudo dpkg -i ../target/debs/trixie/libyang*1.0.73*.deb
       displayName: "Install dependency"
 
     - script: |

--- a/cvl/cvl.go
+++ b/cvl/cvl.go
@@ -885,6 +885,7 @@ func (c *CVL) generateYangParserData(jsonNode *jsonquery.Node, root **yparser.YP
 		if *root, errObj = c.yp.MergeSubtree(*root, topNode); errObj.ErrCode != yparser.YP_SUCCESS {
 			CVL_LOG(WARNING, "Unable to merge translated YANG data(libyang) "+
 				"while translating from request data to YANG format")
+			defer c.yp.FreeNode(topNode)
 			cvlErrObj.ErrCode = CVL_SYNTAX_ERROR
 			return cvlErrObj
 		}
@@ -945,6 +946,7 @@ func (c *CVL) translateToYang(jsonMap *map[string]interface{}, buildSyntaxDOM bo
 			//Visit each top level list in a loop for creating table data
 			cvlError = c.generateYangParserData(jsonNode, &root)
 			if cvlError.ErrCode != CVL_SUCCESS {
+				defer c.yp.FreeNode(root)
 				return nil, cvlError
 			}
 		}
@@ -961,9 +963,10 @@ func (c *CVL) validate(data *yparser.YParserNode) CVLRetCode {
 	if IsTraceAllowed(TRACE_LIBYANG) {
 		TRACE_LOG(TRACE_LIBYANG, "\nValidate1 data=%v\n", c.yp.NodeDump(data))
 	}
-	errObj := c.yp.ValidateSyntax(data, depData)
-	if yparser.YP_SUCCESS != errObj.ErrCode {
-		return CVL_FAILURE
+
+	errObj, _ := c.validateSyntax(data, depData)
+	if CVL_SUCCESS != errObj.ErrCode {
+		return errObj.ErrCode
 	}
 
 	cvlErrObj := c.validateCfgSemantics(c.yv.root)
@@ -1041,6 +1044,7 @@ func (c *CVL) addCfgDataItem(configData *map[string]interface{},
 	var cfgData map[string]interface{} = *configData
 
 	tblName, key := splitRedisKey(cfgDataItem.Key)
+	CVL_LOG(WARNING, "addCfgDataItem(): table: %s, key: %s", tblName, key)
 	if tblName == "" || key == "" {
 		//Bad redis key
 		return "", ""

--- a/cvl/cvl_error_test.go
+++ b/cvl/cvl_error_test.go
@@ -67,18 +67,24 @@ func expandMessagePatterns(ex *CVLErrorInfo) {
 		ex.Msg = strings.ReplaceAll(ex.Msg, "{{field}}", ex.Field)
 		ex.Msg = strings.ReplaceAll(ex.Msg, "{{value}}", ex.Value)
 		ex.Msg = strings.TrimSuffix(ex.Msg, " \"\"") // if value is empty
+	case invalidValueNoValueErrMessage:
+		ex.Msg = strings.ReplaceAll(ex.Msg, "{{field}}", ex.Field)
 	case unknownFieldErrMessage:
+		ex.Msg = strings.ReplaceAll(ex.Msg, "{{field}}", ex.Field)
+	case missingKeyErrMessage:
 		ex.Msg = strings.ReplaceAll(ex.Msg, "{{field}}", ex.Field)
 	}
 }
 
 const (
-	invalidValueErrMessage   = "Field \"{{field}}\" has invalid value \"{{value}}\""
-	unknownFieldErrMessage   = "Unknown field \"{{field}}\""
-	genericValueErrMessage   = "Data validation failed"
-	mustExpressionErrMessage = "Must expression validation failed"
-	whenExpressionErrMessage = "When expression validation failed"
-	instanceInUseErrMessage  = "Validation failed for Delete operation, given instance is in use"
+	invalidValueErrMessage        = "Field \"{{field}}\" has invalid value \"{{value}}\""
+	invalidValueNoValueErrMessage = "Field \"{{field}}\" has invalid value"
+	unknownFieldErrMessage        = "Unknown field \"{{field}}\""
+	genericValueErrMessage        = "Data validation failed"
+	mustExpressionErrMessage      = "Must expression validation failed"
+	whenExpressionErrMessage      = "When expression validation failed"
+	instanceInUseErrMessage       = "Validation failed for Delete operation, given instance is in use"
+	missingKeyErrMessage          = "Missing Key \"{{field}}\"."
 )
 
 func verifyValidateEditConfig(t *testing.T, data []CVLEditConfigData, exp CVLErrorInfo) {

--- a/cvl/cvl_semantics.go
+++ b/cvl/cvl_semantics.go
@@ -281,7 +281,10 @@ func (c *CVL) generateYangListData(jsonNode *jsonquery.Node,
 			listConatinerNode = c.addYangNode(origTableName, topNode, origTableName, "")
 			topNodesAdded = true
 		}
-		keyValuePair := getRedisToYangKeys(tableName, redisKey)
+		keyValuePair, cvlErrObj := getRedisToYangKeys(tableName, redisKey)
+		if cvlErrObj.ErrCode != CVL_SUCCESS {
+			return nil, cvlErrObj
+		}
 		keyCompCount := len(keyValuePair)
 		totalKeyComb := 1
 		var keyIndices []int
@@ -1527,8 +1530,8 @@ func (c *CVL) checkDepDataCompatible(tblName, key, reftblName, refTblKey, leafRe
 	}
 
 	// Fetch key value pair for both current table and ref table
-	tblKeysKVP := getRedisToYangKeys(tblName, key)
-	refTblKeysKVP := getRedisToYangKeys(reftblName, refTblKey)
+	tblKeysKVP, _ := getRedisToYangKeys(tblName, key)
+	refTblKeysKVP, _ := getRedisToYangKeys(reftblName, refTblKey)
 
 	// Determine the leafref
 	leafRef := getLeafRefInfo(reftblName, leafRefField, tblName)

--- a/cvl/cvl_syntax.go
+++ b/cvl/cvl_syntax.go
@@ -225,7 +225,10 @@ func (c *CVL) generateTableData(config bool, jsonNode *jsonquery.Node) (*yparser
 			}
 			topNodesAdded = true
 		}
-		keyValuePair := getRedisToYangKeys(tableName, jsonNode.Data)
+		keyValuePair, cvlErrObj := getRedisToYangKeys(tableName, jsonNode.Data)
+		if cvlErrObj.ErrCode != CVL_SUCCESS {
+			return nil, cvlErrObj
+		}
 		keyCompCount := len(keyValuePair)
 		totalKeyComb := 1
 		var keyIndices []int

--- a/cvl/cvl_test.go
+++ b/cvl/cvl_test.go
@@ -1559,10 +1559,10 @@ func TestValidateEditConfig_Create_Syntax_IncompleteKey_Negative(t *testing.T) {
 	}
 
 	verifyValidateEditConfig(t, cfgData, CVLErrorInfo{
-		ErrCode:   cvl.CVL_SYNTAX_MISSING_FIELD,
+		ErrCode:   CVL_SYNTAX_ERROR,
 		TableName: "ACL_RULE",
-		Field:     "aclname",
-		Msg:       invalidValueErrMessage,
+		Field:     "rulename",
+		Msg:       missingKeyErrMessage,
 	})
 }
 
@@ -1783,10 +1783,10 @@ func TestValidateEditConfig_Delete_InvalidKey_Negative(t *testing.T) {
 	}
 
 	verifyValidateEditConfig(t, cfgData, CVLErrorInfo{
-		ErrCode:   cvl.CVL_SYNTAX_MISSING_FIELD,
+		ErrCode:   CVL_SYNTAX_ERROR,
 		TableName: "ACL_RULE",
-		Field:     "aclname",
-		Msg:       invalidValueErrMessage,
+		Field:     "rulename",
+		Msg:       missingKeyErrMessage,
 	})
 }
 
@@ -1811,10 +1811,10 @@ func TestValidateEditConfig_Update_Semantic_Invalid_Key_Negative(t *testing.T) {
 	}
 
 	verifyValidateEditConfig(t, cfgData, CVLErrorInfo{
-		ErrCode:   cvl.CVL_SYNTAX_MISSING_FIELD,
+		ErrCode:   CVL_SYNTAX_ERROR,
 		TableName: "ACL_RULE",
-		Field:     "aclname",
-		Msg:       invalidValueErrMessage,
+		Field:     "rulename",
+		Msg:       missingKeyErrMessage,
 	})
 }
 

--- a/cvl/cvl_when_test.go
+++ b/cvl/cvl_when_test.go
@@ -22,6 +22,7 @@ package cvl_test
 import (
 	"testing"
 
+	"github.com/Azure/sonic-mgmt-common/cvl"
 	cmn "github.com/Azure/sonic-mgmt-common/cvl/common"
 )
 
@@ -44,7 +45,8 @@ func TestValidateEditConfig_When_Exp_In_Choice_Negative(t *testing.T) {
 			map[string]string{
 				"PACKET_ACTION":     "FORWARD",
 				"IP_TYPE":           "IPV6",
-				"SRC_IP":            "10.1.1.1/32", //Invalid field
+				"SRC_IP":            "10.1.1.1/32", //Invalid field due to IP_TYPE
+				"DST_IP":            "10.1.1.2/32", //Invalid too
 				"L4_SRC_PORT":       "1909",
 				"IP_PROTOCOL":       "103",
 				"L4_DST_PORT_RANGE": "9000-12000",
@@ -54,11 +56,11 @@ func TestValidateEditConfig_When_Exp_In_Choice_Negative(t *testing.T) {
 	}
 
 	verifyValidateEditConfig(t, cfgDataRule, CVLErrorInfo{
-		ErrCode:   CVL_SEMANTIC_ERROR,
+		ErrCode:   cvl.CVL_SEMANTIC_ERROR,
 		TableName: "ACL_RULE",
-		//Keys:      []string{"TestACL1", "Rule1"},  <<< BUG: cvl is not populating the key
-		Field: "SRC_IP",
-		Value: "10.1.1.1/32",
+		//Keys: []string{"TestACL1", "Rule1"}, <<< BUG: cvl is not populating the key
+		Field: "DST_IP",
+		Value: "10.1.1.2/32",
 		Msg:   whenExpressionErrMessage,
 	})
 }

--- a/cvl/internal/util/util.go
+++ b/cvl/internal/util/util.go
@@ -25,16 +25,17 @@ package util
 
 extern void customLogCallback(LY_LOG_LEVEL, char* msg, char* path);
 
-static void customLogCb(LY_LOG_LEVEL level, const char* msg, const char* path) {
-	customLogCallback(level, (char*)msg, (char*)path);
+static void customLogCb(LY_LOG_LEVEL level, const char* msg, const char* data_path, const char * schema_path, uint64_t line) {
+	(void)line;
+	customLogCallback(level, (char*)msg, (char*)data_path?data_path:schema_path);
 }
 
 static void ly_set_log_callback(int enable) {
-	ly_set_log_clb(customLogCb, 1);
+	ly_set_log_clb(customLogCb);
 	if (enable == 1) {
-		ly_verb(LY_LLDBG);
+		ly_log_level(LY_LLDBG);
 	} else {
-		ly_verb(LY_LLERR);
+		ly_log_level(LY_LLERR);
 	}
 }
 

--- a/cvl/internal/util/util.go
+++ b/cvl/internal/util/util.go
@@ -29,6 +29,7 @@ package util
 typedef const char const_char_t;
 extern void customLogCallback(LY_LOG_LEVEL, const_char_t* msg, const_char_t* path);
 
+#if defined(LY_ARRAY_COUNT)
 static void customLogCb(LY_LOG_LEVEL level, const char* msg, const char* data_path, const char * schema_path, uint64_t line) {
 	(void)line;
 	customLogCallback(level, msg, data_path ? data_path : schema_path);
@@ -42,6 +43,20 @@ static void ly_set_log_callback(int enable) {
 		ly_log_level(LY_LLERR);
 	}
 }
+#else
+static void customLogCb(LY_LOG_LEVEL level, const char* msg, const char* path) {
+	customLogCallback(level, msg, path);
+}
+
+static void ly_set_log_callback(int enable) {
+	ly_set_log_clb(customLogCb, 1);
+	if (enable == 1) {
+		ly_verb(LY_LLDBG);
+	} else {
+		ly_verb(LY_LLERR);
+	}
+}
+#endif
 
 */
 import "C"

--- a/cvl/internal/util/util.go
+++ b/cvl/internal/util/util.go
@@ -23,11 +23,15 @@ package util
 #cgo LDFLAGS: -lyang
 #include <libyang/libyang.h>
 
-extern void customLogCallback(LY_LOG_LEVEL, char* msg, char* path);
+// Typedef so cgo preserves the const qualifier on customLogCallback's args.
+// Without it, gcc emits -Wdiscarded-qualifiers when libyang's callback (which
+// passes const char*) calls into our Go-side handler.
+typedef const char const_char_t;
+extern void customLogCallback(LY_LOG_LEVEL, const_char_t* msg, const_char_t* path);
 
 static void customLogCb(LY_LOG_LEVEL level, const char* msg, const char* data_path, const char * schema_path, uint64_t line) {
 	(void)line;
-	customLogCallback(level, (char*)msg, (char*)data_path?data_path:schema_path);
+	customLogCallback(level, msg, data_path ? data_path : schema_path);
 }
 
 static void ly_set_log_callback(int enable) {
@@ -188,7 +192,7 @@ func IsTraceSet() bool {
 changing libyang's global log setting */
 
 //export customLogCallback
-func customLogCallback(level C.LY_LOG_LEVEL, msg *C.char, path *C.char) {
+func customLogCallback(level C.LY_LOG_LEVEL, msg *C.const_char_t, path *C.const_char_t) {
 	if level == C.LY_LLERR {
 		CVL_LEVEL_LOG(WARNING, "[libyang Error] %s (path: %s)", C.GoString(msg), C.GoString(path))
 	} else {

--- a/cvl/internal/yparser/ly_path.go
+++ b/cvl/internal/yparser/ly_path.go
@@ -33,6 +33,7 @@ import (
 #include <stdio.h>
 #include <string.h>
 
+#if defined(LY_ARRAY_COUNT)
 const char *golys_module_from_prefix(const struct lys_module *module, const char *prefix)
 {
 	const struct lysp_module *mod;
@@ -51,6 +52,17 @@ const char *golys_module_from_prefix(const struct lys_module *module, const char
 
 	return NULL;
 }
+#else
+// Stub - libyang1 already stores fully-qualified prefixes in must / when /
+// leafref expressions, so rewriteXPathPrefix early-returns for libyang1 and
+// never reaches this helper.
+const char *golys_module_from_prefix(const struct lys_module *module, const char *prefix)
+{
+	(void)module;
+	(void)prefix;
+	return NULL;
+}
+#endif
 */
 import "C"
 
@@ -214,7 +226,10 @@ var lyPredicatePattern = regexp.MustCompile(`^\[([^=]*)=('[^']*'|"[^"]*")]`)
  *  - "No memory."
  */
 
-// Regex patterns to extract target node name and value from libyang error message.
+// Regex patterns to extract target node name and value from libyang error
+// message. Defaults match libyang3; init() rewrites the version-specific
+// patterns under libyang1 (which phrases things differently — e.g.
+// "Failed to find …" instead of "Term node … not found").
 var (
 	lyBadValue    = regexp.MustCompile(`[Vv]alue "([^"]*)"[ \.]`)
 	lyUnsatisfied = regexp.MustCompile(`Unsatisfied (?:pattern|range|length) - (?:value |string |)"([^"]*)" `)
@@ -223,6 +238,13 @@ var (
 	lyUnknownElem = regexp.MustCompile(`Term node "([^"]*)" not found\.`)
 	lyMandatory   = regexp.MustCompile(`Mandatory node "([^"]*)" instance does not exist\.`)
 )
+
+func init() {
+	if Libyang1 {
+		lyBadValue = regexp.MustCompile(`[Vv]alue "([^"]*)" `)
+		lyUnknownElem = regexp.MustCompile(`Failed to find "([^"]*)" `)
+	}
+}
 
 // parseLyMessage matches a libyang returned log message using given
 // regex patterns and returns the first matched group.
@@ -267,6 +289,10 @@ func parseLyMessage(s string, regex ...*regexp.Regexp) string {
 var lyXPathPrefix = regexp.MustCompile("[[/][A-Za-z0-9_-]+:")
 
 func rewriteXPathPrefix(module *YParserModule, xpath string) string {
+	if Libyang1 {
+		// libyang1 already stores fully-qualified prefixes; nothing to do.
+		return xpath
+	}
 	hasPrefix := make(map[string]bool)
 	prefixes := lyXPathPrefix.FindAllString(xpath, -1)
 

--- a/cvl/internal/yparser/yparser.go
+++ b/cvl/internal/yparser/yparser.go
@@ -40,21 +40,118 @@ import (
 #include <stdio.h>
 #include <string.h>
 
-extern int lyd_check_mandatory_tree(struct lyd_node *root, struct ly_ctx *ctx, const struct lys_module **modules, int mod_count, int options);
-
-int lyd_data_validate(struct lyd_node **node, int options, struct ly_ctx *ctx)
+size_t golysc_ext_instance_array_count(struct lysc_ext_instance *arr)
 {
-	int ret = -1;
+	return LY_ARRAY_COUNT(arr);
+}
 
-	//Check mandatory elements as it is skipped for LYD_OPT_EDIT
-	ret = lyd_check_mandatory_tree(*node, ctx, NULL, 0, LYD_OPT_CONFIG | LYD_OPT_NOEXTDEPS);
+struct lysc_ext_instance *golysc_ext_instance_array_idx(struct lysc_ext_instance *arr, size_t idx)
+{
+	return &arr[idx];
+}
 
-	if (ret != 0)
-	{
-		return ret;
+size_t golysc_must_array_count(struct lysc_must *arr)
+{
+	return LY_ARRAY_COUNT(arr);
+}
+
+size_t golyd_value_array_count(struct lyd_value **arr)
+{
+	return LY_ARRAY_COUNT(arr);
+}
+
+struct lyd_value *golyd_value_array_idx(struct lyd_value **arr, size_t idx)
+{
+	return arr[idx];
+}
+
+struct ly_ctx *goly_ctx_new(const char *search_dir, uint16_t options)
+{
+	struct ly_ctx *ctx = NULL;
+	if (ly_ctx_new(search_dir, options, &ctx) != LY_SUCCESS) {
+		return NULL;
+	}
+	return ctx;
+}
+
+struct lyd_node *golyd_new_inner(struct lyd_node *parent, const struct lys_module *module, const char *name)
+{
+	struct lyd_node *node = NULL;
+	if (lyd_new_inner(parent, module, name, 0, &node) != LY_SUCCESS) {
+		return NULL;
+	}
+	return node;
+}
+
+struct lyd_node *golyd_new_list2(struct lyd_node *parent, const struct lys_module *module, const char *name, const char *keylist, uint32_t options)
+{
+	struct lyd_node *node = NULL;
+
+	if (lyd_new_list2(parent, module, name, keylist, options, &node) != LY_SUCCESS) {
+		return NULL;
+	}
+	return node;
+}
+
+size_t golysc_node_list_keys_count(const struct lysc_node *node)
+{
+	const struct lysc_node *n;
+	const struct lysc_node_list *l;
+	size_t cnt = 0;
+
+	if (node->nodetype != LYS_LIST) {
+		return 0;
 	}
 
-	return lyd_validate(node, options, ctx);
+	l = (const struct lysc_node_list *)node;
+
+	for (n=l->child; n != NULL; n = n->next) {
+		if (n->flags & LYS_KEY) {
+			cnt++;
+		}
+	}
+	return cnt;
+}
+
+const char *golysc_node_get_when(const struct lysc_node *node)
+{
+	struct lysc_when **when = NULL;
+
+	switch (node->nodetype) {
+	case LYS_CHOICE:
+		const struct lysc_node_choice *ch = (const struct lysc_node_choice *)node;
+		when = ch->when;
+	case LYS_CASE:
+		const struct lysc_node_case *ca = (const struct lysc_node_case *)node;
+		when = ca->when;
+	}
+
+	if (when == NULL || LY_ARRAY_COUNT(when) == 0) {
+		return NULL;
+	}
+	return lyxp_get_expr(when[0]->cond);
+}
+
+static ly_bool lysc_node_is_union(const struct lysc_node *node)
+{
+	struct lysc_type *type;
+
+	if (node == NULL) {
+		return 0;
+	}
+	if (node->nodetype == LYS_LEAF) {
+		type = ((struct lysc_node_leaf *)node)->type;
+	} else if (node->nodetype == LYS_LEAFLIST) {
+		type = ((struct lysc_node_leaflist *)node)->type;
+	} else {
+		return 0;
+	}
+
+	if (type->basetype != LY_TYPE_UNION) {
+		return 0;
+	}
+
+	return 1;
 }
 
 struct leaf_value {
@@ -65,9 +162,9 @@ struct leaf_value {
 int lyd_multi_new_leaf(struct lyd_node *parent, const struct lys_module *module,
 	struct leaf_value *leafValArr, int size)
 {
-        const char *name, *val;
+	const char *name, *val;
 	struct lyd_node *leaf;
-	struct lys_type *type = NULL;
+	struct lysc_type *type = NULL;
 	int has_ptr_type = 0;
 	int idx = 0;
 
@@ -81,162 +178,140 @@ int lyd_multi_new_leaf(struct lyd_node *parent, const struct lys_module *module,
 		name = leafValArr[idx].name;
 		val = leafValArr[idx].value;
 
-		if (NULL == (leaf = lyd_new_leaf(parent, module, name, val)))
+		if (lyd_new_term(parent, module, name, val, 0, &leaf) != LY_SUCCESS)
 		{
+			fprintf(stderr, "lyd_multi_new_leaf(): lyd_new_term(%s, %s) failed\n", name, val);
 			return -1;
 		}
-
-		//Validate all union types as it is skipped for LYD_OPT_EDIT
-		if (((struct lys_node_leaflist*)leaf->schema)->type.base == LY_TYPE_UNION)
-		{
-			type = &((struct lys_node_leaflist*)leaf->schema)->type;
-
-			//save the has_ptr_type field
-			has_ptr_type = type->info.uni.has_ptr_type;
-
-			//Work around, set to 0 to check all union types
-			type->info.uni.has_ptr_type = 0;
-
-			if (lyd_validate_value(leaf->schema, val))
-			{
-				return -1;
-			}
-
-			//Restore has_ptr_type
-			type->info.uni.has_ptr_type = has_ptr_type;
-		}
 	}
-
 	return 0;
 }
 
-struct lyd_node *lyd_find_node(struct lyd_node *root, const char *xpath)
+int lyd_node_leafref_match_in_union(const struct lys_module *module, const char *xpath, const char *value)
 {
-	struct ly_set *set = NULL;
-	struct lyd_node *node = NULL;
-
-	if (root == NULL)
-	{
-		return NULL;
-	}
-
-	set = lyd_find_path(root, xpath);
-	if (set == NULL || set->number == 0) {
-		return  NULL;
-	}
-
-	node = set->set.d[0];
-	ly_set_free(set);
-
-	return node;
-}
-
-int lyd_node_leafref_match_in_union(struct lys_module *module, const char *xpath, const char *value)
-{
-	struct ly_set *set = NULL;
-	struct lys_node *node = NULL;
+	const struct lysc_node *node = NULL;
 	int idx = 0;
-	struct lys_node_leaflist* lNode;
+	struct ly_set *set = NULL;
 
 	if (module == NULL)
 	{
 		return -1;
 	}
 
-	set = lys_find_path(module, NULL, xpath);
-	if (set == NULL || set->number == 0) {
-		return  -1;
+	if (lys_find_xpath(module->ctx, NULL, xpath, 0, &set) != LY_SUCCESS || set == NULL) {
+		return -1;
 	}
 
-	node = set->set.s[0];
-	ly_set_free(set);
+	if (set->count == 0) {
+		ly_set_free(set, NULL);
+		return -1;
+	}
 
-	//Now check if it matches with any leafref node
-	lNode = (struct lys_node_leaflist*)node;
+	node = set->snodes[0];
+	ly_set_free(set, NULL);
 
-	for (idx = 0; idx < lNode->type.info.uni.count; idx++)
+	if (!lysc_node_is_union(node)) {
+		return -1;
+	}
+
+	if (lysc_node_lref_targets(node, &set) != LY_SUCCESS || set == NULL)
 	{
-		if (lNode->type.info.uni.types[idx].base != LY_TYPE_LEAFREF)
-		{
-			//Look for leafref type only
-			continue;
-		}
+		return -1;
+	}
 
-		if (0 == lyd_validate_value((struct lys_node*)
-		    lNode->type.info.uni.types[idx].info.lref.target, value))
+	for (idx = 0; idx < set->count; idx++) {
+		if (lyd_value_validate(module->ctx, set->snodes[idx], value, strlen(value), NULL, NULL, NULL) == LY_SUCCESS)
 		{
+			ly_set_free(set, NULL);
 			return 0;
 		}
 	}
 
+	ly_set_free(set, NULL);
 	return -1;
 }
 
-struct lys_node* lys_get_snode(struct ly_set *set, int idx) {
-	if (set == NULL || set->number == 0) {
+struct lysc_xpath_targets {
+	const char **xpathlist; // path list
+	size_t count; // actual path count
+};
+
+void golys_xpath_targets_free(struct lysc_xpath_targets *paths)
+{
+	size_t i;
+
+	if (paths == NULL) {
+		return;
+	}
+
+	free(paths->xpathlist);
+	free(paths);
+}
+
+static struct lysc_xpath_targets *golys_xpath_targets_alloc(size_t cnt)
+{
+	struct lysc_xpath_targets *paths = malloc(sizeof(*paths));
+	paths->xpathlist = malloc(sizeof(*paths->xpathlist) * cnt);
+	paths->count = cnt;
+	return paths;
+}
+
+static const char *nonLeafRef = "non-leafref";
+struct lysc_xpath_targets *golys_xpath_targets_get(const struct lysc_node *node)
+{
+	struct lysc_type *type;
+	struct lysc_xpath_targets *paths = NULL;
+	LY_ARRAY_COUNT_TYPE u;
+
+	if (node == NULL) {
 		return NULL;
 	}
 
-	return set->set.s[idx];
-}
+	type = ((struct lysc_node_leaf *)node)->type;
+	if (type->basetype == LY_TYPE_UNION) {
+		// union with possible leafrefs
+		struct lysc_type_union *type_un = (struct lysc_type_union *)type;
 
-int lyd_change_leaf_data(struct lyd_node *leaf, const char *val_str) {
-  return lyd_change_leaf((struct lyd_node_leaf_list *)leaf, val_str);
-}
+		paths = golys_xpath_targets_alloc(LY_ARRAY_COUNT(type_un->types));
 
-struct lys_leaf_ref_path {
-	const char *path[10]; //max 10 path
-	int count; //actual path count
-};
+		LY_ARRAY_FOR(type_un->types, u) {
+			struct lysc_type_leafref *lref_type;
 
-const char *nonLeafRef = "non-leafref";
-struct lys_leaf_ref_path* lys_get_leafrefs(struct lys_node_leaf *node) {
-	static struct lys_leaf_ref_path leafrefs;
-	memset(&leafrefs, 0, sizeof(leafrefs));
-
-	int nonLeafRefCnt = 0;
-
-	if (node->type.base == LY_TYPE_LEAFREF) {
-		leafrefs.path[0] = node->type.info.lref.path;
-		leafrefs.count = 1;
-
-	} else if (node->type.base == LY_TYPE_UNION) {
-		int typeCnt = 0;
-		for (; typeCnt < node->type.info.uni.count; typeCnt++) {
-			if (node->type.info.uni.types[typeCnt].base != LY_TYPE_LEAFREF) {
-				if (nonLeafRefCnt == 0) {
-					leafrefs.path[leafrefs.count] = nonLeafRef; //data type, not leafref
-					leafrefs.count += 1;
-					nonLeafRefCnt++;
-				}
-
+			if (type_un->types[u]->basetype != LY_TYPE_LEAFREF) {
+				paths->xpathlist[u] = nonLeafRef;
 				continue;
 			}
 
-			leafrefs.path[leafrefs.count] = node->type.info.uni.types[typeCnt].info.lref.path;
-			leafrefs.count += 1;
+			lref_type = (struct lysc_type_leafref *)type_un->types[u];
+
+			if (lref_type->path && lyxp_get_expr(lref_type->path) != NULL) {
+				paths->xpathlist[u] = lyxp_get_expr(lref_type->path);
+			} else {
+				paths->xpathlist[u] = nonLeafRef;
+			}
+		}
+	} else if (type->basetype == LY_TYPE_LEAFREF) {
+		struct lysc_type_leafref *lref_type = (struct lysc_type_leafref *)type;
+
+		paths = golys_xpath_targets_alloc(1);
+
+		if (lref_type->path && lyxp_get_expr(lref_type->path) != NULL) {
+			paths->xpathlist[0] = lyxp_get_expr(lref_type->path);
+		} else {
+			paths->xpathlist[0] = nonLeafRef;
 		}
 	}
-
-	if ((leafrefs.count - nonLeafRefCnt) > 0) {
-		return &leafrefs;
-	} else {
-		return NULL;
-	}
+	return paths;
 }
-
 */
 import "C"
 
 type YParserCtx C.struct_ly_ctx
 type YParserNode C.struct_lyd_node
-type YParserSNode C.struct_lys_node
+type YParserSNode C.struct_lysc_node
 type YParserModule C.struct_lys_module
 
 var ypCtx *YParserCtx
-var ypOpModule *YParserModule
-var ypOpRoot *YParserNode //Operation root
-var ypOpNode *YParserNode //Operation node
 
 type XpathExpression struct {
 	Expr    string
@@ -278,9 +353,7 @@ type YParserLeafValue struct {
 }
 
 type YParser struct {
-	//ctx *YParserCtx    //Parser context
-	root      *YParserNode //Top evel root for validation
-	operation string       //Edit operation
+	// Empty
 }
 
 // YParserError YParser Error Structure
@@ -321,13 +394,6 @@ const (
 	YP_INTERNAL_UNKNOWN
 )
 
-const (
-	YP_NOP = 1 + iota
-	YP_OP_CREATE
-	YP_OP_UPDATE
-	YP_OP_DELETE
-)
-
 // cvl-yin generator adds this prefix to all user defined error messages.
 const customErrorPrefix = "[Error]"
 
@@ -350,9 +416,9 @@ func init() {
 
 func Debug(on bool) {
 	if on {
-		C.ly_verb(C.LY_LLDBG)
+		C.ly_log_level(C.LY_LLDBG)
 	} else {
-		C.ly_verb(C.LY_LLERR)
+		C.ly_log_level(C.LY_LLERR)
 	}
 }
 
@@ -360,45 +426,70 @@ func Initialize() {
 	if !yparserInitialized {
 		cs := C.CString(CVL_SCHEMA)
 		defer C.free(unsafe.Pointer(cs))
-		ypCtx = (*YParserCtx)(C.ly_ctx_new(cs, 0))
-		C.ly_verb(C.LY_LLERR)
+		ypCtx = (*YParserCtx)(C.goly_ctx_new(cs, 0))
+		C.ly_log_level(C.LY_LLERR)
 		//	yparserInitialized = true
 	}
 }
 
 func Finish() {
 	if yparserInitialized {
-		C.ly_ctx_destroy((*C.struct_ly_ctx)(ypCtx), nil)
+		C.ly_ctx_destroy((*C.struct_ly_ctx)(ypCtx))
 		//	yparserInitialized = false
 	}
 }
 
 // ParseSchemaFile Parse YIN schema file
 func ParseSchemaFile(modelFile string) (*YParserModule, YParserError) {
-	module := C.lys_parse_path((*C.struct_ly_ctx)(ypCtx), C.CString(modelFile), C.LYS_IN_YIN)
-	if module == nil {
+	var module *C.struct_lys_module
+	csModelFile := C.CString(modelFile)
+	defer C.free(unsafe.Pointer(csModelFile))
+	if C.lys_parse_path((*C.struct_ly_ctx)(ypCtx), csModelFile, C.LYS_IN_YIN, &module) != C.LY_SUCCESS {
 		return nil, getErrorDetails()
-	}
-
-	if strings.Contains(modelFile, "sonic-common.yin") {
-		ypOpModule = (*YParserModule)(module)
-		ypOpRoot = (*YParserNode)(C.lyd_new(nil, (*C.struct_lys_module)(ypOpModule), C.CString("operation")))
-		ypOpNode = (*YParserNode)(C.lyd_new_leaf((*C.struct_lyd_node)(ypOpRoot), (*C.struct_lys_module)(ypOpModule), C.CString("operation"), C.CString("NOP")))
 	}
 
 	return (*YParserModule)(module), YParserError{ErrCode: YP_SUCCESS}
 }
 
-// AddChildNode Add child node to a parent node
-func (yp *YParser) AddChildNode(module *YParserModule, parent *YParserNode, name string) *YParserNode {
+func (yp *YParser) AddContainerNode(module *YParserModule, parent *YParserNode, name string) (*YParserNode, YParserError) {
 	nameCStr := C.CString(name)
 	defer C.free(unsafe.Pointer(nameCStr))
-	ret := (*YParserNode)(C.lyd_new((*C.struct_lyd_node)(parent), (*C.struct_lys_module)(module), (*C.char)(nameCStr)))
+	ret := (*YParserNode)(C.golyd_new_inner((*C.struct_lyd_node)(parent), (*C.struct_lys_module)(module), (*C.char)(nameCStr)))
 	if ret == nil {
 		TRACE_LOG(TRACE_YPARSER, "Failed parsing node %s", name)
+		return ret, getErrorDetails()
 	}
 
-	return ret
+	return ret, YParserError{ErrCode: YP_SUCCESS}
+}
+
+func (yp *YParser) AddListNode(module *YParserModule, parent *YParserNode, name string, keys []*YParserLeafValue) (*YParserNode, YParserError) {
+	var keylist string
+
+	// All key values predicate in the form of "[key1='val1'][key2='val2']...", they do not have to be ordered.
+	for index := 0; index < len(keys); index++ {
+		if (keys[index] == nil) || (keys[index].Name == "") {
+			break
+		}
+
+		keylist += "["
+		keylist += keys[index].Name
+		keylist += "='"
+		keylist += keys[index].Value
+		keylist += "']"
+	}
+
+	nameCStr := C.CString(name)
+	defer C.free(unsafe.Pointer(nameCStr))
+	keylistCStr := C.CString(keylist)
+	defer C.free(unsafe.Pointer(keylistCStr))
+	ret := (*YParserNode)(C.golyd_new_list2((*C.struct_lyd_node)(parent), (*C.struct_lys_module)(module), (*C.char)(nameCStr), (*C.char)(keylistCStr), 0))
+	if ret == nil {
+		TRACE_LOG(TRACE_YPARSER, "Failed parsing node %s", name)
+		return ret, getErrorDetails()
+	}
+
+	return ret, YParserError{ErrCode: YP_SUCCESS}
 }
 
 // IsLeafrefMatchedInUnion Check if value matches with leafref node in union
@@ -414,6 +505,9 @@ func (yp *YParser) IsLeafrefMatchedInUnion(module *YParserModule, xpath, value s
 
 // AddMultiLeafNodes dd child node to a parent node
 func (yp *YParser) AddMultiLeafNodes(module *YParserModule, parent *YParserNode, multiLeaf []*YParserLeafValue) YParserError {
+	if len(multiLeaf) == 0 {
+		return YParserError{ErrCode: YP_SUCCESS}
+	}
 
 	leafValArr := make([]C.struct_leaf_value, len(multiLeaf))
 	tmpArr := make([]*C.char, len(multiLeaf)*2)
@@ -423,7 +517,6 @@ func (yp *YParser) AddMultiLeafNodes(module *YParserModule, parent *YParserNode,
 		if (multiLeaf[index] == nil) || (multiLeaf[index].Name == "") {
 			break
 		}
-
 		//Accumulate all name/value in array to be passed in lyd_multi_new_leaf()
 		nameCStr := C.CString(multiLeaf[index].Name)
 		valCStr := C.CString(multiLeaf[index].Value)
@@ -458,7 +551,8 @@ func (yp *YParser) NodeDump(root *YParserNode) string {
 		return ""
 	} else {
 		var outBuf *C.char
-		C.lyd_print_mem(&outBuf, (*C.struct_lyd_node)(root), C.LYD_XML, C.LYP_WITHSIBLINGS)
+		C.lyd_print_mem(&outBuf, (*C.struct_lyd_node)(root), C.LYD_JSON, C.LYD_PRINT_WITHSIBLINGS)
+		defer C.free(unsafe.Pointer(outBuf))
 		return C.GoString(outBuf)
 	}
 }
@@ -476,7 +570,7 @@ func (yp *YParser) MergeSubtree(root, node *YParserNode) (*YParserNode, YParserE
 		TRACE_LOG(TRACE_YPARSER, "Root subtree = %v\n", rootdumpStr)
 	}
 
-	if C.lyd_merge_to_ctx(&rootTmp, (*C.struct_lyd_node)(node), C.LYD_OPT_DESTRUCT, (*C.struct_ly_ctx)(ypCtx)) != 0 {
+	if C.lyd_merge_siblings(&rootTmp, (*C.struct_lyd_node)(node), C.LYD_MERGE_DESTRUCT) != C.LY_SUCCESS {
 		return (*YParserNode)(rootTmp), getErrorDetails()
 	}
 
@@ -488,34 +582,16 @@ func (yp *YParser) MergeSubtree(root, node *YParserNode) (*YParserNode, YParserE
 	return (*YParserNode)(rootTmp), YParserError{ErrCode: YP_SUCCESS}
 }
 
-func (yp *YParser) DestroyCache() YParserError {
-
-	if yp.root != nil {
-		C.lyd_free_withsiblings((*C.struct_lyd_node)(yp.root))
-		yp.root = nil
-	}
-
-	return YParserError{ErrCode: YP_SUCCESS}
-}
-
-// SetOperation Set operation
-func (yp *YParser) SetOperation(op string) YParserError {
-	if ypOpNode == nil {
-		return YParserError{ErrCode: YP_INTERNAL_UNKNOWN}
-	}
-
-	if C.lyd_change_leaf_data((*C.struct_lyd_node)(ypOpNode), C.CString(op)) != 0 {
-		return YParserError{ErrCode: YP_INTERNAL_UNKNOWN}
-	}
-
-	yp.operation = op
-	return YParserError{ErrCode: YP_SUCCESS}
-}
-
 // createTempDepData merge depdata and data to create temp data. used in syntax, semantic and custom validation
-func (yp *YParser) createTempDepData(dataTmp *(*C.struct_lyd_node), depData *YParserNode) YParserError {
+func (yp *YParser) mergeDepData(data *(*C.struct_lyd_node), depData *YParserNode, destruct bool) YParserError {
+	var flags C.uint16_t
 
-	if C.lyd_merge_to_ctx(dataTmp, (*C.struct_lyd_node)(depData), C.LYD_OPT_DESTRUCT, (*C.struct_ly_ctx)(ypCtx)) != 0 {
+	flags = 0
+	if destruct {
+		flags |= C.LYD_MERGE_DESTRUCT
+	}
+
+	if C.lyd_merge_siblings(data, (*C.struct_lyd_node)(depData), flags) != C.LY_SUCCESS {
 		TRACE_LOG((TRACE_SYNTAX | TRACE_LIBYANG), "Unable to merge dependent data\n")
 		return getErrorDetails()
 	}
@@ -523,21 +599,27 @@ func (yp *YParser) createTempDepData(dataTmp *(*C.struct_lyd_node), depData *YPa
 }
 
 // ValidateSyntax Perform syntax checks
-func (yp *YParser) ValidateSyntax(data, depData *YParserNode) YParserError {
-	dataTmp := (*C.struct_lyd_node)(data)
+func (yp *YParser) ValidateSyntax(data *YParserNode, depData *YParserNode) YParserError {
+	if data == nil {
+		return YParserError{ErrCode: YP_INTERNAL_UNKNOWN}
+	}
 
-	if data != nil && depData != nil {
-		//merge ependent data for synatx validation - Update/Delete case
-		err := yp.createTempDepData(&dataTmp, depData)
+	dataPtr := (*C.struct_lyd_node)(data)
+
+	if depData != nil {
+		// merge dependent data for syntax validation - Update/Delete case
+		// This is a destructive merge, depData is no longer valid.
+		err := yp.mergeDepData(&dataPtr, depData, true)
+		depData = nil
 		if err.ErrCode != YP_SUCCESS {
 			return err
 		}
 	}
 
 	//Just validate syntax
-	if C.lyd_data_validate(&dataTmp, C.LYD_OPT_EDIT|C.LYD_OPT_NOEXTDEPS, (*C.struct_ly_ctx)(ypCtx)) != 0 {
+	if C.lyd_validate_all(&dataPtr, (*C.struct_ly_ctx)(ypCtx), C.LYD_VALIDATE_PRESENT|C.LYD_VALIDATE_NO_STATE|C.LYD_VALIDATE_NOEXTDEPS, nil) != C.LY_SUCCESS {
 		if IsTraceAllowed(TRACE_ONERROR) {
-			strData := yp.NodeDump((*YParserNode)(dataTmp))
+			strData := yp.NodeDump((*YParserNode)(dataPtr))
 			TRACE_LOG(TRACE_ONERROR, "Failed to validate Syntax, data = %v", strData)
 		}
 		return getErrorDetails()
@@ -548,7 +630,7 @@ func (yp *YParser) ValidateSyntax(data, depData *YParserNode) YParserError {
 
 func (yp *YParser) FreeNode(node *YParserNode) YParserError {
 	if node != nil {
-		C.lyd_free_withsiblings((*C.struct_lyd_node)(node))
+		C.lyd_free_all((*C.struct_lyd_node)(node))
 		node = nil
 	}
 
@@ -562,41 +644,28 @@ func translateLYErrToYParserErr(LYErrcode int) YParserRetCode {
 	switch LYErrcode {
 	case C.LYVE_SUCCESS: /**< no error */
 		ypErrCode = YP_SUCCESS
-	case C.LYVE_XML_MISS, C.LYVE_INARG, C.LYVE_MISSELEM: /**< missing XML object */
-		ypErrCode = YP_SYNTAX_MISSING_FIELD
-	case C.LYVE_XML_INVAL, C.LYVE_XML_INCHAR, C.LYVE_INMOD, C.LYVE_INELEM, C.LYVE_INVAL, C.LYVE_MCASEDATA: /**< invalid XML object */
-		ypErrCode = YP_SYNTAX_INVALID_FIELD
-	case C.LYVE_EOF, C.LYVE_INSTMT, C.LYVE_INPAR, C.LYVE_INID, C.LYVE_MISSSTMT, C.LYVE_MISSARG: /**< invalid statement (schema) */
+	case C.LYVE_SYNTAX: /**< generic syntax error */
 		ypErrCode = YP_SYNTAX_INVALID_INPUT_DATA
-	case C.LYVE_TOOMANY: /**< too many instances of some object */
-		ypErrCode = YP_SYNTAX_MULTIPLE_INSTANCE
-	case C.LYVE_DUPID, C.LYVE_DUPLEAFLIST, C.LYVE_DUPLIST, C.LYVE_NOUNIQ: /**< duplicated identifier (schema) */
-		ypErrCode = YP_SYNTAX_DUPLICATE
-	case C.LYVE_ENUM_INVAL: /**< invalid enum value (schema) */
-		ypErrCode = YP_SYNTAX_ENUM_INVALID
-	case C.LYVE_ENUM_INNAME: /**< invalid enum name (schema) */
-		ypErrCode = YP_SYNTAX_ENUM_INVALID_NAME
-	case C.LYVE_ENUM_WS: /**< enum name with leading/trailing whitespaces (schema) */
-		ypErrCode = YP_SYNTAX_ENUM_WHITESPACE
-	case C.LYVE_KEY_NLEAF, C.LYVE_KEY_CONFIG, C.LYVE_KEY_TYPE: /**< list key is not a leaf (schema) */
-		ypErrCode = YP_SEMANTIC_KEY_INVALID
-	case C.LYVE_KEY_MISS, C.LYVE_PATH_MISSKEY: /**< list key not found (schema) */
-		ypErrCode = YP_SEMANTIC_KEY_NOT_EXIST
-	case C.LYVE_KEY_DUP: /**< duplicated key identifier (schema) */
-		ypErrCode = YP_SEMANTIC_KEY_DUPLICATE
-	case C.LYVE_NOMIN: /**< min-elements constraint not honored (data) */
-		ypErrCode = YP_SYNTAX_MINIMUM_INVALID
-	case C.LYVE_NOMAX: /**< max-elements constraint not honored (data) */
-		ypErrCode = YP_SYNTAX_MAXIMUM_INVALID
-	case C.LYVE_NOMUST, C.LYVE_NOWHEN, C.LYVE_INWHEN, C.LYVE_NOLEAFREF: /**< unsatisfied must condition (data) */
+	case C.LYVE_SYNTAX_YANG: /**< YANG-related syntax error */
+		ypErrCode = YP_SYNTAX_INVALID_INPUT_DATA
+	case C.LYVE_SYNTAX_YIN: /**< YIN-related syntax error */
+		ypErrCode = YP_SYNTAX_INVALID_INPUT_DATA
+	case C.LYVE_REFERENCE: /**< invalid referencing or using an item */
 		ypErrCode = YP_SEMANTIC_DEPENDENT_DATA_MISSING
-	case C.LYVE_NOMANDCHOICE: /**< max-elements constraint not honored (data) */
-		ypErrCode = YP_SEMANTIC_MANDATORY_DATA_MISSING
-	case C.LYVE_PATH_EXISTS: /**< target node already exists (path) */
-		ypErrCode = YP_SEMANTIC_KEY_ALREADY_EXIST
+	case C.LYVE_XPATH: /**< invalid XPath expression */
+		ypErrCode = YP_SEMANTIC_KEY_NOT_EXIST
+	case C.LYVE_SEMANTICS: /**< generic semantic error */
+		ypErrCode = YP_SEMANTIC_KEY_INVALID
+	case C.LYVE_SYNTAX_XML: /**< XML-related syntax error */
+		ypErrCode = YP_SYNTAX_INVALID_FIELD
+	case C.LYVE_SYNTAX_JSON: /**< JSON-related syntax error */
+		ypErrCode = YP_SYNTAX_INVALID_FIELD
+	case C.LYVE_DATA: /**< YANG data does not reflect some of the module restrictions */
+		ypErrCode = YP_SEMANTIC_DEPENDENT_DATA_MISSING
+	case C.LYVE_OTHER:
+		ypErrCode = YP_INTERNAL_UNKNOWN
 	default:
 		ypErrCode = YP_INTERNAL_UNKNOWN
-
 	}
 	return ypErrCode
 }
@@ -613,25 +682,27 @@ func getErrorDetails() YParserError {
 	var errMsg, errPath, errAppTag string
 
 	ctx := (*C.struct_ly_ctx)(ypCtx)
-	ypErrFirst := C.ly_err_first(ctx)
+	ypErrLast := C.ly_err_last(ctx)
 
-	if ypErrFirst == nil {
+	if ypErrLast == nil {
 		return YParserError{
 			ErrCode: ypErrCode,
 		}
 	}
 
-	if (ypErrFirst != nil) && ypErrFirst.prev.no == C.LY_SUCCESS {
+	if ypErrLast.err == C.LY_SUCCESS {
 		return YParserError{
 			ErrCode: YP_SUCCESS,
 		}
 	}
 
-	if ypErrFirst != nil {
-		errMsg = C.GoString(ypErrFirst.prev.msg)
-		errPath = C.GoString(ypErrFirst.prev.path)
-		errAppTag = C.GoString(ypErrFirst.prev.apptag)
+	errMsg = C.GoString(ypErrLast.msg)
+	if ypErrLast.data_path != nil {
+		errPath = C.GoString(ypErrLast.data_path)
+	} else {
+		errPath = C.GoString(ypErrLast.schema_path)
 	}
+	errAppTag = C.GoString(ypErrLast.apptag)
 
 	// Try to resolve table, keys and field name from the error path.
 	errtableName, key, ElemName = parseLyPath(errPath)
@@ -649,10 +720,10 @@ func getErrorDetails() YParserError {
 		errText = errMsg[len(customErrorPrefix):]
 	}
 
-	switch C.ly_errno {
+	switch ypErrLast.err {
 	case C.LY_EVALID:
 		// validation failure
-		ypErrCode = translateLYErrToYParserErr(int(ypErrFirst.prev.vecode))
+		ypErrCode = translateLYErrToYParserErr(int(ypErrLast.vecode))
 		if len(ElemName) != 0 {
 			errMessage = "Field \"" + ElemName + "\" has invalid value"
 			if len(ElemVal) != 0 {
@@ -695,110 +766,82 @@ func getErrorDetails() YParserError {
 	return errObj
 }
 
-func FindNode(root *YParserNode, xpath string) *YParserNode {
-	return (*YParserNode)(C.lyd_find_node((*C.struct_lyd_node)(root), C.CString(xpath)))
-}
-
 func GetModelNs(module *YParserModule) (ns, prefix string) {
 	return C.GoString(((*C.struct_lys_module)(module)).ns),
 		C.GoString(((*C.struct_lys_module)(module)).prefix)
 }
 
 // Get model details for child under list/choice/case
-func getModelChildInfo(l *YParserListInfo, node *C.struct_lys_node,
+func getModelChildInfo(l *YParserListInfo, node *C.struct_lysc_node, module *YParserModule,
 	underWhen bool, whenExpr *WhenExpression) {
 
-	for sChild := node.child; sChild != nil; sChild = sChild.next {
+	for sChild := C.lysc_node_child(node); sChild != nil; sChild = sChild.next {
 		switch sChild.nodetype {
 		case C.LYS_LIST:
-			nodeInnerList := (*C.struct_lys_node_list)(unsafe.Pointer(sChild))
-			innerListkeys := (*[10]*C.struct_lys_node_leaf)(unsafe.Pointer(nodeInnerList.keys))
-			if nodeInnerList.keys_size == 1 {
-				keyName := C.GoString(innerListkeys[0].name)
-				l.MapLeaf = append(l.MapLeaf, keyName)
+			keysCnt := C.golysc_node_list_keys_count(sChild)
+			if keysCnt == 1 {
+				// fetch key leaf
+				for sChildInner := C.lysc_node_child(sChild); sChildInner != nil; sChildInner = sChildInner.next {
+					if sChildInner.nodetype == C.LYS_LEAF && (sChildInner.flags&C.LYS_KEY) != 0 {
+						keyName := C.GoString(sChildInner.name)
+						l.MapLeaf = append(l.MapLeaf, keyName)
+						break
+					}
+				}
 				// Now, find and add the first non-key leaf.
-				for sChildInner := nodeInnerList.child; sChildInner != nil; sChildInner = sChildInner.next {
-					if sChildInner.nodetype == C.LYS_LEAF {
-						// Check if the leaf is not a key.
-						if name := C.GoString(sChildInner.name); name != keyName {
-							l.MapLeaf = append(l.MapLeaf, name)
-							break
-						}
+				for sChildInner := C.lysc_node_child(sChild); sChildInner != nil; sChildInner = sChildInner.next {
+					if sChildInner.nodetype == C.LYS_LEAF && (sChildInner.flags&C.LYS_KEY) == 0 {
+						name := C.GoString(sChildInner.name)
+						l.MapLeaf = append(l.MapLeaf, name)
+						break
 					}
 				}
 			} else { // should never hit here, as linter does the validation
-				listName := C.GoString(nodeInnerList.name)
-				TRACE_LOG(TRACE_YPARSER, "Inner List %s for Dynamic fields has %d keys", listName, nodeInnerList.keys_size)
+				listName := C.GoString(sChild.name)
+				TRACE_LOG(TRACE_YPARSER, "Inner List %s for Dynamic fields has %d keys", listName, keysCnt)
 			}
-		case C.LYS_USES:
-			nodeUses := (*C.struct_lys_node_uses)(unsafe.Pointer(sChild))
-			if nodeUses.when != nil {
-				usesWhenExp := WhenExpression{
-					Expr: C.GoString(nodeUses.when.cond),
+		case C.LYS_CHOICE, C.LYS_CASE:
+			when := C.golysc_node_get_when(sChild)
+			if when != nil {
+				cWhenExp := WhenExpression{
+					Expr: C.GoString(when),
 				}
 				listName := l.ListName + "_LIST"
 				l.WhenExpr[listName] = append(l.WhenExpr[listName],
-					&usesWhenExp)
-				getModelChildInfo(l, sChild, true, &usesWhenExp)
+					&cWhenExp)
+				getModelChildInfo(l, sChild, module, true, &cWhenExp)
 			} else {
-				getModelChildInfo(l, sChild, false, nil)
-			}
-		case C.LYS_CHOICE:
-			nodeChoice := (*C.struct_lys_node_choice)(unsafe.Pointer(sChild))
-			if nodeChoice.when != nil {
-				chWhenExp := WhenExpression{
-					Expr: C.GoString(nodeChoice.when.cond),
-				}
-				listName := l.ListName + "_LIST"
-				l.WhenExpr[listName] = append(l.WhenExpr[listName],
-					&chWhenExp)
-				getModelChildInfo(l, sChild, true, &chWhenExp)
-			} else {
-				getModelChildInfo(l, sChild, false, nil)
-			}
-		case C.LYS_CASE:
-			nodeCase := (*C.struct_lys_node_case)(unsafe.Pointer(sChild))
-			if nodeCase.when != nil {
-				csWhenExp := WhenExpression{
-					Expr: C.GoString(nodeCase.when.cond),
-				}
-				listName := l.ListName + "_LIST"
-				l.WhenExpr[listName] = append(l.WhenExpr[listName],
-					&csWhenExp)
-				getModelChildInfo(l, sChild, true, &csWhenExp)
-			} else {
-				if underWhen {
-					getModelChildInfo(l, sChild, underWhen, whenExpr)
+				if underWhen && sChild.nodetype == C.LYS_CASE {
+					// Why only nodetype == C.LYS_CASE? old code was like that
+					getModelChildInfo(l, sChild, module, underWhen, whenExpr)
 				} else {
-					getModelChildInfo(l, sChild, false, nil)
+					getModelChildInfo(l, sChild, module, false, nil)
 				}
 			}
 		case C.LYS_LEAF, C.LYS_LEAFLIST:
-			sleaf := (*C.struct_lys_node_leaf)(unsafe.Pointer(sChild))
-			if sleaf == nil {
-				continue
-			}
-
-			leafName := C.GoString(sleaf.name)
-
+			leafName := C.GoString(sChild.name)
+			var nodeMusts (*C.struct_lysc_must)
+			var nodeWhen (**C.struct_lysc_when)
 			if sChild.nodetype == C.LYS_LEAF {
+				sleaf := (*C.struct_lysc_node_leaf)(unsafe.Pointer(sChild))
+				nodeMusts = sleaf.musts
+				nodeWhen = sleaf.when
 				if sleaf.dflt != nil {
-					l.DfltLeafVal[leafName] = C.GoString(sleaf.dflt)
+					l.DfltLeafVal[leafName] = C.GoString(C.lyd_value_get_canonical((*C.struct_ly_ctx)(ypCtx), sleaf.dflt))
 				}
 			} else {
-				sLeafList := (*C.struct_lys_node_leaflist)(unsafe.Pointer(sChild))
-				if sleaf.dflt != nil {
-					//array of default values
-					dfltValArr := (*[256]*C.char)(unsafe.Pointer(sLeafList.dflt))
-
+				sLeafList := (*C.struct_lysc_node_leaflist)(unsafe.Pointer(sChild))
+				nodeMusts = sLeafList.musts
+				nodeWhen = sLeafList.when
+				if sLeafList.dflts != nil {
 					tmpValStr := ""
-					for idx := 0; idx < int(sLeafList.dflt_size); idx++ {
+					for idx := 0; idx < int(C.golyd_value_array_count(sLeafList.dflts)); idx++ {
 						if idx > 0 {
 							//Separate multiple values by ,
 							tmpValStr = tmpValStr + ","
 						}
 
-						tmpValStr = tmpValStr + C.GoString(dfltValArr[idx])
+						tmpValStr = tmpValStr + C.GoString(C.lyd_value_get_canonical((*C.struct_ly_ctx)(ypCtx), C.golyd_value_array_idx(sLeafList.dflts, (C.size_t)(idx))))
 					}
 
 					//Remove last ','
@@ -821,21 +864,22 @@ func getModelChildInfo(l *YParserListInfo, node *C.struct_lys_node,
 			}
 
 			//Check for leafref expression
-			leafRefs := C.lys_get_leafrefs(sleaf)
+			leafRefs := C.golys_xpath_targets_get(sChild)
+			defer C.golys_xpath_targets_free(leafRefs)
 			if leafRefs != nil {
-				leafRefPaths := (*[10]*C.char)(unsafe.Pointer(&leafRefs.path))
+				leafRefPaths := (*[256]*C.char)(unsafe.Pointer(leafRefs.xpathlist))
 				for idx := 0; idx < int(leafRefs.count); idx++ {
-					l.LeafRef[leafName] = append(l.LeafRef[leafName],
-						C.GoString(leafRefPaths[idx]))
+					path := rewriteXPathPrefix(module, C.GoString(leafRefPaths[idx]))
+					l.LeafRef[leafName] = append(l.LeafRef[leafName], path)
 				}
 			}
 
 			//Check for must expression; one must expession only per leaf
-			if sleaf.must_size > 0 {
-				must := (*[20]C.struct_lys_restr)(unsafe.Pointer(sleaf.must))
-				for idx := 0; idx < int(sleaf.must_size); idx++ {
-					exp := XpathExpression{Expr: C.GoString(must[idx].expr)}
-
+			if nodeMusts != nil {
+				must := (*[20]C.struct_lysc_must)(unsafe.Pointer(nodeMusts))
+				for idx := 0; idx < int(C.golysc_must_array_count(nodeMusts)); idx++ {
+					mustexpr := rewriteXPathPrefix(module, C.GoString(C.lyxp_get_expr(must[idx].cond)))
+					exp := XpathExpression{Expr: mustexpr}
 					if must[idx].eapptag != nil {
 						exp.ErrCode = C.GoString(must[idx].eapptag)
 					}
@@ -849,20 +893,22 @@ func getModelChildInfo(l *YParserListInfo, node *C.struct_lys_node,
 			}
 
 			//Check for when expression
-			if sleaf.when != nil {
+			if nodeWhen != nil {
+				when := (*[20]*C.struct_lysc_when)(unsafe.Pointer(nodeWhen))
+				whenexpr := rewriteXPathPrefix(module, C.GoString(C.lyxp_get_expr(when[0].cond)))
 				l.WhenExpr[leafName] = append(l.WhenExpr[leafName],
 					&WhenExpression{
-						Expr:      C.GoString(sleaf.when.cond),
+						Expr:      whenexpr,
 						NodeNames: []string{leafName},
 					})
 			}
 
 			//Check for custom extension
-			if sleaf.ext_size > 0 {
-				exts := (*[10]*C.struct_lys_ext_instance)(unsafe.Pointer(sleaf.ext))
-				for idx := 0; idx < int(sleaf.ext_size); idx++ {
-					if C.GoString(exts[idx].def.name) == "custom-validation" {
-						argVal := C.GoString(exts[idx].arg_value)
+			if sChild.exts != nil {
+				for idx := 0; idx < int(C.golysc_ext_instance_array_count(sChild.exts)); idx++ {
+					ext := C.golysc_ext_instance_array_idx(sChild.exts, (C.size_t)(idx))
+					if C.GoString(ext.def.name) == "custom-validation" {
+						argVal := C.GoString(ext.argument)
 						if argVal != "" {
 							l.CustValidation[leafName] = append(l.CustValidation[leafName], argVal)
 						}
@@ -885,24 +931,29 @@ func GetModelListInfo(module *YParserModule) []*YParserListInfo {
 	var list []*YParserListInfo
 
 	mod := (*C.struct_lys_module)(module)
-	set := C.lys_find_path(mod, nil,
-		C.CString(fmt.Sprintf("/%s/*", C.GoString(mod.name))))
-
-	if set == nil {
+	if mod == nil || mod.compiled == nil || mod.compiled.data == nil {
 		return nil
 	}
 
-	for idx := 0; idx < int(set.number); idx++ { //for each container
+	// Each container has a base container, then a set of containers under that.
+	// We need to skip over the base container
+	if mod.compiled.data.nodetype != C.LYS_CONTAINER {
+		return nil
+	}
+	cbase := (*C.struct_lysc_node_container)(unsafe.Pointer(mod.compiled.data))
 
-		snode := C.lys_get_snode(set, C.int(idx))
-		snodec := (*C.struct_lys_node_container)(unsafe.Pointer(snode))
-		slist := (*C.struct_lys_node_list)(unsafe.Pointer(snodec.child))
+	for snode := cbase.child; snode != nil; snode = snode.next { //for each container
+		if snode.nodetype != C.LYS_CONTAINER {
+			continue
+		}
+		snodec := (*C.struct_lysc_node_container)(unsafe.Pointer(snode))
 
 		//for each list
-		for ; slist != nil; slist = (*C.struct_lys_node_list)(unsafe.Pointer(slist.next)) {
+		for n := snodec.child; n != nil; n = n.next {
 			var l YParserListInfo
-			listName := C.GoString(slist.name)
-			l.RedisTableName = C.GoString(snodec.name)
+			slist := (*C.struct_lysc_node_list)(unsafe.Pointer(n))
+			listName := C.GoString(n.name)
+			l.RedisTableName = C.GoString(snode.name)
 
 			tableName := listName
 			if strings.HasSuffix(tableName, "_LIST") {
@@ -929,17 +980,18 @@ func GetModelListInfo(module *YParserModule) []*YParserListInfo {
 			l.MandatoryNodes = make(map[string]bool)
 
 			//Add keys
-			keys := (*[10]*C.struct_lys_node_leaf)(unsafe.Pointer(slist.keys))
-			for idx := 0; idx < int(slist.keys_size); idx++ {
-				keyName := C.GoString(keys[idx].name)
-				l.Keys = append(l.Keys, keyName)
+			for child := slist.child; child != nil; child = child.next {
+				if (child.flags & C.LYS_KEY) != 0 {
+					l.Keys = append(l.Keys, C.GoString(child.name))
+				}
 			}
 
 			//Check for must expression
-			if slist.must_size > 0 {
-				must := (*[10]C.struct_lys_restr)(unsafe.Pointer(slist.must))
-				for idx := 0; idx < int(slist.must_size); idx++ {
-					exp := XpathExpression{Expr: C.GoString(must[idx].expr)}
+			if slist.musts != nil {
+				must := (*[10]C.struct_lysc_must)(unsafe.Pointer(slist.musts))
+				for idx := 0; idx < int(C.golysc_must_array_count(slist.musts)); idx++ {
+					mustexp := rewriteXPathPrefix(module, C.GoString(C.lyxp_get_expr(must[idx].cond)))
+					exp := XpathExpression{Expr: mustexp}
 					if must[idx].eapptag != nil {
 						exp.ErrCode = C.GoString(must[idx].eapptag)
 					}
@@ -953,13 +1005,11 @@ func GetModelListInfo(module *YParserModule) []*YParserListInfo {
 			}
 
 			//Check for custom extension
-			if slist.ext_size > 0 {
-				exts := (*[10]*C.struct_lys_ext_instance)(unsafe.Pointer(slist.ext))
-				for idx := 0; idx < int(slist.ext_size); idx++ {
-
-					extName := C.GoString(exts[idx].def.name)
-					argVal := C.GoString(exts[idx].arg_value)
-
+			if n.exts != nil {
+				for idx := 0; idx < int(C.golysc_ext_instance_array_count(n.exts)); idx++ {
+					ext := C.golysc_ext_instance_array_idx(n.exts, (C.size_t)(idx))
+					extName := C.GoString(ext.def.name)
+					argVal := C.GoString(ext.argument)
 					switch extName {
 					case "custom-validation":
 						if argVal != "" {
@@ -990,12 +1040,10 @@ func GetModelListInfo(module *YParserModule) []*YParserListInfo {
 			}
 
 			getModelChildInfo(&l,
-				(*C.struct_lys_node)(unsafe.Pointer(slist)), false, nil)
+				(*C.struct_lysc_node)(unsafe.Pointer(slist)), module, false, nil)
 
 			list = append(list, &l)
 		} //each list inside a container
 	} //each container
-
-	C.free(unsafe.Pointer(set))
 	return list
 }

--- a/cvl/internal/yparser/yparser.go
+++ b/cvl/internal/yparser/yparser.go
@@ -600,10 +600,6 @@ func (yp *YParser) mergeDepData(data *(*C.struct_lyd_node), depData *YParserNode
 
 // ValidateSyntax Perform syntax checks
 func (yp *YParser) ValidateSyntax(data *YParserNode, depData *YParserNode) YParserError {
-	if data == nil {
-		return YParserError{ErrCode: YP_INTERNAL_UNKNOWN}
-	}
-
 	dataPtr := (*C.struct_lyd_node)(data)
 
 	if depData != nil {

--- a/cvl/internal/yparser/yparser.go
+++ b/cvl/internal/yparser/yparser.go
@@ -40,30 +40,42 @@ import (
 #include <stdio.h>
 #include <string.h>
 
-size_t golysc_ext_instance_array_count(struct lysc_ext_instance *arr)
-{
-	return LY_ARRAY_COUNT(arr);
-}
+// Canonical typedefs over libyang's schema node, must, when, ext_instance
+// and per-nodetype subtype structs, so the rest of the file refers to each
+// type by a single yp_* name.
+typedef struct lysc_node yp_snode_t;
+typedef struct lysc_node_leaf yp_snode_leaf_t;
+typedef struct lysc_node_leaflist yp_snode_leaflist_t;
+typedef struct lysc_node_list yp_snode_list_t;
+typedef struct lysc_node_container yp_snode_container_t;
+typedef struct lysc_must yp_must_t;
+typedef struct lysc_when yp_when_t;
+typedef struct lysc_ext_instance yp_ext_t;
 
-struct lysc_ext_instance *golysc_ext_instance_array_idx(struct lysc_ext_instance *arr, size_t idx)
-{
-	return &arr[idx];
-}
-
-size_t golysc_must_array_count(struct lysc_must *arr)
-{
-	return LY_ARRAY_COUNT(arr);
-}
-
-size_t golyd_value_array_count(struct lyd_value **arr)
-{
-	return LY_ARRAY_COUNT(arr);
-}
-
-struct lyd_value *golyd_value_array_idx(struct lyd_value **arr, size_t idx)
-{
-	return arr[idx];
-}
+// YPC_* mirrors of YParser{Ret,Err}Code values for use from C in
+// yp_translate_validation_code(). Values must match the Go constants in
+// yparser.go.
+#define YPC_SUCCESS                         1000
+#define YPC_SYNTAX_ERROR                    1001
+#define YPC_SEMANTIC_ERROR                  1002
+#define YPC_SYNTAX_MISSING_FIELD            1003
+#define YPC_SYNTAX_INVALID_FIELD            1004
+#define YPC_SYNTAX_INVALID_INPUT_DATA       1005
+#define YPC_SYNTAX_MULTIPLE_INSTANCE        1006
+#define YPC_SYNTAX_DUPLICATE                1007
+#define YPC_SYNTAX_ENUM_INVALID             1008
+#define YPC_SYNTAX_ENUM_INVALID_NAME        1009
+#define YPC_SYNTAX_ENUM_WHITESPACE          1010
+#define YPC_SYNTAX_OUT_OF_RANGE             1011
+#define YPC_SYNTAX_MINIMUM_INVALID          1012
+#define YPC_SYNTAX_MAXIMUM_INVALID          1013
+#define YPC_SEMANTIC_DEPENDENT_DATA_MISSING 1014
+#define YPC_SEMANTIC_MANDATORY_DATA_MISSING 1015
+#define YPC_SEMANTIC_KEY_ALREADY_EXIST      1016
+#define YPC_SEMANTIC_KEY_NOT_EXIST          1017
+#define YPC_SEMANTIC_KEY_DUPLICATE          1018
+#define YPC_SEMANTIC_KEY_INVALID            1019
+#define YPC_INTERNAL_UNKNOWN                1020
 
 struct ly_ctx *goly_ctx_new(const char *search_dir, uint16_t options)
 {
@@ -72,6 +84,13 @@ struct ly_ctx *goly_ctx_new(const char *search_dir, uint16_t options)
 		return NULL;
 	}
 	return ctx;
+}
+
+// Thin wrapper around lys_parse_path so the caller does not have to deal
+// with libyang's return-value-vs-out-param convention directly.
+int goly_parse_path(struct ly_ctx *ctx, const char *path, struct lys_module **module)
+{
+	return lys_parse_path(ctx, path, LYS_IN_YIN, module);
 }
 
 struct lyd_node *golyd_new_inner(struct lyd_node *parent, const struct lys_module *module, const char *name)
@@ -132,6 +151,37 @@ const char *golysc_node_get_when(const struct lysc_node *node)
 	return lyxp_get_expr(when[0]->cond);
 }
 
+struct leaf_value {
+	const char *name;
+	const char *value;
+};
+
+int lyd_multi_new_leaf(struct lyd_node *parent, const struct lys_module *module,
+	struct leaf_value *leafValArr, int size)
+{
+	const char *name, *val;
+	struct lyd_node *leaf;
+	int idx = 0;
+
+	for (idx = 0; idx < size; idx++)
+	{
+		if ((leafValArr[idx].name == NULL) || (leafValArr[idx].value == NULL))
+		{
+			continue;
+		}
+
+		name = leafValArr[idx].name;
+		val = leafValArr[idx].value;
+
+		if (lyd_new_term(parent, module, name, val, 0, &leaf) != LY_SUCCESS)
+		{
+			fprintf(stderr, "lyd_multi_new_leaf(): lyd_new_term(%s, %s) failed\n", name, val);
+			return -1;
+		}
+	}
+	return 0;
+}
+
 static ly_bool lysc_node_is_union(const struct lysc_node *node)
 {
 	struct lysc_type *type;
@@ -152,39 +202,6 @@ static ly_bool lysc_node_is_union(const struct lysc_node *node)
 	}
 
 	return 1;
-}
-
-struct leaf_value {
-	const char *name;
-	const char *value;
-};
-
-int lyd_multi_new_leaf(struct lyd_node *parent, const struct lys_module *module,
-	struct leaf_value *leafValArr, int size)
-{
-	const char *name, *val;
-	struct lyd_node *leaf;
-	struct lysc_type *type = NULL;
-	int has_ptr_type = 0;
-	int idx = 0;
-
-	for (idx = 0; idx < size; idx++)
-	{
-		if ((leafValArr[idx].name == NULL) || (leafValArr[idx].value == NULL))
-		{
-			continue;
-		}
-
-		name = leafValArr[idx].name;
-		val = leafValArr[idx].value;
-
-		if (lyd_new_term(parent, module, name, val, 0, &leaf) != LY_SUCCESS)
-		{
-			fprintf(stderr, "lyd_multi_new_leaf(): lyd_new_term(%s, %s) failed\n", name, val);
-			return -1;
-		}
-	}
-	return 0;
 }
 
 int lyd_node_leafref_match_in_union(const struct lys_module *module, const char *xpath, const char *value)
@@ -231,6 +248,9 @@ int lyd_node_leafref_match_in_union(const struct lys_module *module, const char 
 	return -1;
 }
 
+// Result type for golys_xpath_targets_get. The struct itself is not
+// libyang-specific so it lives outside the #if; the path-extraction logic
+// however differs and is gated below.
 struct lysc_xpath_targets {
 	const char **xpathlist; // path list
 	size_t count; // actual path count
@@ -238,8 +258,6 @@ struct lysc_xpath_targets {
 
 void golys_xpath_targets_free(struct lysc_xpath_targets *paths)
 {
-	size_t i;
-
 	if (paths == NULL) {
 		return;
 	}
@@ -257,6 +275,7 @@ static struct lysc_xpath_targets *golys_xpath_targets_alloc(size_t cnt)
 }
 
 static const char *nonLeafRef = "non-leafref";
+
 struct lysc_xpath_targets *golys_xpath_targets_get(const struct lysc_node *node)
 {
 	struct lysc_type *type;
@@ -303,12 +322,287 @@ struct lysc_xpath_targets *golys_xpath_targets_get(const struct lysc_node *node)
 	}
 	return paths;
 }
+
+// ----- yp_* accessors ----------------------------------------------------
+// Thin accessors over libyang's schema structs. They keep Go from poking at
+// libyang struct fields directly; signatures use the yp_* typedefs defined
+// above.
+
+// Get first child of a schema node (container/list/choice/case).
+const yp_snode_t *yp_node_child(const yp_snode_t *n)
+{
+	return lysc_node_child(n);
+}
+
+// Is this leaf node a key of its parent list?
+int yp_node_is_key(const yp_snode_t *n)
+{
+	return (n != NULL && (n->flags & LYS_KEY)) ? 1 : 0;
+}
+
+// Extensions on a schema node.
+size_t yp_node_exts_count(const yp_snode_t *n)
+{
+	if (n == NULL || n->exts == NULL) {
+		return 0;
+	}
+	return LY_ARRAY_COUNT(n->exts);
+}
+const char *yp_node_ext_def_name(const yp_snode_t *n, size_t idx)
+{
+	if (n == NULL || n->exts == NULL) {
+		return NULL;
+	}
+	return n->exts[idx].def->name;
+}
+const char *yp_node_ext_argument(const yp_snode_t *n, size_t idx)
+{
+	if (n == NULL || n->exts == NULL) {
+		return NULL;
+	}
+	return n->exts[idx].argument;
+}
+
+// Must arrays on leaf / leaflist / list / container nodes.
+yp_must_t *yp_node_musts(const yp_snode_t *n)
+{
+	if (n == NULL) {
+		return NULL;
+	}
+	switch (n->nodetype) {
+	case LYS_LEAF:
+		return ((const yp_snode_leaf_t *)n)->musts;
+	case LYS_LEAFLIST:
+		return ((const yp_snode_leaflist_t *)n)->musts;
+	case LYS_LIST:
+		return ((const yp_snode_list_t *)n)->musts;
+	case LYS_CONTAINER:
+		return ((const yp_snode_container_t *)n)->musts;
+	}
+	return NULL;
+}
+size_t yp_node_musts_count(const yp_snode_t *n)
+{
+	yp_must_t *m = yp_node_musts(n);
+	return m ? LY_ARRAY_COUNT(m) : 0;
+}
+const char *yp_node_must_cond_at(yp_must_t *musts, size_t idx)
+{
+	return lyxp_get_expr(musts[idx].cond);
+}
+const char *yp_node_must_apptag_at(yp_must_t *musts, size_t idx)
+{
+	return musts[idx].eapptag;
+}
+const char *yp_node_must_emsg_at(yp_must_t *musts, size_t idx)
+{
+	return musts[idx].emsg;
+}
+
+// Default value of a leaf as the canonical string (NULL if none).
+const char *yp_leaf_dflt(struct ly_ctx *ctx, const yp_snode_t *n)
+{
+	const yp_snode_leaf_t *leaf;
+	if (n == NULL || n->nodetype != LYS_LEAF) {
+		return NULL;
+	}
+	leaf = (const yp_snode_leaf_t *)n;
+	if (leaf->dflt == NULL) {
+		return NULL;
+	}
+	return lyd_value_get_canonical(ctx, leaf->dflt);
+}
+size_t yp_leaflist_dflts_count(const yp_snode_t *n)
+{
+	const yp_snode_leaflist_t *ll;
+	if (n == NULL || n->nodetype != LYS_LEAFLIST) {
+		return 0;
+	}
+	ll = (const yp_snode_leaflist_t *)n;
+	if (ll->dflts == NULL) {
+		return 0;
+	}
+	return LY_ARRAY_COUNT(ll->dflts);
+}
+const char *yp_leaflist_dflt_at(struct ly_ctx *ctx, const yp_snode_t *n, size_t idx)
+{
+	const yp_snode_leaflist_t *ll;
+	if (n == NULL || n->nodetype != LYS_LEAFLIST) {
+		return NULL;
+	}
+	ll = (const yp_snode_leaflist_t *)n;
+	return lyd_value_get_canonical(ctx, ll->dflts[idx]);
+}
+
+// min-elements and max-elements field names are stable across libyang
+// versions; just need the typedef-aware cast.
+uint32_t yp_leaflist_min(const yp_snode_t *n)
+{
+	if (n == NULL || n->nodetype != LYS_LEAFLIST) {
+		return 0;
+	}
+	return ((const yp_snode_leaflist_t *)n)->min;
+}
+
+uint32_t yp_list_max(const yp_snode_t *n)
+{
+	if (n == NULL || n->nodetype != LYS_LIST) {
+		return 0;
+	}
+	return ((const yp_snode_list_t *)n)->max;
+}
+
+// Returns the first "when" expression on a leaf/leaflist (NULL if none).
+const char *yp_leaf_when_cond(const yp_snode_t *n)
+{
+	yp_when_t **when = NULL;
+	if (n == NULL) {
+		return NULL;
+	}
+	switch (n->nodetype) {
+	case LYS_LEAF:
+		when = ((const yp_snode_leaf_t *)n)->when;
+		break;
+	case LYS_LEAFLIST:
+		when = ((const yp_snode_leaflist_t *)n)->when;
+		break;
+	}
+	if (when == NULL || LY_ARRAY_COUNT(when) == 0) {
+		return NULL;
+	}
+	return lyxp_get_expr(when[0]->cond);
+}
+
+// Returns the top-level container under module that holds the data lists,
+// or NULL if the module's top isn't a container.
+const yp_snode_t *yp_module_top_container(const struct lys_module *mod)
+{
+	if (mod == NULL || mod->compiled == NULL || mod->compiled->data == NULL) {
+		return NULL;
+	}
+	if (mod->compiled->data->nodetype != LYS_CONTAINER) {
+		return NULL;
+	}
+	return mod->compiled->data;
+}
+
+// Aggregated error info filled in by yp_get_last_error.
+struct yp_error_info {
+	uint32_t err;     // overall error code (LY_EVALID, LY_EINVAL, LY_EMEM, ...)
+	uint32_t vecode;  // LYVE_* validation sub-code
+	const char *msg;
+	const char *path;
+	const char *apptag;
+};
+
+// Fills *info with details of the last error on ctx. Return values:
+//   0  no error item available
+//   1  last error item is LY_SUCCESS (no real error)
+//   2  real error, *info populated
+int yp_get_last_error(struct ly_ctx *ctx, struct yp_error_info *info)
+{
+	const struct ly_err_item *err = ly_err_last(ctx);
+	if (err == NULL) {
+		return 0;
+	}
+	if (err->err == LY_SUCCESS) {
+		return 1;
+	}
+	info->err = err->err;
+	info->vecode = err->vecode;
+	info->msg = err->msg;
+	info->path = err->data_path ? err->data_path : err->schema_path;
+	info->apptag = err->apptag;
+	return 2;
+}
+
+// ---- yp_* wrappers for the data-tree functions used by Go ----
+// Wrap the libyang functions whose flag enums and out-param conventions are
+// awkward to spell directly from Go, so the Go-side call sites stay short.
+
+void yp_ly_set_loglevel(int level)
+{
+	ly_log_level(level);
+}
+
+void yp_ly_ctx_destroy(struct ly_ctx *ctx)
+{
+	ly_ctx_destroy(ctx);
+}
+
+void yp_lyd_free(struct lyd_node *node)
+{
+	if (node != NULL) {
+		lyd_free_all(node);
+	}
+}
+char *yp_lyd_print_mem(struct lyd_node *node)
+{
+	char *out = NULL;
+	lyd_print_mem(&out, node, LYD_JSON, LYD_PRINT_WITHSIBLINGS);
+	return out;
+}
+int yp_lyd_merge(struct lyd_node **dst, struct lyd_node *src, int destruct, struct ly_ctx *ctx)
+{
+	uint16_t flags = destruct ? LYD_MERGE_DESTRUCT : 0;
+	(void)ctx;
+	return lyd_merge_siblings(dst, src, flags);
+}
+int yp_lyd_validate_edit(struct ly_ctx *ctx, struct lyd_node **data)
+{
+	return lyd_validate_all(data, ctx,
+		LYD_VALIDATE_PRESENT | LYD_VALIDATE_NO_STATE | LYD_VALIDATE_NOEXTDEPS,
+		NULL);
+}
+
+// Map a libyang validation error code to one of the YPC_* mirror values.
+// The Go side casts the result to YParserRetCode directly. Lives in C so
+// the switch on libyang's LYVE_* enumeration is self-contained.
+int yp_translate_validation_code(int vecode, const char *apptag, const char *msg)
+{
+	switch (vecode) {
+	case LYVE_SUCCESS:
+		return YPC_SUCCESS;
+	case LYVE_SYNTAX:
+	case LYVE_SYNTAX_YANG:
+	case LYVE_SYNTAX_YIN:
+		return YPC_SYNTAX_INVALID_INPUT_DATA;
+	case LYVE_REFERENCE:
+		return YPC_SEMANTIC_DEPENDENT_DATA_MISSING;
+	case LYVE_XPATH:
+		return YPC_SEMANTIC_KEY_NOT_EXIST;
+	case LYVE_SEMANTICS:
+		return YPC_SEMANTIC_KEY_INVALID;
+	case LYVE_SYNTAX_XML:
+	case LYVE_SYNTAX_JSON:
+		return YPC_SYNTAX_INVALID_FIELD;
+	case LYVE_DATA:
+		if (apptag != NULL && strcmp(apptag, "too-few-elements") == 0) {
+			return YPC_SYNTAX_MINIMUM_INVALID;
+		}
+		if (apptag != NULL && strcmp(apptag, "too-many-elements") == 0) {
+			return YPC_SYNTAX_MAXIMUM_INVALID;
+		}
+		if (msg != NULL && strncmp(msg, "Invalid enumeration value", 25) == 0) {
+			return YPC_SYNTAX_ENUM_INVALID;
+		}
+		if (msg != NULL && strncmp(msg, "Unsatisfied", 11) == 0) {
+			return YPC_SYNTAX_OUT_OF_RANGE;
+		}
+		if (msg != NULL && strncmp(msg, "Mandatory", 9) == 0) {
+			return YPC_SYNTAX_MISSING_FIELD;
+		}
+		return YPC_SYNTAX_INVALID_INPUT_DATA;
+	}
+	return YPC_INTERNAL_UNKNOWN;
+}
+
 */
 import "C"
 
 type YParserCtx C.struct_ly_ctx
 type YParserNode C.struct_lyd_node
-type YParserSNode C.struct_lysc_node
+type YParserSNode C.yp_snode_t
 type YParserModule C.struct_lys_module
 
 var ypCtx *YParserCtx
@@ -416,9 +710,9 @@ func init() {
 
 func Debug(on bool) {
 	if on {
-		C.ly_log_level(C.LY_LLDBG)
+		C.yp_ly_set_loglevel(C.LY_LLDBG)
 	} else {
-		C.ly_log_level(C.LY_LLERR)
+		C.yp_ly_set_loglevel(C.LY_LLERR)
 	}
 }
 
@@ -427,14 +721,14 @@ func Initialize() {
 		cs := C.CString(CVL_SCHEMA)
 		defer C.free(unsafe.Pointer(cs))
 		ypCtx = (*YParserCtx)(C.goly_ctx_new(cs, 0))
-		C.ly_log_level(C.LY_LLERR)
+		C.yp_ly_set_loglevel(C.LY_LLERR)
 		//	yparserInitialized = true
 	}
 }
 
 func Finish() {
 	if yparserInitialized {
-		C.ly_ctx_destroy((*C.struct_ly_ctx)(ypCtx))
+		C.yp_ly_ctx_destroy((*C.struct_ly_ctx)(ypCtx))
 		//	yparserInitialized = false
 	}
 }
@@ -444,7 +738,7 @@ func ParseSchemaFile(modelFile string) (*YParserModule, YParserError) {
 	var module *C.struct_lys_module
 	csModelFile := C.CString(modelFile)
 	defer C.free(unsafe.Pointer(csModelFile))
-	if C.lys_parse_path((*C.struct_ly_ctx)(ypCtx), csModelFile, C.LYS_IN_YIN, &module) != C.LY_SUCCESS {
+	if C.goly_parse_path((*C.struct_ly_ctx)(ypCtx), csModelFile, &module) != 0 {
 		return nil, getErrorDetails()
 	}
 
@@ -545,16 +839,14 @@ func (yp *YParser) AddMultiLeafNodes(module *YParserModule, parent *YParserNode,
 
 }
 
-// NodeDump Return entire subtree in XML format in string
+// NodeDump Return entire subtree as a serialized string.
 func (yp *YParser) NodeDump(root *YParserNode) string {
 	if root == nil {
 		return ""
-	} else {
-		var outBuf *C.char
-		C.lyd_print_mem(&outBuf, (*C.struct_lyd_node)(root), C.LYD_JSON, C.LYD_PRINT_WITHSIBLINGS)
-		defer C.free(unsafe.Pointer(outBuf))
-		return C.GoString(outBuf)
 	}
+	outBuf := C.yp_lyd_print_mem((*C.struct_lyd_node)(root))
+	defer C.free(unsafe.Pointer(outBuf))
+	return C.GoString(outBuf)
 }
 
 // MergeSubtree Merge source with destination
@@ -570,7 +862,7 @@ func (yp *YParser) MergeSubtree(root, node *YParserNode) (*YParserNode, YParserE
 		TRACE_LOG(TRACE_YPARSER, "Root subtree = %v\n", rootdumpStr)
 	}
 
-	if C.lyd_merge_siblings(&rootTmp, (*C.struct_lyd_node)(node), C.LYD_MERGE_DESTRUCT) != C.LY_SUCCESS {
+	if C.yp_lyd_merge(&rootTmp, (*C.struct_lyd_node)(node), 1, (*C.struct_ly_ctx)(ypCtx)) != C.LY_SUCCESS {
 		return (*YParserNode)(rootTmp), getErrorDetails()
 	}
 
@@ -584,14 +876,11 @@ func (yp *YParser) MergeSubtree(root, node *YParserNode) (*YParserNode, YParserE
 
 // createTempDepData merge depdata and data to create temp data. used in syntax, semantic and custom validation
 func (yp *YParser) mergeDepData(data *(*C.struct_lyd_node), depData *YParserNode, destruct bool) YParserError {
-	var flags C.uint16_t
-
-	flags = 0
+	d := C.int(0)
 	if destruct {
-		flags |= C.LYD_MERGE_DESTRUCT
+		d = 1
 	}
-
-	if C.lyd_merge_siblings(data, (*C.struct_lyd_node)(depData), flags) != C.LY_SUCCESS {
+	if C.yp_lyd_merge(data, (*C.struct_lyd_node)(depData), d, (*C.struct_ly_ctx)(ypCtx)) != C.LY_SUCCESS {
 		TRACE_LOG((TRACE_SYNTAX | TRACE_LIBYANG), "Unable to merge dependent data\n")
 		return getErrorDetails()
 	}
@@ -613,7 +902,7 @@ func (yp *YParser) ValidateSyntax(data *YParserNode, depData *YParserNode) YPars
 	}
 
 	//Just validate syntax
-	if C.lyd_validate_all(&dataPtr, (*C.struct_ly_ctx)(ypCtx), C.LYD_VALIDATE_PRESENT|C.LYD_VALIDATE_NO_STATE|C.LYD_VALIDATE_NOEXTDEPS, nil) != C.LY_SUCCESS {
+	if C.yp_lyd_validate_edit((*C.struct_ly_ctx)(ypCtx), &dataPtr) != C.LY_SUCCESS {
 		if IsTraceAllowed(TRACE_ONERROR) {
 			strData := yp.NodeDump((*YParserNode)(dataPtr))
 			TRACE_LOG(TRACE_ONERROR, "Failed to validate Syntax, data = %v", strData)
@@ -625,76 +914,24 @@ func (yp *YParser) ValidateSyntax(data *YParserNode, depData *YParserNode) YPars
 }
 
 func (yp *YParser) FreeNode(node *YParserNode) YParserError {
-	if node != nil {
-		C.lyd_free_all((*C.struct_lyd_node)(node))
-		node = nil
-	}
-
+	C.yp_lyd_free((*C.struct_lyd_node)(node))
 	return YParserError{ErrCode: YP_SUCCESS}
 }
 
-/* This function translates LIBYANG error code to valid YPARSER error code. */
+/* This function translates LIBYANG error code to valid YPARSER error code.
+ * The translation table itself lives in C (yp_translate_validation_code)
+ * so the switch over libyang's LYVE_* enum stays in one place. */
 func translateLYErrToYParserErr(LYErrcode int, apptag string, msg string) YParserRetCode {
-	var ypErrCode YParserRetCode
-
-	// YP_SYNTAX_MISSING_FIELD
-	// YP_SYNTAX_INVALID_FIELD            /* Invalid Field  */
-	// YP_SYNTAX_INVALID_INPUT_DATA       /* Invalid Input Data */
-	// YP_SYNTAX_MULTIPLE_INSTANCE        /* Multiple Field Instances */
-	// YP_SYNTAX_DUPLICATE                /* Duplicate Fields  */
-	// YP_SYNTAX_ENUM_INVALID             /* Invalid enum value */
-	// YP_SYNTAX_ENUM_INVALID_NAME        /* Invalid enum name  */
-	// YP_SYNTAX_ENUM_WHITESPACE          /* Enum name with leading/trailing whitespaces */
-	// YP_SYNTAX_OUT_OF_RANGE             /* Value out of range/length/pattern (data) */
-	// YP_SYNTAX_MINIMUM_INVALID          /* min-elements constraint not honored  */
-	// YP_SYNTAX_MAXIMUM_INVALID          /* max-elements constraint not honored */
-	// YP_SEMANTIC_DEPENDENT_DATA_MISSING /* Dependent Data is missing */
-	// YP_SEMANTIC_MANDATORY_DATA_MISSING /* Mandatory Data is missing */
-	// YP_SEMANTIC_KEY_ALREADY_EXIST      /* Key already existing */
-	// YP_SEMANTIC_KEY_NOT_EXIST          /* Key is missing */
-	// YP_SEMANTIC_KEY_DUPLICATE          /* Duplicate key */
-	// YP_SEMANTIC_KEY_INVALID            /* Invalid key */
-	// YP_INTERNAL_UNKNOWN
-
-	switch LYErrcode {
-	case C.LYVE_SUCCESS: /**< no error */
-		ypErrCode = YP_SUCCESS
-	case C.LYVE_SYNTAX: /**< generic syntax error */
-		ypErrCode = YP_SYNTAX_INVALID_INPUT_DATA
-	case C.LYVE_SYNTAX_YANG: /**< YANG-related syntax error */
-		ypErrCode = YP_SYNTAX_INVALID_INPUT_DATA
-	case C.LYVE_SYNTAX_YIN: /**< YIN-related syntax error */
-		ypErrCode = YP_SYNTAX_INVALID_INPUT_DATA
-	case C.LYVE_REFERENCE: /**< invalid referencing or using an item */
-		ypErrCode = YP_SEMANTIC_DEPENDENT_DATA_MISSING
-	case C.LYVE_XPATH: /**< invalid XPath expression */
-		ypErrCode = YP_SEMANTIC_KEY_NOT_EXIST
-	case C.LYVE_SEMANTICS: /**< generic semantic error */
-		ypErrCode = YP_SEMANTIC_KEY_INVALID
-	case C.LYVE_SYNTAX_XML: /**< XML-related syntax error */
-		ypErrCode = YP_SYNTAX_INVALID_FIELD
-	case C.LYVE_SYNTAX_JSON: /**< JSON-related syntax error */
-		ypErrCode = YP_SYNTAX_INVALID_FIELD
-	case C.LYVE_DATA: /**< YANG data does not reflect some of the module restrictions */
-		if apptag == "too-few-elements" {
-			ypErrCode = YP_SYNTAX_MINIMUM_INVALID
-		} else if apptag == "too-many-elements" {
-			ypErrCode = YP_SYNTAX_MAXIMUM_INVALID
-		} else if strings.HasPrefix(msg, "Invalid enumeration value") {
-			ypErrCode = YP_SYNTAX_ENUM_INVALID
-		} else if strings.HasPrefix(msg, "Unsatisfied") {
-			ypErrCode = YP_SYNTAX_OUT_OF_RANGE
-		} else if strings.HasPrefix(msg, "Mandatory") {
-			ypErrCode = YP_SYNTAX_MISSING_FIELD
-		} else {
-			ypErrCode = YP_SYNTAX_INVALID_INPUT_DATA
-		}
-	case C.LYVE_OTHER:
-		ypErrCode = YP_INTERNAL_UNKNOWN
-	default:
-		ypErrCode = YP_INTERNAL_UNKNOWN
+	var apptagCstr, msgCstr *C.char
+	if apptag != "" {
+		apptagCstr = C.CString(apptag)
+		defer C.free(unsafe.Pointer(apptagCstr))
 	}
-	return ypErrCode
+	if msg != "" {
+		msgCstr = C.CString(msg)
+		defer C.free(unsafe.Pointer(msgCstr))
+	}
+	return YParserRetCode(C.yp_translate_validation_code(C.int(LYErrcode), apptagCstr, msgCstr))
 }
 
 /* This function performs parsing and processing of LIBYANG error messages. */
@@ -708,28 +945,17 @@ func getErrorDetails() YParserError {
 	var ypErrCode YParserRetCode = YP_INTERNAL_UNKNOWN
 	var errMsg, errPath, errAppTag string
 
-	ctx := (*C.struct_ly_ctx)(ypCtx)
-	ypErrLast := C.ly_err_last(ctx)
-
-	if ypErrLast == nil {
-		return YParserError{
-			ErrCode: ypErrCode,
-		}
+	var errInfo C.struct_yp_error_info
+	switch C.yp_get_last_error((*C.struct_ly_ctx)(ypCtx), &errInfo) {
+	case 0:
+		return YParserError{ErrCode: ypErrCode}
+	case 1:
+		return YParserError{ErrCode: YP_SUCCESS}
 	}
 
-	if ypErrLast.err == C.LY_SUCCESS {
-		return YParserError{
-			ErrCode: YP_SUCCESS,
-		}
-	}
-
-	errMsg = C.GoString(ypErrLast.msg)
-	if ypErrLast.data_path != nil {
-		errPath = C.GoString(ypErrLast.data_path)
-	} else {
-		errPath = C.GoString(ypErrLast.schema_path)
-	}
-	errAppTag = C.GoString(ypErrLast.apptag)
+	errMsg = C.GoString(errInfo.msg)
+	errPath = C.GoString(errInfo.path)
+	errAppTag = C.GoString(errInfo.apptag)
 
 	// Try to resolve table, keys and field name from the error path.
 	errtableName, key, ElemName = parseLyPath(errPath)
@@ -738,7 +964,7 @@ func getErrorDetails() YParserError {
 		// libyang generated error message.. try to extract the field value & name
 		ElemVal = parseLyMessage(errMsg, lyBadValue, lyUnsatisfied)
 		if len(ElemName) == 0 { // if not resolved from path
-			ElemName = parseLyMessage(errMsg, lyMandatory)
+			ElemName = parseLyMessage(errMsg, lyMandatory, lyElemPrefix, lyElemSuffix)
 		}
 	} else {
 		/* Custom contraint error message like in must statement.
@@ -747,10 +973,10 @@ func getErrorDetails() YParserError {
 		errText = errMsg[len(customErrorPrefix):]
 	}
 
-	switch ypErrLast.err {
+	switch errInfo.err {
 	case C.LY_EVALID:
 		// validation failure
-		ypErrCode = translateLYErrToYParserErr(int(ypErrLast.vecode), errAppTag, errMsg)
+		ypErrCode = translateLYErrToYParserErr(int(errInfo.vecode), errAppTag, errMsg)
 		if len(ElemName) != 0 {
 			errMessage = "Field \"" + ElemName + "\" has invalid value"
 			if len(ElemVal) != 0 {
@@ -799,25 +1025,25 @@ func GetModelNs(module *YParserModule) (ns, prefix string) {
 }
 
 // Get model details for child under list/choice/case
-func getModelChildInfo(l *YParserListInfo, node *C.struct_lysc_node, module *YParserModule,
+func getModelChildInfo(l *YParserListInfo, node *C.yp_snode_t, module *YParserModule,
 	underWhen bool, whenExpr *WhenExpression) {
 
-	for sChild := C.lysc_node_child(node); sChild != nil; sChild = sChild.next {
+	for sChild := C.yp_node_child(node); sChild != nil; sChild = sChild.next {
 		switch sChild.nodetype {
 		case C.LYS_LIST:
 			keysCnt := C.golysc_node_list_keys_count(sChild)
 			if keysCnt == 1 {
 				// fetch key leaf
-				for sChildInner := C.lysc_node_child(sChild); sChildInner != nil; sChildInner = sChildInner.next {
-					if sChildInner.nodetype == C.LYS_LEAF && (sChildInner.flags&C.LYS_KEY) != 0 {
+				for sChildInner := C.yp_node_child(sChild); sChildInner != nil; sChildInner = sChildInner.next {
+					if sChildInner.nodetype == C.LYS_LEAF && C.yp_node_is_key(sChildInner) != 0 {
 						keyName := C.GoString(sChildInner.name)
 						l.MapLeaf = append(l.MapLeaf, keyName)
 						break
 					}
 				}
 				// Now, find and add the first non-key leaf.
-				for sChildInner := C.lysc_node_child(sChild); sChildInner != nil; sChildInner = sChildInner.next {
-					if sChildInner.nodetype == C.LYS_LEAF && (sChildInner.flags&C.LYS_KEY) == 0 {
+				for sChildInner := C.yp_node_child(sChild); sChildInner != nil; sChildInner = sChildInner.next {
+					if sChildInner.nodetype == C.LYS_LEAF && C.yp_node_is_key(sChildInner) == 0 {
 						name := C.GoString(sChildInner.name)
 						l.MapLeaf = append(l.MapLeaf, name)
 						break
@@ -847,31 +1073,20 @@ func getModelChildInfo(l *YParserListInfo, node *C.struct_lysc_node, module *YPa
 			}
 		case C.LYS_LEAF, C.LYS_LEAFLIST:
 			leafName := C.GoString(sChild.name)
-			var nodeMusts (*C.struct_lysc_must)
-			var nodeWhen (**C.struct_lysc_when)
 			if sChild.nodetype == C.LYS_LEAF {
-				sleaf := (*C.struct_lysc_node_leaf)(unsafe.Pointer(sChild))
-				nodeMusts = sleaf.musts
-				nodeWhen = sleaf.when
-				if sleaf.dflt != nil {
-					l.DfltLeafVal[leafName] = C.GoString(C.lyd_value_get_canonical((*C.struct_ly_ctx)(ypCtx), sleaf.dflt))
+				if dflt := C.yp_leaf_dflt((*C.struct_ly_ctx)(ypCtx), sChild); dflt != nil {
+					l.DfltLeafVal[leafName] = C.GoString(dflt)
 				}
 			} else {
-				sLeafList := (*C.struct_lysc_node_leaflist)(unsafe.Pointer(sChild))
-				nodeMusts = sLeafList.musts
-				nodeWhen = sLeafList.when
-				if sLeafList.dflts != nil {
+				if dfltCnt := C.yp_leaflist_dflts_count(sChild); dfltCnt > 0 {
 					tmpValStr := ""
-					for idx := 0; idx < int(C.golyd_value_array_count(sLeafList.dflts)); idx++ {
+					for idx := C.size_t(0); idx < dfltCnt; idx++ {
 						if idx > 0 {
 							//Separate multiple values by ,
 							tmpValStr = tmpValStr + ","
 						}
-
-						tmpValStr = tmpValStr + C.GoString(C.lyd_value_get_canonical((*C.struct_ly_ctx)(ypCtx), C.golyd_value_array_idx(sLeafList.dflts, (C.size_t)(idx))))
+						tmpValStr = tmpValStr + C.GoString(C.yp_leaflist_dflt_at((*C.struct_ly_ctx)(ypCtx), sChild, idx))
 					}
-
-					//Remove last ','
 					l.DfltLeafVal[leafName] = tmpValStr
 				}
 
@@ -879,7 +1094,7 @@ func getModelChildInfo(l *YParserListInfo, node *C.struct_lysc_node, module *YPa
 				// Reusing MandatoryNodes map itself to store this info.. Different error codes
 				// are needed for min-elements and mandatory true violations. Cvl will have to
 				// rely on the "@" field name suffix in db dataMap to differentiate.
-				if sLeafList.min > 0 {
+				if C.yp_leaflist_min(sChild) > 0 {
 					l.MandatoryNodes[leafName] = true
 				}
 			}
@@ -902,16 +1117,15 @@ func getModelChildInfo(l *YParserListInfo, node *C.struct_lysc_node, module *YPa
 			}
 
 			//Check for must expression; one must expession only per leaf
-			if nodeMusts != nil {
-				must := (*[20]C.struct_lysc_must)(unsafe.Pointer(nodeMusts))
-				for idx := 0; idx < int(C.golysc_must_array_count(nodeMusts)); idx++ {
-					mustexpr := rewriteXPathPrefix(module, C.GoString(C.lyxp_get_expr(must[idx].cond)))
+			if musts := C.yp_node_musts(sChild); musts != nil {
+				for idx := C.size_t(0); idx < C.yp_node_musts_count(sChild); idx++ {
+					mustexpr := rewriteXPathPrefix(module, C.GoString(C.yp_node_must_cond_at(musts, idx)))
 					exp := XpathExpression{Expr: mustexpr}
-					if must[idx].eapptag != nil {
-						exp.ErrCode = C.GoString(must[idx].eapptag)
+					if apptag := C.yp_node_must_apptag_at(musts, idx); apptag != nil {
+						exp.ErrCode = C.GoString(apptag)
 					}
-					if must[idx].emsg != nil {
-						exp.ErrStr = strings.TrimPrefix(C.GoString(must[idx].emsg), customErrorPrefix)
+					if emsg := C.yp_node_must_emsg_at(musts, idx); emsg != nil {
+						exp.ErrStr = strings.TrimPrefix(C.GoString(emsg), customErrorPrefix)
 					}
 
 					l.XpathExpr[leafName] = append(l.XpathExpr[leafName],
@@ -920,9 +1134,8 @@ func getModelChildInfo(l *YParserListInfo, node *C.struct_lysc_node, module *YPa
 			}
 
 			//Check for when expression
-			if nodeWhen != nil {
-				when := (*[20]*C.struct_lysc_when)(unsafe.Pointer(nodeWhen))
-				whenexpr := rewriteXPathPrefix(module, C.GoString(C.lyxp_get_expr(when[0].cond)))
+			if whenCond := C.yp_leaf_when_cond(sChild); whenCond != nil {
+				whenexpr := rewriteXPathPrefix(module, C.GoString(whenCond))
 				l.WhenExpr[leafName] = append(l.WhenExpr[leafName],
 					&WhenExpression{
 						Expr:      whenexpr,
@@ -931,14 +1144,10 @@ func getModelChildInfo(l *YParserListInfo, node *C.struct_lysc_node, module *YPa
 			}
 
 			//Check for custom extension
-			if sChild.exts != nil {
-				for idx := 0; idx < int(C.golysc_ext_instance_array_count(sChild.exts)); idx++ {
-					ext := C.golysc_ext_instance_array_idx(sChild.exts, (C.size_t)(idx))
-					if C.GoString(ext.def.name) == "custom-validation" {
-						argVal := C.GoString(ext.argument)
-						if argVal != "" {
-							l.CustValidation[leafName] = append(l.CustValidation[leafName], argVal)
-						}
+			for idx := C.size_t(0); idx < C.yp_node_exts_count(sChild); idx++ {
+				if C.GoString(C.yp_node_ext_def_name(sChild, idx)) == "custom-validation" {
+					if argVal := C.GoString(C.yp_node_ext_argument(sChild, idx)); argVal != "" {
+						l.CustValidation[leafName] = append(l.CustValidation[leafName], argVal)
 					}
 				}
 			}
@@ -958,27 +1167,21 @@ func GetModelListInfo(module *YParserModule) []*YParserListInfo {
 	var list []*YParserListInfo
 
 	mod := (*C.struct_lys_module)(module)
-	if mod == nil || mod.compiled == nil || mod.compiled.data == nil {
+	// Each model has a base container at the top, with the per-table
+	// containers under it. Skip the base container.
+	topContainer := C.yp_module_top_container(mod)
+	if topContainer == nil {
 		return nil
 	}
 
-	// Each container has a base container, then a set of containers under that.
-	// We need to skip over the base container
-	if mod.compiled.data.nodetype != C.LYS_CONTAINER {
-		return nil
-	}
-	cbase := (*C.struct_lysc_node_container)(unsafe.Pointer(mod.compiled.data))
-
-	for snode := cbase.child; snode != nil; snode = snode.next { //for each container
+	for snode := C.yp_node_child(topContainer); snode != nil; snode = snode.next { //for each container
 		if snode.nodetype != C.LYS_CONTAINER {
 			continue
 		}
-		snodec := (*C.struct_lysc_node_container)(unsafe.Pointer(snode))
 
 		//for each list
-		for n := snodec.child; n != nil; n = n.next {
+		for n := C.yp_node_child(snode); n != nil; n = n.next {
 			var l YParserListInfo
-			slist := (*C.struct_lysc_node_list)(unsafe.Pointer(n))
 			listName := C.GoString(n.name)
 			l.RedisTableName = C.GoString(snode.name)
 
@@ -995,8 +1198,8 @@ func GetModelListInfo(module *YParserModule) []*YParserListInfo {
 			l.RedisKeyDelim = "|"
 			//Default table size is -1 i.e. size limit
 			l.RedisTableSize = -1
-			if slist.max > 0 {
-				l.RedisTableSize = int(slist.max)
+			if listMax := C.yp_list_max(n); listMax > 0 {
+				l.RedisTableSize = int(listMax)
 			}
 
 			l.LeafRef = make(map[string][]string)
@@ -1007,23 +1210,22 @@ func GetModelListInfo(module *YParserModule) []*YParserListInfo {
 			l.MandatoryNodes = make(map[string]bool)
 
 			//Add keys
-			for child := slist.child; child != nil; child = child.next {
-				if (child.flags & C.LYS_KEY) != 0 {
+			for child := C.yp_node_child(n); child != nil; child = child.next {
+				if C.yp_node_is_key(child) != 0 {
 					l.Keys = append(l.Keys, C.GoString(child.name))
 				}
 			}
 
 			//Check for must expression
-			if slist.musts != nil {
-				must := (*[10]C.struct_lysc_must)(unsafe.Pointer(slist.musts))
-				for idx := 0; idx < int(C.golysc_must_array_count(slist.musts)); idx++ {
-					mustexp := rewriteXPathPrefix(module, C.GoString(C.lyxp_get_expr(must[idx].cond)))
+			if musts := C.yp_node_musts(n); musts != nil {
+				for idx := C.size_t(0); idx < C.yp_node_musts_count(n); idx++ {
+					mustexp := rewriteXPathPrefix(module, C.GoString(C.yp_node_must_cond_at(musts, idx)))
 					exp := XpathExpression{Expr: mustexp}
-					if must[idx].eapptag != nil {
-						exp.ErrCode = C.GoString(must[idx].eapptag)
+					if apptag := C.yp_node_must_apptag_at(musts, idx); apptag != nil {
+						exp.ErrCode = C.GoString(apptag)
 					}
-					if must[idx].emsg != nil {
-						exp.ErrStr = strings.TrimPrefix(C.GoString(must[idx].emsg), customErrorPrefix)
+					if emsg := C.yp_node_must_emsg_at(musts, idx); emsg != nil {
+						exp.ErrStr = strings.TrimPrefix(C.GoString(emsg), customErrorPrefix)
 					}
 
 					l.XpathExpr[listName] = append(l.XpathExpr[listName],
@@ -1032,29 +1234,25 @@ func GetModelListInfo(module *YParserModule) []*YParserListInfo {
 			}
 
 			//Check for custom extension
-			if n.exts != nil {
-				for idx := 0; idx < int(C.golysc_ext_instance_array_count(n.exts)); idx++ {
-					ext := C.golysc_ext_instance_array_idx(n.exts, (C.size_t)(idx))
-					extName := C.GoString(ext.def.name)
-					argVal := C.GoString(ext.argument)
-					switch extName {
-					case "custom-validation":
-						if argVal != "" {
-							l.CustValidation[listName] = append(l.CustValidation[listName], argVal)
-						}
-					case "db-name":
-						l.DbName = argVal
-					case "key-delim":
-						l.RedisKeyDelim = argVal
-					case "key-pattern":
-						l.RedisKeyPattern = argVal
-					case "dependent-on":
-						l.DependentOnTable = argVal
-					case "tbl-key":
-						l.Key = argVal
+			for idx := C.size_t(0); idx < C.yp_node_exts_count(n); idx++ {
+				extName := C.GoString(C.yp_node_ext_def_name(n, idx))
+				argVal := C.GoString(C.yp_node_ext_argument(n, idx))
+				switch extName {
+				case "custom-validation":
+					if argVal != "" {
+						l.CustValidation[listName] = append(l.CustValidation[listName], argVal)
 					}
+				case "db-name":
+					l.DbName = argVal
+				case "key-delim":
+					l.RedisKeyDelim = argVal
+				case "key-pattern":
+					l.RedisKeyPattern = argVal
+				case "dependent-on":
+					l.DependentOnTable = argVal
+				case "tbl-key":
+					l.Key = argVal
 				}
-
 			}
 
 			//Add default key pattern
@@ -1066,8 +1264,7 @@ func GetModelListInfo(module *YParserModule) []*YParserListInfo {
 				l.RedisKeyPattern = strings.Join(keyPattern, l.RedisKeyDelim)
 			}
 
-			getModelChildInfo(&l,
-				(*C.struct_lysc_node)(unsafe.Pointer(slist)), module, false, nil)
+			getModelChildInfo(&l, n, module, false, nil)
 
 			list = append(list, &l)
 		} //each list inside a container

--- a/cvl/internal/yparser/yparser.go
+++ b/cvl/internal/yparser/yparser.go
@@ -40,9 +40,20 @@ import (
 #include <stdio.h>
 #include <string.h>
 
-// Canonical typedefs over libyang's schema node, must, when, ext_instance
-// and per-nodetype subtype structs, so the rest of the file refers to each
-// type by a single yp_* name.
+// Version detection. libyang3's <libyang/tree.h> defines LY_ARRAY_COUNT;
+// libyang1 has no such macro. <libyang/libyang.h> pulls in tree.h, so the
+// macro is reliably visible by the time we test it.
+#if defined(LY_ARRAY_COUNT)
+enum { yp_is_libyang1 = 0 };
+#else
+enum { yp_is_libyang1 = 1 };
+#endif
+
+// Canonical typedefs over libyang's schema node, must, when, ext_instance and
+// per-nodetype subtype structs. libyang3 renamed everything to lysc_* once it
+// introduced parsed/compiled schema separation. Using these typedefs lets the
+// rest of the file refer to types by a single name in both builds.
+#if defined(LY_ARRAY_COUNT)
 typedef struct lysc_node yp_snode_t;
 typedef struct lysc_node_leaf yp_snode_leaf_t;
 typedef struct lysc_node_leaflist yp_snode_leaflist_t;
@@ -51,6 +62,16 @@ typedef struct lysc_node_container yp_snode_container_t;
 typedef struct lysc_must yp_must_t;
 typedef struct lysc_when yp_when_t;
 typedef struct lysc_ext_instance yp_ext_t;
+#else
+typedef struct lys_node yp_snode_t;
+typedef struct lys_node_leaf yp_snode_leaf_t;
+typedef struct lys_node_leaflist yp_snode_leaflist_t;
+typedef struct lys_node_list yp_snode_list_t;
+typedef struct lys_node_container yp_snode_container_t;
+typedef struct lys_restr yp_must_t;
+typedef struct lys_when yp_when_t;
+typedef struct lys_ext_instance yp_ext_t;
+#endif
 
 // YPC_* mirrors of YParser{Ret,Err}Code values for use from C in
 // yp_translate_validation_code(). Values must match the Go constants in
@@ -77,6 +98,7 @@ typedef struct lysc_ext_instance yp_ext_t;
 #define YPC_SEMANTIC_KEY_INVALID            1019
 #define YPC_INTERNAL_UNKNOWN                1020
 
+#if defined(LY_ARRAY_COUNT)
 struct ly_ctx *goly_ctx_new(const char *search_dir, uint16_t options)
 {
 	struct ly_ctx *ctx = NULL;
@@ -85,14 +107,34 @@ struct ly_ctx *goly_ctx_new(const char *search_dir, uint16_t options)
 	}
 	return ctx;
 }
+#else
+struct ly_ctx *goly_ctx_new(const char *search_dir, uint16_t options)
+{
+	return ly_ctx_new(search_dir, options);
+}
+#endif
 
-// Thin wrapper around lys_parse_path so the caller does not have to deal
-// with libyang's return-value-vs-out-param convention directly.
+// Workaround the libyang3 lys_parse_path signature change (return value
+// vs. out-param). Kept as a single wrapper so the Go caller does not have
+// to care which version is in use.
+#if defined(LY_ARRAY_COUNT)
 int goly_parse_path(struct ly_ctx *ctx, const char *path, struct lys_module **module)
 {
 	return lys_parse_path(ctx, path, LYS_IN_YIN, module);
 }
+#else
+int goly_parse_path(struct ly_ctx *ctx, const char *path, struct lys_module **module)
+{
+	const struct lys_module *m = lys_parse_path(ctx, path, LYS_IN_YIN);
+	if (m == NULL) {
+		return 1;
+	}
+	*module = (struct lys_module *)m;
+	return 0;
+}
+#endif
 
+#if defined(LY_ARRAY_COUNT)
 struct lyd_node *golyd_new_inner(struct lyd_node *parent, const struct lys_module *module, const char *name)
 {
 	struct lyd_node *node = NULL;
@@ -101,7 +143,18 @@ struct lyd_node *golyd_new_inner(struct lyd_node *parent, const struct lys_modul
 	}
 	return node;
 }
+#else
+struct lyd_node *golyd_new_inner(struct lyd_node *parent, const struct lys_module *module, const char *name)
+{
+	return lyd_new(parent, (struct lys_module *)module, name);
+}
+#endif
 
+// In libyang3 lyd_new_list2 expects a keylist string of the form
+// "[k1='v1'][k2='v2']...". libyang1 has no equivalent, so the libyang1 path
+// creates the bare list node and the Go-side AddListNode adds the key leaves
+// afterward via AddMultiLeafNodes.
+#if defined(LY_ARRAY_COUNT)
 struct lyd_node *golyd_new_list2(struct lyd_node *parent, const struct lys_module *module, const char *name, const char *keylist, uint32_t options)
 {
 	struct lyd_node *node = NULL;
@@ -111,7 +164,16 @@ struct lyd_node *golyd_new_list2(struct lyd_node *parent, const struct lys_modul
 	}
 	return node;
 }
+#else
+struct lyd_node *golyd_new_list2(struct lyd_node *parent, const struct lys_module *module, const char *name, const char *keylist, uint32_t options)
+{
+	(void)keylist;
+	(void)options;
+	return lyd_new(parent, (struct lys_module *)module, name);
+}
+#endif
 
+#if defined(LY_ARRAY_COUNT)
 size_t golysc_node_list_keys_count(const struct lysc_node *node)
 {
 	const struct lysc_node *n;
@@ -131,7 +193,17 @@ size_t golysc_node_list_keys_count(const struct lysc_node *node)
 	}
 	return cnt;
 }
+#else
+size_t golysc_node_list_keys_count(const struct lys_node *node)
+{
+	if (node->nodetype != LYS_LIST) {
+		return 0;
+	}
+	return ((const struct lys_node_list *)node)->keys_size;
+}
+#endif
 
+#if defined(LY_ARRAY_COUNT)
 const char *golysc_node_get_when(const struct lysc_node *node)
 {
 	struct lysc_when **when = NULL;
@@ -150,12 +222,35 @@ const char *golysc_node_get_when(const struct lysc_node *node)
 	}
 	return lyxp_get_expr(when[0]->cond);
 }
+#else
+const char *golysc_node_get_when(const struct lys_node *node)
+{
+	struct lys_when *when = NULL;
+
+	switch (node->nodetype) {
+	case LYS_CHOICE:
+		when = ((const struct lys_node_choice *)node)->when;
+		break;
+	case LYS_CASE:
+		when = ((const struct lys_node_case *)node)->when;
+		break;
+	case LYS_USES:
+		when = ((const struct lys_node_uses *)node)->when;
+		break;
+	}
+	if (when == NULL) {
+		return NULL;
+	}
+	return when->cond;
+}
+#endif
 
 struct leaf_value {
 	const char *name;
 	const char *value;
 };
 
+#if defined(LY_ARRAY_COUNT)
 int lyd_multi_new_leaf(struct lyd_node *parent, const struct lys_module *module,
 	struct leaf_value *leafValArr, int size)
 {
@@ -181,7 +276,54 @@ int lyd_multi_new_leaf(struct lyd_node *parent, const struct lys_module *module,
 	}
 	return 0;
 }
+#else
+int lyd_multi_new_leaf(struct lyd_node *parent, const struct lys_module *module,
+	struct leaf_value *leafValArr, int size)
+{
+	const char *name, *val;
+	struct lyd_node *leaf;
+	struct lys_type *type;
+	int has_ptr_type;
+	int idx;
 
+	for (idx = 0; idx < size; idx++)
+	{
+		if ((leafValArr[idx].name == NULL) || (leafValArr[idx].value == NULL))
+		{
+			continue;
+		}
+
+		name = leafValArr[idx].name;
+		val = leafValArr[idx].value;
+
+		leaf = lyd_new_leaf(parent, (struct lys_module *)module, name, val);
+		if (leaf == NULL)
+		{
+			return -1;
+		}
+
+		// Validate union members explicitly; libyang1 skips union validation
+		// when LYD_OPT_EDIT is in effect, so we work around it by forcing it
+		// here. Toggling has_ptr_type makes lyd_validate_value check every
+		// alternative.
+		if (((struct lys_node_leaflist *)leaf->schema)->type.base == LY_TYPE_UNION)
+		{
+			type = &((struct lys_node_leaflist *)leaf->schema)->type;
+			has_ptr_type = type->info.uni.has_ptr_type;
+			type->info.uni.has_ptr_type = 0;
+			if (lyd_validate_value(leaf->schema, val))
+			{
+				type->info.uni.has_ptr_type = has_ptr_type;
+				return -1;
+			}
+			type->info.uni.has_ptr_type = has_ptr_type;
+		}
+	}
+	return 0;
+}
+#endif
+
+#if defined(LY_ARRAY_COUNT)
 static ly_bool lysc_node_is_union(const struct lysc_node *node)
 {
 	struct lysc_type *type;
@@ -247,6 +389,46 @@ int lyd_node_leafref_match_in_union(const struct lys_module *module, const char 
 	ly_set_free(set, NULL);
 	return -1;
 }
+#else
+int lyd_node_leafref_match_in_union(struct lys_module *module, const char *xpath, const char *value)
+{
+	struct ly_set *set = NULL;
+	struct lys_node *node = NULL;
+	struct lys_node_leaflist *lNode;
+	int idx = 0;
+
+	if (module == NULL)
+	{
+		return -1;
+	}
+
+	set = lys_find_path(module, NULL, xpath);
+	if (set == NULL || set->number == 0) {
+		return -1;
+	}
+
+	node = set->set.s[0];
+	ly_set_free(set);
+
+	// Walk union members looking for a leafref whose target accepts value.
+	lNode = (struct lys_node_leaflist *)node;
+	for (idx = 0; idx < lNode->type.info.uni.count; idx++)
+	{
+		if (lNode->type.info.uni.types[idx].base != LY_TYPE_LEAFREF)
+		{
+			continue;
+		}
+
+		if (lyd_validate_value((struct lys_node *)
+		    lNode->type.info.uni.types[idx].info.lref.target, value) == 0)
+		{
+			return 0;
+		}
+	}
+
+	return -1;
+}
+#endif
 
 // Result type for golys_xpath_targets_get. The struct itself is not
 // libyang-specific so it lives outside the #if; the path-extraction logic
@@ -276,6 +458,7 @@ static struct lysc_xpath_targets *golys_xpath_targets_alloc(size_t cnt)
 
 static const char *nonLeafRef = "non-leafref";
 
+#if defined(LY_ARRAY_COUNT)
 struct lysc_xpath_targets *golys_xpath_targets_get(const struct lysc_node *node)
 {
 	struct lysc_type *type;
@@ -322,25 +505,121 @@ struct lysc_xpath_targets *golys_xpath_targets_get(const struct lysc_node *node)
 	}
 	return paths;
 }
+#else
+struct lysc_xpath_targets *golys_xpath_targets_get(const struct lys_node *node)
+{
+	const struct lys_node_leaf *leaf;
+	struct lysc_xpath_targets *paths = NULL;
+	int u;
+	int non_leafref_cnt = 0;
+	size_t out;
+
+	if (node == NULL) {
+		return NULL;
+	}
+	leaf = (const struct lys_node_leaf *)node;
+
+	if (leaf->type.base == LY_TYPE_LEAFREF) {
+		paths = golys_xpath_targets_alloc(1);
+		paths->xpathlist[0] = leaf->type.info.lref.path;
+		return paths;
+	}
+	if (leaf->type.base != LY_TYPE_UNION) {
+		return NULL;
+	}
+
+	// Union: include each leafref alternative's xpath; collapse all non-leafref
+	// alternatives into a single "non-leafref" marker, mirroring the libyang3
+	// path so the Go caller sees a consistent view.
+	paths = golys_xpath_targets_alloc(leaf->type.info.uni.count);
+	out = 0;
+	for (u = 0; u < leaf->type.info.uni.count; u++) {
+		if (leaf->type.info.uni.types[u].base != LY_TYPE_LEAFREF) {
+			if (non_leafref_cnt == 0) {
+				paths->xpathlist[out++] = nonLeafRef;
+				non_leafref_cnt++;
+			}
+			continue;
+		}
+		paths->xpathlist[out++] = leaf->type.info.uni.types[u].info.lref.path;
+	}
+	paths->count = out;
+	if ((paths->count - non_leafref_cnt) == 0) {
+		golys_xpath_targets_free(paths);
+		return NULL;
+	}
+	return paths;
+}
+#endif
 
 // ----- yp_* accessors ----------------------------------------------------
-// Thin accessors over libyang's schema structs. They keep Go from poking at
-// libyang struct fields directly; signatures use the yp_* typedefs defined
-// above.
+// Thin accessors over libyang's schema structs. They exist so that Go does
+// not poke directly at version-specific struct fields, which lets the same
+// Go code compile against either libyang3 or libyang1. Signatures use the
+// yp_* typedefs defined above; bodies are #if-gated where the libyang APIs
+// diverge.
 
 // Get first child of a schema node (container/list/choice/case).
+#if defined(LY_ARRAY_COUNT)
 const yp_snode_t *yp_node_child(const yp_snode_t *n)
 {
 	return lysc_node_child(n);
 }
+#else
+const yp_snode_t *yp_node_child(const yp_snode_t *n)
+{
+	if (n == NULL) {
+		return NULL;
+	}
+	switch (n->nodetype) {
+	case LYS_CONTAINER:
+	case LYS_LIST:
+	case LYS_CHOICE:
+	case LYS_CASE:
+	case LYS_USES:
+	case LYS_GROUPING:
+	case LYS_INPUT:
+	case LYS_OUTPUT:
+	case LYS_NOTIF:
+	case LYS_RPC:
+	case LYS_ACTION:
+		return n->child;
+	}
+	return NULL;
+}
+#endif
 
-// Is this leaf node a key of its parent list?
+// Is this leaf node a key of its parent list? libyang3 stores this as a
+// LYS_KEY flag bit directly on the node; libyang1 has no such flag and we
+// instead walk up to the parent list and search its keys[] array.
+#if defined(LY_ARRAY_COUNT)
 int yp_node_is_key(const yp_snode_t *n)
 {
 	return (n != NULL && (n->flags & LYS_KEY)) ? 1 : 0;
 }
+#else
+int yp_node_is_key(const yp_snode_t *n)
+{
+	const struct lys_node_list *list;
+	uint8_t i;
+	if (n == NULL || n->nodetype != LYS_LEAF) {
+		return 0;
+	}
+	if (n->parent == NULL || n->parent->nodetype != LYS_LIST) {
+		return 0;
+	}
+	list = (const struct lys_node_list *)n->parent;
+	for (i = 0; i < list->keys_size; i++) {
+		if ((const struct lys_node *)list->keys[i] == n) {
+			return 1;
+		}
+	}
+	return 0;
+}
+#endif
 
 // Extensions on a schema node.
+#if defined(LY_ARRAY_COUNT)
 size_t yp_node_exts_count(const yp_snode_t *n)
 {
 	if (n == NULL || n->exts == NULL) {
@@ -362,8 +641,32 @@ const char *yp_node_ext_argument(const yp_snode_t *n, size_t idx)
 	}
 	return n->exts[idx].argument;
 }
+#else
+size_t yp_node_exts_count(const yp_snode_t *n)
+{
+	if (n == NULL) {
+		return 0;
+	}
+	return n->ext_size;
+}
+const char *yp_node_ext_def_name(const yp_snode_t *n, size_t idx)
+{
+	if (n == NULL || n->ext == NULL) {
+		return NULL;
+	}
+	return n->ext[idx]->def->name;
+}
+const char *yp_node_ext_argument(const yp_snode_t *n, size_t idx)
+{
+	if (n == NULL || n->ext == NULL) {
+		return NULL;
+	}
+	return n->ext[idx]->arg_value;
+}
+#endif
 
 // Must arrays on leaf / leaflist / list / container nodes.
+#if defined(LY_ARRAY_COUNT)
 yp_must_t *yp_node_musts(const yp_snode_t *n)
 {
 	if (n == NULL) {
@@ -398,8 +701,59 @@ const char *yp_node_must_emsg_at(yp_must_t *musts, size_t idx)
 {
 	return musts[idx].emsg;
 }
+#else
+yp_must_t *yp_node_musts(const yp_snode_t *n)
+{
+	if (n == NULL) {
+		return NULL;
+	}
+	switch (n->nodetype) {
+	case LYS_LEAF:
+		return ((const yp_snode_leaf_t *)n)->must;
+	case LYS_LEAFLIST:
+		return ((const yp_snode_leaflist_t *)n)->must;
+	case LYS_LIST:
+		return ((const yp_snode_list_t *)n)->must;
+	case LYS_CONTAINER:
+		return ((const yp_snode_container_t *)n)->must;
+	}
+	return NULL;
+}
+size_t yp_node_musts_count(const yp_snode_t *n)
+{
+	if (n == NULL) {
+		return 0;
+	}
+	switch (n->nodetype) {
+	case LYS_LEAF:
+		return ((const yp_snode_leaf_t *)n)->must_size;
+	case LYS_LEAFLIST:
+		return ((const yp_snode_leaflist_t *)n)->must_size;
+	case LYS_LIST:
+		return ((const yp_snode_list_t *)n)->must_size;
+	case LYS_CONTAINER:
+		return ((const yp_snode_container_t *)n)->must_size;
+	}
+	return 0;
+}
+const char *yp_node_must_cond_at(yp_must_t *musts, size_t idx)
+{
+	return musts[idx].expr;
+}
+const char *yp_node_must_apptag_at(yp_must_t *musts, size_t idx)
+{
+	return musts[idx].eapptag;
+}
+const char *yp_node_must_emsg_at(yp_must_t *musts, size_t idx)
+{
+	return musts[idx].emsg;
+}
+#endif
 
-// Default value of a leaf as the canonical string (NULL if none).
+// Default value of a leaf (NULL if none). libyang3 returns the canonical
+// representation via lyd_value_get_canonical; libyang1 stores the original
+// string directly on the schema node.
+#if defined(LY_ARRAY_COUNT)
 const char *yp_leaf_dflt(struct ly_ctx *ctx, const yp_snode_t *n)
 {
 	const yp_snode_leaf_t *leaf;
@@ -433,6 +787,31 @@ const char *yp_leaflist_dflt_at(struct ly_ctx *ctx, const yp_snode_t *n, size_t 
 	ll = (const yp_snode_leaflist_t *)n;
 	return lyd_value_get_canonical(ctx, ll->dflts[idx]);
 }
+#else
+const char *yp_leaf_dflt(struct ly_ctx *ctx, const yp_snode_t *n)
+{
+	(void)ctx;
+	if (n == NULL || n->nodetype != LYS_LEAF) {
+		return NULL;
+	}
+	return ((const yp_snode_leaf_t *)n)->dflt;
+}
+size_t yp_leaflist_dflts_count(const yp_snode_t *n)
+{
+	if (n == NULL || n->nodetype != LYS_LEAFLIST) {
+		return 0;
+	}
+	return ((const yp_snode_leaflist_t *)n)->dflt_size;
+}
+const char *yp_leaflist_dflt_at(struct ly_ctx *ctx, const yp_snode_t *n, size_t idx)
+{
+	(void)ctx;
+	if (n == NULL || n->nodetype != LYS_LEAFLIST) {
+		return NULL;
+	}
+	return ((const yp_snode_leaflist_t *)n)->dflt[idx];
+}
+#endif
 
 // min-elements and max-elements field names are stable across libyang
 // versions; just need the typedef-aware cast.
@@ -453,6 +832,9 @@ uint32_t yp_list_max(const yp_snode_t *n)
 }
 
 // Returns the first "when" expression on a leaf/leaflist (NULL if none).
+// libyang3 stores when as a LY_ARRAY of pointers; libyang1 stores a single
+// pointer to a struct lys_when.
+#if defined(LY_ARRAY_COUNT)
 const char *yp_leaf_when_cond(const yp_snode_t *n)
 {
 	yp_when_t **when = NULL;
@@ -472,9 +854,35 @@ const char *yp_leaf_when_cond(const yp_snode_t *n)
 	}
 	return lyxp_get_expr(when[0]->cond);
 }
+#else
+const char *yp_leaf_when_cond(const yp_snode_t *n)
+{
+	yp_when_t *when = NULL;
+	if (n == NULL) {
+		return NULL;
+	}
+	switch (n->nodetype) {
+	case LYS_LEAF:
+		when = ((const yp_snode_leaf_t *)n)->when;
+		break;
+	case LYS_LEAFLIST:
+		when = ((const yp_snode_leaflist_t *)n)->when;
+		break;
+	}
+	if (when == NULL) {
+		return NULL;
+	}
+	return when->cond;
+}
+#endif
 
-// Returns the top-level container under module that holds the data lists,
-// or NULL if the module's top isn't a container.
+// Returns the top-level container under module that holds the data lists.
+// libyang3 exposes a compiled-tree pointer; libyang1 keeps top-level nodes
+// directly on the module via lys_find_path("/$module/*"). The libyang1
+// variant returns the parent of the first matched node — which is exactly
+// the top container we want — so callers can iterate its children the same
+// way as in libyang3.
+#if defined(LY_ARRAY_COUNT)
 const yp_snode_t *yp_module_top_container(const struct lys_module *mod)
 {
 	if (mod == NULL || mod->compiled == NULL || mod->compiled->data == NULL) {
@@ -485,6 +893,25 @@ const yp_snode_t *yp_module_top_container(const struct lys_module *mod)
 	}
 	return mod->compiled->data;
 }
+#else
+const yp_snode_t *yp_module_top_container(const struct lys_module *mod)
+{
+	const yp_snode_t *n;
+	if (mod == NULL) {
+		return NULL;
+	}
+	// Walk mod->data forward looking for the first container. libyang1
+	// keeps top-level uses/augment expansions and other non-container
+	// schema nodes in this same list, so a simple "first node must be a
+	// container" check would miss the container we actually want.
+	for (n = mod->data; n != NULL; n = n->next) {
+		if (n->nodetype == LYS_CONTAINER) {
+			return n;
+		}
+	}
+	return NULL;
+}
+#endif
 
 // Aggregated error info filled in by yp_get_last_error.
 struct yp_error_info {
@@ -499,6 +926,7 @@ struct yp_error_info {
 //   0  no error item available
 //   1  last error item is LY_SUCCESS (no real error)
 //   2  real error, *info populated
+#if defined(LY_ARRAY_COUNT)
 int yp_get_last_error(struct ly_ctx *ctx, struct yp_error_info *info)
 {
 	const struct ly_err_item *err = ly_err_last(ctx);
@@ -515,21 +943,53 @@ int yp_get_last_error(struct ly_ctx *ctx, struct yp_error_info *info)
 	info->apptag = err->apptag;
 	return 2;
 }
+#else
+int yp_get_last_error(struct ly_ctx *ctx, struct yp_error_info *info)
+{
+	// libyang1 returns the head of a list; the most recent error is on
+	// .prev (a circular list trick).
+	const struct ly_err_item *head = ly_err_first(ctx);
+	const struct ly_err_item *last;
+	if (head == NULL) {
+		return 0;
+	}
+	last = head->prev;
+	if (last->no == LY_SUCCESS) {
+		return 1;
+	}
+	info->err = last->no;
+	info->vecode = last->vecode;
+	info->msg = last->msg;
+	info->path = last->path;
+	info->apptag = last->apptag;
+	return 2;
+}
+#endif
 
-// ---- yp_* wrappers for the data-tree functions used by Go ----
-// Wrap the libyang functions whose flag enums and out-param conventions are
-// awkward to spell directly from Go, so the Go-side call sites stay short.
+// ---- libyang3/libyang1 wrappers for the data-tree functions used by Go ----
+// These hide the changes in API names, flag enums and out-param conventions
+// between the two libyang versions so the Go-side call sites stay version-
+// agnostic.
 
 void yp_ly_set_loglevel(int level)
 {
+#if defined(LY_ARRAY_COUNT)
 	ly_log_level(level);
+#else
+	ly_verb(level);
+#endif
 }
 
 void yp_ly_ctx_destroy(struct ly_ctx *ctx)
 {
+#if defined(LY_ARRAY_COUNT)
 	ly_ctx_destroy(ctx);
+#else
+	ly_ctx_destroy(ctx, NULL);
+#endif
 }
 
+#if defined(LY_ARRAY_COUNT)
 void yp_lyd_free(struct lyd_node *node)
 {
 	if (node != NULL) {
@@ -554,10 +1014,47 @@ int yp_lyd_validate_edit(struct ly_ctx *ctx, struct lyd_node **data)
 		LYD_VALIDATE_PRESENT | LYD_VALIDATE_NO_STATE | LYD_VALIDATE_NOEXTDEPS,
 		NULL);
 }
+#else
+// libyang1 doesn't export lyd_check_mandatory_tree in its public header but
+// it is a symbol in the shared library; declare it manually so the validate
+// wrapper can call it.
+extern int lyd_check_mandatory_tree(struct lyd_node *root, struct ly_ctx *ctx, const struct lys_module **modules, int mod_count, int options);
+
+void yp_lyd_free(struct lyd_node *node)
+{
+	if (node != NULL) {
+		lyd_free_withsiblings(node);
+	}
+}
+char *yp_lyd_print_mem(struct lyd_node *node)
+{
+	char *out = NULL;
+	lyd_print_mem(&out, node, LYD_XML, LYP_WITHSIBLINGS);
+	return out;
+}
+int yp_lyd_merge(struct lyd_node **dst, struct lyd_node *src, int destruct, struct ly_ctx *ctx)
+{
+	int flags = destruct ? LYD_OPT_DESTRUCT : 0;
+	return lyd_merge_to_ctx(dst, src, flags, ctx);
+}
+int yp_lyd_validate_edit(struct ly_ctx *ctx, struct lyd_node **data)
+{
+	// libyang1 skips the mandatory-tree check under LYD_OPT_EDIT, so we
+	// invoke it explicitly first to keep behavior consistent with libyang3.
+	int ret = lyd_check_mandatory_tree(*data, ctx, NULL, 0,
+		LYD_OPT_CONFIG | LYD_OPT_NOEXTDEPS);
+	if (ret != 0) {
+		return ret;
+	}
+	return lyd_validate(data, LYD_OPT_EDIT | LYD_OPT_NOEXTDEPS, ctx);
+}
+#endif
 
 // Map a libyang validation error code to one of the YPC_* mirror values.
-// The Go side casts the result to YParserRetCode directly. Lives in C so
-// the switch on libyang's LYVE_* enumeration is self-contained.
+// The Go side casts the result to YParserRetCode directly. The two switch
+// statements look different because libyang1 and libyang3 use entirely
+// different LYVE_* enumerations.
+#if defined(LY_ARRAY_COUNT)
 int yp_translate_validation_code(int vecode, const char *apptag, const char *msg)
 {
 	switch (vecode) {
@@ -596,6 +1093,71 @@ int yp_translate_validation_code(int vecode, const char *apptag, const char *msg
 	}
 	return YPC_INTERNAL_UNKNOWN;
 }
+#else
+int yp_translate_validation_code(int vecode, const char *apptag, const char *msg)
+{
+	(void)apptag;
+	(void)msg;
+	switch (vecode) {
+	case LYVE_SUCCESS:
+		return YPC_SUCCESS;
+	case LYVE_XML_MISS:
+	case LYVE_INARG:
+	case LYVE_MISSELEM:
+		return YPC_SYNTAX_MISSING_FIELD;
+	case LYVE_XML_INVAL:
+	case LYVE_XML_INCHAR:
+	case LYVE_INMOD:
+	case LYVE_INELEM:
+	case LYVE_INVAL:
+	case LYVE_MCASEDATA:
+		return YPC_SYNTAX_INVALID_FIELD;
+	case LYVE_EOF:
+	case LYVE_INSTMT:
+	case LYVE_INPAR:
+	case LYVE_INID:
+	case LYVE_MISSSTMT:
+	case LYVE_MISSARG:
+		return YPC_SYNTAX_INVALID_INPUT_DATA;
+	case LYVE_TOOMANY:
+		return YPC_SYNTAX_MULTIPLE_INSTANCE;
+	case LYVE_DUPID:
+	case LYVE_DUPLEAFLIST:
+	case LYVE_DUPLIST:
+	case LYVE_NOUNIQ:
+		return YPC_SYNTAX_DUPLICATE;
+	case LYVE_ENUM_INVAL:
+		return YPC_SYNTAX_ENUM_INVALID;
+	case LYVE_ENUM_INNAME:
+		return YPC_SYNTAX_ENUM_INVALID_NAME;
+	case LYVE_ENUM_WS:
+		return YPC_SYNTAX_ENUM_WHITESPACE;
+	case LYVE_KEY_NLEAF:
+	case LYVE_KEY_CONFIG:
+	case LYVE_KEY_TYPE:
+		return YPC_SEMANTIC_KEY_INVALID;
+	case LYVE_KEY_MISS:
+	case LYVE_PATH_MISSKEY:
+		return YPC_SEMANTIC_KEY_NOT_EXIST;
+	case LYVE_KEY_DUP:
+		return YPC_SEMANTIC_KEY_DUPLICATE;
+	case LYVE_NOMIN:
+		return YPC_SYNTAX_MINIMUM_INVALID;
+	case LYVE_NOMAX:
+		return YPC_SYNTAX_MAXIMUM_INVALID;
+	case LYVE_NOMUST:
+	case LYVE_NOWHEN:
+	case LYVE_INWHEN:
+	case LYVE_NOLEAFREF:
+		return YPC_SEMANTIC_DEPENDENT_DATA_MISSING;
+	case LYVE_NOMANDCHOICE:
+		return YPC_SEMANTIC_MANDATORY_DATA_MISSING;
+	case LYVE_PATH_EXISTS:
+		return YPC_SEMANTIC_KEY_ALREADY_EXIST;
+	}
+	return YPC_INTERNAL_UNKNOWN;
+}
+#endif
 
 */
 import "C"
@@ -604,6 +1166,11 @@ type YParserCtx C.struct_ly_ctx
 type YParserNode C.struct_lyd_node
 type YParserSNode C.yp_snode_t
 type YParserModule C.struct_lys_module
+
+// Libyang1 is true when this package was built against libyang v1 headers.
+// Callers (e.g. tests) can branch on this to handle version-specific
+// behavior without needing build tags themselves.
+const Libyang1 = C.yp_is_libyang1 != 0
 
 var ypCtx *YParserCtx
 
@@ -760,17 +1327,24 @@ func (yp *YParser) AddContainerNode(module *YParserModule, parent *YParserNode, 
 func (yp *YParser) AddListNode(module *YParserModule, parent *YParserNode, name string, keys []*YParserLeafValue) (*YParserNode, YParserError) {
 	var keylist string
 
-	// All key values predicate in the form of "[key1='val1'][key2='val2']...", they do not have to be ordered.
-	for index := 0; index < len(keys); index++ {
-		if (keys[index] == nil) || (keys[index].Name == "") {
-			break
-		}
+	// libyang3 wants the keys baked into the call as a predicate-string of
+	// the form "[key1='val1'][key2='val2']..."; libyang1 has no equivalent
+	// and instead expects the list node to be created bare and the key
+	// leaves appended afterwards. golyd_new_list2 ignores keylist under
+	// libyang1, so we keep the predicate-build only when it actually has
+	// somewhere to land.
+	if !Libyang1 {
+		for index := 0; index < len(keys); index++ {
+			if (keys[index] == nil) || (keys[index].Name == "") {
+				break
+			}
 
-		keylist += "["
-		keylist += keys[index].Name
-		keylist += "='"
-		keylist += keys[index].Value
-		keylist += "']"
+			keylist += "["
+			keylist += keys[index].Name
+			keylist += "='"
+			keylist += keys[index].Value
+			keylist += "']"
+		}
 	}
 
 	nameCStr := C.CString(name)
@@ -781,6 +1355,12 @@ func (yp *YParser) AddListNode(module *YParserModule, parent *YParserNode, name 
 	if ret == nil {
 		TRACE_LOG(TRACE_YPARSER, "Failed parsing node %s", name)
 		return ret, getErrorDetails()
+	}
+
+	if Libyang1 {
+		if err := yp.AddMultiLeafNodes(module, ret, keys); err.ErrCode != YP_SUCCESS {
+			return nil, err
+		}
 	}
 
 	return ret, YParserError{ErrCode: YP_SUCCESS}
@@ -920,7 +1500,8 @@ func (yp *YParser) FreeNode(node *YParserNode) YParserError {
 
 /* This function translates LIBYANG error code to valid YPARSER error code.
  * The translation table itself lives in C (yp_translate_validation_code)
- * so the switch over libyang's LYVE_* enum stays in one place. */
+ * because the LYVE_* enum values differ entirely between libyang versions
+ * and would not compile against the wrong header set if left in Go. */
 func translateLYErrToYParserErr(LYErrcode int, apptag string, msg string) YParserRetCode {
 	var apptagCstr, msgCstr *C.char
 	if apptag != "" {


### PR DESCRIPTION
SONiC Libyang3 upgrade Tracking ticket https://github.com/sonic-net/sonic-buildimage/issues/22385 

This PR depends on the other PRs mentioned in the above tracking ticket.

The API changes between libyang1 and libyang3 are drastic.

The cvl test cases are currently passing all tests.

This depends on libyang3's [devel](https://github.com/CESNET/libyang/tree/devel) branch plus this rejected patch:
- https://github.com/CESNET/libyang/pull/2362 -- will never be accepted upstream. libyang maintainer says sonic-yang-mgmt needs to be rearchitected, it is a bad application design to need such a flag.

Or the libyang3 package built via sonic-buildimage which is based on v3.7.8 + all the necessary patches, part of https://github.com/sonic-net/sonic-buildimage/pull/21679

Fixes https://github.com/sonic-net/sonic-buildimage/issues/22385

See comment https://github.com/sonic-net/sonic-mgmt-common/pull/157#issuecomment-4463781541 for the description about supporting both libyang1 and libyang3