### PR TITLE
Management framework transformer component support/enhancement for  DELETE at any yang depth 

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -118,7 +118,7 @@ stages:
 
         ./translib.test -test.v -logtostderr || STATUS=1
 
-        ./transformer.test -test.v -logtostderr -v=5 || STATUS=1
+        ./transformer.test -test.v -logtostderr || STATUS=1
 
         ./testapp.test -test.v -logtostderr || STATUS=1
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -98,8 +98,8 @@ stages:
 
         pushd build/tests/cvl
 
-        #CVL_SCHEMA_PATH=testdata/schema \
-        #    ./cvl.test -test.v -logtostderr || STATUS=1
+        CVL_SCHEMA_PATH=testdata/schema \
+            ./cvl.test -test.v -logtostderr || STATUS=1
 
         popd
 
@@ -114,9 +114,9 @@ stages:
         export CVL_SCHEMA_PATH=${DEBDIR}/usr/sbin/schema
         export YANG_MODELS_PATH=${DEBDIR}/usr/models/yang
 
-        #./db.test -test.v -logtostderr || STATUS=1
+        ./db.test -test.v -logtostderr || STATUS=1
 
-        #./translib.test -test.v -logtostderr || STATUS=1
+        ./translib.test -test.v -logtostderr || STATUS=1
 
         ./transformer.test -test.v -logtostderr -v=5 || STATUS=1
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -98,8 +98,8 @@ stages:
 
         pushd build/tests/cvl
 
-        CVL_SCHEMA_PATH=testdata/schema \
-            ./cvl.test -test.v -logtostderr || STATUS=1
+        #CVL_SCHEMA_PATH=testdata/schema \
+        #    ./cvl.test -test.v -logtostderr || STATUS=1
 
         popd
 
@@ -114,11 +114,11 @@ stages:
         export CVL_SCHEMA_PATH=${DEBDIR}/usr/sbin/schema
         export YANG_MODELS_PATH=${DEBDIR}/usr/models/yang
 
-        ./db.test -test.v -logtostderr || STATUS=1
+        #./db.test -test.v -logtostderr || STATUS=1
 
-        ./translib.test -test.v -logtostderr || STATUS=1
+        #./translib.test -test.v -logtostderr || STATUS=1
 
-        ./transformer.test -test.v -logtostderr || STATUS=1
+        ./transformer.test -test.v -logtostderr -v=5 || STATUS=1
 
         ./testapp.test -test.v -logtostderr || STATUS=1
 

--- a/translib/common_app.go
+++ b/translib/common_app.go
@@ -740,6 +740,7 @@ func (app *CommonApp) cmnAppCRUCommonDbOpn(d *db.DB, opcode int, dbMap map[strin
 						A leaf-list field in redis has "@" suffix as per swsssdk convention.
 						*/
 						resTblRw := db.Value{Field: map[string]string{}}
+						resTblRw = checkAndProcessLeafList(existingEntry, tblRw, UPDATE, d, tblNm, tblKey)
 						log.Info("Processing Table row ", resTblRw)
 						err = d.ModEntry(cmnAppTs, db.Key{Comp: []string{tblKey}}, resTblRw)
 						if err != nil {
@@ -772,6 +773,7 @@ func (app *CommonApp) cmnAppCRUCommonDbOpn(d *db.DB, opcode int, dbMap map[strin
 						A leaf-list field in redis has "@" suffix as per swsssdk convention.
 						*/
 						resTblRw := db.Value{Field: map[string]string{}}
+						resTblRw = checkAndProcessLeafList(existingEntry, tblRw, UPDATE, d, tblNm, tblKey)
 						err = d.ModEntry(cmnAppTs, db.Key{Comp: []string{tblKey}}, resTblRw)
 						if err != nil {
 							log.Warning("UPDATE case - d.ModEntry() failure")

--- a/translib/common_app.go
+++ b/translib/common_app.go
@@ -400,7 +400,6 @@ func (app *CommonApp) processDelete(d *db.DB) (SetResponse, error) {
 	var resp SetResponse
 
 	log.Infof("processDelete:path = %s, deleteEmptyEntry = %v", app.pathInfo.Path, app.deleteEmptyEntry)
-
 	if err = app.processCommon(d, DELETE); err != nil {
 		log.Warning(err)
 		resp = SetResponse{ErrSrc: AppErr}
@@ -604,9 +603,11 @@ func (app *CommonApp) translateCRUDCommon(d *db.DB, opcode int) ([]db.WatchKeys,
 	}
 
 	var resultTblList []string
+	resultTblMap := make(map[string]bool)
 	for _, dbMap := range result { //Get dependency list for all tables in result
-		for _, resMap := range dbMap { //Get dependency list for all tables in result
-			for tblnm := range resMap { //Get dependency list for all tables in result
+		for tblnm := range dbMap[db.ConfigDB] {
+			if !resultTblMap[tblnm] {
+				resultTblMap[tblnm] = true
 				resultTblList = append(resultTblList, tblnm)
 			}
 		}
@@ -738,7 +739,12 @@ func (app *CommonApp) cmnAppCRUCommonDbOpn(d *db.DB, opcode int, dbMap map[strin
 						A leaf-list field in redis has "@" suffix as per swsssdk convention.
 						*/
 						resTblRw := db.Value{Field: map[string]string{}}
-						resTblRw = checkAndProcessLeafList(existingEntry, tblRw, UPDATE, d, tblNm, tblKey)
+						/* for north-bound REPLACE request always swap the whole leaf-list */
+						if app.cmnAppOpcode == REPLACE {
+							resTblRw = tblRw
+						} else {
+							resTblRw = checkAndProcessLeafList(existingEntry, tblRw, UPDATE, d, tblNm, tblKey)
+						}
 						log.Info("Processing Table row ", resTblRw)
 						err = d.ModEntry(cmnAppTs, db.Key{Comp: []string{tblKey}}, resTblRw)
 						if err != nil {
@@ -771,7 +777,12 @@ func (app *CommonApp) cmnAppCRUCommonDbOpn(d *db.DB, opcode int, dbMap map[strin
 						A leaf-list field in redis has "@" suffix as per swsssdk convention.
 						*/
 						resTblRw := db.Value{Field: map[string]string{}}
-						resTblRw = checkAndProcessLeafList(existingEntry, tblRw, UPDATE, d, tblNm, tblKey)
+						/* for north-bound REPLACE request always swap the whole leaf-list */
+						if app.cmnAppOpcode == REPLACE {
+							resTblRw = tblRw
+						} else {
+							resTblRw = checkAndProcessLeafList(existingEntry, tblRw, UPDATE, d, tblNm, tblKey)
+						}
 						err = d.ModEntry(cmnAppTs, db.Key{Comp: []string{tblKey}}, resTblRw)
 						if err != nil {
 							log.Warning("UPDATE case - d.ModEntry() failure")
@@ -891,6 +902,228 @@ func (app *CommonApp) cmnAppCRUCommonDbOpn(d *db.DB, opcode int, dbMap map[strin
 	return err
 }
 
+func deleteFields(existingEntry db.Value, d *db.DB, cmnAppTs *db.TableSpec, tblKey string, tblRw db.Value, deleteEmptyEntry bool) error {
+	var err error
+	log.V(4).Info("DELETE case - fields/cols to delete hence delete only those fields.")
+	/* handle leaf-list merge if any leaf-list exists */
+	tblNm := cmnAppTs.Name
+	resTblRw := checkAndProcessLeafList(existingEntry, tblRw, DELETE, d, tblNm, tblKey)
+	log.V(4).Info("DELETE case - checkAndProcessLeafList() returned table row ", resTblRw)
+	if len(resTblRw.Field) > 0 {
+		if !deleteEmptyEntry {
+			/* add the NULL field if the last field gets deleted && deleteEmpyEntry is false */
+			deleteCount := 0
+			for field := range existingEntry.Field {
+				if resTblRw.Has(field) {
+					deleteCount++
+				}
+			}
+			if deleteCount == len(existingEntry.Field) {
+				nullTblRw := db.Value{Field: map[string]string{"NULL": "NULL"}}
+				log.Info("Last field gets deleted, add NULL field to keep an db entry")
+				err = d.ModEntry(cmnAppTs, db.Key{Comp: []string{tblKey}}, nullTblRw)
+				if err != nil {
+					log.Warning("UPDATE case - d.ModEntry() failure")
+					return err
+				}
+			}
+		}
+		/* deleted fields */
+		err := d.DeleteEntryFields(cmnAppTs, db.Key{Comp: []string{tblKey}}, resTblRw)
+		if err != nil {
+			log.Warning("DELETE case - d.DeleteEntryFields() failure")
+			return err
+		}
+	}
+	return err
+}
+
+func (app *CommonApp) handleChildDeleteForOcReplaceAndDelete(d *db.DB, sortedDelTblLst []string, moduleNm string) error {
+	/* resultTblLst has child first, parent later order */
+	var err error
+
+	for _, tblNm := range sortedDelTblLst {
+		log.V(4).Info("In Yang to DB map returned from transformer looking for table = ", tblNm)
+		var parentKeysList []string
+		if tblVal, ok := app.cmnAppTableMap[DELETE][db.ConfigDB][tblNm]; ok {
+			cmnAppTs := &db.TableSpec{Name: tblNm}
+			if len(tblVal) == 0 {
+				log.Info("No table instances/rows found hence mark entire table to be deleted = ", tblNm)
+				/* handle child table cleanup when North Bound oper is REPLACE- TODO.
+				   For north bound DELETE child yang hierarchy traversal for target/request
+				   URI will populate the relevant child tables in the result map and
+				   SortAsPerTblDeps() on the tables in result map will take care of child table getting
+				   processed.There is no need to check CVL dependencies it being unaware of table mapped under
+				   under target URI.
+				*/
+				if app.cmnAppOpcode == REPLACE {
+					log.V(4).Info("process Table level Delete For North Bound Replace oper")
+					/* TODO - For North Bound REPLACE operation payload translation can result in
+					   data being populated in UPDATE map based on table ownership and also the
+					   scope of db-mapping at the target URL.DELETE map will contain whats not present
+					   in the payload in yang hiercharchy beneath the target URL.Thus data needs to be
+					   processed in order resolving dependencies to achieve the end result */
+				}
+				log.Info("deleting table = ", tblNm)
+				err = d.DeleteTable(cmnAppTs)
+				if err != nil {
+					log.Warning("d.DelTable() failure")
+					return err
+				}
+				continue
+			}
+			// Sort keys to make a list in order multiple keys first, single key last
+			ordDbKeyLst := transformer.SortSncTableDbKeys(tblNm, tblVal)
+			log.V(4).Infof("DELETE case - ordered list of DB keys for tbl %v = %v", tblNm, ordDbKeyLst)
+
+			for _, tblKey := range ordDbKeyLst {
+				tblRw := tblVal[tblKey]
+				if len(tblRw.Field) == 0 {
+					log.Info("DELETE case - no fields/cols to delete hence mark for delete the entire row having key = ", tblKey)
+					if app.cmnAppOpcode == REPLACE {
+						parentKeysList = append(parentKeysList, tblKey)
+					} else {
+						// DELETE case. We rely on the infra generated children as infra does the complete yang tree traversal.
+						// The SortAsPerTblDeps and keys sorting for same table makes sure that all children are deleted first.
+						// There is no need to check CVL dependencies. Just delete the entry.
+						log.Info("Delete entry ", cmnAppTs, db.Key{Comp: []string{tblKey}})
+						err = d.DeleteEntry(cmnAppTs, db.Key{Comp: []string{tblKey}})
+						if err != nil {
+							if cvl.CVLRetCode(err.(tlerr.TranslibCVLFailure).Code) == cvl.CVL_SEMANTIC_KEY_NOT_EXIST {
+								log.Infof("Ignore delete that cannot be processed for table %v key %v that does not exist. err %v", tblNm, tblKey, err.(tlerr.TranslibCVLFailure).CVLErrorInfo.ConstraintErrMsg)
+								err = nil
+							} else {
+								log.Warning("DELETE case - d.DeleteEntry() failure")
+								return err
+							}
+						}
+					}
+				} else {
+					// In case we have FillFields available in the tblRw, do not send the request to DB.
+					if len(tblRw.Field) == 1 {
+						if tblRw.Has("FillFields") {
+							continue
+						}
+					}
+					log.Info("DELETE case - fields/cols to delete hence delete only those fields.")
+					existingEntry, exstErr := d.GetEntry(cmnAppTs, db.Key{Comp: []string{tblKey}})
+					if exstErr != nil {
+						log.Info("Table Entry from which the fields are to be deleted does not exist. Ignore error for non existant instance for idempotency")
+						continue
+					}
+					if log.V(3) {
+						log.Info("Fields delete", cmnAppTs, db.Key{Comp: []string{tblKey}}, tblRw)
+					}
+					err = deleteFields(existingEntry, d, cmnAppTs, tblKey, tblRw, app.deleteEmptyEntry)
+					if err != nil {
+						log.Warning("DELETE case - deleteFields failure ")
+						return err
+					}
+				}
+			}
+			/* Delete the dependent entries for all keys in parentKeysList in case of REPLACE */
+			if app.cmnAppOpcode == REPLACE && len(parentKeysList) > 0 {
+				// TODO as mentioned in above comment
+			}
+		}
+	}
+	return err
+}
+
+func processChildTablesforDelete(d *db.DB, parentTblNm string, ordTblList []string) error {
+	var err error
+
+	cvlSess, err := d.NewValidationSession()
+	if err != nil || cvlSess == nil {
+		log.Info("getCVLDepDataForDelete : cvl.ValidationSessOpen failed")
+		return err
+	}
+	defer cvl.ValidationSessClose(cvlSess)
+
+	childrenWithinModule := make(map[string]bool)
+	// Get all children tables within the same module that are to be considered for delete
+	for _, ordtbl := range ordTblList {
+		if ordtbl == parentTblNm {
+			// Handle the child tables only till you reach the parent table entry
+			break
+		}
+		// Check if the child table is in DB. If no keys available then ignore the table
+		dbTblSpec := &db.TableSpec{Name: ordtbl}
+		chldKeys, getTblErr := d.GetKeys(dbTblSpec)
+		if getTblErr != nil {
+			log.V(4).Infof("GetKeys() failed for child table - %v - error - %v", ordtbl, getTblErr)
+			continue
+		}
+		if len(chldKeys) == 0 {
+			log.V(4).Infof("Child table %v not availble in DB. Hence not required to consider for Delete", ordtbl)
+			continue
+		}
+		childrenWithinModule[ordtbl] = true
+	}
+	if len(childrenWithinModule) == 0 {
+		log.V(4).Info("No action to take for child tables in DB")
+		return nil
+	}
+	log.Info("Since parent table is to be deleted, first deleting children within the same module= ", childrenWithinModule)
+
+	// Get all keys for parent table and check if the child table has a key based relationship
+	log.V(4).Info("Get Keys for parent Tbl ", parentTblNm)
+	parentTblSpec := &db.TableSpec{Name: parentTblNm}
+	parentTblKeys, getKeysErr := d.GetKeys(parentTblSpec)
+	if getKeysErr != nil {
+		log.Warningf("GetKeys() failed for parent table - %v - error - %v", parentTblNm, getKeysErr)
+	}
+	if len(parentTblKeys) == 0 {
+		log.Info("No DB data found so no action to take for parent table ", parentTblNm)
+		return nil
+	}
+
+	parentTblKeyMap := make(map[string]db.Value)
+	log.V(4).Info("parent table keys - ", parentTblKeys)
+	for _, parentKey := range parentTblKeys {
+		parentTblKeyMap[strings.Join(parentKey.Comp, "|")] = db.Value{}
+	}
+	log.V(4).Info("parent table key map - ", parentTblKeyMap)
+	// Sort the parent keys in child first order
+	ordParentTblKeys := transformer.SortSncTableDbKeys(parentTblNm, parentTblKeyMap)
+	log.V(4).Info("Sorted parent table keys - ", ordParentTblKeys)
+
+	// Delete Child table within the ordered list only if the child has a key based relationship to the parent
+	// If yes, then delete the child table
+	for _, parentKey := range ordParentTblKeys {
+		depList := cvlSess.GetDepDataForDelete(parentTblNm + "|" + parentKey)
+		log.V(4).Infof("GetDepDataForDelete for tblKey %v returned %v", parentKey, depList)
+		// GetDepDataForDelete gives in Parent first order. Hence traverse from the last element to delete last child first
+		for idx := len(depList) - 1; idx >= 0; idx-- {
+			depEntry := depList[idx]
+			for childInst, childInstData := range depEntry.Entry {
+				chldInstList := strings.SplitN(childInst, "|", 2)
+				if len(chldInstList) < 2 {
+					// No key available in the child table. Cannot process child table
+					continue
+				}
+				chldTbl := chldInstList[0]
+				// Check if the child table is in the list of children within the same module
+				// Delete the child instance if they have a key dependency to parent instance only
+				if _, deleteChildOk := childrenWithinModule[chldTbl]; deleteChildOk && len(childInstData) == 0 {
+					log.V(4).Infof("Child table %v has key relationship with parent table %v . Hence delete child", chldTbl, parentTblNm)
+					chldKey := chldInstList[1]
+					chldTs := &db.TableSpec{Name: chldTbl}
+					log.V(4).Info("DELETE case - child table instance to be deleted = ", chldKey)
+					err := d.DeleteEntry(chldTs, db.Key{Comp: []string{chldKey}})
+					if err != nil {
+						log.Warning("DELETE case - child table instance DeleteEntry failure ")
+						return err
+					}
+				} else {
+					log.Infof("Dependency table(%v) is either not child of same module or child table does not have a key dependency to parent table", chldTbl)
+				}
+			}
+		}
+	}
+	return nil
+}
+
 func (app *CommonApp) cmnAppDelDbOpn(d *db.DB, opcode int, dbMap map[string]map[string]db.Value) error {
 	var err error
 	var cmnAppTs, dbTblSpec *db.TableSpec
@@ -915,6 +1148,15 @@ func (app *CommonApp) cmnAppDelDbOpn(d *db.DB, opcode int, dbMap map[string]map[
 	}
 	log.Info("getModuleNmFromPath() returned module name = ", moduleNm)
 
+	isSonicUri := strings.HasPrefix(app.pathInfo.Path, "/sonic")
+	if !isSonicUri && (opcode == REPLACE || opcode == DELETE) {
+		log.V(4).Info("Special Handling for DELETE/REPLACE on non-sonic path")
+		err = app.handleChildDeleteForOcReplaceAndDelete(d, resultTblLst, moduleNm)
+		if err != nil {
+			log.Warning("handleChildDeleteForOcReplaceAndDelete() failed ", err)
+		}
+		return err
+	}
 	/* resultTblLst has child first, parent later order */
 	for _, tblNm := range resultTblLst {
 		log.Info("In Yang to DB map returned from transformer looking for table = ", tblNm)
@@ -935,21 +1177,22 @@ func (app *CommonApp) cmnAppDelDbOpn(d *db.DB, opcode int, dbMap map[string]map[
 			}
 			if len(tblVal) == 0 {
 				log.Info("DELETE case - No table instances/rows found hence delete entire table = ", tblNm)
-				if !app.skipOrdTableChk {
-					for _, ordtbl := range ordTblList {
-						if ordtbl == tblNm {
-							// Handle the child tables only till you reach the parent table entry
-							break
-						}
-						log.Info("Since parent table is to be deleted, first deleting child table = ", ordtbl)
-						dbTblSpec = &db.TableSpec{Name: ordtbl}
-						err = d.DeleteTable(dbTblSpec)
-						if err != nil {
-							log.Warning("DELETE case - d.DeleteTable() failure for Table = ", ordtbl)
-							return err
-						}
+				skipChildDelete := false
+				if len(ordTblList) == 1 && ordTblList[0] == tblNm {
+					skipChildDelete = true
+				}
+				if !skipChildDelete && !app.skipOrdTableChk {
+					// Delete Child table within same module only if the child has a key based relationship to the parent
+					// Get all keys for parent table and check if the child table has a key based relationship
+					// If yes, then delete the child table
+					err = processChildTablesforDelete(d, tblNm, ordTblList)
+					if err != nil {
+						log.Warning("processChildTablesforDelete() failed ", err)
+						return err
 					}
 				}
+				// Finally delete the parent table.
+				log.V(4).Info("DELETE case - Delete entire table = ", tblNm)
 				err = d.DeleteTable(cmnAppTs)
 				if err != nil {
 					log.Warning("DELETE case - d.DeleteTable() failure for Table = ", tblNm)
@@ -958,7 +1201,6 @@ func (app *CommonApp) cmnAppDelDbOpn(d *db.DB, opcode int, dbMap map[string]map[
 				log.Info("DELETE case - Deleted entire table = ", tblNm)
 				// Continue to repeat ordered deletion for all tables
 				continue
-
 			}
 			// Sort keys to make a list in order multiple keys first, single key last
 			ordDbKeyLst := transformer.SortSncTableDbKeys(tblNm, tblVal)
@@ -988,16 +1230,10 @@ func (app *CommonApp) cmnAppDelDbOpn(d *db.DB, opcode int, dbMap map[string]map[
 					}
 					err = d.DeleteEntry(cmnAppTs, db.Key{Comp: []string{tblKey}})
 					if err != nil {
-						switch e := err.(type) {
-						case tlerr.TranslibCVLFailure:
-							if cvl.CVLRetCode(e.Code) == cvl.CVL_SEMANTIC_KEY_NOT_EXIST {
-								log.Infof("Ignore delete that cannot be processed for table %v key %v that does not exist. err %v", tblNm, tblKey, e.CVLErrorInfo.ConstraintErrMsg)
-								err = nil
-							} else {
-								log.Warning("DELETE case - d.DeleteEntry() failure")
-								return err
-							}
-						default:
+						if cvl.CVLRetCode(err.(tlerr.TranslibCVLFailure).Code) == cvl.CVL_SEMANTIC_KEY_NOT_EXIST {
+							log.Infof("Ignore delete that cannot be processed for table %v key %v that does not exist. err %v", tblNm, tblKey, err.(tlerr.TranslibCVLFailure).CVLErrorInfo.ConstraintErrMsg)
+							err = nil
+						} else {
 							log.Warning("DELETE case - d.DeleteEntry() failure")
 							return err
 						}
@@ -1016,34 +1252,13 @@ func (app *CommonApp) cmnAppDelDbOpn(d *db.DB, opcode int, dbMap map[string]map[
 						log.Info("Table Entry from which the fields are to be deleted does not exist. Ignore error for non existant instance for idempotency")
 						continue
 					}
+
+					log.Info("Fields delete", cmnAppTs, db.Key{Comp: []string{tblKey}}, tblRw)
 					/* handle leaf-list merge if any leaf-list exists */
-					resTblRw := checkAndProcessLeafList(existingEntry, tblRw, DELETE, d, tblNm, tblKey)
-					log.Info("DELETE case - checkAndProcessLeafList() returned table row ", resTblRw)
-					if len(resTblRw.Field) > 0 {
-						if !app.deleteEmptyEntry {
-							/* add the NULL field if the last field gets deleted && deleteEmpyEntry is false */
-							deleteCount := 0
-							for field := range existingEntry.Field {
-								if resTblRw.Has(field) {
-									deleteCount++
-								}
-							}
-							if deleteCount == len(existingEntry.Field) {
-								nullTblRw := db.Value{Field: map[string]string{"NULL": "NULL"}}
-								log.Info("Last field gets deleted, add NULL field to keep an db entry")
-								err = d.ModEntry(cmnAppTs, db.Key{Comp: []string{tblKey}}, nullTblRw)
-								if err != nil {
-									log.Warning("UPDATE case - d.ModEntry() failure")
-									return err
-								}
-							}
-						}
-						/* deleted fields */
-						err := d.DeleteEntryFields(cmnAppTs, db.Key{Comp: []string{tblKey}}, resTblRw)
-						if err != nil {
-							log.Warning("DELETE case - d.DeleteEntryFields() failure")
-							return err
-						}
+					err = deleteFields(existingEntry, d, cmnAppTs, tblKey, tblRw, app.deleteEmptyEntry)
+					if err != nil {
+						log.Warning("DELETE case - deleteFields failure ")
+						return err
 					}
 				}
 			}

--- a/translib/common_app.go
+++ b/translib/common_app.go
@@ -400,6 +400,7 @@ func (app *CommonApp) processDelete(d *db.DB) (SetResponse, error) {
 	var resp SetResponse
 
 	log.Infof("processDelete:path = %s, deleteEmptyEntry = %v", app.pathInfo.Path, app.deleteEmptyEntry)
+
 	if err = app.processCommon(d, DELETE); err != nil {
 		log.Warning(err)
 		resp = SetResponse{ErrSrc: AppErr}
@@ -739,12 +740,6 @@ func (app *CommonApp) cmnAppCRUCommonDbOpn(d *db.DB, opcode int, dbMap map[strin
 						A leaf-list field in redis has "@" suffix as per swsssdk convention.
 						*/
 						resTblRw := db.Value{Field: map[string]string{}}
-						/* for north-bound REPLACE request always swap the whole leaf-list */
-						if app.cmnAppOpcode == REPLACE {
-							resTblRw = tblRw
-						} else {
-							resTblRw = checkAndProcessLeafList(existingEntry, tblRw, UPDATE, d, tblNm, tblKey)
-						}
 						log.Info("Processing Table row ", resTblRw)
 						err = d.ModEntry(cmnAppTs, db.Key{Comp: []string{tblKey}}, resTblRw)
 						if err != nil {
@@ -777,12 +772,6 @@ func (app *CommonApp) cmnAppCRUCommonDbOpn(d *db.DB, opcode int, dbMap map[strin
 						A leaf-list field in redis has "@" suffix as per swsssdk convention.
 						*/
 						resTblRw := db.Value{Field: map[string]string{}}
-						/* for north-bound REPLACE request always swap the whole leaf-list */
-						if app.cmnAppOpcode == REPLACE {
-							resTblRw = tblRw
-						} else {
-							resTblRw = checkAndProcessLeafList(existingEntry, tblRw, UPDATE, d, tblNm, tblKey)
-						}
 						err = d.ModEntry(cmnAppTs, db.Key{Comp: []string{tblKey}}, resTblRw)
 						if err != nil {
 							log.Warning("UPDATE case - d.ModEntry() failure")

--- a/translib/db/db.go
+++ b/translib/db/db.go
@@ -333,6 +333,10 @@ func (d *DB) IsDirtified() bool {
 	return (len(d.txCmds) > 0)
 }
 
+func GetDBInstName(dbNo DBNum) string {
+	return getDBInstName(dbNo)
+}
+
 func getDBInstName(dbNo DBNum) string {
 	switch dbNo {
 	case ApplDB:

--- a/translib/db/db_config.go
+++ b/translib/db/db_config.go
@@ -159,3 +159,7 @@ func getDbPassword(dbName string) string {
 	}
 	return password
 }
+
+func GetDbConfigMap() map[string]interface{} {
+	return dbConfigMap
+}

--- a/translib/transformer/test/openconfig-test-xfmr-annot.yang
+++ b/translib/transformer/test/openconfig-test-xfmr-annot.yang
@@ -242,46 +242,40 @@ module openconfig-test-xfmr-annot {
       }
     }
 
-    deviation "/oc-test-xfmr:test-xfmr/oc-test-xfmr:test-ni-instances/oc-test-xfmr:test-ni-instance/oc-test-xfmr:test-protocols/" +
-              "oc-test-xfmr:test-protocol/oc-test-xfmr:bgp" {
+    deviation /oc-test-xfmr:test-xfmr/oc-test-xfmr:test-ni-instances/oc-test-xfmr:test-ni-instance/oc-test-xfmr:test-protocols/oc-test-xfmr:test-protocol/oc-test-xfmr:bgp {
       deviate add {
 	      sonic-ext:validate-xfmr "validate_bgp_proto";
       }
     }
 
-    deviation "/oc-test-xfmr:test-xfmr/oc-test-xfmr:test-ni-instances/oc-test-xfmr:test-ni-instance/oc-test-xfmr:test-protocols/" +
-              "oc-test-xfmr:test-protocol/oc-test-xfmr:bgp/oc-test-xfmr:network-cfgs/oc-test-xfmr:network-cfg" {
+    deviation /oc-test-xfmr:test-xfmr/oc-test-xfmr:test-ni-instances/oc-test-xfmr:test-ni-instance/oc-test-xfmr:test-protocols/oc-test-xfmr:test-protocol/oc-test-xfmr:bgp/oc-test-xfmr:network-cfgs/oc-test-xfmr:network-cfg {
       deviate add {
 	      sonic-ext:table-name "TEST_BGP_NETWORK_CFG";
         sonic-ext:key-transformer "test_bgp_network_cfg_key_xfmr";
       }
     }
 
-    deviation "/oc-test-xfmr:test-xfmr/oc-test-xfmr:test-ni-instances/oc-test-xfmr:test-ni-instance/oc-test-xfmr:test-protocols/" +
-              "oc-test-xfmr:test-protocol/oc-test-xfmr:ospfv2" {
+    deviation /oc-test-xfmr:test-xfmr/oc-test-xfmr:test-ni-instances/oc-test-xfmr:test-ni-instance/oc-test-xfmr:test-protocols/oc-test-xfmr:test-protocol/oc-test-xfmr:ospfv2 {
       deviate add {
 	      sonic-ext:validate-xfmr "validate_ospfv2_proto";
       }
     }
 
-    deviation "/oc-test-xfmr:test-xfmr/oc-test-xfmr:test-ni-instances/oc-test-xfmr:test-ni-instance/oc-test-xfmr:test-protocols/" +
-              "oc-test-xfmr:test-protocol/oc-test-xfmr:ospfv2/oc-test:global" {
+    deviation /oc-test-xfmr:test-xfmr/oc-test-xfmr:test-ni-instances/oc-test-xfmr:test-ni-instance/oc-test-xfmr:test-protocols/oc-test-xfmr:test-protocol/oc-test-xfmr:ospfv2/oc-test:global {
       deviate add {
         sonic-ext:table-name "TEST_OSPFV2_ROUTER";
         sonic-ext:key-transformer "test_ospfv2_router_key_xfmr";
       }
     }
 
-    deviation "/oc-test-xfmr:test-xfmr/oc-test-xfmr:test-ni-instances/oc-test-xfmr:test-ni-instance/oc-test-xfmr:test-protocols/" +
-              "oc-test-xfmr:test-protocol/oc-test-xfmr:ospfv2/oc-test:global/oc-test-xfmr:route-distribution-lists" {
-      devitae add {
+    deviation /oc-test-xfmr:test-xfmr/oc-test-xfmr:test-ni-instances/oc-test-xfmr:test-ni-instance/oc-test-xfmr:test-protocols/oc-test-xfmr:test-protocol/oc-test-xfmr:ospfv2/oc-test:global/oc-test-xfmr:route-distribution-lists {
+      deviate add {
         sonic-ext:table-name "NONE";
       }
     }
 
-    deviation "/oc-test-xfmr:test-xfmr/oc-test-xfmr:test-ni-instances/oc-test-xfmr:test-ni-instance/oc-test-xfmr:test-protocols/" +
-              "oc-test-xfmr:test-protocol/oc-test-xfmr:ospfv2/oc-test:global/oc-test-xfmr:route-distribution-lists/oc-test-xfmr:route-distribution-list" {
-      devitae add {
+    deviation /oc-test-xfmr:test-xfmr/oc-test-xfmr:test-ni-instances/oc-test-xfmr:test-ni-instance/oc-test-xfmr:test-protocols/oc-test-xfmr:test-protocol/oc-test-xfmr:ospfv2/oc-test:global/oc-test-xfmr:route-distribution-lists/oc-test-xfmr:route-distribution-list {
+      deviate add {
         sonic-ext:table-name "TEST_OSPFV2_ROUTER_DISTRIBUTION";
         sonic-ext:key-transformer "test_ospfv2_router_distribution_key_xfmr;
       }

--- a/translib/transformer/test/openconfig-test-xfmr-annot.yang
+++ b/translib/transformer/test/openconfig-test-xfmr-annot.yang
@@ -81,7 +81,7 @@ module openconfig-test-xfmr-annot {
     deviation /oc-test-xfmr:test-xfmr/oc-test-xfmr:test-sensor-groups/oc-test-xfmr:test-sensor-group/oc-test-xfmr:test-sensor-types/oc-test-xfmr:test-sensor-type/oc-test-xfmr:sensor-a-light-sensors {
       deviate add {
 	sonic-ext:table-name "NONE";
-        sonic-ext:get-validate "light_sensor_validate";
+        sonic-ext:validate-xfmr "light_sensor_validate";
       }
     }
 

--- a/translib/transformer/test/openconfig-test-xfmr-annot.yang
+++ b/translib/transformer/test/openconfig-test-xfmr-annot.yang
@@ -111,6 +111,21 @@ module openconfig-test-xfmr-annot {
       }
     }
 
+    deviation /oc-test-xfmr:test-xfmr/oc-test-xfmr:test-sets/oc-test-xfmr:system-zone-device-data {
+      deviate add {
+            sonic-ext:table-name "DEVICE_ZONE_METADATA";
+            sonic-ext:key-name "local-zonehost";
+            sonic-ext:table-owner "false";
+      }
+    }
+
+    deviation /oc-test-xfmr:test-xfmr/oc-test-xfmr:test-sets/oc-test-xfmr:transport-zone {
+      deviate add {
+            sonic-ext:table-name "TRANSPORT_ZONE";
+            sonic-ext:key-name "transport-host";
+      }
+    }
+
     deviation /oc-test-xfmr:test-xfmr/oc-test-xfmr:test-sets/oc-test-xfmr:test-set {
       deviate add {
             sonic-ext:table-name "TEST_SET_TABLE";
@@ -166,6 +181,109 @@ module openconfig-test-xfmr-annot {
       deviate add {
 	sonic-ext:table-name "TEST_SENSOR_GLOBAL";
         sonic-ext:key-name "global_sensor";
+      }
+    }
+
+    deviation /oc-test-xfmr:test-xfmr/oc-test-xfmr:test-ntp {
+      deviate add {
+	      sonic-ext:table-name "TEST_NTP";
+        sonic-ext:key-name "global"
+      }
+    }
+
+    deviation /oc-test-xfmr:test-xfmr/oc-test-xfmr:test-ntp/oc-test-xfmr:config/oc-test-xfmr:enable-ntp-auth {
+      deviate add {
+        sonic-ext:field-name "auth-enabled";
+      }
+    }
+
+    deviation /oc-test-xfmr:test-xfmr/oc-test-xfmr:test-ntp/oc-test-xfmr:test-ntp-keys {
+      deviate add {
+	      sonic-ext:table-name "NONE";
+      }
+    }
+
+    deviation /oc-test-xfmr:test-xfmr/oc-test-xfmr:test-ntp/oc-test-xfmr:test-ntp-keys/oc-test-xfmr:test-ntp-key {
+      deviate add {
+	      sonic-ext:table-name "TEST_NTP_AUTHENTICATION_KEY";
+        //sonic-ext:key-transformer "test_ntp_authentication_key_xfmr";
+      }
+    }
+
+    deviation /oc-test-xfmr:test-xfmr/oc-test-xfmr:test-ntp/oc-test-xfmr:test-ntp-keys/oc-test-xfmr:test-ntp-key/oc-test-xfmr:key-type {
+      deviate add {
+	      sonic-ext:field-transformer "test_ntp_auth_key_type_xfmr";
+      }
+    }
+
+    deviation /oc-test-xfmr:test-xfmr/oc-test-xfmr:test-ntp/oc-test-xfmr:test-ntp-servers/oc-test-xfmr:test-ntp-server {
+      deviate add {
+	      sonic-ext:table-name "TEST_NTP_SERVER";
+      }
+    }
+
+    deviation /oc-test-xfmr:test-xfmr/oc-test-xfmr:test-ni-instances/oc-test-xfmr:test-ni-instance {
+      deviate add {
+	      sonic-ext:table-name "TEST_VRF";
+        sonic-ext:key-transformer "test_ni_instance_key_xfmr";
+      }
+    }
+
+    deviation /oc-test-xfmr:test-xfmr/oc-test-xfmr:test-ni-instances/oc-test-xfmr:test-ni-instance/oc-test-xfmr:test-protocols {
+      deviate add {
+	      sonic-ext:table-name "NONE";
+      }
+    }
+
+    deviation /oc-test-xfmr:test-xfmr/oc-test-xfmr:test-ni-instances/oc-test-xfmr:test-ni-instance/oc-test-xfmr:test-protocols/oc-test-xfmr:test-protocol {
+      deviate add {
+	      sonic-ext:table-transformer "test_ni_instance_protocol_table_xfmr";
+        sonic-ext:key-transformer "test_ni_instance_protocol_key_xfmr";
+      }
+    }
+
+    deviation "/oc-test-xfmr:test-xfmr/oc-test-xfmr:test-ni-instances/oc-test-xfmr:test-ni-instance/oc-test-xfmr:test-protocols/" +
+              "oc-test-xfmr:test-protocol/oc-test-xfmr:bgp" {
+      deviate add {
+	      sonic-ext:validate-xfmr "validate_bgp_proto";
+      }
+    }
+
+    deviation "/oc-test-xfmr:test-xfmr/oc-test-xfmr:test-ni-instances/oc-test-xfmr:test-ni-instance/oc-test-xfmr:test-protocols/" +
+              "oc-test-xfmr:test-protocol/oc-test-xfmr:bgp/oc-test-xfmr:network-cfgs/oc-test-xfmr:network-cfg" {
+      deviate add {
+	      sonic-ext:table-name "TEST_BGP_NETWORK_CFG";
+        sonic-ext:key-transformer "test_bgp_network_cfg_key_xfmr";
+      }
+    }
+
+    deviation "/oc-test-xfmr:test-xfmr/oc-test-xfmr:test-ni-instances/oc-test-xfmr:test-ni-instance/oc-test-xfmr:test-protocols/" +
+              "oc-test-xfmr:test-protocol/oc-test-xfmr:ospfv2" {
+      deviate add {
+	      sonic-ext:validate-xfmr "validate_ospfv2_proto";
+      }
+    }
+
+    deviation "/oc-test-xfmr:test-xfmr/oc-test-xfmr:test-ni-instances/oc-test-xfmr:test-ni-instance/oc-test-xfmr:test-protocols/" +
+              "oc-test-xfmr:test-protocol/oc-test-xfmr:ospfv2/oc-test:global" {
+      deviate add {
+        sonic-ext:table-name "TEST_OSPFV2_ROUTER";
+        sonic-ext:key-transformer "test_ospfv2_router_key_xfmr";
+      }
+    }
+
+    deviation "/oc-test-xfmr:test-xfmr/oc-test-xfmr:test-ni-instances/oc-test-xfmr:test-ni-instance/oc-test-xfmr:test-protocols/" +
+              "oc-test-xfmr:test-protocol/oc-test-xfmr:ospfv2/oc-test:global/oc-test-xfmr:route-distribution-lists" {
+      devitae add {
+        sonic-ext:table-name "NONE";
+      }
+    }
+
+    deviation "/oc-test-xfmr:test-xfmr/oc-test-xfmr:test-ni-instances/oc-test-xfmr:test-ni-instance/oc-test-xfmr:test-protocols/" +
+              "oc-test-xfmr:test-protocol/oc-test-xfmr:ospfv2/oc-test:global/oc-test-xfmr:route-distribution-lists/oc-test-xfmr:route-distribution-list" {
+      devitae add {
+        sonic-ext:table-name "TEST_OSPFV2_ROUTER_DISTRIBUTION";
+        sonic-ext:key-transformer "test_ospfv2_router_distribution_key_xfmr;
       }
     }
 }

--- a/translib/transformer/test/openconfig-test-xfmr-annot.yang
+++ b/translib/transformer/test/openconfig-test-xfmr-annot.yang
@@ -277,7 +277,7 @@ module openconfig-test-xfmr-annot {
     deviation /oc-test-xfmr:test-xfmr/oc-test-xfmr:test-ni-instances/oc-test-xfmr:test-ni-instance/oc-test-xfmr:test-protocols/oc-test-xfmr:test-protocol/oc-test-xfmr:ospfv2/oc-test:global/oc-test-xfmr:route-distribution-lists/oc-test-xfmr:route-distribution-list {
       deviate add {
         sonic-ext:table-name "TEST_OSPFV2_ROUTER_DISTRIBUTION";
-        sonic-ext:key-transformer "test_ospfv2_router_distribution_key_xfmr;
+        sonic-ext:key-transformer "test_ospfv2_router_distribution_key_xfmr";
       }
     }
 }

--- a/translib/transformer/test/openconfig-test-xfmr-annot.yang
+++ b/translib/transformer/test/openconfig-test-xfmr-annot.yang
@@ -186,99 +186,98 @@ module openconfig-test-xfmr-annot {
 
     deviation /oc-test-xfmr:test-xfmr/oc-test-xfmr:test-ntp {
       deviate add {
-	      sonic-ext:table-name "TEST_NTP";
-        sonic-ext:key-name "global";
+            sonic-ext:table-name "TEST_NTP";
+            sonic-ext:key-name "global";
       }
     }
 
     deviation /oc-test-xfmr:test-xfmr/oc-test-xfmr:test-ntp/oc-test-xfmr:config/oc-test-xfmr:enable-ntp-auth {
       deviate add {
-        sonic-ext:field-name "auth-enabled";
+            sonic-ext:field-name "auth-enabled";
       }
     }
 
     deviation /oc-test-xfmr:test-xfmr/oc-test-xfmr:test-ntp/oc-test-xfmr:test-ntp-keys {
       deviate add {
-	      sonic-ext:table-name "NONE";
+            sonic-ext:table-name "NONE";
       }
     }
 
     deviation /oc-test-xfmr:test-xfmr/oc-test-xfmr:test-ntp/oc-test-xfmr:test-ntp-keys/oc-test-xfmr:test-ntp-key {
       deviate add {
-	      sonic-ext:table-name "TEST_NTP_AUTHENTICATION_KEY";
-        //sonic-ext:key-transformer "test_ntp_authentication_key_xfmr";
+            sonic-ext:table-name "TEST_NTP_AUTHENTICATION_KEY";
+            //sonic-ext:key-transformer "test_ntp_authentication_key_xfmr";
       }
     }
 
     deviation /oc-test-xfmr:test-xfmr/oc-test-xfmr:test-ntp/oc-test-xfmr:test-ntp-keys/oc-test-xfmr:test-ntp-key/oc-test-xfmr:key-type {
       deviate add {
-	      sonic-ext:field-transformer "test_ntp_auth_key_type_xfmr";
+            sonic-ext:field-transformer "test_ntp_auth_key_type_xfmr";
       }
     }
 
     deviation /oc-test-xfmr:test-xfmr/oc-test-xfmr:test-ntp/oc-test-xfmr:test-ntp-servers/oc-test-xfmr:test-ntp-server {
       deviate add {
-	      sonic-ext:table-name "TEST_NTP_SERVER";
+            sonic-ext:table-name "TEST_NTP_SERVER";
       }
     }
 
     deviation /oc-test-xfmr:test-xfmr/oc-test-xfmr:test-ni-instances/oc-test-xfmr:test-ni-instance {
       deviate add {
-	      sonic-ext:table-name "TEST_VRF";
-        sonic-ext:key-transformer "test_ni_instance_key_xfmr";
+            sonic-ext:table-name "TEST_VRF";
+            sonic-ext:key-transformer "test_ni_instance_key_xfmr";
       }
     }
 
     deviation /oc-test-xfmr:test-xfmr/oc-test-xfmr:test-ni-instances/oc-test-xfmr:test-ni-instance/oc-test-xfmr:test-protocols {
       deviate add {
-	      sonic-ext:table-name "NONE";
+            sonic-ext:table-name "NONE";
       }
     }
 
     deviation /oc-test-xfmr:test-xfmr/oc-test-xfmr:test-ni-instances/oc-test-xfmr:test-ni-instance/oc-test-xfmr:test-protocols/oc-test-xfmr:test-protocol {
       deviate add {
-	      sonic-ext:table-transformer "test_ni_instance_protocol_table_xfmr";
-        sonic-ext:key-transformer "test_ni_instance_protocol_key_xfmr";
+            sonic-ext:table-transformer "test_ni_instance_protocol_table_xfmr";
+            sonic-ext:key-transformer "test_ni_instance_protocol_key_xfmr";
       }
     }
 
     deviation /oc-test-xfmr:test-xfmr/oc-test-xfmr:test-ni-instances/oc-test-xfmr:test-ni-instance/oc-test-xfmr:test-protocols/oc-test-xfmr:test-protocol/oc-test-xfmr:bgp {
       deviate add {
-	      sonic-ext:validate-xfmr "validate_bgp_proto";
+            sonic-ext:validate-xfmr "validate_bgp_proto";
       }
     }
 
     deviation /oc-test-xfmr:test-xfmr/oc-test-xfmr:test-ni-instances/oc-test-xfmr:test-ni-instance/oc-test-xfmr:test-protocols/oc-test-xfmr:test-protocol/oc-test-xfmr:bgp/oc-test-xfmr:network-cfgs/oc-test-xfmr:network-cfg {
       deviate add {
-	      sonic-ext:table-name "TEST_BGP_NETWORK_CFG";
-        sonic-ext:key-transformer "test_bgp_network_cfg_key_xfmr";
+            sonic-ext:table-name "TEST_BGP_NETWORK_CFG";
+            sonic-ext:key-transformer "test_bgp_network_cfg_key_xfmr";
       }
     }
 
     deviation /oc-test-xfmr:test-xfmr/oc-test-xfmr:test-ni-instances/oc-test-xfmr:test-ni-instance/oc-test-xfmr:test-protocols/oc-test-xfmr:test-protocol/oc-test-xfmr:ospfv2 {
       deviate add {
-	      sonic-ext:validate-xfmr "validate_ospfv2_proto";
+            sonic-ext:validate-xfmr "validate_ospfv2_proto";
       }
     }
 
     deviation /oc-test-xfmr:test-xfmr/oc-test-xfmr:test-ni-instances/oc-test-xfmr:test-ni-instance/oc-test-xfmr:test-protocols/oc-test-xfmr:test-protocol/oc-test-xfmr:ospfv2/oc-test:global {
       deviate add {
-        sonic-ext:table-name "TEST_OSPFV2_ROUTER";
-        sonic-ext:key-transformer "test_ospfv2_router_key_xfmr";
+            sonic-ext:table-name "TEST_OSPFV2_ROUTER";
+            sonic-ext:key-transformer "test_ospfv2_router_key_xfmr";
       }
     }
 
     deviation /oc-test-xfmr:test-xfmr/oc-test-xfmr:test-ni-instances/oc-test-xfmr:test-ni-instance/oc-test-xfmr:test-protocols/oc-test-xfmr:test-protocol/oc-test-xfmr:ospfv2/oc-test:global/oc-test-xfmr:route-distribution-lists {
       deviate add {
-        sonic-ext:table-name "NONE";
+            sonic-ext:table-name "NONE";
       }
     }
 
     deviation /oc-test-xfmr:test-xfmr/oc-test-xfmr:test-ni-instances/oc-test-xfmr:test-ni-instance/oc-test-xfmr:test-protocols/oc-test-xfmr:test-protocol/oc-test-xfmr:ospfv2/oc-test:global/oc-test-xfmr:route-distribution-lists/oc-test-xfmr:route-distribution-list {
       deviate add {
-        sonic-ext:table-name "TEST_OSPFV2_ROUTER_DISTRIBUTION";
-        sonic-ext:key-transformer "test_ospfv2_router_distribution_key_xfmr";
+            sonic-ext:table-name "TEST_OSPFV2_ROUTER_DISTRIBUTION";
+            sonic-ext:key-transformer "test_ospfv2_router_distribution_key_xfmr";
       }
     }
 }
-

--- a/translib/transformer/test/openconfig-test-xfmr-annot.yang
+++ b/translib/transformer/test/openconfig-test-xfmr-annot.yang
@@ -187,7 +187,7 @@ module openconfig-test-xfmr-annot {
     deviation /oc-test-xfmr:test-xfmr/oc-test-xfmr:test-ntp {
       deviate add {
 	      sonic-ext:table-name "TEST_NTP";
-        sonic-ext:key-name "global"
+        sonic-ext:key-name "global";
       }
     }
 

--- a/translib/transformer/test/openconfig-test-xfmr.yang
+++ b/translib/transformer/test/openconfig-test-xfmr.yang
@@ -50,6 +50,23 @@ module openconfig-test-xfmr {
       "IP-layer test set with IPv6 addresses";
   }
 
+  identity TEST_NTP_AUTH_TYPE {
+    description
+      "Base identity for encryption schemes supported for NTP authentication keys";
+  }
+
+  identity TEST_NTP_AUTH_MD5 {
+    base TEST_NTP_AUTH_TYPE;
+    description
+      "MD5 encryption method";
+  }
+
+  identity TEST_NTP_AUTH_SHA {
+    base TEST_NTP_AUTH_TYPE;
+    description
+      "SHA encryption method";
+  }
+
   grouping test-sensor-group-top {
     description
       "Top level grouping for test-sensor-group configuration and operational
@@ -174,6 +191,59 @@ module openconfig-test-xfmr {
 
   // grouping statements
 
+  grouping system-zone {
+    description
+      "system-zone related data for test-sets";
+    container system-zone-device-data {  
+      container config {
+        leaf metric {
+          type uint32;
+        }
+        leaf hold-interval {
+          type uint32;
+        }
+      }
+      container state {
+        config false;
+        leaf metric {
+          type uint32;
+        }
+        leaf hold-interval {
+          type uint32;
+        }
+      }
+    }
+  }
+
+  grouping transport-zone-data {
+    container transport-zone {
+      container config {
+        leaf transport-keepalive-interval {
+          type uint32;
+        }
+        leaf restart-time {
+          type uint32;
+        }
+        leaf delay-time {
+          type uint32;
+          default 5;
+        }
+      }
+      container state {
+        config false;
+        leaf transport-keepalive-interval {
+          type uint32;
+        }
+        leaf restart-time {
+          type uint32;
+        }
+        leaf delay-time {
+          type uint32;
+        }
+      }
+    }
+  }
+
   grouping test-set-top {
     description
       "Access list entries variables top level container";
@@ -215,7 +285,9 @@ module openconfig-test-xfmr {
             "Test set  state information";
           uses test-set-config;
         }
-       }
+      }
+       uses system-zone;
+       uses transport-zone-data;
     }
   } 
 
@@ -655,6 +727,294 @@ module openconfig-test-xfmr {
           }
     }
   }
+
+  grouping bgp-data {
+    container bgp {
+      container network-cfgs {
+        list network-cfg {
+          key "network-id";
+          leaf network-id {
+            type leafref {
+              path "../config/network-id";
+            }
+          }
+          container config {
+            leaf network-id {
+              type uint32;
+            }
+            leaf policy-name {
+              type string;
+            }
+            leaf backdoor {
+              type boolean;
+            }
+          }
+          container state {
+            config false;
+            leaf network-id {
+              type uint32;
+            }
+            leaf policy-name {
+              type string;
+            }
+            leaf backdoor {
+              type boolean;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  grouping ospfv2-data {
+    container ospfv2 {
+      container global {
+        container config {
+          leaf enabled {
+            type boolean;
+          }
+          leaf write-multiplier {
+            type uint32;
+          }
+          leaf maximum-paths {
+            type uint32;
+          }
+        }
+        container state {
+          config false;
+          leaf enable {
+            type boolean;
+          }
+          leaf write-multiplier {
+            type uint32;
+          }
+          leaf maximum-paths {
+            type uint32;
+          }
+        } 
+        container timers {
+          container config {
+            leaf initial-delay {
+              type uint32;
+            }
+            leaf max-delay {
+              type uint32;
+            }
+          }
+          container state {
+            config false;
+            leaf initial-delay {
+              type uint32;
+            }
+            leaf max-delay {
+              type uint32;
+            }
+          }
+        }
+        container route-distribution-lists {
+          list route-distribution-list {
+            key "distribution-id";
+            leaf distribution-id {
+              type leafref {
+                path "../config/distribution-id";
+              }
+            }
+            container config {
+              leaf distribution-id {
+                type uint32;
+              }
+              leaf priority {
+                type uint32;
+              }
+              leaf table-id {
+                type uint32;
+              }
+            }
+            container state {
+              config false;
+              leaf distribution-id {
+                type uint32;
+              }
+              leaf priority {
+                type uint32;
+              }
+              leaf table-id {
+                type uint32;
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  grouping test-protocols-data {
+    container test-protocols {
+      list test-protocol {
+        key "name";
+        leaf name {
+          type leafref {
+            path "../config/name";
+          }
+        }
+        container config {
+          leaf name {
+            type string;
+          }
+        }
+        container state {
+          config false;
+          leaf name {
+            type string;
+          }
+        }
+
+        uses bgp-data;
+        uses ospfv2-data;
+      }
+    }
+  }
+
+  grouping test-ni-instance-data {
+    container test-ni-instances {
+      list test-ni-instance {
+        key "ni-name";
+        leaf ni-name {
+          type leafref {
+            path "../config/ni-name";
+          }
+          description
+            "Name of the test ni instance";
+        }
+        container config {
+          description
+            "Configuration parameters for the test ni instance";
+          leaf ni-name {
+            type string {
+              pattern "default|vrf-[a-zA-Z0-9]*";
+            }
+          }
+          leaf enabled {
+            type boolean;
+          }
+          leaf description {
+            type string;
+          }
+        }
+        container state {
+          config false;
+          leaf ni-name {
+            type string;
+          }
+          leaf enabled {
+            type boolean;
+          }
+          leaf description {
+            type string;
+          }
+        }
+        uses test-protocols-data;
+      }
+    }
+  }
+
+  grouping test-ntp-data {
+    container test-ntp {
+      container config {
+        leaf enable-ntp-auth {
+          type boolean;
+        }
+        leaf-list trusted-key {
+          type uint32;
+        }
+        leaf ni-name {
+          type string;
+        }
+      }
+      container state {
+        config false;
+        leaf enable-ntp-auth {
+          type boolean;
+        }
+        leaf-list trusted-key {
+          type uint32;
+        }
+        leaf ni-name {
+          type string;
+        }
+      }
+
+      container test-ntp-keys {
+        list test-ntp-key {
+          key "key-id";
+          leaf key-id {
+            type leafref {
+              path "../config/key-id";
+            }
+          }
+          container config {
+            leaf key-id {
+              type uint32;
+            }
+            leaf key-type {
+              type identityref {
+                base TEST_NTP_AUTH_TYPE;
+              }
+            }
+            leaf key-value {
+              type string;
+            }
+          }
+          container state {
+            config false;
+            leaf key-id {
+              type uint32;
+            }
+            leaf key-type {
+              type identityref {
+                base TEST_NTP_AUTH_TYPE;
+              }
+            }
+            leaf key-value {
+              type string;
+            }
+          }
+        }
+      }
+      container test-ntp-server {
+        list test-ntp-server {
+          key "server-id";
+          leaf server-id {
+            type leafref {
+              path "../config/server-id";
+            }
+          }
+          container config {
+            leaf server-id {
+              type uint32;
+            }
+            leaf key-id {
+              type uint32;
+            }
+            leaf min-poll {
+              type uint8;
+            }
+          }
+          container state {
+            config false;
+            leaf server-id {
+              type uint32;
+            }
+            leaf key-id {
+              type uint32;
+            }
+            leaf min-poll {
+              type uint8;
+            }
+          }
+        }
+      }
+    }
+  }
   ///////////////////
 
   // data definition statements
@@ -667,6 +1027,8 @@ module openconfig-test-xfmr {
     uses test-set-top;
     uses interfaces-top;
     uses test-global-sensor-config;
+    uses test-ni-instance-data;
+    uses test-ntp-data;
   }
   // augment statements
 

--- a/translib/transformer/test/sonic-test-xfmr.yang
+++ b/translib/transformer/test/sonic-test-xfmr.yang
@@ -19,6 +19,13 @@ module sonic-test-xfmr {
 			"Initial revision of Sonic transformer test yang.";
 	}
 
+        typedef ntp-key-type {
+                type enumeration {
+                        enum MD5; 
+                        enum SHA1;
+                }
+        }
+
 	container sonic-test-xfmr {
 
 		container TEST_SENSOR_GROUP {
@@ -339,6 +346,182 @@ module sonic-test-xfmr {
                                         }
                                 }
                         }
+                }
+
+                container DEVICE_ZONE_METADATA {
+                        container local-zonehost {
+                                 leaf metric {
+                                   type uint32;
+                                 }
+                                 leaf hold-interval {
+                                   type uint32;
+                                 }
+                                 leaf hwsku {
+                                   type string;                                         
+                                 }
+                                 leaf deployment-id {
+					type uint8;
+                                 }
+                        }
+                }
+
+                container TRANSPORT_ZONE {
+                        container transport-host {
+                                 leaf transport-keepalive-interval {
+                                   type uint32;
+                                 }
+                                 leaf restart-time {
+                                   type uint32;                                         
+                                 }
+                                 leaf delay-time {
+					type uint32;
+                                        default 5;
+                                 }
+                        }
+                }
+
+                container TEST_NTP {
+                        container global {
+                                 leaf auth-enabled {
+                                        type boolean;
+                                 }
+                                 leaf-list trusted-key {
+                                        type leafref {
+                                                path "/sonic-test-xfmr/TEST_NTP_AUTHENTICATION_KEY/NTP_AUTHENTICATION_KEY_LIST/id";
+                                        }                                         
+                                 }
+                                 leaf ni-name {
+                                        type string;
+                                 }
+                        }
+                }
+
+                container TEST_NTP_AUTHENTICATION_KEY {
+                         list NTP_AUTHENTICATION_KEY_LIST {
+                                key "id";
+
+                                leaf id {
+                                        type uint32;
+                                }                                
+                                leaf key-type {
+                                        mandatory true;
+                                        type ntp-key-type;
+                                }
+                                leaf key-value {
+                                        type string;
+                                }                               
+                          }
+                }
+
+                container TEST_NTP_SERVER {
+                         list NTP_SERVER_LIST {
+                                key "server-id";
+
+                                leaf server-id {
+                                        type uint32;
+                                }                                
+                                leaf key-id {
+                                        type leafref {
+                                                path "/sonic-test-xfmr/TEST_NTP_AUTHENTICATION_KEY/NTP_AUTHENTICATION_KEY_LIST/id";
+                                        } 
+                                }
+                                leaf min-poll {
+                                        type uint8 {
+                                                range "3..17";
+                                        }
+                                }                               
+                          }
+                }
+
+                container TEST_VRF {
+                         list TEST_VRF_LIST {
+                                key "test-vrf-name";
+
+                                leaf test-vrf-name {
+                                        type string {
+                                                length "7..15";
+                                                pattern "default|Vrf_[a-zA-Z0-9]+" {
+                                                        error-message "Invalid VRF name";
+                                                        error-app-tag vrf-name-invalid;
+                                                }
+                                        }
+                                }                                
+                                leaf enabled {
+                                        type boolean;
+                                }
+                                leaf description {
+                                        type string;
+                                }                           
+                          }
+                }
+
+                container TEST_BGP_NETWORK_CFG {
+                         list TEST_BGP_NETWORK_CFG_LIST {
+                                key "test-vrf-name network-id";
+
+                                leaf test-vrf-name {
+                                        type leafref {
+                                                path "../../../TEST_VRF/TEST_VRF_LIST/test-vrf-name";
+                                        }
+                                }
+                                leaf network-id {
+                                        type uint32;
+                                }                                
+                                leaf backdoor {
+                                        type boolean;
+                                }                           
+                                leaf policy-name {
+                                        type string;
+                                }
+                          }
+                }
+
+                container TEST_OSPFV2_ROUTER {
+                         list TEST_OSPFV2_ROUTER_LIST {
+                                key "test-vrf-name";
+
+                                leaf test-vrf-name {
+                                        type leafref {
+                                                path "../../../TEST_VRF/TEST_VRF_LIST/test-vrf-name";
+                                        }
+                                }                             
+                                leaf enabled {
+                                        type boolean;
+                                }
+                                leaf write-multiplier {
+                                        type uint32;
+                                }
+                                leaf maximum-paths {
+                                        type uint32;
+                                } 
+                                leaf initial-delay {
+                                        type uint32;
+                                }
+                                leaf max-delay {
+                                        type uint32;
+                                }                          
+                          }
+                }
+
+                container TEST_OSPFV2_ROUTER_DISTRIBUTION {
+                         list TEST_OSPFV2_ROUTER_DISTRIBUTION_LIST {
+                                key "test-vrf-name distribution-id";
+
+                                leaf test-vrf-name {
+                                        type leafref {
+                                                path "../../../TEST_OSPFV2_ROUTER/TEST_OSPFV2_ROUTER_LIST/test-vrf-name";
+                                        }
+                                }                             
+                                leaf distribution-id {
+                                        type uint32;
+                                }
+                                leaf priority {
+                                        type uint32;
+                                }
+                                leaf table-id {
+                                        type uint32;
+                                }                  
+                         }
                 }
 	}
 }

--- a/translib/transformer/test/sonic-test-xfmr.yang
+++ b/translib/transformer/test/sonic-test-xfmr.yang
@@ -439,7 +439,6 @@ module sonic-test-xfmr {
 
                                 leaf test-vrf-name {
                                         type string {
-                                                length "7..15";
                                                 pattern "default|Vrf_[a-zA-Z0-9]+" {
                                                         error-message "Invalid VRF name";
                                                         error-app-tag vrf-name-invalid;

--- a/translib/transformer/testxfmryang_test.go
+++ b/translib/transformer/testxfmryang_test.go
@@ -16,6 +16,9 @@
 //                                                                            //
 ////////////////////////////////////////////////////////////////////////////////
 
+//go:build xfmrtest
+// +build xfmrtest
+
 package transformer_test
 
 import (

--- a/translib/transformer/testxfmryang_test.go
+++ b/translib/transformer/testxfmryang_test.go
@@ -211,7 +211,7 @@ func Test_node_exercising_tableXfmr_virtual_table_and_validate_handler(t *testin
 	/* verify if get like traversal happens correctly when deleting a node having table-xfmr, virtual-table and validate handler annotation in child yang hierachy */
 	t.Log("+++++++++++++++++ Test delete in yang hierachy involing table-xfmr, virtual-table and validate handler annotations +++++++++++++++")
 	prereq_ni_instance := map[string]interface{}{"TEST_VRF": map[string]interface{}{"default": map[string]interface{}{"enabled": "true"},
-		"Vrf_01": map[string]interface{}{"enabled": "false"}, "Vrf_02": map[string]interface{}{"enabled": "false", "description": "Vrf_02 descrip"}}}
+		"Vrf_01": map[string]interface{}{"enabled": "false"}, "Vrf_02": map[string]interface{}{"enabled": "true"}}}
 	prereq_bgp := map[string]interface{}{"TEST_BGP_NETWORK_CFG": map[string]interface{}{"Vrf_01|22": map[string]interface{}{"backdoor": "true", "policy-name": "abcd"},
 		"Vrf_01|33": map[string]interface{}{"policy-name": "fgh"}, "Vrf_02|55": map[string]interface{}{"backdoor": "false"}}}
 	prereq_ospfv2_router := map[string]interface{}{"TEST_OSPFV2_ROUTER": map[string]interface{}{"Vrf_01": map[string]interface{}{"enabled": "true", "write-multiplier": "2"},
@@ -227,7 +227,8 @@ func Test_node_exercising_tableXfmr_virtual_table_and_validate_handler(t *testin
 	loadDB(db.ConfigDB, prereq_bgp)
 	loadDB(db.ConfigDB, prereq_ospfv2_router)
 	loadDB(db.ConfigDB, prereq_ospfv2_router_distribution)
-	url := "/openconfig-test-xfmr:test-xfmr/test-ni-instances/test-ni-instance[ni-name=vrf-01]/test-protocols/test-protocol"
+	url := "/openconfig-test-xfmr:test-xfmr/test-ni-instances/test-ni-instance[ni-name=vrf-01]/test-protocols"
+	expected_ni_instance_vrf_01 := map[string]interface{}{"TEST_VRF": map[string]interface{}{"Vrf_01": map[string]interface{}{"enabled": "false"}}}
 	expected_ni_instance_default := map[string]interface{}{"TEST_VRF": map[string]interface{}{"default": map[string]interface{}{"enabled": "true"}}}
 	expected_ni_instance_vrf_02 := map[string]interface{}{"TEST_VRF": map[string]interface{}{"Vrf_02": map[string]interface{}{"enabled": "true"}}}
 	expected_bgp := map[string]interface{}{"TEST_BGP_NETWORK_CFG": map[string]interface{}{"Vrf_02|55": map[string]interface{}{"backdoor": "false"}}}
@@ -237,7 +238,7 @@ func Test_node_exercising_tableXfmr_virtual_table_and_validate_handler(t *testin
 	t.Run("Delete in yang hierachy involing table-xfmr, virtual-table and validate handler annotations.", processDeleteRequest(url, false))
 	time.Sleep(1 * time.Second)
 	verifyDbResultList := [11]verifyDbResultData{
-		{test: "Verify delete of ni-instance in request URL(vrf-01) is deleted from db.", db_key: "TEST_VRF|Vrf_01", db_result: empty_expected},
+		{test: "Verify ni-instance in request URL(vrf-01) is not deleted from db since URL points to child node.", db_key: "TEST_VRF|Vrf_01", db_result: expected_ni_instance_vrf_01},
 		{test: "Verify default ni-instance not assocaited with ni-instance in request URL is retained in db.", db_key: "TEST_VRF|default", db_result: expected_ni_instance_default},
 		{test: "Verify Vrf_02 ni-instance not assocaited with ni-instance in request URL is retained in db.", db_key: "TEST_VRF|Vrf_02", db_result: expected_ni_instance_vrf_02},
 		{test: "Verify delete of bgp instance(vrf-01|22) assocaited with ni-instance in request URL is deleted from db.", db_key: "TEST_BGP_NETWORK_CFG|Vrf_01|22", db_result: empty_expected},
@@ -298,7 +299,7 @@ func Test_node_exercising_subset_of_fields_in_mapped_table(t *testing.T) {
 	cleanuptbl = map[string]interface{}{"TEST_VRF": map[string]interface{}{"Vrf_01": ""},
 		"TEST_OSPFV2_ROUTER": map[string]interface{}{"Vrf_01": ""}}
 	expected_ospfv2_router = map[string]interface{}{"TEST_OSPFV2_ROUTER": map[string]interface{}{"Vrf_01": map[string]interface{}{"enabled": "true", "write-multiplier": "2"}}}
-	url = "/openconfig-test-xfmr:test-xfmr/test-ni-instances/ni-instance[ni-name=vrf-01]/test-protocols/test-protocol[name=ospfv2]/ospfv2/" +
+	url = "/openconfig-test-xfmr:test-xfmr/test-ni-instances/test-ni-instance[ni-name=vrf-01]/test-protocols/test-protocol[name=ospfv2]/ospfv2/" +
 		"global/timers/config"
 	// Setup
 	loadDB(db.ConfigDB, prereq_ni_instance)

--- a/translib/transformer/testxfmryang_test.go
+++ b/translib/transformer/testxfmryang_test.go
@@ -16,9 +16,6 @@
 //                                                                            //
 ////////////////////////////////////////////////////////////////////////////////
 
-//go:build xfmrtest
-// +build xfmrtest
-
 package transformer_test
 
 import (
@@ -143,11 +140,10 @@ func Test_node_exercising_pre_xfmr_node(t *testing.T) {
 	err_str := "REPLACE not supported at this node."
 	expected_err := tlerr.NotSupportedError{Format: err_str}
 	//expected_err := tlerr.NotSupported("REPLACE not supported at this node.")
-	url := "/openconfig-test-xfmr:test-xfmr"
-	url_body_json := "{\"openconfig-test-xfmr:test-xfmr\":{ \"test-sets\": { \"test-set\": [ { \"name\": \"TestSet_03\", \"type\": \"TEST_SET_IPV4\", \"config\": { \"name\": \"TestSet_03\", \"type\": \"TEST_SET_IPV4\", \"description\": \"testSet_03 description\" } } ] }}}"
+	url := "/openconfig-test-xfmr:test-xfmr/test-sets"
+	url_body_json := "{ \"openconfig-test-xfmr:test-sets\": { \"test-set\": [ { \"name\": \"TestSet_03\", \"type\": \"TEST_SET_IPV4\", \"config\": { \"name\": \"TestSet_03\", \"type\": \"TEST_SET_IPV4\", \"description\": \"testSet_03 description\" } } ] }}"
 	t.Run("Test set on node exercising pre-xfmr.", processSetRequest(url, url_body_json, "PUT", true, expected_err))
 	t.Log("\n\n+++++++++++++ Done Performing set on node exercising pre-xfmr ++++++++++++")
-
 }
 
 func Test_node_with_child_tableXfmr_keyXfmr_fieldNameXfmrs_nonConfigDB_data(t *testing.T) {

--- a/translib/transformer/testxfmryang_test.go
+++ b/translib/transformer/testxfmryang_test.go
@@ -25,9 +25,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Azure/sonic-mgmt-common/cvl"
 	"github.com/Azure/sonic-mgmt-common/translib/db"
 	"github.com/Azure/sonic-mgmt-common/translib/tlerr"
 )
+
+type verifyDbResultData struct {
+	test      string
+	db_key    string
+	db_result map[string]interface{}
+}
 
 func Test_node_exercising_subtree_xfmr_and_virtual_table(t *testing.T) {
 	var pre_req_map, expected_map, cleanuptbl map[string]interface{}
@@ -35,7 +42,7 @@ func Test_node_exercising_subtree_xfmr_and_virtual_table(t *testing.T) {
 
 	t.Log("\n\n+++++++++++++ Performing Set on Yang Node Exercising Subtree-Xfmr and Virtual Table ++++++++++++")
 	url = "/openconfig-test-xfmr:test-xfmr/interfaces"
-	url_body_json = "{ \"openconfig-test-xfmr:interface\": [ { \"id\": \"Eth_0\", \"config\": { \"id\": \"Eth_0\" }, \"ingress-test-sets\": { \"ingress-test-set\": [ { \"set-name\": \"TestSet_01\", \"type\": \"TEST_SET_IPV4\", \"config\": { \"set-name\": \"TestSet_01\", \"type\": \"TEST_SET_IPV4\" } } ] } } ]}"
+	url_body_json = "{\"openconfig-test-xfmr:interface\": [ { \"id\": \"Eth_0\", \"config\": { \"id\": \"Eth_0\" }, \"ingress-test-sets\": { \"ingress-test-set\": [ { \"set-name\": \"TestSet_01\", \"type\": \"TEST_SET_IPV4\", \"config\": { \"set-name\": \"TestSet_01\", \"type\": \"TEST_SET_IPV4\" } } ] } } ]}"
 	expected_map = map[string]interface{}{"TEST_SET_TABLE": map[string]interface{}{"TestSet_01_TEST_SET_IPV4": map[string]interface{}{"ports@": "Eth_0", "type": "IPV4"}}}
 	cleanuptbl = map[string]interface{}{"TEST_SET_TABLE": map[string]interface{}{"TestSet_01_TEST_SET_IPV4": ""}}
 	t.Run("Test set on node exercising subtree-xfmr and virtual table.", processSetRequest(url, url_body_json, "POST", false, nil))
@@ -136,8 +143,8 @@ func Test_node_exercising_pre_xfmr_node(t *testing.T) {
 	err_str := "REPLACE not supported at this node."
 	expected_err := tlerr.NotSupportedError{Format: err_str}
 	//expected_err := tlerr.NotSupported("REPLACE not supported at this node.")
-	url := "/openconfig-test-xfmr:test-xfmr/test-sets"
-	url_body_json := "{ \"openconfig-test-xfmr:test-sets\": { \"test-set\": [ { \"name\": \"TestSet_03\", \"type\": \"TEST_SET_IPV4\", \"config\": { \"name\": \"TestSet_03\", \"type\": \"TEST_SET_IPV4\", \"description\": \"testSet_03 description\" } } ] }}"
+	url := "/openconfig-test-xfmr:test-xfmr"
+	url_body_json := "{\"openconfig-test-xfmr:test-xfmr\":{ \"test-sets\": { \"test-set\": [ { \"name\": \"TestSet_03\", \"type\": \"TEST_SET_IPV4\", \"config\": { \"name\": \"TestSet_03\", \"type\": \"TEST_SET_IPV4\", \"description\": \"testSet_03 description\" } } ] }}}"
 	t.Run("Test set on node exercising pre-xfmr.", processSetRequest(url, url_body_json, "PUT", true, expected_err))
 	t.Log("\n\n+++++++++++++ Done Performing set on node exercising pre-xfmr ++++++++++++")
 
@@ -204,26 +211,168 @@ func Test_node_with_child_tableXfmr_keyXfmr_fieldNameXfmrs_nonConfigDB_data(t *t
 	unloadDB(db.ConfigDB, cleanuptbl)
 }
 
-func Test_delete_on_node_with_default_value(t *testing.T) {
+func Test_node_exercising_tableXfmr_virtual_table_and_validate_handler(t *testing.T) {
+	/* verify if get like traversal happens correctly when deleting a node having table-xfmr, virtual-table and validate handler annotation in child yang hierachy */
+	t.Log("+++++++++++++++++ Test delete in yang hierachy involing table-xfmr, virtual-table and validate handler annotations +++++++++++++++")
+	prereq_ni_instance := map[string]interface{}{"TEST_VRF": map[string]interface{}{"default": map[string]interface{}{"enabled": "true"},
+		"Vrf_01": map[string]interface{}{"enabled": "false"}, "Vrf_02": map[string]interface{}{"enabled": "false", "description": "Vrf_02 descrip"}}}
+	prereq_bgp := map[string]interface{}{"TEST_BGP_NETWORK_CFG": map[string]interface{}{"Vrf_01|22": map[string]interface{}{"backdoor": "true", "policy-name": "abcd"},
+		"Vrf_01|33": map[string]interface{}{"policy-name": "fgh"}, "Vrf_02|55": map[string]interface{}{"backdoor": "false"}}}
+	prereq_ospfv2_router := map[string]interface{}{"TEST_OSPFV2_ROUTER": map[string]interface{}{"Vrf_01": map[string]interface{}{"enabled": "true", "write-multiplier": "2"},
+		"Vrf_02": map[string]interface{}{"enabled": "true"}}}
+	prereq_ospfv2_router_distribution := map[string]interface{}{"TEST_OSPFV2_ROUTER_DISTRIBUTION": map[string]interface{}{"Vrf_01|66": map[string]interface{}{"priority": "6"},
+		"Vrf_01|98": map[string]interface{}{"table-id": "4"}, "Vrf_02|81": map[string]interface{}{"priority": "9", "table-id": "67"}}}
+	cleanuptbl := map[string]interface{}{"TEST_VRF": map[string]interface{}{"default": "", "Vrf_01": "", "Vrf_02": ""},
+		"TEST_BGP_NETWORK_CFG":            map[string]interface{}{"Vrf_01|22": "", "Vrf_01|33": "", "Vrf_02|55": ""},
+		"TEST_OSPFV2_ROUTER":              map[string]interface{}{"Vrf_01": "", "Vrf_02": ""},
+		"TEST_OSPFV2_ROUTER_DISTRIBUTION": map[string]interface{}{"Vrf_01|66": "", "Vrf_01|98": "", "Vrf_02|81": ""}}
+	//Setup
+	loadDB(db.ConfigDB, prereq_ni_instance)
+	loadDB(db.ConfigDB, prereq_bgp)
+	loadDB(db.ConfigDB, prereq_ospfv2_router)
+	loadDB(db.ConfigDB, prereq_ospfv2_router_distribution)
+	url := "/openconfig-test-xfmr:test-xfmr/test-ni-instances/test-ni-instance[ni-name=vrf-01]/test-protocols/test-protocol"
+	expected_ni_instance_default := map[string]interface{}{"TEST_VRF": map[string]interface{}{"default": map[string]interface{}{"enabled": "true"}}}
+	expected_ni_instance_vrf_02 := map[string]interface{}{"TEST_VRF": map[string]interface{}{"Vrf_02": map[string]interface{}{"enabled": "true"}}}
+	expected_bgp := map[string]interface{}{"TEST_BGP_NETWORK_CFG": map[string]interface{}{"Vrf_02|55": map[string]interface{}{"backdoor": "false"}}}
+	expected_ospfv2_router := map[string]interface{}{"TEST_OSPFV2_ROUTER": map[string]interface{}{"Vrf_02": map[string]interface{}{"enabled": "true"}}}
+	expected_ospfv2_router_distribution := map[string]interface{}{"TEST_OSPFV2_ROUTER_DISTRIBUTION": map[string]interface{}{"Vrf_02|81": map[string]interface{}{"priority": "9", "table-id": "67"}}}
+	empty_expected := make(map[string]interface{})
+	t.Run("Delete in yang hierachy involing table-xfmr, virtual-table and validate handler annotations.", processDeleteRequest(url, false))
+	time.Sleep(1 * time.Second)
+	verifyDbResultList := [11]verifyDbResultData{
+		{test: "Verify delete of ni-instance in request URL(vrf-01) is deleted from db.", db_key: "TEST_VRF|Vrf_01", db_result: empty_expected},
+		{test: "Verify default ni-instance not assocaited with ni-instance in request URL is retained in db.", db_key: "TEST_VRF|default", db_result: expected_ni_instance_default},
+		{test: "Verify Vrf_02 ni-instance not assocaited with ni-instance in request URL is retained in db.", db_key: "TEST_VRF|Vrf_02", db_result: expected_ni_instance_vrf_02},
+		{test: "Verify delete of bgp instance(vrf-01|22) assocaited with ni-instance in request URL is deleted from db.", db_key: "TEST_BGP_NETWORK_CFG|Vrf_01|22", db_result: empty_expected},
+		{test: "Verify delete of bgp instance(vrf-01|33) assocaited with ni-instance in request URL is deleted from db.", db_key: "TEST_BGP_NETWORK_CFG|Vrf_01|33", db_result: empty_expected},
+		{test: "Verify bgp instance(vrf-02|55) not assocaited with ni-instance in request URL is retained in db.", db_key: "TEST_BGP_NETWORK_CFG|Vrf_02|55", db_result: expected_bgp},
+		{test: "Verify ospfv2-global/router instance(vrf-01) assocaited with ni-instance in request URL is deleted from db.", db_key: "TEST_OSPFV2_ROUTER|Vrf_01", db_result: empty_expected},
+		{test: "Verify ospfv2-global/router instance(vrf-02) not assocaited with ni-instance in request URL is retained in db.", db_key: "TEST_OSPFV2_ROUTER|Vrf_02",
+			db_result: expected_ospfv2_router},
+		{test: "Verify ospfv2-router-distribution instance(vrf-01|66) assocaited with ni-instance in request URL is deleted from db.", db_key: "TEST_OSPFV2_ROUTER_DISTRIBUTION|Vrf_01|66",
+			db_result: empty_expected},
+		{test: "Verify ospfv2-router-distribution instance(vrf-01|98) assocaited with ni-instance in request URL is deleted from db.", db_key: "TEST_OSPFV2_ROUTER_DISTRIBUTION|Vrf_01|98",
+			db_result: empty_expected},
+		{test: "Verify ospfv2-router-distribution instance(vrf-02|81) not assocaited with ni-instance in request URL is retained in db.", db_key: "TEST_OSPFV2_ROUTER_DISTRIBUTION|Vrf_02|81",
+			db_result: expected_ospfv2_router_distribution},
+	}
+	for _, data := range verifyDbResultList {
+		t.Run(data.test, verifyDbResult(rclient, data.db_key, data.db_result, false))
+	}
+	// Teardown
+	unloadDB(db.ConfigDB, cleanuptbl)
+}
 
+func Test_node_exercising_non_table_owner_annotation(t *testing.T) {
+
+	prereq := map[string]interface{}{"DEVICE_ZONE_METADATA": map[string]interface{}{"local-zonehost": map[string]interface{}{"metric": "32", "hwsku": "testhwsku", "deployment-id": "834"}}}
+	cleanuptbl := map[string]interface{}{"DEVICE_ZONE_METADATA": map[string]interface{}{"local-zonehost": ""}}
+	expected_map := map[string]interface{}{"DEVICE_ZONE_METADATA": map[string]interface{}{"local-zonehost": map[string]interface{}{"hwsku": "testhwsku", "deployment-id": "834"}}}
+	url := "/openconfig-test-xfmr:test-xfmr/test-sets/system-zone-device-data"
+	t.Log("++++++++++++++  Test_delete_on_node_exercising_non_table_owner_annotation  +++++++++++++")
+	prereq = map[string]interface{}{"DEVICE_ZONE_METADATA": map[string]interface{}{"local-zonehost": map[string]interface{}{"metric": "32", "hwsku": "testhwsku", "deployment-id": "834"}}}
+	cleanuptbl = map[string]interface{}{"DEVICE_ZONE_METADATA": map[string]interface{}{"local-zonehost": ""}}
+	expected_map = map[string]interface{}{"DEVICE_ZONE_METADATA": map[string]interface{}{"local-zonehost": map[string]interface{}{"hwsku": "testhwsku", "deployment-id": "834"}}}
+	// Setup
+	loadDB(db.ConfigDB, prereq)
+	t.Run("Delete on node exercising non table owner annotation.", processDeleteRequest(url, false))
+	time.Sleep(1 * time.Second)
+	t.Run("Verify delete on node exercising non table owner annotation.", verifyDbResult(rclient, "DEVICE_ZONE_METADATA|local-zonehost", expected_map, false))
+	// TearDown
+	unloadDB(db.ConfigDB, cleanuptbl)
+}
+
+func Test_node_exercising_subset_of_fields_in_mapped_table(t *testing.T) {
+
+	prereq_ni_instance := map[string]interface{}{"TEST_VRF": map[string]interface{}{"Vrf_01": map[string]interface{}{"enabled": "true"}}}
+	prereq_ospfv2_router := map[string]interface{}{"TEST_OSPFV2_ROUTER": map[string]interface{}{"Vrf_01": map[string]interface{}{"enabled": "true", "write-multiplier": "2",
+		"initial-delay": "40", "max-delay": "100"}}}
+	cleanuptbl := map[string]interface{}{"TEST_VRF": map[string]interface{}{"Vrf_01": ""},
+		"TEST_OSPFV2_ROUTER": map[string]interface{}{"Vrf_01": ""}}
+	expected_ospfv2_router := map[string]interface{}{"TEST_OSPFV2_ROUTER": map[string]interface{}{"Vrf_01": map[string]interface{}{"enabled": "true", "write-multiplier": "2",
+		"initial-delay": "50"}}}
+	url := "/openconfig-test-xfmr:test-xfmr/test-ni-instances/ni-instance[ni-name=vrf-01]/test-protocols/test-protocol[name=ospfv2]/ospfv2/" +
+		"global/timers/config"
+
+	t.Log("++++++++++++++  Test_delete_on_node_exercising_subset_of_fields_in_mapped_table  +++++++++++++")
+	prereq_ni_instance = map[string]interface{}{"TEST_VRF": map[string]interface{}{"Vrf_01": map[string]interface{}{"enabled": "true"}}}
+	prereq_ospfv2_router = map[string]interface{}{"TEST_OSPFV2_ROUTER": map[string]interface{}{"Vrf_01": map[string]interface{}{"enabled": "true", "write-multiplier": "2",
+		"initial-delay": "50"}}}
+	cleanuptbl = map[string]interface{}{"TEST_VRF": map[string]interface{}{"Vrf_01": ""},
+		"TEST_OSPFV2_ROUTER": map[string]interface{}{"Vrf_01": ""}}
+	expected_ospfv2_router = map[string]interface{}{"TEST_OSPFV2_ROUTER": map[string]interface{}{"Vrf_01": map[string]interface{}{"enabled": "true", "write-multiplier": "2"}}}
+	url = "/openconfig-test-xfmr:test-xfmr/test-ni-instances/ni-instance[ni-name=vrf-01]/test-protocols/test-protocol[name=ospfv2]/ospfv2/" +
+		"global/timers/config"
+	// Setup
+	loadDB(db.ConfigDB, prereq_ni_instance)
+	loadDB(db.ConfigDB, prereq_ospfv2_router)
+	t.Run("Delete on node exercising subset of fields in mapped table.", processDeleteRequest(url, false))
+	time.Sleep(1 * time.Second)
+	t.Run("Verify delete on node exercising subset of fields in mapped table.", verifyDbResult(rclient, "TEST_OSPFV2_ROUTER|Vrf_01", expected_ospfv2_router, false))
+	// TearDown
+	unloadDB(db.ConfigDB, cleanuptbl)
+}
+
+func test_node_exercising_db_parent_child_nonkey_leafref_relationship(t *testing.T) {
+	/* oc yang hierarchy parent node's db table mapping has nonkey leafref db child relationship to a
+	   node's db table mapping in the child hierachy & siblings yang nodes having similar relationship */
+	prereq := map[string]interface{}{"TEST_NTP": map[string]interface{}{"global": map[string]interface{}{"trusted-key@": "68", "auth-enabled": "true"}},
+		"TEST_NTP_AUTHENTICATION_KEY": map[string]interface{}{"68": map[string]interface{}{"key-type": "MD5", "key-value": "0x635352e91dd9ddf2ed9542db848d3b31"}}}
+	cleanuptbl := map[string]interface{}{"TEST_NTP": map[string]interface{}{"global": ""}, "TEST_NTP_AUTHENTICATION_KEY": map[string]interface{}{"68": ""}}
+	url := "/openconfig-test-xfmr:test-xfmr/test-ntp/test-ntp-keys"
+	experr := tlerr.TranslibCVLFailure{Code: 1002, CVLErrorInfo: cvl.CVLErrorInfo{ErrCode: 1002, CVLErrDetails: "Config Validation Semantic Error",
+		Msg: "Validation failed for Delete operation, given instance is in use", ConstraintErrMsg: "Validation failed for Delete operation, given instance is in use",
+		TableName: "TEST_NTP_AUTHENTICATION_KEY", Keys: []string{"68"}, Field: "", Value: "", ErrAppTag: ""}}
+	// Setup - Prerequisite
+	loadDB(db.ConfigDB, prereq)
+	t.Log("++++++++++++++  Test_delete_on_node_exercising_db_parent_child_nonkey_leafref_relationship  +++++++++++++")
+	url = "/openconfig-test-xfmr:test-xfmr/test-ntp/test-ntp-keys"
+	t.Run("Test delete of child yang node having parent-child non-key leafref relationship with parent yang node(error-case).", processDeleteRequest(url, true, experr))
+	// Teardown
+	unloadDB(db.ConfigDB, cleanuptbl)
+}
+
+func Test_leaf_node(t *testing.T) {
+
+	/* Test delete on leaf node that has a yang default */
 	cleanuptbl := map[string]interface{}{"TEST_SENSOR_GROUP": map[string]interface{}{"test_group_1": ""}}
 
 	url := "/openconfig-test-xfmr:test-xfmr/test-sensor-groups/test-sensor-group[id=test_group_1]/config/color-hold-time"
 	prereq := map[string]interface{}{"TEST_SENSOR_GROUP": map[string]interface{}{"test_group_1": map[string]interface{}{"colors@": "red,blue,green", "color-hold-time": "30"}}}
 
-	t.Log("++++++++++++++  Test_delete_on_node_with_default_value  +++++++++++++")
-
-	// Setup - Prerequisite - None
+	t.Log("++++++++++++++  Test_delete_on_leaf_node_with_default_value_when_mapped_instance_exists_in_db  +++++++++++++")
+	// Setup
 	unloadDB(db.ConfigDB, cleanuptbl)
 	loadDB(db.ConfigDB, prereq)
-
-	// Payload
 	del_sensor_group_expected := map[string]interface{}{"TEST_SENSOR_GROUP": map[string]interface{}{"test_group_1": map[string]interface{}{"colors@": "red,blue,green", "color-hold-time": "10"}}}
-
-	t.Run("Delete on node having default value", processDeleteRequest(url, false))
+	t.Run("Delete on leaf node having default value when mapped instance exists in db.", processDeleteRequest(url, false))
 	time.Sleep(1 * time.Second)
-	t.Run("Verify delete on node with default value", verifyDbResult(rclient, "TEST_SENSOR_GROUP|test_group_1", del_sensor_group_expected, false))
+	t.Run("Verify delete on leaf node with default value resets to default", verifyDbResult(rclient, "TEST_SENSOR_GROUP|test_group_1", del_sensor_group_expected, false))
+	// Teardown
+	unloadDB(db.ConfigDB, cleanuptbl)
 
+	t.Log("++++++++++++++  Test_delete_on_leaf_node_with_default_value_when_mapped_instance_does_not_exist_db  +++++++++++++") //table mapping to container
+	cleanuptbl = map[string]interface{}{"TRANSPORT_ZONE": map[string]interface{}{"transport-host": ""}}
+	empty_expected := make(map[string]interface{})
+	// Setup
+	unloadDB(db.ConfigDB, cleanuptbl)
+	url = "/openconfig-test-xfmr:test-xfmr/test-sets/transport-zone"
+	t.Run("Delete on leaf node having default value when mapped instance doesn't exists in db and is annotated to a container.", processDeleteRequest(url, false))
+	time.Sleep(1 * time.Second)
+	t.Run("Verify delete on leaf node with default value doesn't reset to default creating an instance in DB when mapped instance is annotated to a container.",
+		verifyDbResult(rclient, "TRANSPORT_ZONE|transport-host", empty_expected, false))
+
+	t.Log("++++++++++++++  Test_delete_on_leaf_node_without_default_value  +++++++++++++")
+	cleanuptbl = map[string]interface{}{"TEST_SENSOR_GLOBAL": map[string]interface{}{"global_sensor": ""}}
+	prereq = map[string]interface{}{"TEST_SENSOR_GLOBAL": map[string]interface{}{"global_sensor": map[string]interface{}{"mode": "testmode", "description": "testdescription"}}}
+	expected_map := map[string]interface{}{"TEST_SENSOR_GLOBAL": map[string]interface{}{"global_sensor": map[string]interface{}{"mode": "testmode"}}}
+	url = "/openconfig-test-xfmr:test-xfmr/global-sensor/description"
+	//Setup
+	loadDB(db.ConfigDB, prereq)
+	t.Run("Delete on leaf node without default value", processDeleteRequest(url, false))
+	time.Sleep(1 * time.Second)
+	t.Run("Verify delete on leaf node without default value", verifyDbResult(rclient, "TEST_SENSOR_GLOBAL|global_sensor", expected_map, false))
 	// Teardown
 	unloadDB(db.ConfigDB, cleanuptbl)
 }
@@ -348,6 +497,26 @@ func Test_leaflist_node(t *testing.T) {
 	unloadDB(db.ConfigDB, cleanuptbl)
 	time.Sleep(1 * time.Second)
 	t.Log("\n\n+++++++++++++ Done Performing Put/Replace on Yang leaf-list Node demonstrating leaf-list contents swap ++++++++++++")
+
+	t.Log("\n\n+++++++++++++ Performing Delete on Yang leaf-list Node - demonstrating specific leaf-list instance deletion & complete leaf-list deletion ++++++++++++++")
+	url = "/openconfig-test-xfmr:test-xfmr/test-sensor-groups/test-sensor-group[id=sensor_group_01]/config/group-colors[group-colors=blue]"
+	pre_req_map = map[string]interface{}{"TEST_SENSOR_GROUP": map[string]interface{}{"sensor_group_01": map[string]interface{}{
+		"colors@": "red,blue,green", "color-hold-time": "30"}}}
+	expected_map = map[string]interface{}{"TEST_SENSOR_GROUP": map[string]interface{}{"sensor_group_01": map[string]interface{}{"colors@": "red,green", "color-hold-time": "30"}}}
+	cleanuptbl = map[string]interface{}{"TEST_SENSOR_GROUP": map[string]interface{}{"sensor_group_01": ""}}
+	loadDB(db.ConfigDB, pre_req_map)
+	time.Sleep(1 * time.Second)
+	t.Run("Test specific leaf-list instance deletion.", processDeleteRequest(url, false))
+	time.Sleep(1 * time.Second)
+	t.Run("Verify specific leaf-list instance deletion.", verifyDbResult(rclient, "TEST_SENSOR_GROUP|sensor_group_01", expected_map, false))
+	time.Sleep(1 * time.Second)
+	url = "/openconfig-test-xfmr:test-xfmr/test-sensor-groups/test-sensor-group[id=sensor_group_01]/config/group-colors"
+	expected_map = map[string]interface{}{"TEST_SENSOR_GROUP": map[string]interface{}{"sensor_group_01": map[string]interface{}{"color-hold-time": "30"}}}
+	t.Run("Test complete leaf-list attribute deletion.", processDeleteRequest(url, false))
+	time.Sleep(1 * time.Second)
+	t.Run("Verify complete leaf-list attribute deletion.", verifyDbResult(rclient, "TEST_SENSOR_GROUP|sensor_group_01", expected_map, false))
+	unloadDB(db.ConfigDB, cleanuptbl)
+	t.Log("\n\n+++++++++++++ Performing Delete on Yang leaf-list Node instance demonstrating specific leaf-list instance deletion ++++++++++++")
 }
 
 func Test_node_exercising_singleton_container_and_keyname_mapping(t *testing.T) {
@@ -1176,8 +1345,8 @@ func Test_sonic_yang_default_value_handling(t *testing.T) {
 // Test partial key at whole list level
 func Test_WholeList_PartialKey(t *testing.T) {
 
-	/* Delete at whole list returning partial key / parent key. Test if only relevant instances are deleted  */
-	parent_prereq := map[string]interface{}{"TEST_SENSOR_GROUP": map[string]interface{}{"sensor_group_1": map[string]interface{}{"NULL": "NULL"}}}
+	/* Delete And Get at a parent yang list node should rerieve/process only those child nodes which are relevant to the parent list key */
+	parent_prereq := map[string]interface{}{"TEST_SENSOR_GROUP": map[string]interface{}{"sensor_group_1": map[string]interface{}{"NULL": "NULL"}, "sensor_group_2": map[string]interface{}{"NULL": "NULL"}}}
 	prereq := map[string]interface{}{"TEST_SENSOR_ZONE_TABLE": map[string]interface{}{"sensor_group_1|zoneA": map[string]interface{}{"description": "sensor_group_1 zoneA instance"}, "sensor_group_2|zoneA": map[string]interface{}{"description": "sensor_group_2 zoneA instance"}}}
 
 	// Setup - Prerequisite
@@ -1201,6 +1370,33 @@ func Test_WholeList_PartialKey(t *testing.T) {
 	time.Sleep(1 * time.Second)
 	t.Run("DELETE on whole list with partial/parent key - verify child table instance with parent key gets deleted", verifyDbResult(rclient, "TEST_SENSOR_ZONE_TABLE|sensor_group_1|zoneA", expected_del, false))
 	t.Run("DELETE on whole list with partial/parent key - verify child table instance not having parent key still exists", verifyDbResult(rclient, "TEST_SENSOR_ZONE_TABLE|sensor_group_2|zoneA", expected_map, false))
+
+	/* Verify if get like traversal is happenning for delete when a yang list node in child hierarchy has partial key of parent */
+	t.Log("++++++++++++++  DELETE On Container with Child Node List With PartialKey of Parent List ++++++++++++++")
+	// Setup - Prerequisite
+	loadDB(db.ConfigDB, parent_prereq)
+	loadDB(db.ConfigDB, prereq)
+	url = "/openconfig-test-xfmr:test-xfmr/test-sensor-groups/test-sensor-group[id=sensor_group_1]/test-sensor-zones"
+	t.Run("Test_Delete_On_Container_with_Child_Node_List_With_PartialKey_of_Parent_List", processDeleteRequest(url, false))
+	time.Sleep(1 * time.Second)
+	t.Run("Verify delete on container with child node list with partial key of parent - releavant child instances get deleted.", verifyDbResult(rclient, "TEST_SENSOR_ZONE_TABLE|sensor_group_1|zoneA", expected_del, false))
+	t.Run("Verify delete on container with child node list with partial key of parent - non-releavant child instances not deleted.", verifyDbResult(rclient, "TEST_SENSOR_ZONE_TABLE|sensor_group_2|zoneA", expected_map, false))
+	time.Sleep(1 * time.Second)
+
+	t.Log("++++++++++++++  DELETE On List Instance With Child Node List With PartialKey Of Parent List ++++++++++++++")
+	// Setup - Prerequisite
+	loadDB(db.ConfigDB, parent_prereq)
+	loadDB(db.ConfigDB, prereq)
+	url = "/openconfig-test-xfmr:test-xfmr/test-sensor-groups/test-sensor-group[id=sensor_group_1]"
+	expected_parent_map := map[string]interface{}{"TEST_SENSOR_GROUP": map[string]interface{}{"sensor_group_2": map[string]interface{}{"NULL": "NULL"}}}
+	t.Run("Test_Delete_On_List_Instance_with_Child_Node_List_With_PartialKey_of_Parent_List", processDeleteRequest(url, false))
+	time.Sleep(1 * time.Second)
+	t.Run("Verify delete on list instance with child node list with partial key of parent - parent instance specified in request gets deleted.", verifyDbResult(rclient, "TEST_SENSOR_GROUP|sensor_group_1", expected_del, false))
+	t.Run("Verify delete on list instance with child node list with partial key of parent - other parent list instances stay intact.", verifyDbResult(rclient, "TEST_SENSOR_GROUP|sensor_group_2", expected_parent_map, false))
+	t.Run("Verify delete on list instance with child node list with partial key of parent - releavant child instances get deleted.", verifyDbResult(rclient, "TEST_SENSOR_ZONE_TABLE|sensor_group_1|zoneA", expected_del, false))
+	t.Run("Verify delete on list instance with child node list with partial key of parent - non-releavant child instances not deleted.s", verifyDbResult(rclient, "TEST_SENSOR_ZONE_TABLE|sensor_group_2|zoneA", expected_map, false))
+
+	t.Log("++++++++++++++  Done Test_GET_And_Delete_Involving_Node_With_PartialKey_Of_Parent +++++++++++++")
 
 	// Teardown
 	unloadDB(db.ConfigDB, parent_prereq)

--- a/translib/transformer/xfmr_interface.go
+++ b/translib/transformer/xfmr_interface.go
@@ -56,6 +56,7 @@ type XfmrParams struct {
 	pruneDone            *bool
 	invokeCRUSubtreeOnce *bool
 	ctxt                 context.Context
+	isNotTblOwner        *bool
 }
 
 // SubscProcType represents subcription process type identifying the type of subscription request made from translib.
@@ -197,8 +198,8 @@ type RpcCallpoint func(body []byte, dbs [db.MaxDB]*db.DB) ([]byte, error)
 // PostXfmrFunc type is defined to use for handling any default handling operations required as part of the CREATE
 // Transformer function definition.
 // Param: XfmrParams structure having database pointers, current db, operation, DB data in multidimensional map, YgotRoot, uri
-// Return: Multi dimensional map to hold the DB data Map (tblName, key and Fields), error
-type PostXfmrFunc func(inParams XfmrParams) (map[string]map[string]db.Value, error)
+// Return: error
+type PostXfmrFunc func(inParams XfmrParams) error
 
 // TableXfmrFunc type is defined to use for table transformer function for dynamic derviation of redis table.
 // Param: XfmrParams structure having database pointers, current db, operation, DB data in multidimensional map, YgotRoot, uri

--- a/translib/transformer/xfmr_intf.go
+++ b/translib/transformer/xfmr_intf.go
@@ -1574,10 +1574,9 @@ var DbToYang_intf_get_ether_counters_xfmr SubTreeXfmrDbToYang = func(inParams Xf
 	return populatePortCounters(inParams, eth_counters)
 }
 
-var intf_post_xfmr PostXfmrFunc = func(inParams XfmrParams) (map[string]map[string]db.Value, error) {
+var intf_post_xfmr PostXfmrFunc = func(inParams XfmrParams) error {
 
 	requestUriPath := (NewPathInfo(inParams.requestUri)).YangPath
-	retDbDataMap := (*inParams.dbDataMap)[inParams.curDb]
 	log.Info("Entering intf_post_xfmr")
 	log.Info(requestUriPath)
 	xpath, _, _ := XfmrRemoveXPATHPredicates(inParams.requestUri)
@@ -1588,7 +1587,7 @@ var intf_post_xfmr PostXfmrFunc = func(inParams XfmrParams) (map[string]map[stri
 		/* Preventing delete at IPv6 config level*/
 		if xpath == "/openconfig-interfaces:interfaces/interface/subinterfaces/subinterface/ipv6/config" {
 			log.Info("In interface Post transformer for DELETE op ==> URI : ", inParams.requestUri)
-			return retDbDataMap, tlerr.NotSupported(err_str)
+			return tlerr.NotSupported(err_str)
 		}
 
 		/* For delete request and for fields with default value, transformer adds subOp map with update operation (to update with default value).
@@ -1613,7 +1612,7 @@ var intf_post_xfmr PostXfmrFunc = func(inParams XfmrParams) (map[string]map[stri
 			}
 		}
 	}
-	return retDbDataMap, nil
+	return nil
 }
 
 var intf_pre_xfmr PreXfmrFunc = func(inParams XfmrParams) error {

--- a/translib/transformer/xfmr_testxfmr_callbacks.go
+++ b/translib/transformer/xfmr_testxfmr_callbacks.go
@@ -902,21 +902,17 @@ var test_ni_instance_protocol_table_xfmr TableXfmrFunc = func(inParams XfmrParam
 					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"]["bgp"] = db.Value{Field: make(map[string]string)}
 					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"]["bgp"].Field["NULL"] = "NULL"
 					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"]["ospfv2"] = db.Value{Field: make(map[string]string)}
-					(*inParams.dbDataMap)[db.ConfigDB]["TTEST_CFG_PROTO_TBL"]["ospfv2"].Field["NULL"] = "NULL"
+					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"]["ospfv2"].Field["NULL"] = "NULL"
 					cfg_tbl_updated = true
 				} else if proto_name == "bgp" {
-					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"] = make(map[string]db.Value)
-					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"] = make(map[string]db.Value)
 					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"] = make(map[string]db.Value)
 					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"]["bgp"] = db.Value{Field: make(map[string]string)}
 					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"]["bgp"].Field["NULL"] = "NULL"
 					cfg_tbl_updated = true
 				} else if proto_name == "ospfv2" {
 					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"] = make(map[string]db.Value)
-					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"] = make(map[string]db.Value)
-					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"] = make(map[string]db.Value)
 					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"]["ospfv2"] = db.Value{Field: make(map[string]string)}
-					(*inParams.dbDataMap)[db.ConfigDB]["TTEST_CFG_PROTO_TBL"]["ospfv2"].Field["NULL"] = "NULL"
+					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"]["ospfv2"].Field["NULL"] = "NULL"
 					cfg_tbl_updated = true
 				} else {
 					err_str := "Invalid protocol key. Key not supported."

--- a/translib/transformer/xfmr_testxfmr_callbacks.go
+++ b/translib/transformer/xfmr_testxfmr_callbacks.go
@@ -904,16 +904,19 @@ var test_ni_instance_protocol_table_xfmr TableXfmrFunc = func(inParams XfmrParam
 					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"]["ospfv2"] = db.Value{Field: make(map[string]string)}
 					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"]["ospfv2"].Field["NULL"] = "NULL"
 					cfg_tbl_updated = true
+					log.Info("test_ni_instance_protocol_table_xfmr returning (*inParams.dbDataMap)[db.ConfigDB]", (*inParams.dbDataMap)[db.ConfigDB])
 				} else if proto_name == "bgp" {
 					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"] = make(map[string]db.Value)
 					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"]["bgp"] = db.Value{Field: make(map[string]string)}
 					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"]["bgp"].Field["NULL"] = "NULL"
 					cfg_tbl_updated = true
+					log.Info("test_ni_instance_protocol_table_xfmr returning (*inParams.dbDataMap)[db.ConfigDB]", (*inParams.dbDataMap)[db.ConfigDB])
 				} else if proto_name == "ospfv2" {
 					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"] = make(map[string]db.Value)
 					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"]["ospfv2"] = db.Value{Field: make(map[string]string)}
 					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"]["ospfv2"].Field["NULL"] = "NULL"
 					cfg_tbl_updated = true
+					log.Info("test_ni_instance_protocol_table_xfmr returning (*inParams.dbDataMap)[db.ConfigDB]", (*inParams.dbDataMap)[db.ConfigDB])
 				} else {
 					err_str := "Invalid protocol key. Key not supported."
 					err = tlerr.NotSupported(err_str)
@@ -927,6 +930,7 @@ var test_ni_instance_protocol_table_xfmr TableXfmrFunc = func(inParams XfmrParam
 			tblList = append(tblList, "CFG_PROTO_TBL")
 		}
 	}
+	log.Info("test_ni_instance_protocol_table_xfmr returning tblList ", tblList, " error", err)
 	return tblList, err
 }
 
@@ -938,6 +942,7 @@ var YangToDb_test_ni_instance_protocol_key_xfmr KeyXfmrYangToDb = func(inParams 
 		pathInfo := NewPathInfo(inParams.uri)
 		ni_name := pathInfo.Var("ni-name")
 		proto_name := pathInfo.Var("name")
+		log.Info("YangToDb_test_ni_instance_protocol_key_xfmr received ni-instance ", ni_name, " protocol name ", name)
 		if (ni_name == "default") || (strings.HasPrefix(ni_name, "vrf-")) {
 			if proto_name == "bgp" {
 				key = "bgp"

--- a/translib/transformer/xfmr_testxfmr_callbacks.go
+++ b/translib/transformer/xfmr_testxfmr_callbacks.go
@@ -971,6 +971,7 @@ var DbToYang_test_ni_instance_protocol_key_xfmr KeyXfmrDbToYang = func(inParams 
 func checkNwInstanceProtocol(inParams XfmrParams, protoNm string) bool {
 	pathInfo := NewPathInfo(inParams.uri)
 	proto_name := pathInfo.Var("name")
+	og.Info("checkNwInstanceProtocol() through validate handler ", proto_name)
 	return proto_name == protoNm
 }
 

--- a/translib/transformer/xfmr_testxfmr_callbacks.go
+++ b/translib/transformer/xfmr_testxfmr_callbacks.go
@@ -906,10 +906,12 @@ var test_ni_instance_protocol_table_xfmr TableXfmrFunc = func(inParams XfmrParam
 					cfg_tbl_updated = true
 				} else if proto_name == "bgp" {
 					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"] = make(map[string]db.Value)
+					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"] = make(map[string]db.Value)
 					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"]["bgp"] = db.Value{Field: make(map[string]string)}
 					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"]["bgp"].Field["NULL"] = "NULL"
 					cfg_tbl_updated = true
 				} else if proto_name == "ospfv2" {
+					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"] = make(map[string]db.Value)
 					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"] = make(map[string]db.Value)
 					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"]["ospfv2"] = db.Value{Field: make(map[string]string)}
 					(*inParams.dbDataMap)[db.ConfigDB]["TTEST_CFG_PROTO_TBL"]["ospfv2"].Field["NULL"] = "NULL"

--- a/translib/transformer/xfmr_testxfmr_callbacks.go
+++ b/translib/transformer/xfmr_testxfmr_callbacks.go
@@ -907,10 +907,12 @@ var test_ni_instance_protocol_table_xfmr TableXfmrFunc = func(inParams XfmrParam
 				} else if proto_name == "bgp" {
 					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"] = make(map[string]db.Value)
 					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"] = make(map[string]db.Value)
+					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"] = make(map[string]db.Value)
 					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"]["bgp"] = db.Value{Field: make(map[string]string)}
 					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"]["bgp"].Field["NULL"] = "NULL"
 					cfg_tbl_updated = true
 				} else if proto_name == "ospfv2" {
+					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"] = make(map[string]db.Value)
 					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"] = make(map[string]db.Value)
 					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"] = make(map[string]db.Value)
 					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"]["ospfv2"] = db.Value{Field: make(map[string]string)}

--- a/translib/transformer/xfmr_testxfmr_callbacks.go
+++ b/translib/transformer/xfmr_testxfmr_callbacks.go
@@ -58,6 +58,11 @@ func init() {
 	XlateFuncBind("DbToYang_test_ni_instance_key_xfmr", DbToYang_test_ni_instance_key_xfmr)
 	XlateFuncBind("YangToDb_test_ni_instance_protocol_key_xfmr", YangToDb_test_ni_instance_protocol_key_xfmr)
 	XlateFuncBind("DbToYang_test_ni_instance_protocol_key_xfmr", DbToYang_test_ni_instance_protocol_key_xfmr)
+	XlateFuncBind("YangToDb_test_bgp_network_cfg_key_xfmr", YangToDb_test_bgp_network_cfg_key_xfmr)
+	XlateFuncBind("DbToYang_test_bgp_network_cfg_key_xfmr", DbToYang_test_bgp_network_cfg_key_xfmr)
+	XlateFuncBind("YangToDb_test_ospfv2_router_distribution_key_xfmr", YangToDb_test_ospfv2_router_distribution_key_xfmr)
+	XlateFuncBind("DbToYang_test_ospfv2_router_distribution_key_xfmr", DbToYang_test_ospfv2_router_distribution_key_xfmr)
+	XlateFuncBind("YangToDb_test_ospfv2_router_key_xfmr", YangToDb_test_ospfv2_router_key_xfmr)
 
 	// Key leafrefed Field transformer functions
 	XlateFuncBind("DbToYang_test_sensor_type_field_xfmr", DbToYang_test_sensor_type_field_xfmr)
@@ -864,7 +869,7 @@ var YangToDb_test_ni_instance_key_xfmr KeyXfmrYangToDb = func(inParams XfmrParam
 		err_str := "Invalid key. Key not supported."
 		err = tlerr.NotSupported(err_str)
 	}
-	log.Info("YangToDb_test_ni_instance_key_xfmr returning", db_ni_name, err)
+	log.Info("YangToDb_test_ni_instance_key_xfmr returning db_ni_name ", db_ni_name, " error ", err)
 	return db_ni_name, err
 }
 
@@ -894,8 +899,10 @@ var test_ni_instance_protocol_table_xfmr TableXfmrFunc = func(inParams XfmrParam
 		pathInfo := NewPathInfo(inParams.uri)
 		ni_name := pathInfo.Var("ni-name")
 		proto_name := pathInfo.Var("name")
+		log.Info("test_ni_instance_protocol_table_xfmr ni-inatnce ", ni_name, " proto name ", proto_name)
 		cfg_tbl_updated := false
 		if inParams.dbDataMap != nil {
+			log.Info("test_ni_instance_protocol_table_xfmr  tblList dbDataMap ", (*inParams.dbDataMap)[db.ConfigDB])
 			if (ni_name == "default") || (strings.HasPrefix(ni_name, "vrf-")) {
 				if proto_name == "" { // inParams.uri at whole list level, hence add all child instances to be traversed
 					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"] = make(map[string]db.Value)
@@ -904,19 +911,19 @@ var test_ni_instance_protocol_table_xfmr TableXfmrFunc = func(inParams XfmrParam
 					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"]["ospfv2"] = db.Value{Field: make(map[string]string)}
 					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"]["ospfv2"].Field["NULL"] = "NULL"
 					cfg_tbl_updated = true
-					log.Info("test_ni_instance_protocol_table_xfmr returning (*inParams.dbDataMap)[db.ConfigDB]", (*inParams.dbDataMap)[db.ConfigDB])
+					log.Info("test_ni_instance_protocol_table_xfmr returning (*inParams.dbDataMap)[db.ConfigDB] ", (*inParams.dbDataMap)[db.ConfigDB])
 				} else if proto_name == "bgp" {
 					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"] = make(map[string]db.Value)
 					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"]["bgp"] = db.Value{Field: make(map[string]string)}
 					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"]["bgp"].Field["NULL"] = "NULL"
 					cfg_tbl_updated = true
-					log.Info("test_ni_instance_protocol_table_xfmr returning (*inParams.dbDataMap)[db.ConfigDB]", (*inParams.dbDataMap)[db.ConfigDB])
+					log.Info("test_ni_instance_protocol_table_xfmr returning (*inParams.dbDataMap)[db.ConfigDB] ", (*inParams.dbDataMap)[db.ConfigDB])
 				} else if proto_name == "ospfv2" {
 					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"] = make(map[string]db.Value)
 					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"]["ospfv2"] = db.Value{Field: make(map[string]string)}
 					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"]["ospfv2"].Field["NULL"] = "NULL"
 					cfg_tbl_updated = true
-					log.Info("test_ni_instance_protocol_table_xfmr returning (*inParams.dbDataMap)[db.ConfigDB]", (*inParams.dbDataMap)[db.ConfigDB])
+					log.Info("test_ni_instance_protocol_table_xfmr returning (*inParams.dbDataMap)[db.ConfigDB] ", (*inParams.dbDataMap)[db.ConfigDB])
 				} else {
 					err_str := "Invalid protocol key. Key not supported."
 					err = tlerr.NotSupported(err_str)
@@ -927,10 +934,11 @@ var test_ni_instance_protocol_table_xfmr TableXfmrFunc = func(inParams XfmrParam
 			}
 		}
 		if cfg_tbl_updated {
-			tblList = append(tblList, "CFG_PROTO_TBL")
+			tblList = append(tblList, "TEST_CFG_PROTO_TBL")
 		}
 	}
-	log.Info("test_ni_instance_protocol_table_xfmr returning tblList ", tblList, " error", err)
+	*inParams.isVirtualTbl = true
+	log.Info("test_ni_instance_protocol_table_xfmr returning tblList ", tblList, " error ", err)
 	return tblList, err
 }
 
@@ -1043,5 +1051,49 @@ var DbToYang_test_ospfv2_router_distribution_key_xfmr KeyXfmrDbToYang = func(inP
 		}
 	}
 	log.Info("DbToYang_test_ospfv2_router_distribution_key_xfmr returning ", rmap)
+	return rmap, nil
+}
+
+var YangToDb_test_bgp_network_cfg_key_xfmr KeyXfmrYangToDb = func(inParams XfmrParams) (string, error) {
+	var db_ni_name, bgp_cfg_db_key string
+	var err error
+	log.Info("YangToDb_test_bgp_network_cfg_key_xfmr ", inParams.uri)
+	pathInfo := NewPathInfo(inParams.uri)
+	ni_name := pathInfo.Var("ni-name")
+	network_id := pathInfo.Var("network-id")
+
+	if strings.HasPrefix(ni_name, "vrf-") {
+		db_ni_name = strings.Replace(ni_name, "vrf-", "Vrf_", 1)
+	} else if strings.HasPrefix(ni_name, "default") {
+		db_ni_name = ni_name
+	} else if ni_name != "" {
+		err_str := "Invalid key. Key not supported."
+		err = tlerr.NotSupported(err_str)
+	}
+
+	if network_id != "" {
+		bgp_cfg_db_key = db_ni_name + "|" + network_id
+	} else {
+		bgp_cfg_db_key = db_ni_name
+	}
+
+	log.Info("YangToDb_test_bgp_network_cfg_key_xfmr returning ", bgp_cfg_db_key, " error ", err)
+	return bgp_cfg_db_key, err
+}
+
+var DbToYang_test_bgp_network_cfg_key_xfmr KeyXfmrDbToYang = func(inParams XfmrParams) (map[string]interface{}, error) {
+	log.Info("DbToYang_test_bgp_network_cfg_key_xfmr ", inParams.uri)
+	var rmap map[string]interface{}
+	var network_id string
+
+	if strings.Contains(inParams.key, "|") {
+		key_split := strings.SplitN(inParams.key, "|", 2)
+		if len(key_split) == 2 {
+			network_id = key_split[1]
+			rmap = make(map[string]interface{})
+			rmap["network-id"] = network_id
+		}
+	}
+	log.Info("DbToYang_test_bgp_network_cfg_key_xfmr returning ", rmap)
 	return rmap, nil
 }

--- a/translib/transformer/xfmr_testxfmr_callbacks.go
+++ b/translib/transformer/xfmr_testxfmr_callbacks.go
@@ -942,7 +942,7 @@ var YangToDb_test_ni_instance_protocol_key_xfmr KeyXfmrYangToDb = func(inParams 
 		pathInfo := NewPathInfo(inParams.uri)
 		ni_name := pathInfo.Var("ni-name")
 		proto_name := pathInfo.Var("name")
-		log.Info("YangToDb_test_ni_instance_protocol_key_xfmr received ni-instance ", ni_name, " protocol name ", name)
+		log.Info("YangToDb_test_ni_instance_protocol_key_xfmr received ni-instance ", ni_name, " protocol name ", proto_name)
 		if (ni_name == "default") || (strings.HasPrefix(ni_name, "vrf-")) {
 			if proto_name == "bgp" {
 				key = "bgp"

--- a/translib/transformer/xfmr_testxfmr_callbacks.go
+++ b/translib/transformer/xfmr_testxfmr_callbacks.go
@@ -41,6 +41,7 @@ func init() {
 
 	// Table transformer functions
 	XlateFuncBind("test_sensor_type_tbl_xfmr", test_sensor_type_tbl_xfmr)
+	XlateFuncBind("test_ni_instance_protocol_table_xfmr", test_ni_instance_protocol_table_xfmr)
 
 	// Key transformer functions
 	XlateFuncBind("YangToDb_test_sensor_type_key_xfmr", YangToDb_test_sensor_type_key_xfmr)
@@ -51,6 +52,12 @@ func init() {
 	XlateFuncBind("DbToYang_test_set_key_xfmr", DbToYang_test_set_key_xfmr)
 	XlateFuncBind("YangToDb_sensor_a_light_sensor_key_xfmr", YangToDb_sensor_a_light_sensor_key_xfmr)
 	XlateFuncBind("DbToYang_sensor_a_light_sensor_key_xfmr", DbToYang_sensor_a_light_sensor_key_xfmr)
+	//XlateFuncBind("YangToDb_test_ntp_authentication_key_xfmr", YangToDb_test_ntp_authentication_key_xfmr)
+	//XlateFuncBind("DbToYang_test_ntp_authentication_key_xfmr", DbToYang_test_ntp_authentication_key_xfmr)
+	XlateFuncBind("YangToDb_test_ni_instance_key_xfmr", YangToDb_test_ni_instance_key_xfmr)
+	XlateFuncBind("DbToYang_test_ni_instance_key_xfmr", DbToYang_test_ni_instance_key_xfmr)
+	XlateFuncBind("YangToDb_test_ni_instance_protocol_key_xfmr", YangToDb_test_ni_instance_protocol_key_xfmr)
+	XlateFuncBind("DbToYang_test_ni_instance_protocol_key_xfmr", DbToYang_test_ni_instance_protocol_key_xfmr)
 
 	// Key leafrefed Field transformer functions
 	XlateFuncBind("DbToYang_test_sensor_type_field_xfmr", DbToYang_test_sensor_type_field_xfmr)
@@ -71,6 +78,8 @@ func init() {
 
 	//validate transformer
 	XlateFuncBind("light_sensor_validate", light_sensor_validate)
+	XlateFuncBind("validate_bgp_proto", validate_bgp_proto)
+	XlateFuncBind("validate_ospfv2_proto", validate_ospfv2_proto)
 
 	// Sonic yang Key transformer functions
 	XlateFuncBind("DbToYang_test_sensor_mode_key_xfmr", DbToYang_test_sensor_mode_key_xfmr)
@@ -112,7 +121,7 @@ var test_pre_xfmr PreXfmrFunc = func(inParams XfmrParams) error {
 	return err
 }
 
-var test_post_xfmr PostXfmrFunc = func(inParams XfmrParams) (map[string]map[string]db.Value, error) {
+var test_post_xfmr PostXfmrFunc = func(inParams XfmrParams) error {
 
 	pathInfo := NewPathInfo(inParams.uri)
 	groupId := pathInfo.Var("id")
@@ -132,7 +141,7 @@ var test_post_xfmr PostXfmrFunc = func(inParams XfmrParams) (map[string]map[stri
 			inParams.subOpDataMap[CREATE] = &subOpCreateMap
 		}
 	}
-	return retDbDataMap, nil
+	return nil
 }
 
 var test_sensor_type_tbl_xfmr TableXfmrFunc = func(inParams XfmrParams) ([]string, error) {
@@ -171,7 +180,7 @@ var YangToDb_test_sensor_type_key_xfmr KeyXfmrYangToDb = func(inParams XfmrParam
 	pathInfo := NewPathInfo(inParams.uri)
 	groupId := pathInfo.Var("id")
 	sensorType := pathInfo.Var("type")
-	if groupId == "" || sensorType == "" {
+	if groupId == "" {
 		return sensor_type_key, err
 	}
 	if len(groupId) > 0 {
@@ -182,6 +191,8 @@ var YangToDb_test_sensor_type_key_xfmr KeyXfmrYangToDb = func(inParams XfmrParam
 		} else if strings.HasPrefix(sensorType, "sensorb_") {
 			sensor_type = strings.Replace(sensorType, "sensorb_", "sensor_type_b_", 1)
 			sensor_type_key = groupId + "|" + sensor_type
+		} else if sensorType == "" && (strings.HasSuffix(inParams.uri, "/test-sensor-type")) && (inParams.oper == GET || inParams.oper == DELETE) {
+			sensor_type_key = groupId
 		} else {
 			err_str := "Invalid key. Key not supported."
 			err = tlerr.NotSupported(err_str)
@@ -760,6 +771,8 @@ var YangToDb_sensor_a_light_sensor_key_xfmr KeyXfmrYangToDb = func(inParams Xfmr
 	sensorType := pathInfo.Var("type")
 	lightSensorTag := pathInfo.Var("tag")
 	if groupId == "" || sensorType == "" {
+		err_str := "Invalid key. Key not supported."
+		err = tlerr.NotSupported(err_str)
 		return light_sensor_key, err
 	}
 	sensor_type := ""
@@ -773,11 +786,10 @@ var YangToDb_sensor_a_light_sensor_key_xfmr KeyXfmrYangToDb = func(inParams Xfmr
 		err_str := "Invalid key. Key not supported."
 		err = tlerr.NotSupported(err_str)
 	}
-	if err == nil {
+	if err == nil && lightSensorTag != "" {
 		sensor_tag := strings.Replace(lightSensorTag, "lightsensor_", "light_sensor_", 1)
 		light_sensor_key += "|" + sensor_tag
 	}
-
 	log.Info("YangToDb_sensor_a_light_sensor_key_xfmr returns", light_sensor_key)
 	return light_sensor_key, err
 }
@@ -814,4 +826,216 @@ func light_sensor_validate(inParams XfmrParams) bool {
 	}
 	log.Info("light_sensor_validate returning ", traversal_valid)
 	return traversal_valid
+}
+
+/*
+var YangToDb_test_ntp_authentication_key_xfmr KeyXfmrYangToDb = func(inParams XfmrParams) (string, error) {
+	log.Info("YangToDb_test_ntp_authentication_key_xfmr", inParams.uri)
+	pathInfo := NewPathInfo(inParams.uri)
+	auth_key := pathInfo.Var("key-id")
+	return auth_key, nil
+
+}
+
+var DbToYang_test_ntp_authentication_key_xfmr KeyXfmrDbToYang = func(inParams XfmrParams) (map[string]interface{}, error) {
+	log.Info("DbToYang_test_ntp_authentication_key_xfmr", inParams.uri)
+	var rmap map[string]interface{}
+	if inParams.key != "" {
+		rmap := make(map[string]interface{})
+		rmap["key-id"] = inParams.key
+	}
+	log.Info("DbToYang_test_ntp_authentication_key_xfmr returning ", rmap)
+	return rmap, nil
+}
+*/
+
+var YangToDb_test_ni_instance_key_xfmr KeyXfmrYangToDb = func(inParams XfmrParams) (string, error) {
+	var db_ni_name string
+	var err error
+	log.Info("YangToDb_test_ni_instance_key_xfmr ", inParams.uri)
+	pathInfo := NewPathInfo(inParams.uri)
+	ni_name := pathInfo.Var("ni-name")
+
+	if strings.HasPrefix(ni_name, "vrf-") {
+		db_ni_name = strings.Replace(ni_name, "vrf-", "Vrf_", 1)
+	} else if strings.HasPrefix(ni_name, "default") {
+		db_ni_name = ni_name
+	} else if ni_name != "" {
+		err_str := "Invalid key. Key not supported."
+		err = tlerr.NotSupported(err_str)
+	}
+	log.Info("YangToDb_test_ni_instance_key_xfmr returning", db_ni_name, err)
+	return db_ni_name, err
+}
+
+var DbToYang_test_ni_instance_key_xfmr KeyXfmrDbToYang = func(inParams XfmrParams) (map[string]interface{}, error) {
+	log.Info("DbToYang_test_ni_instance_key_xfmr ", inParams.uri)
+	var rmap map[string]interface{}
+	var ni_name string
+
+	if inParams.key == "default" {
+		ni_name = "default"
+	} else {
+		ni_name = strings.Replace(inParams.key, "Vrf_", "vrf-", 1)
+	}
+	rmap = make(map[string]interface{})
+	rmap["ni-name"] = ni_name
+
+	log.Info("DbToYang_test_ni_instance_key_xfmr returning ", rmap)
+	return rmap, nil
+}
+
+var test_ni_instance_protocol_table_xfmr TableXfmrFunc = func(inParams XfmrParams) ([]string, error) {
+	var tblList []string
+	var err error
+
+	log.Info("test_ni_instance_protocol_table_xfmr", inParams.uri)
+	if inParams.oper == GET || inParams.oper == DELETE {
+		pathInfo := NewPathInfo(inParams.uri)
+		ni_name := pathInfo.Var("ni-name")
+		proto_name := pathInfo.Var("name")
+		cfg_tbl_updated := false
+		if inParams.dbDataMap != nil {
+			if (ni_name == "default") || (strings.HasPrefix(ni_name, "vrf-")) {
+				if proto_name == "" { // inParams.uri at whole list level, hence add all child instances to be traversed
+					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"] = make(map[string]db.Value)
+					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"]["bgp"] = db.Value{Field: make(map[string]string)}
+					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"]["bgp"].Field["NULL"] = "NULL"
+					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"]["ospfv2"] = db.Value{Field: make(map[string]string)}
+					(*inParams.dbDataMap)[db.ConfigDB]["TTEST_CFG_PROTO_TBL"]["ospfv2"].Field["NULL"] = "NULL"
+					cfg_tbl_updated = true
+				} else if proto_name == "bgp" {
+					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"] = make(map[string]db.Value)
+					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"]["bgp"] = db.Value{Field: make(map[string]string)}
+					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"]["bgp"].Field["NULL"] = "NULL"
+					cfg_tbl_updated = true
+				} else if proto_name == "ospfv2" {
+					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"] = make(map[string]db.Value)
+					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"]["ospfv2"] = db.Value{Field: make(map[string]string)}
+					(*inParams.dbDataMap)[db.ConfigDB]["TTEST_CFG_PROTO_TBL"]["ospfv2"].Field["NULL"] = "NULL"
+					cfg_tbl_updated = true
+				} else {
+					err_str := "Invalid protocol key. Key not supported."
+					err = tlerr.NotSupported(err_str)
+				}
+			} else {
+				err_str := "Invalid ni-instance key. Key not supported."
+				err = tlerr.NotSupported(err_str)
+			}
+		}
+		if cfg_tbl_updated {
+			tblList = append(tblList, "CFG_PROTO_TBL")
+		}
+	}
+	return tblList, err
+}
+
+var YangToDb_test_ni_instance_protocol_key_xfmr KeyXfmrYangToDb = func(inParams XfmrParams) (string, error) {
+	var key string
+	var err error
+
+	if inParams.oper == GET || inParams.oper == DELETE {
+		pathInfo := NewPathInfo(inParams.uri)
+		ni_name := pathInfo.Var("ni-name")
+		proto_name := pathInfo.Var("name")
+		if (ni_name == "default") || (strings.HasPrefix(ni_name, "vrf-")) {
+			if proto_name == "bgp" {
+				key = "bgp"
+			} else if proto_name == "ospfv2" {
+				key = "ospfv2"
+			} else if proto_name != "" {
+				err_str := "Invalid protocol key. Key not supported."
+				err = tlerr.NotSupported(err_str)
+			}
+		} else {
+			err_str := "Invalid ni-instance key. Key not supported."
+			err = tlerr.NotSupported(err_str)
+		}
+	}
+	log.Info("YangToDb_test_ni_instance_protocol_key_xfmr returning key ", key, " error ", err)
+	return key, err
+}
+
+var DbToYang_test_ni_instance_protocol_key_xfmr KeyXfmrDbToYang = func(inParams XfmrParams) (map[string]interface{}, error) {
+	rmap := make(map[string]interface{})
+	rmap["name"] = inParams.key
+	log.Info("DbToYang_test_ni_instance_protocol_key_xfmr returning ", rmap)
+	return rmap, nil
+}
+
+func checkNwInstanceProtocol(inParams XfmrParams, protoNm string) bool {
+	pathInfo := NewPathInfo(inParams.uri)
+	proto_name := pathInfo.Var("name")
+	return proto_name == protoNm
+}
+
+func validate_bgp_proto(inParams XfmrParams) bool {
+	return checkNwInstanceProtocol(inParams, "bgp")
+}
+
+func validate_ospfv2_proto(inParams XfmrParams) bool {
+	return checkNwInstanceProtocol(inParams, "ospfv2")
+}
+
+var YangToDb_test_ospfv2_router_key_xfmr KeyXfmrYangToDb = func(inParams XfmrParams) (string, error) {
+	var ospfv2_db_key string
+	var err error
+	log.Info("YangToDb_test_ospfv2_router_key_xfmr ", inParams.uri)
+	pathInfo := NewPathInfo(inParams.uri)
+	ni_name := pathInfo.Var("ni-name")
+
+	if strings.HasPrefix(ni_name, "vrf-") {
+		ospfv2_db_key = strings.Replace(ni_name, "vrf-", "Vrf_", 1)
+	} else if strings.HasPrefix(ni_name, "default") {
+		ospfv2_db_key = ni_name
+	} else if ni_name != "" {
+		err_str := "Invalid network-instance key. Key not supported."
+		err = tlerr.NotSupported(err_str)
+	}
+	log.Info("YangToDb_test_ospfv2_router_key_xfmr returning ", ospfv2_db_key, " error ", err)
+	return ospfv2_db_key, err
+}
+
+var YangToDb_test_ospfv2_router_distribution_key_xfmr KeyXfmrYangToDb = func(inParams XfmrParams) (string, error) {
+	var db_ni_name, ospfv2_db_key string
+	var err error
+	log.Info("YangToDb_test_ospfv2_router_distribution_key_xfmr ", inParams.uri)
+	pathInfo := NewPathInfo(inParams.uri)
+	ni_name := pathInfo.Var("ni-name")
+	distribution_id := pathInfo.Var("distribution-id")
+
+	if strings.HasPrefix(ni_name, "vrf-") {
+		db_ni_name = strings.Replace(ni_name, "vrf-", "Vrf_", 1)
+	} else if strings.HasPrefix(ni_name, "default") {
+		db_ni_name = ni_name
+	} else if ni_name != "" {
+		err_str := "Invalid key. Key not supported."
+		err = tlerr.NotSupported(err_str)
+	}
+
+	if distribution_id != "" {
+		ospfv2_db_key = db_ni_name + "|" + distribution_id
+	} else {
+		ospfv2_db_key = db_ni_name
+	}
+
+	log.Info("YangToDb_test_ospfv2_router_distribution_key_xfmr returning ", ospfv2_db_key, " error ", err)
+	return ospfv2_db_key, err
+}
+
+var DbToYang_test_ospfv2_router_distribution_key_xfmr KeyXfmrDbToYang = func(inParams XfmrParams) (map[string]interface{}, error) {
+	log.Info("DbToYang_test_ospfv2_router_distribution_key_xfmr ", inParams.uri)
+	var rmap map[string]interface{}
+	var distribution_id string
+
+	if strings.Contains(inParams.key, "|") {
+		key_split := strings.SplitN(inParams.key, "|", 2)
+		if len(key_split) == 2 {
+			distribution_id = key_split[1]
+			rmap = make(map[string]interface{})
+			rmap["distribution-id"] = distribution_id
+		}
+	}
+	log.Info("DbToYang_test_ospfv2_router_distribution_key_xfmr returning ", rmap)
+	return rmap, nil
 }

--- a/translib/transformer/xfmr_testxfmr_callbacks.go
+++ b/translib/transformer/xfmr_testxfmr_callbacks.go
@@ -971,7 +971,7 @@ var DbToYang_test_ni_instance_protocol_key_xfmr KeyXfmrDbToYang = func(inParams 
 func checkNwInstanceProtocol(inParams XfmrParams, protoNm string) bool {
 	pathInfo := NewPathInfo(inParams.uri)
 	proto_name := pathInfo.Var("name")
-	og.Info("checkNwInstanceProtocol() through validate handler ", proto_name)
+	log.Info("checkNwInstanceProtocol() through validate handler ", proto_name)
 	return proto_name == protoNm
 }
 

--- a/translib/transformer/xlate.go
+++ b/translib/transformer/xlate.go
@@ -612,7 +612,7 @@ func XlateFromDb(uri string, ygRoot *ygot.GoStruct, dbs [db.MaxDB]*db.DB, data R
 	qparams := inParamsForGet.queryParams
 	ygSchema := inParamsForGet.ygSchema
 	inParamsForGet = formXlateFromDbParams(dbs[cdb], dbs, cdb, ygRoot, uri, requestUri, xpath, GET, "", "",
-		&dbData, txCache, nil, false, qparams, inParamsForGet.reqCtxt, nil)
+		&dbData, txCache, nil, qparams, inParamsForGet.reqCtxt, nil)
 	inParamsForGet.dbTblKeyGetCache = dbTblKeyGetCache
 	inParamsForGet.xfmrDbTblKeyCache = tblXfmrCache
 	inParamsForGet.ygSchema = ygSchema

--- a/translib/transformer/xlate_datastructs.go
+++ b/translib/transformer/xlate_datastructs.go
@@ -72,10 +72,11 @@ type XfmrTranslateSubscribeInfo struct {
 }
 
 type xpathTblKeyExtractRet struct {
-	xpath        string
-	tableName    string
-	dbKey        string
-	isVirtualTbl bool
+	xpath         string
+	tableName     string
+	dbKey         string
+	isVirtualTbl  bool
+	isNotTblOwner bool
 }
 
 type xlateFromDbParams struct {
@@ -96,7 +97,6 @@ type xlateFromDbParams struct {
 	tbl               string
 	tblKey            string
 	resultMap         map[string]interface{}
-	validate          bool
 	xfmrDbTblKeyCache map[string]tblKeyCache
 	queryParams       QueryParams
 	dbTblKeyGetCache  map[db.DBNum]map[string]map[string]bool
@@ -114,6 +114,7 @@ type xlateToParams struct {
 	uri                     string
 	requestUri              string
 	xpath                   string
+	parentXpath             string
 	keyName                 string
 	jsonData                interface{}
 	resultMap               map[Operation]RedisDbMap
@@ -126,6 +127,7 @@ type xlateToParams struct {
 	name                    string
 	value                   interface{}
 	tableName               string
+	isNotTblOwner           bool
 	yangDefValMap           map[string]map[string]db.Value
 	yangAuxValMap           map[string]map[string]db.Value
 	xfmrDbTblKeyCache       map[string]tblKeyCache
@@ -148,6 +150,7 @@ type qpSubtreePruningErr struct {
 }
 
 type Operation int
+type subOpDataMapType map[Operation]*RedisDbMap
 
 type ContentType uint8
 

--- a/translib/transformer/xlate_del_to_db.go
+++ b/translib/transformer/xlate_del_to_db.go
@@ -38,9 +38,7 @@ func tblKeyDataGet(xlateParams xlateToParams, dbDataMap *map[db.DBNum]map[string
 	isVirtualTbl := false
 
 	xfmrLogDebug("Get table data for  (\"%v\")", xlateParams.uri)
-	if (xYangSpecMap[xlateParams.xpath].tableName != nil) && (len(*xYangSpecMap[xlateParams.xpath].tableName) > 0) {
-		tblList = append(tblList, *xYangSpecMap[xlateParams.xpath].tableName)
-	} else if xYangSpecMap[xlateParams.xpath].xfmrTbl != nil {
+	if xYangSpecMap[xlateParams.xpath].xfmrTbl != nil {
 		xfmrTblFunc := *xYangSpecMap[xlateParams.xpath].xfmrTbl
 		if len(xfmrTblFunc) > 0 {
 			inParams := formXfmrInputRequest(xlateParams.d, dbs, cdb, xlateParams.ygRoot, xlateParams.uri, xlateParams.requestUri, xlateParams.oper, xlateParams.keyName, dbDataMap, nil, nil, xlateParams.txCache)
@@ -53,41 +51,47 @@ func tblKeyDataGet(xlateParams xlateToParams, dbDataMap *map[db.DBNum]map[string
 			}
 		}
 	}
-	tbl := xlateParams.tableName
-	if tbl != "" {
-		if !contains(tblList, tbl) {
-			tblList = append(tblList, tbl)
-		}
-	}
 	return tblList, isVirtualTbl, err
 }
 
-func subTreeXfmrDelDataGet(xlateParams xlateToParams, dbDataMap *map[db.DBNum]map[string]map[string]db.Value, cdb db.DBNum, spec *yangXpathInfo, chldSpec *yangXpathInfo, subTreeResMap *map[string]map[string]db.Value) error {
+func subTreeXfmrDelDataGet(xlateParams xlateToParams, dbDataMap *map[db.DBNum]map[string]map[string]db.Value, cdb db.DBNum, spec *yangXpathInfo, chldSpec *yangXpathInfo, subTreeResMap *map[string]map[string]db.Value) (bool, error) {
 	var dbs [db.MaxDB]*db.DB
 	dbs[cdb] = xlateParams.d
+	validate := true
 
 	xfmrLogDebug("Handle subtree for  (\"%v\")", xlateParams.uri)
-	if len(chldSpec.xfmrFunc) > 0 {
-		if (len(spec.xfmrFunc) == 0) || ((len(spec.xfmrFunc) > 0) &&
-			(spec.xfmrFunc != chldSpec.xfmrFunc)) {
-			inParams := formXfmrInputRequest(xlateParams.d, dbs, cdb, xlateParams.ygRoot, xlateParams.uri, xlateParams.requestUri, xlateParams.oper, "",
-				dbDataMap, xlateParams.subOpDataMap, nil, xlateParams.txCache)
-			retMap, err := xfmrHandler(inParams, chldSpec.xfmrFunc)
-			if err != nil {
-				xfmrLogDebug("Error returned by %v: %v", chldSpec.xfmrFunc, err)
-				return err
-			}
-			mapCopy(*subTreeResMap, retMap)
-			if xlateParams.pCascadeDelTbl != nil && len(*inParams.pCascadeDelTbl) > 0 {
-				for _, tblNm := range *inParams.pCascadeDelTbl {
-					if !contains(*xlateParams.pCascadeDelTbl, tblNm) {
-						*xlateParams.pCascadeDelTbl = append(*xlateParams.pCascadeDelTbl, tblNm)
-					}
-				}
+
+	// Evaluate validate xfmr if available for subtree
+	if (len(chldSpec.validateFunc) > 0) && (chldSpec.validateFunc != spec.validateFunc) {
+		xfmrLogDebug("Invoke validate Xfmr function %v for uri %v", spec.validateFunc, xlateParams.uri)
+		xpathKeyExtRet, err := xpathKeyExtract(xlateParams.d, xlateParams.ygRoot, xlateParams.oper, xlateParams.uri, xlateParams.requestUri, nil, xlateParams.subOpDataMap, xlateParams.txCache, xlateParams.xfmrDbTblKeyCache, dbs)
+		if err == nil {
+			inParams := formXfmrInputRequest(xlateParams.d, dbs, db.ConfigDB, xlateParams.ygRoot, xlateParams.uri, xlateParams.requestUri, xlateParams.oper, xpathKeyExtRet.dbKey, dbDataMap, xlateParams.subOpDataMap, nil, xlateParams.txCache)
+			res := validateHandlerFunc(inParams, chldSpec.validateFunc)
+			if !res {
+				// Return the validation status to caller to indicates further traversal not required
+				validate = res
+				return validate, err
 			}
 		}
 	}
-	return nil
+
+	inParams := formXfmrInputRequest(xlateParams.d, dbs, cdb, xlateParams.ygRoot, xlateParams.uri, xlateParams.requestUri, xlateParams.oper, "",
+		dbDataMap, xlateParams.subOpDataMap, nil, xlateParams.txCache)
+	retMap, err := xfmrHandler(inParams, chldSpec.xfmrFunc)
+	if err != nil {
+		xfmrLogDebug("Error returned by %v: %v", chldSpec.xfmrFunc, err)
+		return validate, err
+	}
+	mapCopy(*subTreeResMap, retMap)
+	if xlateParams.pCascadeDelTbl != nil && len(*inParams.pCascadeDelTbl) > 0 {
+		for _, tblNm := range *inParams.pCascadeDelTbl {
+			if !contains(*xlateParams.pCascadeDelTbl, tblNm) {
+				*xlateParams.pCascadeDelTbl = append(*xlateParams.pCascadeDelTbl, tblNm)
+			}
+		}
+	}
+	return validate, nil
 }
 
 func yangListDelData(xlateParams xlateToParams, dbDataMap *map[db.DBNum]map[string]map[string]db.Value, subTreeResMap *map[string]map[string]db.Value, isFirstCall bool) error {
@@ -96,7 +100,6 @@ func yangListDelData(xlateParams xlateToParams, dbDataMap *map[db.DBNum]map[stri
 	var tblList []string
 	xfmrLogDebug("yangListDelData Received xlateParams - %v \n dbDataMap - %v\n subTreeResMap - %v\n isFirstCall - %v", xlateParams, dbDataMap, subTreeResMap, isFirstCall)
 	fillFields := false
-	removedFillFields := false
 	virtualTbl := false
 	tblOwner := true
 	keyName := xlateParams.keyName
@@ -139,8 +142,17 @@ func yangListDelData(xlateParams xlateToParams, dbDataMap *map[db.DBNum]map[stri
 		xlateParams.keyName = keyName
 	}
 
-	tblList, virtualTbl, err = tblKeyDataGet(xlateParams, dbDataMap, cdb)
-	if err != nil {
+	if xYangSpecMap[xlateParams.xpath].xfmrTbl != nil {
+		tblList, virtualTbl, err = tblKeyDataGet(xlateParams, dbDataMap, cdb)
+		if err != nil {
+			return err
+		}
+	} else if len(xlateParams.tableName) > 0 {
+		tblList = append(tblList, xlateParams.tableName)
+	}
+
+	if len(tblList) == 0 {
+		xfmrLogInfo("Unable to traverse list as no table information available at URI %v. Please check if table mapping available", xlateParams.uri)
 		return err
 	}
 
@@ -164,48 +176,66 @@ func yangListDelData(xlateParams xlateToParams, dbDataMap *map[db.DBNum]map[stri
 		xfmrLogDebug("Parent Uri - %v, ParentTbl - %v, parentKey - %v", parentUri, parentTbl, parentKey)
 	}
 
-	if len(tblList) == 0 {
-		xfmrLogInfo("Unable to traverse list as no table information available at URI %v. Please check if table mapping available", xlateParams.uri)
-	}
-
 	for _, tbl := range tblList {
 		tblData, ok := (*dbDataMap)[cdb][tbl]
 		xfmrLogDebug("Process Tbl - %v", tbl)
+		removedFillFields := false
 		var curTbl, curKey string
 		var cerr error
 		if ok {
 			for dbKey := range tblData {
 				xfmrLogDebug("Process Tbl - %v with dbKey - %v", tbl, dbKey)
-				_, curUri, _, kerr := dbKeyToYangDataConvert(xlateParams.uri, xlateParams.requestUri, xlateParams.xpath, tbl, xlateParams.d, dbs, dbDataMap, dbKey, separator, xlateParams.txCache, xlateParams.oper)
-				if kerr != nil {
+				rmap, curUri, _, kerr := dbKeyToYangDataConvert(xlateParams.uri, xlateParams.requestUri, xlateParams.xpath, tbl, xlateParams.d, dbs, dbDataMap, dbKey, separator, xlateParams.txCache, xlateParams.oper)
+				if kerr != nil || len(rmap) == 0 {
 					continue
 				}
-				if spec.virtualTbl != nil && *spec.virtualTbl {
-					virtualTbl = true
+				if spec.virtualTbl != nil {
+					virtualTbl = *spec.virtualTbl
 				}
 
-				// Not required to check for table inheritence case here as we have a subtree and subtree is already processed before we get here
+				var dbs [db.MaxDB]*db.DB
+				xpathKeyExtRet, xerr := xpathKeyExtract(xlateParams.d, xlateParams.ygRoot, xlateParams.oper, curUri, xlateParams.requestUri, nil, xlateParams.subOpDataMap, xlateParams.txCache, xlateParams.xfmrDbTblKeyCache, dbs)
+				curKey = xpathKeyExtRet.dbKey
+				curTbl = xpathKeyExtRet.tableName
+				if dbKey != curKey {
+					xfmrLogDebug("Mismatch in dbKey and key derived from uri. dbKey : %v, key from uri: %v. Cannot traverse instance at URI %v. Please check the key mapping", dbKey, curKey, curUri)
+					continue
+				}
+
+				//Not required to check for table inheritence case here as we have a subtree and subtree is already processed before we get here
 				// We only need to traverse nested subtrees here
 				if len(spec.xfmrFunc) == 0 {
-					var dbs [db.MaxDB]*db.DB
-					xpathKeyExtRet, xerr := xpathKeyExtract(xlateParams.d, xlateParams.ygRoot, xlateParams.oper, curUri, xlateParams.requestUri, nil, xlateParams.subOpDataMap, xlateParams.txCache, xlateParams.xfmrDbTblKeyCache, dbs)
-					curKey = xpathKeyExtRet.dbKey
-					curTbl = xpathKeyExtRet.tableName
+					if spec.virtualTbl == nil && xpathKeyExtRet.isVirtualTbl {
+						virtualTbl = xpathKeyExtRet.isVirtualTbl
+					}
+					if spec.tblOwner != nil {
+						tblOwner = *spec.tblOwner
+					} else {
+						tblOwner = !xpathKeyExtRet.isNotTblOwner
+					}
+
 					cerr = xerr
 					xfmrLogDebug("Current Uri - %v, CurrentTbl - %v, CurrentKey - %v", curUri, curTbl, curKey)
+					// Invoke the validate Xfmr function to evaluate if further processing is required
+					parentSpec, parentOk := xYangSpecMap[xlateParams.parentXpath]
 
-					if dbKey != curKey {
-						xfmrLogDebug("Mismatch in dbKey and key derived from uri. dbKey : %v, key from uri: %v. Cannot traverse instance at URI %v. Please check the key mapping", dbKey, curKey, curUri)
-						continue
+					if len(spec.validateFunc) > 0 && (isFirstCall ||
+						(parentOk && (spec.validateFunc != parentSpec.validateFunc))) {
+						xfmrLogDebug("Invoke validate Xfmr function %v for uri %v", spec.validateFunc, curUri)
+						inParams := formXfmrInputRequest(xlateParams.d, dbs, db.ConfigDB, xlateParams.ygRoot, curUri, xlateParams.requestUri, xlateParams.oper, curKey, dbDataMap, xlateParams.subOpDataMap, nil, xlateParams.txCache)
+						res := validateHandlerFunc(inParams, spec.validateFunc)
+						if !res {
+							continue
+						}
 					}
+
 					if isFirstCall {
 						if perr == nil && cerr == nil {
 							if len(curTbl) > 0 && parentTbl != curTbl {
 								/* Non-inhertited table case */
 								xfmrLogDebug("Non-inhertaed table case, URI - %v", curUri)
-								if spec.tblOwner != nil && !*spec.tblOwner {
+								if !tblOwner {
 									xfmrLogDebug("For URI - %v, table owner - %v", xlateParams.uri, *spec.tblOwner)
-									tblOwner = false
 									/* Fill only fields */
 									fillFields = true
 								}
@@ -216,17 +246,15 @@ func yangListDelData(xlateParams xlateToParams, dbDataMap *map[db.DBNum]map[stri
 									if parentKey == curKey { // List within list or List within container, where container map to entire table
 										xfmrLogDebug("Parent key is same as current key")
 										xfmrLogDebug("Request from NBI is at same level as that of current list - %v", curUri)
-										if spec.tblOwner != nil && !*spec.tblOwner {
-											xfmrLogDebug("For URI - %v, table owner - %v", xlateParams.uri, *spec.tblOwner)
-											tblOwner = false // since query is at this level, this will make sure to add instance to result
+										if !tblOwner {
+											xfmrLogDebug("For URI - %v, table owner - %v", xlateParams.uri, tblOwner)
 										}
 										/* Fill only fields */
 										fillFields = true
 									} else { /*same table but different keys */
 										xfmrLogDebug("Inherited table but parent key is NOT same as current key")
-										if spec.tblOwner != nil && !*spec.tblOwner {
+										if !tblOwner {
 											xfmrLogDebug("For URI - %v, table owner - %v", xlateParams.uri, *spec.tblOwner)
-											tblOwner = false
 											/* Fill only fields */
 											fillFields = true
 										}
@@ -234,116 +262,143 @@ func yangListDelData(xlateParams xlateToParams, dbDataMap *map[db.DBNum]map[stri
 								} else {
 									/*same table but no parent-key exists, parent must be a container wth just tableNm annot with no keyXfmr/Nm */
 									xfmrLogDebug("Inherited table but no parent key available")
-									if spec.tblOwner != nil && !*spec.tblOwner {
+									if !tblOwner {
 										xfmrLogDebug("For URI - %v, table owner - %v", xlateParams.uri, *spec.tblOwner)
-										tblOwner = false
 										/* Fill only fields */
 										fillFields = true
 
 									}
 								}
 							} else { //  len(curTbl) = 0
-								log.Warning("No table found for Uri - %v ", curUri)
+								log.Warning("No table found for Uri -  ", curUri)
 							}
 						}
 					} else {
 						/* if table instance already filled and there are no feilds present then it's instance level delete.
 						If fields present then its fields delet and not instance delete
 						*/
-						if tblData, tblDataOk := xlateParams.result[curTbl]; tblDataOk {
-							if fieldMap, fieldMapOk := tblData[curKey]; fieldMapOk {
-								xfmrLogDebug("Found table instance same as that of requestUri")
-								if len(fieldMap.Field) > 0 {
-									/* Fill only fields */
-									xfmrLogDebug("Found table instance same as that of requestUri with fields.")
-									fillFields = true
+						if !tblOwner {
+							xfmrLogDebug("For URI - %v, table owner - %v", xlateParams.uri, tblOwner)
+							/* Fill only fields */
+							fillFields = true
+						} else {
+							if tblData, tblDataOk := xlateParams.result[curTbl]; tblDataOk {
+								if fieldMap, fieldMapOk := tblData[curKey]; fieldMapOk {
+									xfmrLogDebug("Found table instance same as that of requestUri")
+									if len(fieldMap.Field) > 0 {
+										//* Fill only fields
+										xfmrLogDebug("Found table instance same as that of requestUri with fields.")
+										fillFields = true
+									}
 								}
 							}
 						}
-					} // end of if isFirstCall
-				} // end if !subtree case
-				xfmrLogDebug("For URI - %v , table-owner - %v, fillFields - %v", curUri, tblOwner, fillFields)
-				if fillFields || spec.hasChildSubTree || isFirstCall {
-					for yangChldName := range spec.yangEntry.Dir {
-						chldXpath := xlateParams.xpath + "/" + yangChldName
-						chldUri := curUri + "/" + yangChldName
-						chldSpec, ok := xYangSpecMap[chldXpath]
-						chldSpecYangEntry := spec.yangEntry.Dir[yangChldName]
-						if ok && ((chldSpecYangEntry != nil) && (!chldSpecYangEntry.ReadOnly())) {
-							chldYangType := chldSpec.yangType
-							curXlateParams := xlateParams
-							curXlateParams.uri = chldUri
-							curXlateParams.xpath = chldXpath
-							curXlateParams.tableName = ""
-							curXlateParams.keyName = ""
 
-							if (chldSpec.dbIndex == db.ConfigDB) && (len(chldSpec.xfmrFunc) > 0) {
-								err = subTreeXfmrDelDataGet(curXlateParams, dbDataMap, cdb, spec, chldSpec, subTreeResMap)
-								if err != nil {
-									return err
+					} // end of if isFirstCall
+				} else { // end if !subtree case
+					if !spec.hasChildSubTree {
+						return err
+					}
+				}
+
+				skipSibling := false
+
+				xfmrLogDebug("For URI - %v , table-owner - %v, fillFields - %v", curUri, tblOwner, fillFields)
+				for yangChldName := range spec.yangEntry.Dir {
+					chldXpath := xlateParams.xpath + "/" + yangChldName
+					chldUri := curUri + "/" + yangChldName
+					chldSpec, ok := xYangSpecMap[chldXpath]
+					chldSpecYangEntry := spec.yangEntry.Dir[yangChldName]
+					if ok && ((chldSpecYangEntry != nil) && (!chldSpecYangEntry.ReadOnly())) {
+						chldYangType := chldSpec.yangType
+						curXlateParams := xlateParams
+						curXlateParams.uri = chldUri
+						curXlateParams.xpath = chldXpath
+						curXlateParams.tableName = ""
+						curXlateParams.keyName = ""
+						curXlateParams.parentXpath = xlateParams.xpath
+
+						if (chldSpec.dbIndex == db.ConfigDB) && (len(chldSpec.xfmrFunc) > 0) {
+							if (len(spec.xfmrFunc) == 0) ||
+								((len(spec.xfmrFunc) > 0) && (spec.xfmrFunc != chldSpec.xfmrFunc)) {
+								validate, serr := subTreeXfmrDelDataGet(curXlateParams, dbDataMap, cdb, spec, chldSpec, subTreeResMap)
+								if serr != nil {
+									// Subtree returned error
+									return serr
+								} else if !validate {
+									// No error from subtree but validates to false
+									continue
 								}
 							}
-							if chldYangType == YANG_CONTAINER {
-								err = yangContainerDelData(curXlateParams, dbDataMap, subTreeResMap, false)
+							if !chldSpec.hasChildSubTree {
+								continue
+							}
+						}
+						if chldYangType == YANG_CONTAINER {
+							err = yangContainerDelData(curXlateParams, dbDataMap, subTreeResMap, false)
+							if err != nil {
+								return err
+							}
+						} else if chldYangType == YANG_LIST {
+							err = yangListDelData(curXlateParams, dbDataMap, subTreeResMap, false)
+							if err != nil {
+								return err
+							}
+						} else if (chldSpec.dbIndex == db.ConfigDB) && ((chldYangType == YANG_LEAF) || (chldYangType == YANG_LEAF_LIST)) && !virtualTbl && (len(chldSpec.xfmrFunc) == 0) {
+							/* Do not fill table in resultMap for virtual table and subtree cases */
+							if len(curTbl) == 0 {
+								continue
+							}
+							if len(curKey) == 0 { //at list level key should always be there
+								xfmrLogDebug("No key avaialble for URI - %v", curUri)
+								continue
+							}
+							if chldYangType == YANG_LEAF && chldSpec.isKey {
+								if _, tblDataOk := xlateParams.result[curTbl][curKey]; !tblDataOk {
+									if !tblOwner { //add dummy field to identify when to fill fields only at children traversal
+										addInstanceToDeleteMap(curTbl, curKey, curXlateParams.result, "FillFields", "true", xlateParams.pCascadeDelTbl)
+									} else {
+										addInstanceToDeleteMap(curTbl, curKey, curXlateParams.result, "", "", xlateParams.pCascadeDelTbl)
+									}
+								}
+							} else if fillFields && !skipSibling {
+								//strip off the leaf/leaf-list for mapFillDataUtil takes URI without it
+								curXlateParams.uri = xlateParams.uri
+								curXlateParams.name = chldSpecYangEntry.Name
+								curXlateParams.tableName = curTbl
+								curXlateParams.keyName = curKey
+								if chldYangType == YANG_LEAF_LIST {
+									curXlateParams.value = []interface{}{}
+								}
+
+								err = mapFillDataUtil(curXlateParams)
 								if err != nil {
-									return err
-								}
-							} else if chldYangType == YANG_LIST {
-								err = yangListDelData(curXlateParams, dbDataMap, subTreeResMap, false)
-								if err != nil {
-									return err
-								}
-							} else if (chldSpec.dbIndex == db.ConfigDB) && ((chldYangType == YANG_LEAF) || (chldYangType == YANG_LEAF_LIST)) && !virtualTbl {
-								if len(curTbl) == 0 {
-									continue
-								}
-								if len(curKey) == 0 { //at list level key should always be there
-									xfmrLogDebug("No key available for URI - %v", curUri)
-									continue
-								}
-								if chldYangType == YANG_LEAF && chldSpec.isKey {
-									if isFirstCall {
-										if !tblOwner { //add dummy field to identify when to fill fields only at children traversal
-											dataToDBMapAdd(curTbl, curKey, curXlateParams.result, "FillFields", "true")
-										} else {
-											dataToDBMapAdd(curTbl, curKey, curXlateParams.result, "", "")
+									xfmrLogDebug("Error received (\"%v\")", err)
+									switch e := err.(type) {
+									case tlerr.TranslibXfmrRetError:
+										ecode := e.XlateFailDelReq
+										log.Warningf("Error received (\"%v\"), ecode :%v", err, ecode)
+										if ecode {
+											return err
 										}
 									}
-								} else if fillFields {
-									//strip off the leaf/leaf-list for mapFillDataUtil takes URI without it
-									curXlateParams.uri = xlateParams.uri
-									curXlateParams.name = chldSpecYangEntry.Name
-									curXlateParams.tableName = curTbl
-									curXlateParams.keyName = curKey
-									err = mapFillDataUtil(curXlateParams)
-									if err != nil {
-										xfmrLogDebug("Error received (\"%v\")", err)
-										switch e := err.(type) {
-										case tlerr.TranslibXfmrRetError:
-											ecode := e.XlateFailDelReq
-											log.Warningf("Error received (\"%v\"), ecode :%v", err, ecode)
-											if ecode {
-												return err
-											}
-										}
-									}
-									if !removedFillFields {
-										if fieldMap, ok := curXlateParams.result[curTbl][curKey]; ok {
-											if len(fieldMap.Field) > 1 {
-												delete(curXlateParams.result[curTbl][curKey].Field, "FillFields")
+								}
+								if !removedFillFields {
+									if fieldMap, ok := curXlateParams.result[curTbl][curKey]; ok {
+										if len(fieldMap.Field) > 1 {
+											delete(curXlateParams.result[curTbl][curKey].Field, "FillFields")
+											removedFillFields = true
+										} else if len(fieldMap.Field) == 1 {
+											if _, ok := curXlateParams.result[curTbl][curKey].Field["FillFields"]; !ok {
 												removedFillFields = true
-											} else if len(fieldMap.Field) == 1 {
-												if _, ok := curXlateParams.result[curTbl][curKey].Field["FillFields"]; !ok {
-													removedFillFields = true
-												}
 											}
 										}
 									}
 								}
-							} // end of Leaf case
-						} // if rw
-					} // end of curUri children traversal loop
-				} // Child Subtree or fill fields
+							}
+						} // end of Leaf case
+					} // if rw
+				} // end of curUri children traversal loop
 			} // end of for dbKey loop
 		} // end of tbl in dbDataMap
 	} // end of for tbl loop
@@ -358,6 +413,8 @@ func yangContainerDelData(xlateParams xlateToParams, dbDataMap *map[db.DBNum]map
 	dbs[cdb] = xlateParams.d
 	removedFillFields := false
 	var curTbl, curKey string
+	virtualTbl := false
+	tblOwner := true
 
 	if !ok {
 		return err
@@ -374,7 +431,6 @@ func yangContainerDelData(xlateParams xlateToParams, dbDataMap *map[db.DBNum]map
 	xfmrLogDebug("Traverse container for DELETE at URI (\"%v\")", xlateParams.uri)
 
 	fillFields := false
-
 	// Not required to process parent and current table as subtree is already invoked before we get here
 	// We only need to traverse nested subtrees here
 	if len(spec.xfmrFunc) == 0 {
@@ -393,8 +449,19 @@ func yangContainerDelData(xlateParams xlateToParams, dbDataMap *map[db.DBNum]map
 				}
 			}
 		}
+		if spec.virtualTbl != nil {
+			virtualTbl = *spec.virtualTbl
+		} else if xpathKeyExtRet.isVirtualTbl {
+			virtualTbl = xpathKeyExtRet.isVirtualTbl
+		}
 
-		if isFirstCall {
+		if spec.tblOwner != nil {
+			tblOwner = *spec.tblOwner
+		} else {
+			tblOwner = !xpathKeyExtRet.isNotTblOwner
+		}
+
+		if isFirstCall && !virtualTbl {
 			parentUri := parentUriGet(xlateParams.uri)
 			var dbs [db.MaxDB]*db.DB
 			parentXpathKeyExtRet, perr := xpathKeyExtract(xlateParams.d, xlateParams.ygRoot, xlateParams.oper, parentUri, xlateParams.requestUri, nil, xlateParams.subOpDataMap, xlateParams.txCache, xlateParams.xfmrDbTblKeyCache, dbs)
@@ -405,133 +472,177 @@ func yangContainerDelData(xlateParams xlateToParams, dbDataMap *map[db.DBNum]map
 					xfmrLogDebug("DELETE handling at Container parentTbl %v, curTbl %v, curKey %v", parentTbl, curTbl, curKey)
 					if parentTbl != curTbl {
 						// Non inhertited table
-						if (spec.tblOwner != nil) && !(*spec.tblOwner) {
+						if !tblOwner {
 							// Fill fields only
 							xfmrLogDebug("DELETE handling at Container Non inhertited table and not table Owner")
-							dataToDBMapAdd(curTbl, curKey, xlateParams.result, "FillFields", "true")
+							addInstanceToDeleteMap(curTbl, curKey, xlateParams.result, "FillFields", "true", xlateParams.pCascadeDelTbl)
 							fillFields = true
-						} else if (spec.keyName != nil && len(*spec.keyName) > 0) || len(spec.xfmrKey) > 0 {
-							// Table owner && Key transformer present. Fill table instance
-							xfmrLogDebug("DELETE handling at Container Non inhertited table & table Owner")
-							dataToDBMapAdd(curTbl, curKey, xlateParams.result, "", "")
 						} else {
-							// Fallback case. Ideally should not enter here
-							fillFields = true
+							// Table owner and valid key present (either through inheritence or annotation). Hence mark the instance for delete
+							xfmrLogDebug("DELETE handling at Container Non inhertited table & table Owner")
+							addInstanceToDeleteMap(curTbl, curKey, xlateParams.result, "", "", xlateParams.pCascadeDelTbl)
 						}
 					} else {
 						if curKey != parentKey {
-							if (spec.tblOwner != nil) && !(*spec.tblOwner) {
+							if !tblOwner {
 								xfmrLogDebug("DELETE handling at Container inhertited table and not table Owner")
-								dataToDBMapAdd(curTbl, curKey, xlateParams.result, "FillFields", "true")
+								addInstanceToDeleteMap(curTbl, curKey, xlateParams.result, "FillFields", "true", xlateParams.pCascadeDelTbl)
 								fillFields = true
 							} else {
 								// Instance delete
 								xfmrLogDebug("DELETE handling at Container Non inhertited table & table Owner")
-								dataToDBMapAdd(curTbl, curKey, xlateParams.result, "", "")
+								addInstanceToDeleteMap(curTbl, curKey, xlateParams.result, "", "", xlateParams.pCascadeDelTbl)
 							}
 						} else {
-							// if Instance already filled do not fill fields
 							xfmrLogDebug("DELETE handling at Container Inherited table")
 							//Fill fields only
-							if len(curTbl) > 0 && len(curKey) > 0 {
-								dataToDBMapAdd(curTbl, curKey, xlateParams.result, "FillFields", "true")
-								fillFields = true
-							}
+							addInstanceToDeleteMap(curTbl, curKey, xlateParams.result, "FillFields", "true", xlateParams.pCascadeDelTbl)
+							fillFields = true
 						}
 					}
 				} else {
-					if (spec.tblOwner != nil) && !(*spec.tblOwner) {
+					if !tblOwner {
 						// Fill fields only
 						xfmrLogDebug("DELETE handling at Container Non inhertited table and not table Owner No Key available. table: %v, key: %v", curTbl, curKey)
 					} else {
 						// Table owner && Key transformer present. Fill table instance
 						xfmrLogDebug("DELETE handling at Container Non inhertited table & table Owner. No Key Delete complete TABLE : %v", curTbl)
-						dataToDBMapAdd(curTbl, curKey, xlateParams.result, "", "")
+						addInstanceToDeleteMap(curTbl, curKey, xlateParams.result, "", "", xlateParams.pCascadeDelTbl)
 					}
 				}
 			} else {
+				// Unable to determine table key entry mapped at this level. traverse to children.
 				xfmrLogDebug("perr: %v cerr: %v curTbl: %v, curKey: %v", perr, cerr, curTbl, curKey)
 			}
-		} else {
-			// Inherited Table. We always expect the curTbl entry in xlateParams.result
-			// if Instance already filled do not fill fields
-			xfmrLogDebug("DELETE handling at Container Inherited table curTbl: %v, curKey %v", curTbl, curKey)
-			if tblMap, ok := xlateParams.result[curTbl]; ok {
-				if fieldMap, ok := tblMap[curKey]; ok {
-					if len(fieldMap.Field) == 0 {
-						xfmrLogDebug("Inhertited table & Instance delete case. Skip fields fill")
+		} else if !isFirstCall {
+			// Invoke the validate transformer if available. Not required for firstCall as its called at entry point
+			parentSpec, parentOk := xYangSpecMap[xlateParams.parentXpath]
+			if (len(spec.validateFunc) > 0) && (parentOk && (spec.validateFunc != parentSpec.validateFunc)) {
+				xfmrLogDebug("Invoke validate Xfmr function %v fo uri %v", spec.validateFunc, xlateParams.uri)
+				inParams := formXfmrInputRequest(xlateParams.d, dbs, db.ConfigDB, xlateParams.ygRoot, xlateParams.uri, xlateParams.requestUri, xlateParams.oper, curKey, nil, xlateParams.subOpDataMap, nil, xlateParams.txCache)
+				res := validateHandlerFunc(inParams, spec.validateFunc)
+				if !res {
+					return err
+				}
+			}
+			if !virtualTbl {
+				xfmrLogDebug("DELETE handling at Container Inherited table curTbl: %v, curKey %v", curTbl, curKey)
+				// We always expect table mapped to container to have a valid key.
+				if !tblOwner {
+					xfmrLogDebug("Non table owner child node handling. Fields fill for table :%v", curTbl)
+					if len(curTbl) > 0 && len(curKey) > 0 {
+						if fldMap, ok := xlateParams.result[curTbl][curKey]; !ok {
+							addInstanceToDeleteMap(curTbl, curKey, xlateParams.result, "FillFields", "true", xlateParams.pCascadeDelTbl)
+							fillFields = true
+						} else {
+							if len(fldMap.Field) > 0 {
+								fillFields = true
+							}
+						}
+					}
+				} else if len(curTbl) > 0 {
+					xfmrLogDebug("DELETE handling at child container mapped table curTbl: %v, curKey %v", curTbl, curKey)
+					// Mark the instance for delete if its a table owner. For derived tables from parent, entry should already exist during parent traversal.
+					if len(curKey) > 0 {
+						if fieldMap, ok := xlateParams.result[curTbl][curKey]; ok {
+							// Identify if DB instance existence check is required. If exists add to resultMap else ignore and continue traversal.
+							if len(fieldMap.Field) > 0 {
+								fillFields = true
+							}
+						} else {
+							addInstanceToDeleteMap(curTbl, curKey, xlateParams.result, "", "", xlateParams.pCascadeDelTbl)
+						}
 					} else {
-						xfmrLogDebug("Inhertited table & fields fill for table :%v", curTbl)
-						fillFields = true
+						// We expect a valid key always. If key not present it will be considered as complete table delete
+						// TODO: Identify if DB instance existence check is required. If exists add to resultMap else ignore and continue traversal.
+						addInstanceToDeleteMap(curTbl, curKey, xlateParams.result, "", "", xlateParams.pCascadeDelTbl)
 					}
 				}
 			}
 		}
-
+	} else {
+		if !spec.hasChildSubTree {
+			return err
+		}
 	}
+
 	xfmrLogDebug("URI %v fillFields %v, hasChildSubtree  %v, isFirstCall %v", xlateParams.uri, fillFields, spec.hasChildSubTree, isFirstCall)
 
-	if fillFields || spec.hasChildSubTree || isFirstCall {
-		for yangChldName := range spec.yangEntry.Dir {
-			chldXpath := xlateParams.xpath + "/" + yangChldName
-			chldUri := xlateParams.uri + "/" + yangChldName
-			chldSpec, ok := xYangSpecMap[chldXpath]
-			chldSpecYangEntry := spec.yangEntry.Dir[yangChldName]
-			if ok && ((chldSpecYangEntry != nil) && (!chldSpecYangEntry.ReadOnly())) {
-				chldYangType := chldSpec.yangType
-				curXlateParams := xlateParams
-				curXlateParams.uri = chldUri
-				curXlateParams.xpath = chldXpath
-				curXlateParams.tableName = curTbl
-				curXlateParams.keyName = curKey
+	skipSibling := false
+	for yangChldName := range spec.yangEntry.Dir {
+		chldXpath := xlateParams.xpath + "/" + yangChldName
+		chldUri := xlateParams.uri + "/" + yangChldName
+		chldSpec, ok := xYangSpecMap[chldXpath]
+		chldSpecYangEntry := spec.yangEntry.Dir[yangChldName]
+		if ok && ((chldSpecYangEntry != nil) && (!chldSpecYangEntry.ReadOnly())) {
+			chldYangType := chldSpec.yangType
+			curXlateParams := xlateParams
+			curXlateParams.uri = chldUri
+			curXlateParams.xpath = chldXpath
+			curXlateParams.tableName = curTbl
+			curXlateParams.keyName = curKey
+			curXlateParams.parentXpath = xlateParams.xpath
 
-				if (chldSpec.dbIndex == db.ConfigDB) && (len(chldSpec.xfmrFunc) > 0) {
-					err = subTreeXfmrDelDataGet(curXlateParams, dbDataMap, cdb, spec, chldSpec, subTreeResMap)
-					if err != nil {
-						return err
+			if (chldSpec.dbIndex == db.ConfigDB) && (len(chldSpec.xfmrFunc) > 0) {
+				if (len(spec.xfmrFunc) == 0) || ((len(spec.xfmrFunc) > 0) &&
+					(spec.xfmrFunc != chldSpec.xfmrFunc)) {
+
+					validate, serr := subTreeXfmrDelDataGet(curXlateParams, dbDataMap, cdb, spec, chldSpec, subTreeResMap)
+					if serr != nil {
+						// Return the subtree error
+						return serr
+					} else if !validate {
+						// No error from subtree but validates to false
+						return nil
 					}
 				}
-				if chldYangType == YANG_CONTAINER {
-					err = yangContainerDelData(curXlateParams, dbDataMap, subTreeResMap, false)
-					if err != nil {
-						return err
-					}
-				} else if chldYangType == YANG_LIST {
-					err = yangListDelData(curXlateParams, dbDataMap, subTreeResMap, false)
-					if err != nil {
-						return err
-					}
-				} else if (chldSpec.dbIndex == db.ConfigDB) && (chldYangType == YANG_LEAF || chldYangType == YANG_LEAF_LIST) && fillFields {
-					//strip off the leaf/leaf-list for mapFillDataUtil takes URI without it
-					curXlateParams.uri = xlateParams.uri
-					curXlateParams.name = chldSpecYangEntry.Name
-					err = mapFillDataUtil(curXlateParams)
-					if err != nil {
-						xfmrLogDebug("Error received during leaf fill (\"%v\")", err)
-						switch e := err.(type) {
-						case tlerr.TranslibXfmrRetError:
-							ecode := e.XlateFailDelReq
-							log.Warningf("Error received (\"%v\"), ecode :%v", err, ecode)
-							if ecode {
-								return err
-							}
+				if !chldSpec.hasChildSubTree {
+					continue
+				}
+			}
+			if chldYangType == YANG_CONTAINER {
+				err = yangContainerDelData(curXlateParams, dbDataMap, subTreeResMap, false)
+				if err != nil {
+					return err
+				}
+			} else if chldYangType == YANG_LIST {
+				err = yangListDelData(curXlateParams, dbDataMap, subTreeResMap, false)
+				if err != nil {
+					return err
+				}
+			} else if (chldSpec.dbIndex == db.ConfigDB) && (chldYangType == YANG_LEAF || chldYangType == YANG_LEAF_LIST) && fillFields && !skipSibling {
+				//strip off the leaf/leaf-list for mapFillDataUtil takes URI without it
+				curXlateParams.uri = xlateParams.uri
+				curXlateParams.name = chldSpecYangEntry.Name
+				if chldYangType == YANG_LEAF_LIST {
+					curXlateParams.value = []interface{}{}
+				}
+				err = mapFillDataUtil(curXlateParams)
+				if err != nil {
+					xfmrLogDebug("Error received during leaf fill (\"%v\")", err)
+					switch e := err.(type) {
+					case tlerr.TranslibXfmrRetError:
+						ecode := e.XlateFailDelReq
+						log.Warningf("Error received (\"%v\"), ecode :%v", err, ecode)
+						if ecode {
+							return err
 						}
 					}
-					if !removedFillFields {
-						if fieldMap, ok := curXlateParams.result[curTbl][curKey]; ok {
-							if len(fieldMap.Field) > 1 {
-								delete(curXlateParams.result[curTbl][curKey].Field, "FillFields")
+				}
+				if !removedFillFields {
+					if fieldMap, ok := curXlateParams.result[curTbl][curKey]; ok {
+						if len(fieldMap.Field) > 1 {
+							delete(curXlateParams.result[curTbl][curKey].Field, "FillFields")
+							removedFillFields = true
+						} else if len(fieldMap.Field) == 1 {
+							if _, ok := curXlateParams.result[curTbl][curKey].Field["FillFields"]; !ok {
 								removedFillFields = true
-							} else if len(fieldMap.Field) == 1 {
-								if _, ok := curXlateParams.result[curTbl][curKey].Field["FillFields"]; !ok {
-									removedFillFields = true
-								}
 							}
 						}
 					}
-				} else {
-					xfmrLogDebug("%v", "Instance Fill case. Have filled the result table with table and key")
 				}
+			} else {
+				xfmrLogDebug("%v", "Instance Fill case. Have filled the result table with table and key")
 			}
 		}
 	}
@@ -564,6 +675,7 @@ func allChildTblGetToDelete(xlateParams xlateToParams) (map[string]map[string]db
 	if ok && spec.yangEntry != nil {
 		xlateParams.uri = xlateParams.requestUri
 		xlateParams.xpath = xpath
+		xlateParams.parentXpath = parentXpathGet(xpath)
 		yangType := spec.yangType
 		if yangType == YANG_LIST {
 			err = yangListDelData(xlateParams, &dbDataMap, &subTreeResMap, isFirstCall)
@@ -585,19 +697,15 @@ func dbMapDelete(d *db.DB, ygRoot *ygot.GoStruct, oper Operation, uri string, re
 	var cascadeDelTbl []string
 
 	/* Check if the parent table exists for RFC compliance */
-	var exists bool
 	var dbs [db.MaxDB]*db.DB
 	subOpMapDiscard := make(map[Operation]*RedisDbMap)
-	exists, err = verifyParentTable(d, dbs, ygRoot, oper, uri, nil, txCache, subOpMapDiscard, nil)
-	xfmrLogDebug("verifyParentTable() returned - exists - %v, err - %v", exists, err)
-	if err != nil {
-		if exists {
-			// Special case when we delete at container that does exist. Not required to do translation. Do not return error either.
-			return nil
-		}
-		log.Warningf("Cannot perform Operation %v on URI %v due to - %v", oper, uri, err)
-		return err
+	exists, parChkErr := verifyParentTable(d, dbs, ygRoot, oper, uri, nil, txCache, subOpMapDiscard, nil)
+	xfmrLogDebug("verifyParentTable() returned - exists - %v, err - %v", exists, parChkErr)
+	if parChkErr != nil && !exists {
+		log.Warningf("Cannot perform Operation %v on URI %v due to - %v", oper, uri, parChkErr)
+		return parChkErr
 	}
+	// Special case: If Resource not found in DB when we delete at container node(requestUri - parChkErr != nil && exists), continue to traverse to get child tables. Also identify a leaf case having default value when table does not exist to skip default value setting for non existent entry.
 	if !exists {
 		errStr := fmt.Sprintf("Parent table does not exist for uri(%v)", uri)
 		return tlerr.InternalError{Format: errStr}
@@ -641,11 +749,16 @@ func dbMapDelete(d *db.DB, ygRoot *ygot.GoStruct, oper Operation, uri string, re
 				}
 			}
 
-			if spec.cascadeDel == XFMR_ENABLE && xpathKeyExtRet.tableName != "" && xpathKeyExtRet.tableName != XFMR_NONE_STRING {
-				if !contains(cascadeDelTbl, xpathKeyExtRet.tableName) {
-					cascadeDelTbl = append(cascadeDelTbl, xpathKeyExtRet.tableName)
+			if len(xYangSpecMap[xpathKeyExtRet.xpath].validateFunc) > 0 && specYangType != YANG_LIST {
+				// For list cases evaluate for every instance to make sure the validation is done for the current instance
+				inParams := formXfmrInputRequest(d, dbs, db.ConfigDB, ygRoot, uri, requestUri, oper, xpathKeyExtRet.dbKey, nil, subOpDataMap, nil, txCache)
+				res := validateHandlerFunc(inParams, xYangSpecMap[xpathKeyExtRet.xpath].validateFunc)
+				if !res {
+					// Validate xfmr returns not valid hence, no further traversal required. return here
+					return nil
 				}
 			}
+
 			curXlateParams := formXlateToDbParam(d, ygRoot, oper, uri, requestUri, xpathKeyExtRet.xpath, xpathKeyExtRet.dbKey, jsonData, resultMap, result, txCache, nil, subOpDataMap, &cascadeDelTbl, &xfmrErr, "", "", xpathKeyExtRet.tableName, nil, nil, nil)
 			curXlateParams.xfmrDbTblKeyCache = make(map[string]tblKeyCache)
 			if len(spec.xfmrFunc) > 0 {
@@ -658,14 +771,15 @@ func dbMapDelete(d *db.DB, ygRoot *ygot.GoStruct, oper Operation, uri string, re
 				} else {
 					return err
 				}
-				// TODO: Nested subtree invoke
-				curResult, cerr := allChildTblGetToDelete(curXlateParams)
-				if cerr != nil {
-					return cerr
-				} else {
-					mapCopy(result, curResult)
+				// Traverse the tree only if the yang tree has a nested subtree
+				if spec.hasChildSubTree {
+					curResult, cerr := allChildTblGetToDelete(curXlateParams)
+					if cerr != nil {
+						return cerr
+					} else {
+						mapCopy(result, curResult)
+					}
 				}
-
 				if inParams.pCascadeDelTbl != nil && len(*inParams.pCascadeDelTbl) > 0 {
 					for _, tblNm := range *inParams.pCascadeDelTbl {
 						if !contains(cascadeDelTbl, tblNm) {
@@ -674,20 +788,22 @@ func dbMapDelete(d *db.DB, ygRoot *ygot.GoStruct, oper Operation, uri string, re
 					}
 				}
 			} else if specYangType == YANG_LEAF || specYangType == YANG_LEAF_LIST {
-				if len(xpathKeyExtRet.tableName) > 0 && len(xpathKeyExtRet.dbKey) > 0 {
+				xpath := xpathKeyExtRet.xpath
+				_, ok := xYangSpecMap[xpath]
+				if parChkErr != nil && exists && specYangType == YANG_LEAF && ok && len(xYangSpecMap[xpath].defVal) > 0 {
+					xfmrLogDebug("Do not reset to default for DELETE on leaf having default but maps to a table annotated at container that does not exist.")
+				} else if len(xpathKeyExtRet.tableName) > 0 && len(xpathKeyExtRet.dbKey) > 0 {
 					dataToDBMapAdd(xpathKeyExtRet.tableName, xpathKeyExtRet.dbKey, result, "", "")
-					xpath := xpathKeyExtRet.xpath
 					pathList := strings.Split(xpath, "/")
 					uriItemList := splitUri(strings.TrimSuffix(uri, "/"))
 					uriItemListLen := len(uriItemList)
 					var luri string
 					if uriItemListLen > 0 {
-						luri = strings.Join(uriItemList[:uriItemListLen-1], "/") //strip off the leaf/leaf-list for mapFillDataUtil takes URI without it
+						luri = "/" + strings.Join(uriItemList[:uriItemListLen-1], "/") //strip off the leaf/leaf-list for mapFillDataUtil takes URI without it
 
 					}
 
 					if specYangType == YANG_LEAF {
-						_, ok := xYangSpecMap[xpath]
 						if ok && len(xYangSpecMap[xpath].defVal) > 0 {
 							// Do not fill def value if leaf does not map to any redis field
 							dbSpecXpath := xpathKeyExtRet.tableName + "/" + xYangSpecMap[xpath].fieldName
@@ -760,15 +876,6 @@ func dbMapDelete(d *db.DB, ygRoot *ygot.GoStruct, oper Operation, uri string, re
 					mapCopy(result, curResult)
 				}
 				xfmrLogDebug("allChildTblGetToDelete result: %v  subtree curResult: %v", result, curResult)
-				// Add the child tables to delete when table at request URI is not available or its complete table delete request (not specific instance)
-				chResult := make(map[string]map[string]db.Value)
-				if (len(xpathKeyExtRet.tableName) == 0 || (len(xpathKeyExtRet.tableName) > 0 && len(xpathKeyExtRet.dbKey) == 0)) && len(spec.childTable) > 0 {
-					for _, child := range spec.childTable {
-						chResult[child] = make(map[string]db.Value)
-					}
-					xfmrLogDebug("Before adding children result: %v  result with child tables: %v", result, chResult)
-				}
-				mapCopy(result, chResult)
 			}
 
 			if xYangModSpecMap != nil {
@@ -782,7 +889,7 @@ func dbMapDelete(d *db.DB, ygRoot *ygot.GoStruct, oper Operation, uri string, re
 					var dbresult = make(RedisDbMap)
 					dbresult[db.ConfigDB] = result
 					inParams := formXfmrInputRequest(d, dbs, db.ConfigDB, ygRoot, uri, requestUri, oper, "", &dbresult, subOpDataMap, nil, txCache)
-					result, err = postXfmrHandlerFunc(xfmrPost, inParams)
+					err = postXfmrHandlerFunc(xfmrPost, inParams)
 					if err != nil {
 						return err
 					}
@@ -969,6 +1076,18 @@ func sonicYangReqToDbMapDelete(xlateParams xlateToParams) error {
 	}
 	xlateParams.resultMap[oper][db.ConfigDB] = xlateParams.result
 	return nil
+}
+
+func addInstanceToDeleteMap(tableName string, dbKey string, result map[string]map[string]db.Value, field string, value string, pCascadeDelTbl *[]string) {
+	dataToDBMapAdd(tableName, dbKey, result, field, value)
+	/* Add table to cascade delete list if annotation is available only for complete instance Delete case. */
+	if len(field) == 0 {
+		if tblSpecInfo, ok := xDbSpecMap[tableName]; ok && tblSpecInfo.cascadeDel == XFMR_ENABLE {
+			if pCascadeDelTbl != nil && !contains(*pCascadeDelTbl, tableName) {
+				*pCascadeDelTbl = append(*pCascadeDelTbl, tableName)
+			}
+		}
+	}
 }
 
 func checkAndProcessSonicYangNesetedListDelete(xlateParams xlateToParams, parentListNm string, nestedChildNm string) error {

--- a/translib/transformer/xlate_del_to_db.go
+++ b/translib/transformer/xlate_del_to_db.go
@@ -159,6 +159,8 @@ func yangListDelData(xlateParams xlateToParams, dbDataMap *map[db.DBNum]map[stri
 	xfmrLogDebug("tblList(%v), tbl(%v), key(%v)  for URI (\"%v\")", tblList, xlateParams.tableName, xlateParams.keyName, xlateParams.uri)
 	for _, tbl := range tblList {
 		curDbDataMap, ferr := fillDbDataMapForTbl(xlateParams.uri, xlateParams.xpath, tbl, keyName, cdb, dbs, xlateParams.dbTblKeyGetCache, nil)
+		log.Info("********************************** ferr ", ferr, " curDbData ", curDbDataMap)
+		log.Info("*****************************  ", (*dbDataMap)[cdb])
 		if (ferr == nil) && len(curDbDataMap) > 0 {
 			mapCopy((*dbDataMap)[cdb], curDbDataMap[cdb])
 		}
@@ -202,7 +204,7 @@ func yangListDelData(xlateParams xlateToParams, dbDataMap *map[db.DBNum]map[stri
 					continue
 				}
 
-				//Not required to check for table inheritence case here as we have a subtree and subtree is already processed before we get here
+				// Not required to check for table inheritence case here as we have a subtree and subtree is already processed before we get here
 				// We only need to traverse nested subtrees here
 				if len(spec.xfmrFunc) == 0 {
 					if spec.virtualTbl == nil && xpathKeyExtRet.isVirtualTbl {

--- a/translib/transformer/xlate_to_db.go
+++ b/translib/transformer/xlate_to_db.go
@@ -352,13 +352,22 @@ func dbMapDataFill(uri string, tableName string, keyName string, d map[string]in
 
 func dbMapDataFillForNestedList(tableName string, key string, nestedListDbEntry *yang.Entry, jsonData interface{}, result map[string]map[string]db.Value) {
 	/*function to process CRU request for nested/child list of list under table level container in sonic yang.*/
-	nestedListData := reflect.ValueOf(jsonData) //nested list slice/array containing its instances
+
 	/*As per current sonic yang structure in community nested list has only one key leaf that
 	  corresponds to dynamic field-name case.
 	*/
 	nestedListYangKeyName := strings.Split(nestedListDbEntry.Key, " ")[0]
-	for idx := 0; idx < nestedListData.Len(); idx++ {
-		nestedListInstance := nestedListData.Index(idx).Interface().(map[string]interface{}) //child/nested list instance
+	nestedListData, ok := jsonData.([]interface{}) //nested list slice/array containing its instances
+	if !ok {
+		log.Warningf("Invalid nested list data.")
+		return
+	}
+	for _, instance := range nestedListData {
+		nestedListInstance, ok := instance.(map[string]interface{}) //child/nested list instance
+		if !ok {
+			xfmrLogInfo("Invalid nested list instance type")
+			continue
+		}
 		fieldXpath := tableName + "/" + nestedListYangKeyName
 		fieldDbEntry := nestedListDbEntry.Dir[nestedListYangKeyName]
 		fieldName, err := unmarshalJsonToDbData(fieldDbEntry, fieldXpath, nestedListYangKeyName, nestedListInstance[nestedListYangKeyName])
@@ -736,7 +745,7 @@ func dbMapCreate(d *db.DB, ygRoot *ygot.GoStruct, oper Operation, uri string, re
 				if ok {
 					dbSpecField := tableName + "/" + fldNm
 					dbSpecInfo, dbFldok := xDbSpecMap[dbSpecField]
-					if dbFldok {
+					if dbFldok && dbSpecInfo != nil {
 						if dbSpecInfo.yangType == YANG_LEAF {
 							resultMap[UPDATE] = make(RedisDbMap)
 							resultMap[UPDATE][db.ConfigDB] = result
@@ -746,7 +755,7 @@ func dbMapCreate(d *db.DB, ygRoot *ygot.GoStruct, oper Operation, uri string, re
 						} else {
 							log.Warningf("For URI - %v, unrecognized terminal YANG node type", uri)
 						}
-					} else if !dbFldok {
+					} else if !dbFldok { //check for nested list case
 						nestedChildName := fldNm
 						dbSpecPath := tableName + "/" + fldPth[SONIC_TBL_CHILD_INDEX] + "/" + nestedChildName
 						dbSpecNestedChildInfo, ok := xDbSpecMap[dbSpecPath]
@@ -765,7 +774,8 @@ func dbMapCreate(d *db.DB, ygRoot *ygot.GoStruct, oper Operation, uri string, re
 						} else {
 							log.Warningf("For URI - %v, no entry found in xDbSpecMap for table(%v)/field(%v)", uri, tableName, fldNm)
 						}
-
+					} else {
+						log.Warningf("For URI - %v, no data found in xDbSpecMap for path - %v", uri, dbSpecField)
 					}
 				} else {
 					log.Warningf("For URI - %v, no entry found in xDbSpecMap with tableName - %v", uri, tableName)
@@ -838,7 +848,7 @@ func dbMapCreate(d *db.DB, ygRoot *ygot.GoStruct, oper Operation, uri string, re
 					var dbs [db.MaxDB]*db.DB
 					inParams := formXfmrInputRequest(d, dbs, db.ConfigDB, ygRoot, uri, requestUri, oper, "", &dbDataMap, subOpDataMap, nil, txCache)
 					inParams.yangDefValMap = yangDefValMap
-					result, err = postXfmrHandlerFunc(xfmrPost, inParams)
+					err = postXfmrHandlerFunc(xfmrPost, inParams)
 					if err != nil {
 						return err
 					}
@@ -1161,7 +1171,6 @@ func yangReqToDbMapCreate(xlateParams xlateToParams) error {
 
 func verifyParentTableSonic(d *db.DB, dbs [db.MaxDB]*db.DB, oper Operation, uri string, dbData RedisDbMap) (bool, error) {
 	var err error
-	var tableEntryFields db.Value
 
 	xpath, dbKey, table := sonicXpathKeyExtract(uri)
 	xfmrLogDebug("uri: %v xpath: %v table: %v, key: %v", uri, xpath, table, dbKey)
@@ -1188,7 +1197,7 @@ func verifyParentTableSonic(d *db.DB, dbs [db.MaxDB]*db.DB, oper Operation, uri 
 			tableExists = dbTableExistsInDbData(cdb, table, dbKey, dbData)
 		} else {
 			// Valid table mapping exists. Read the table entry from DB
-			tableExists, derr, tableEntryFields = dbTableExists(d, table, dbKey, oper)
+			tableExists, derr = dbTableExists(d, table, dbKey, oper)
 			if hasSingletonContainer && oper == DELETE {
 				// Special case when we delete at container that does'nt exist. Return true to skip translation.
 				if !tableExists {
@@ -1216,8 +1225,8 @@ func verifyParentTableSonic(d *db.DB, dbs [db.MaxDB]*db.DB, oper Operation, uri 
 		} else {
 			/*For CRUD operations on a nested list-intance or nested-list[intance]/leaf query
 			  check if nested-list instance exists in DB. For GET operation the resource check for
-			  nested list instance will be checked before populating data tinto yang from dbData,
-			  to optimize processing since dbdata will be referenced there anyways using nested list
+			  nested list instance will be done before populating data into yang from DBdata to
+			  optimize processing, since DBdata will be referenced there anyways using nested list
 			  instance key-value */
 			if len(pathList) > SONIC_TBL_CHILD_INDEX && oper != GET {
 				//extract nested-list name from pathList
@@ -1225,14 +1234,7 @@ func verifyParentTableSonic(d *db.DB, dbs [db.MaxDB]*db.DB, oper Operation, uri 
 				dbSpecField := table + "/" + pathElement
 				_, ok := xDbSpecMap[dbSpecField]
 				if !ok && pathElement != "" {
-					var nestedListErr error
-					dbData := map[string]map[string]db.Value{
-						table: {
-							dbKey: tableEntryFields,
-						},
-					}
-					nestedListErr = sonicNestedListRequestResourceCheck(uri, table, dbKey, pathList[SONIC_TBL_CHILD_INDEX-1], pathElement, dbData, oper)
-					if nestedListErr != nil {
+					if nestedListErr := sonicNestedListRequestResourceCheck(uri, table, dbKey, pathList[SONIC_TBL_CHILD_INDEX-1], pathElement, d, oper); nestedListErr != nil && oper != DELETE {
 						return false, nestedListErr
 					}
 				}
@@ -1307,7 +1309,7 @@ func verifyParentTblSubtree(dbs [db.MaxDB]*db.DB, uri string, xfmrFuncNm string,
 							parentTblExists = false
 							goto Exit
 						}
-						exists, err, _ = dbTableExists(dptr, table, dbKey, oper)
+						exists, err = dbTableExists(dptr, table, dbKey, oper)
 					} else {
 						d := dbs[dbNo]
 						if dbKey == "*" { //dbKey is "*" for GET on entire list
@@ -1320,7 +1322,7 @@ func verifyParentTblSubtree(dbs [db.MaxDB]*db.DB, uri string, xfmrFuncNm string,
 							xfmrLogDebug("Found table instance in dbData")
 							goto Exit
 						}
-						exists, err, _ = dbTableExists(d, table, dbKey, oper)
+						exists, err = dbTableExists(d, table, dbKey, oper)
 					}
 					if !exists || err != nil {
 						log.Warningf("Parent Tbl :%v, dbKey: %v does not exist for URI %v", table, dbKey, uri)
@@ -1346,6 +1348,7 @@ Exit:
 func verifyParentTableOc(d *db.DB, dbs [db.MaxDB]*db.DB, ygRoot *ygot.GoStruct, oper Operation, uri string, dbData RedisDbMap, txCache interface{}, subOpDataMap map[Operation]*RedisDbMap, dbTblKeyCache map[string]tblKeyCache) (bool, error) {
 	var err error
 	var cdb db.DBNum
+	var parentTable string
 	uriList := splitUri(uri)
 	parentTblExists := true
 	curUri := "/"
@@ -1442,7 +1445,7 @@ func verifyParentTableOc(d *db.DB, dbs [db.MaxDB]*db.DB, ygRoot *ygot.GoStruct, 
 					}
 					// Read the table entry from DB
 					if !existsInDbData {
-						exists, derr, _ := dbTableExists(d, xpathKeyExtRet.tableName, xpathKeyExtRet.dbKey, oper)
+						exists, derr := dbTableExists(d, xpathKeyExtRet.tableName, xpathKeyExtRet.dbKey, oper)
 						if derr != nil {
 							return false, derr
 						}
@@ -1453,6 +1456,7 @@ func verifyParentTableOc(d *db.DB, dbs [db.MaxDB]*db.DB, ygRoot *ygot.GoStruct, 
 							break
 						}
 					}
+					parentTable = xpathKeyExtRet.tableName
 				} else {
 					// We always expect a valid table and key to be returned. Else we cannot validate parent check
 					parentTblExists = false
@@ -1510,7 +1514,9 @@ func verifyParentTableOc(d *db.DB, dbs [db.MaxDB]*db.DB, ygRoot *ygot.GoStruct, 
 			}
 			return true, nil
 		}
-
+		if !((strings.HasSuffix(uri, "]")) || (strings.HasSuffix(uri, "]/"))) { //uri points to entire list
+			return true, nil
+		}
 		d = dbs[xpathInfo.dbIndex]
 		var xpathKeyExtRet xpathTblKeyExtractRet
 		var xerr error
@@ -1526,9 +1532,8 @@ func verifyParentTableOc(d *db.DB, dbs [db.MaxDB]*db.DB, ygRoot *ygot.GoStruct, 
 		if xpathKeyExtRet.isVirtualTbl {
 			return true, nil
 		}
-		if !((strings.HasSuffix(uri, "]")) || (strings.HasSuffix(uri, "]/"))) { //uri points to entire list
-			return true, nil
-		} else if len(xpathKeyExtRet.tableName) > 0 && len(xpathKeyExtRet.dbKey) > 0 {
+
+		if len(xpathKeyExtRet.tableName) > 0 && len(xpathKeyExtRet.dbKey) > 0 {
 			// Read the table entry from DB
 			exists := false
 			var derr error
@@ -1538,7 +1543,7 @@ func verifyParentTableOc(d *db.DB, dbs [db.MaxDB]*db.DB, ygRoot *ygot.GoStruct, 
 				xfmrLogDebug("db index for xpath - %v is %v", xpath, cdb)
 				exists = dbTableExistsInDbData(cdb, xpathKeyExtRet.tableName, xpathKeyExtRet.dbKey, dbData)
 				if !exists {
-					exists, derr, _ = dbTableExists(dbs[cdb], xpathKeyExtRet.tableName, xpathKeyExtRet.dbKey, oper)
+					exists, derr = dbTableExists(dbs[cdb], xpathKeyExtRet.tableName, xpathKeyExtRet.dbKey, oper)
 					if derr != nil {
 						return false, derr
 					}
@@ -1549,7 +1554,7 @@ func verifyParentTableOc(d *db.DB, dbs [db.MaxDB]*db.DB, ygRoot *ygot.GoStruct, 
 					}
 				}
 			} else {
-				exists, derr, _ = dbTableExists(d, xpathKeyExtRet.tableName, xpathKeyExtRet.dbKey, oper)
+				exists, derr = dbTableExists(d, xpathKeyExtRet.tableName, xpathKeyExtRet.dbKey, oper)
 			}
 			if derr != nil {
 				log.Warningf("ParentTable GetEntry failed for table: %v, key: %v err: %v", xpathKeyExtRet.tableName, xpathKeyExtRet.dbKey, derr)
@@ -1566,28 +1571,34 @@ func verifyParentTableOc(d *db.DB, dbs [db.MaxDB]*db.DB, ygRoot *ygot.GoStruct, 
 			log.Warningf("Parent table check: Unable to get valid table and key err: %v, table %v, key %v. Please verify table and key mapping", xerr, xpathKeyExtRet.tableName, xpathKeyExtRet.dbKey)
 			return false, xerr
 		}
-	} else if yangType == YANG_CONTAINER && oper == DELETE && ((xpathInfo.keyName != nil && len(*xpathInfo.keyName) > 0) || len(xpathInfo.xfmrKey) > 0) {
-		// If the delete is at container level and the container is mapped to a unique table, then check for table existence to avoid CVL throwing error
-		parentUri := ""
-		if len(parentUriList) > 0 {
-			parentUri = strings.Join(parentUriList, "/")
-			parentUri = "/" + parentUri
+	} else if oper == DELETE && (len(xpathInfo.xfmrFunc) == 0) && ((yangType == YANG_LEAF && len(xpathInfo.defVal) > 0) || (yangType == YANG_CONTAINER && ((xpathInfo.keyName != nil && len(*xpathInfo.keyName) > 0) || len(xpathInfo.xfmrKey) > 0))) {
+		// If the delete is at container/leaf(having default value) that is mapped to a unique table, then check for table existence to avoid CVL throwing error or reset default value at the leaf when table does not exist.
+
+		// Check for virtual table case at curUri
+		if xpathInfo.virtualTbl != nil && *xpathInfo.virtualTbl {
+			xfmrLogDebug("virtual table case for uri - %v", uri)
+			return true, nil
 		}
-		// Get table for parent xpath
-		parentTable, perr := dbTableFromUriGet(d, ygRoot, oper, parentUri, uri, nil, txCache, nil)
+		var perr error
+		if yangType == YANG_CONTAINER {
+			parentUri := ""
+			if len(parentUriList) > 0 {
+				parentUri = strings.Join(parentUriList, "/")
+				parentUri = "/" + parentUri
+			}
+			// Get table for parent xpath
+			parentTable, perr = dbTableFromUriGet(d, ygRoot, oper, parentUri, uri, nil, txCache, nil)
+		}
 		// Get table for current xpath
-		var xpathKeyExtRet xpathTblKeyExtractRet
-		var cerr error
-		if oper == GET {
-			xpathKeyExtRet, cerr = xpathKeyExtractForGet(d, ygRoot, oper, uri, uri, nil, subOpDataMap, txCache, dbTblKeyCache, dbs)
-		} else {
-			xpathKeyExtRet, cerr = xpathKeyExtract(d, ygRoot, oper, uri, uri, nil, subOpDataMap, txCache, nil, dbs)
+		xpathKeyExtRet, cerr := xpathKeyExtract(d, ygRoot, oper, uri, uri, nil, subOpDataMap, txCache, nil, dbs)
+		if xpathKeyExtRet.isVirtualTbl {
+			return true, nil
 		}
 		curKey := xpathKeyExtRet.dbKey
 		curTable := xpathKeyExtRet.tableName
 		if len(curTable) > 0 {
 			if perr == nil && cerr == nil && (curTable != parentTable) && len(curKey) > 0 {
-				exists, derr, _ := dbTableExists(d, curTable, curKey, oper)
+				exists, derr := dbTableExists(d, curTable, curKey, oper)
 				if !exists {
 					return true, derr
 				} else {

--- a/translib/transformer/xlate_to_db.go
+++ b/translib/transformer/xlate_to_db.go
@@ -1234,7 +1234,7 @@ func verifyParentTableSonic(d *db.DB, dbs [db.MaxDB]*db.DB, oper Operation, uri 
 				dbSpecField := table + "/" + pathElement
 				_, ok := xDbSpecMap[dbSpecField]
 				if !ok && pathElement != "" {
-					if nestedListErr := sonicNestedListRequestResourceCheck(uri, table, dbKey, pathList[SONIC_TBL_CHILD_INDEX-1], pathElement, d, oper); nestedListErr != nil && oper != DELETE {
+					if nestedListErr := sonicNestedListRequestResourceCheck(uri, table, dbKey, pathList[SONIC_TBL_CHILD_INDEX-1], pathElement, d, oper); nestedListErr != nil {
 						return false, nestedListErr
 					}
 				}

--- a/translib/transformer/xlate_xfmr_handler.go
+++ b/translib/transformer/xlate_xfmr_handler.go
@@ -339,36 +339,25 @@ func keyXfmrHandler(inParams XfmrParams, xfmrFuncNm string) (string, error) {
 }
 
 /* Invoke the post tansformer */
-func postXfmrHandlerFunc(xfmrPost string, inParams XfmrParams) (map[string]map[string]db.Value, error) {
-	const (
-		POST_XFMR_RET_ARGS     = 2
-		POST_XFMR_RET_VAL_INDX = 0
-		POST_XFMR_RET_ERR_INDX = 1
-	)
-	retData := make(map[string]map[string]db.Value)
+func postXfmrHandlerFunc(xfmrPost string, inParams XfmrParams) error {
+	const POST_XFMR_RET_ERR_INDX = 0
 	xfmrLogDebug("Before calling post xfmr %v, inParams %v", xfmrPost, inParams)
 	ret, err := XlateFuncCall(xfmrPost, inParams)
 	xfmrLogDebug("After calling post xfmr %v, inParams %v", xfmrPost, inParams)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	if (ret != nil) && (len(ret) > 0) {
-		if len(ret) == POST_XFMR_RET_ARGS {
-			// post xfmr returns err as second value in return data list from <xfmr_func>.Call()
-			if ret[POST_XFMR_RET_ERR_INDX].Interface() != nil {
-				err = ret[POST_XFMR_RET_ERR_INDX].Interface().(error)
-				if err != nil {
-					log.Warningf("Transformer function(\"%v\") returned error - %v.", xfmrPost, err)
-					return retData, err
-				}
+		// post xfmr returns err as the only value in return data list from <xfmr_func>.Call()
+		if ret[POST_XFMR_RET_ERR_INDX].Interface() != nil {
+			err = ret[POST_XFMR_RET_ERR_INDX].Interface().(error)
+			if err != nil {
+				log.Warningf("Transformer function(\"%v\") returned error - %v.", xfmrPost, err)
+				return err
 			}
 		}
-		if ret[POST_XFMR_RET_VAL_INDX].Interface() != nil {
-			retData = ret[POST_XFMR_RET_VAL_INDX].Interface().(map[string]map[string]db.Value)
-			xfmrLogDebug("Post xfmr function : %v retData : %v", xfmrPost, retData)
-		}
 	}
-	return retData, err
+	return err
 }
 
 /* Invoke the pre tansformer */


### PR DESCRIPTION
This enhancement to the transformer component in management framework will support DELETE operations using OpenConfig YANG models, enabling configuration data deletion through YANG data tree traversal. 

The DELETE operation will remove data resources under the specified target resource, identified by the RESTCONF target resource URI, which can be at any depth within a YANG data model.

Previously, deleting data resources with the DELETE operation at any depth of a YANG model was challenging, and support was limited to removing the target resource, not the hierarchy beneath it. This feature aims to address this issues by supporting  DELETE operation at any YANG depth.

This enhancement will be the base or prerequisite for supporting PUT/REPLACE operations at any yang depth, the support for the same will be brought in as a subsequent PR. 