### PR TITLE
model based delete handling in transformer infra for openconfig yangs

### DIFF
--- a/models/yang/annotations/sonic-extensions.yang
+++ b/models/yang/annotations/sonic-extensions.yang
@@ -75,9 +75,10 @@ module sonic-extensions {
     description "Transformer name that will perform post-translation tasks.";
   }
 
-  extension get-validate {
-    argument "get-validate-name";
-    description "Validation callpoint used to validate a YANG node during data translation back to YANG as a response to GET.";
+  extension validate-xfmr {
+    argument "validate-xfmr-name";
+    description "Validation callpoint used to validate a YANG node during data translation.
+		 Equivalent to XPath evaluation on when statement";
   }
 
   extension db-name {

--- a/models/yang/annotations/sonic-extensions.yang
+++ b/models/yang/annotations/sonic-extensions.yang
@@ -76,8 +76,8 @@ module sonic-extensions {
   }
 
   extension get-validate {
-	    argument "get-validate-name";
-	    description "Validation callpoint used to validate a YANG node during data translation back to YANG as a response to GET.";
+    argument "get-validate-name";
+    description "Validation callpoint used to validate a YANG node during data translation back to YANG as a response to GET.";
   }
 
   extension db-name {
@@ -107,7 +107,9 @@ module sonic-extensions {
 
   extension table-owner {
     argument "table-owner-flag";
-    description "Owner of the redis-db table.";
+    description  "Indicates table ownership of the redis-db table annotated at the node.
+                  The extension is applicable to the nodes annotated with table-name or table-transformer and having no subtree-transformer annotation.
+                  The table-owner is deemed to be true unless it is annotated with its value to 'false'.";
   }
 
   extension virtual-table {

--- a/translib/common_app.go
+++ b/translib/common_app.go
@@ -911,7 +911,7 @@ func deleteFields(existingEntry db.Value, d *db.DB, cmnAppTs *db.TableSpec, tblK
 			}
 			if deleteCount == len(existingEntry.Field) {
 				nullTblRw := db.Value{Field: map[string]string{"NULL": "NULL"}}
-				log.Info("Last field gets deleted, add NULL field to keep an db entry")
+				log.V(4).Infof("All existing fields(%v) getting deleted, add NULL field to keep the db entry/instance(%v)", existingEntry.Field, tblNm + "|" + tblKey)
 				err = d.ModEntry(cmnAppTs, db.Key{Comp: []string{tblKey}}, nullTblRw)
 				if err != nil {
 					log.Warning("UPDATE case - d.ModEntry() failure")

--- a/translib/common_app.go
+++ b/translib/common_app.go
@@ -911,7 +911,7 @@ func deleteFields(existingEntry db.Value, d *db.DB, cmnAppTs *db.TableSpec, tblK
 			}
 			if deleteCount == len(existingEntry.Field) {
 				nullTblRw := db.Value{Field: map[string]string{"NULL": "NULL"}}
-				log.V(4).Infof("All existing fields(%v) getting deleted, add NULL field to keep the db entry/instance(%v)", existingEntry.Field, tblNm + "|" + tblKey)
+				log.V(4).Infof("All existing fields(%v) getting deleted, add NULL field to keep the db entry/instance(%v)", existingEntry.Field, tblNm+"|"+tblKey)
 				err = d.ModEntry(cmnAppTs, db.Key{Comp: []string{tblKey}}, nullTblRw)
 				if err != nil {
 					log.Warning("UPDATE case - d.ModEntry() failure")

--- a/translib/common_app.go
+++ b/translib/common_app.go
@@ -604,9 +604,11 @@ func (app *CommonApp) translateCRUDCommon(d *db.DB, opcode int) ([]db.WatchKeys,
 	}
 
 	var resultTblList []string
+	resultTblMap := make(map[string]bool)
 	for _, dbMap := range result { //Get dependency list for all tables in result
-		for _, resMap := range dbMap { //Get dependency list for all tables in result
-			for tblnm := range resMap { //Get dependency list for all tables in result
+		for tblnm := range dbMap[db.ConfigDB] {
+			if !resultTblMap[tblnm] {
+				resultTblMap[tblnm] = true
 				resultTblList = append(resultTblList, tblnm)
 			}
 		}
@@ -891,6 +893,228 @@ func (app *CommonApp) cmnAppCRUCommonDbOpn(d *db.DB, opcode int, dbMap map[strin
 	return err
 }
 
+func deleteFields(existingEntry db.Value, d *db.DB, cmnAppTs *db.TableSpec, tblKey string, tblRw db.Value, deleteEmptyEntry bool) error {
+	var err error
+	log.V(4).Info("DELETE case - fields/cols to delete hence delete only those fields.")
+	/* handle leaf-list merge if any leaf-list exists */
+	tblNm := cmnAppTs.Name
+	resTblRw := checkAndProcessLeafList(existingEntry, tblRw, DELETE, d, tblNm, tblKey)
+	log.V(4).Info("DELETE case - checkAndProcessLeafList() returned table row ", resTblRw)
+	if len(resTblRw.Field) > 0 {
+		if !deleteEmptyEntry {
+			/* add the NULL field if the last field gets deleted && deleteEmpyEntry is false */
+			deleteCount := 0
+			for field := range existingEntry.Field {
+				if resTblRw.Has(field) {
+					deleteCount++
+				}
+			}
+			if deleteCount == len(existingEntry.Field) {
+				nullTblRw := db.Value{Field: map[string]string{"NULL": "NULL"}}
+				log.Info("Last field gets deleted, add NULL field to keep an db entry")
+				err = d.ModEntry(cmnAppTs, db.Key{Comp: []string{tblKey}}, nullTblRw)
+				if err != nil {
+					log.Warning("UPDATE case - d.ModEntry() failure")
+					return err
+				}
+			}
+		}
+		/* deleted fields */
+		err := d.DeleteEntryFields(cmnAppTs, db.Key{Comp: []string{tblKey}}, resTblRw)
+		if err != nil {
+			log.Warning("DELETE case - d.DeleteEntryFields() failure")
+			return err
+		}
+	}
+	return err
+}
+
+func (app *CommonApp) handleChildDeleteForOcReplaceAndDelete(d *db.DB, sortedDelTblLst []string, moduleNm string) error {
+	/* resultTblLst has child first, parent later order */
+	var err error
+
+	for _, tblNm := range sortedDelTblLst {
+		log.V(4).Info("In Yang to DB map returned from transformer looking for table = ", tblNm)
+		var parentKeysList []string
+		if tblVal, ok := app.cmnAppTableMap[DELETE][db.ConfigDB][tblNm]; ok {
+			cmnAppTs := &db.TableSpec{Name: tblNm}
+			if len(tblVal) == 0 {
+				log.Info("No table instances/rows found hence mark entire table to be deleted = ", tblNm)
+				/* handle child table cleanup when North Bound oper is REPLACE- TODO.
+				   For north bound DELETE child yang hierarchy traversal for target/request
+				   URI will populate the relevant child tables in the result map and
+				   SortAsPerTblDeps() on the tables in result map will take care of child table getting
+				   processed.There is no need to check CVL dependencies it being unaware of table mapped under
+				   under target URI.
+				*/
+				if app.cmnAppOpcode == REPLACE {
+					log.V(4).Info("process Table level Delete For North Bound Replace oper")
+					/* TODO - For North Bound REPLACE operation payload translation can result in
+					   data being populated in UPDATE map based on table ownership and also the
+					   scope of db-mapping at the target URL.DELETE map will contain whats not present
+					   in the payload in yang hiercharchy beneath the target URL.Thus data needs to be
+					   processed in order resolving dependencies to achieve the end result */
+				}
+				log.Info("deleting table = ", tblNm)
+				err = d.DeleteTable(cmnAppTs)
+				if err != nil {
+					log.Warning("d.DelTable() failure")
+					return err
+				}
+				continue
+			}
+			// Sort keys to make a list in order multiple keys first, single key last
+			ordDbKeyLst := transformer.SortSncTableDbKeys(tblNm, tblVal)
+			log.V(4).Infof("DELETE case - ordered list of DB keys for tbl %v = %v", tblNm, ordDbKeyLst)
+
+			for _, tblKey := range ordDbKeyLst {
+				tblRw := tblVal[tblKey]
+				if len(tblRw.Field) == 0 {
+					log.Info("DELETE case - no fields/cols to delete hence mark for delete the entire row having key = ", tblKey)
+					if app.cmnAppOpcode == REPLACE {
+						parentKeysList = append(parentKeysList, tblKey)
+					} else {
+						// DELETE case. We rely on the infra generated children as infra does the complete yang tree traversal.
+						// The SortAsPerTblDeps and keys sorting for same table makes sure that all children are deleted first.
+						// There is no need to check CVL dependencies. Just delete the entry.
+						log.Info("Delete entry ", cmnAppTs, db.Key{Comp: []string{tblKey}})
+						err = d.DeleteEntry(cmnAppTs, db.Key{Comp: []string{tblKey}})
+						if err != nil {
+							if cvl.CVLRetCode(err.(tlerr.TranslibCVLFailure).Code) == cvl.CVL_SEMANTIC_KEY_NOT_EXIST {
+								log.Infof("Ignore delete that cannot be processed for table %v key %v that does not exist. err %v", tblNm, tblKey, err.(tlerr.TranslibCVLFailure).CVLErrorInfo.ConstraintErrMsg)
+								err = nil
+							} else {
+								log.Warning("DELETE case - d.DeleteEntry() failure")
+								return err
+							}
+						}
+					}
+				} else {
+					// In case we have FillFields available in the tblRw, do not send the request to DB.
+					if len(tblRw.Field) == 1 {
+						if tblRw.Has("FillFields") {
+							continue
+						}
+					}
+					log.Info("DELETE case - fields/cols to delete hence delete only those fields.")
+					existingEntry, exstErr := d.GetEntry(cmnAppTs, db.Key{Comp: []string{tblKey}})
+					if exstErr != nil {
+						log.Info("Table Entry from which the fields are to be deleted does not exist. Ignore error for non existant instance for idempotency")
+						continue
+					}
+					if log.V(3) {
+						log.Info("Fields delete", cmnAppTs, db.Key{Comp: []string{tblKey}}, tblRw)
+					}
+					err = deleteFields(existingEntry, d, cmnAppTs, tblKey, tblRw, app.deleteEmptyEntry)
+					if err != nil {
+						log.Warning("DELETE case - deleteFields failure ")
+						return err
+					}
+				}
+			}
+			/* Delete the dependent entries for all keys in parentKeysList in case of REPLACE */
+			if app.cmnAppOpcode == REPLACE && len(parentKeysList) > 0 {
+				// TODO as mentioned in above comment
+			}
+		}
+	}
+	return err
+}
+
+func processChildTablesforDelete(d *db.DB, parentTblNm string, ordTblList []string) error {
+	var err error
+
+	cvlSess, err := d.NewValidationSession()
+	if err != nil || cvlSess == nil {
+		log.Info("getCVLDepDataForDelete : cvl.ValidationSessOpen failed")
+		return err
+	}
+	defer cvl.ValidationSessClose(cvlSess)
+
+	childrenWithinModule := make(map[string]bool)
+	// Get all children tables within the same module that are to be considered for delete
+	for _, ordtbl := range ordTblList {
+		if ordtbl == parentTblNm {
+			// Handle the child tables only till you reach the parent table entry
+			break
+		}
+		// Check if the child table is in DB. If no keys available then ignore the table
+		dbTblSpec := &db.TableSpec{Name: ordtbl}
+		chldKeys, getTblErr := d.GetKeys(dbTblSpec)
+		if getTblErr != nil {
+			log.V(4).Infof("GetKeys() failed for child table - %v - error - %v", ordtbl, getTblErr)
+			continue
+		}
+		if len(chldKeys) == 0 {
+			log.V(4).Infof("Child table %v not availble in DB. Hence not required to consider for Delete", ordtbl)
+			continue
+		}
+		childrenWithinModule[ordtbl] = true
+	}
+	if len(childrenWithinModule) == 0 {
+		log.V(4).Info("No action to take for child tables in DB")
+		return nil
+	}
+	log.Info("Since parent table is to be deleted, first deleting children within the same module= ", childrenWithinModule)
+
+	// Get all keys for parent table and check if the child table has a key based relationship
+	log.V(4).Info("Get Keys for parent Tbl ", parentTblNm)
+	parentTblSpec := &db.TableSpec{Name: parentTblNm}
+	parentTblKeys, getKeysErr := d.GetKeys(parentTblSpec)
+	if getKeysErr != nil {
+		log.Warningf("GetKeys() failed for parent table - %v - error - %v", parentTblNm, getKeysErr)
+	}
+	if len(parentTblKeys) == 0 {
+		log.Info("No DB data found so no action to take for parent table ", parentTblNm)
+		return nil
+	}
+
+	parentTblKeyMap := make(map[string]db.Value)
+	log.V(4).Info("parent table keys - ", parentTblKeys)
+	for _, parentKey := range parentTblKeys {
+		parentTblKeyMap[strings.Join(parentKey.Comp, "|")] = db.Value{}
+	}
+	log.V(4).Info("parent table key map - ", parentTblKeyMap)
+	// Sort the parent keys in child first order
+	ordParentTblKeys := transformer.SortSncTableDbKeys(parentTblNm, parentTblKeyMap)
+	log.V(4).Info("Sorted parent table keys - ", ordParentTblKeys)
+
+	// Delete Child table within the ordered list only if the child has a key based relationship to the parent
+	// If yes, then delete the child table
+	for _, parentKey := range ordParentTblKeys {
+		depList := cvlSess.GetDepDataForDelete(parentTblNm + "|" + parentKey)
+		log.V(4).Infof("GetDepDataForDelete for tblKey %v returned %v", parentKey, depList)
+		// GetDepDataForDelete gives in Parent first order. Hence traverse from the last element to delete last child first
+		for idx := len(depList) - 1; idx >= 0; idx-- {
+			depEntry := depList[idx]
+			for childInst, childInstData := range depEntry.Entry {
+				chldInstList := strings.SplitN(childInst, "|", 2)
+				if len(chldInstList) < 2 {
+					// No key available in the child table. Cannot process child table
+					continue
+				}
+				chldTbl := chldInstList[0]
+				// Check if the child table is in the list of children within the same module
+				// Delete the child instance if they have a key dependency to parent instance only
+				if _, deleteChildOk := childrenWithinModule[chldTbl]; deleteChildOk && len(childInstData) == 0 {
+					log.V(4).Infof("Child table %v has key relationship with parent table %v . Hence delete child", chldTbl, parentTblNm)
+					chldKey := chldInstList[1]
+					chldTs := &db.TableSpec{Name: chldTbl}
+					log.V(4).Info("DELETE case - child table instance to be deleted = ", chldKey)
+					err := d.DeleteEntry(chldTs, db.Key{Comp: []string{chldKey}})
+					if err != nil {
+						log.Warning("DELETE case - child table instance DeleteEntry failure ")
+						return err
+					}
+				} else {
+					log.Infof("Dependency table(%v) is either not child of same module or child table does not have a key dependency to parent table", chldTbl)
+				}
+			}
+		}
+	}
+	return nil
+}
+
 func (app *CommonApp) cmnAppDelDbOpn(d *db.DB, opcode int, dbMap map[string]map[string]db.Value) error {
 	var err error
 	var cmnAppTs, dbTblSpec *db.TableSpec
@@ -915,6 +1139,15 @@ func (app *CommonApp) cmnAppDelDbOpn(d *db.DB, opcode int, dbMap map[string]map[
 	}
 	log.Info("getModuleNmFromPath() returned module name = ", moduleNm)
 
+	isSonicUri := strings.HasPrefix(app.pathInfo.Path, "/sonic")
+	if !isSonicUri && (opcode == REPLACE || opcode == DELETE) {
+		log.V(4).Info("Special Handling for DELETE/REPLACE on non-sonic path")
+		err = app.handleChildDeleteForOcReplaceAndDelete(d, resultTblLst, moduleNm)
+		if err != nil {
+			log.Warning("handleChildDeleteForOcReplaceAndDelete() failed ", err)
+		}
+		return err
+	}
 	/* resultTblLst has child first, parent later order */
 	for _, tblNm := range resultTblLst {
 		log.Info("In Yang to DB map returned from transformer looking for table = ", tblNm)
@@ -935,21 +1168,22 @@ func (app *CommonApp) cmnAppDelDbOpn(d *db.DB, opcode int, dbMap map[string]map[
 			}
 			if len(tblVal) == 0 {
 				log.Info("DELETE case - No table instances/rows found hence delete entire table = ", tblNm)
-				if !app.skipOrdTableChk {
-					for _, ordtbl := range ordTblList {
-						if ordtbl == tblNm {
-							// Handle the child tables only till you reach the parent table entry
-							break
-						}
-						log.Info("Since parent table is to be deleted, first deleting child table = ", ordtbl)
-						dbTblSpec = &db.TableSpec{Name: ordtbl}
-						err = d.DeleteTable(dbTblSpec)
-						if err != nil {
-							log.Warning("DELETE case - d.DeleteTable() failure for Table = ", ordtbl)
-							return err
-						}
+				skipChildDelete := false
+				if len(ordTblList) == 1 && ordTblList[0] == tblNm {
+					skipChildDelete = true
+				}
+				if !skipChildDelete && !app.skipOrdTableChk {
+					// Delete Child table within same module only if the child has a key based relationship to the parent
+					// Get all keys for parent table and check if the child table has a key based relationship
+					// If yes, then delete the child table
+					err = processChildTablesforDelete(d, tblNm, ordTblList)
+					if err != nil {
+						log.Warning("processChildTablesforDelete() failed ", err)
+						return err
 					}
 				}
+				// Finally delete the parent table.
+				log.V(4).Info("DELETE case - Delete entire table = ", tblNm)
 				err = d.DeleteTable(cmnAppTs)
 				if err != nil {
 					log.Warning("DELETE case - d.DeleteTable() failure for Table = ", tblNm)
@@ -958,7 +1192,6 @@ func (app *CommonApp) cmnAppDelDbOpn(d *db.DB, opcode int, dbMap map[string]map[
 				log.Info("DELETE case - Deleted entire table = ", tblNm)
 				// Continue to repeat ordered deletion for all tables
 				continue
-
 			}
 			// Sort keys to make a list in order multiple keys first, single key last
 			ordDbKeyLst := transformer.SortSncTableDbKeys(tblNm, tblVal)
@@ -988,16 +1221,10 @@ func (app *CommonApp) cmnAppDelDbOpn(d *db.DB, opcode int, dbMap map[string]map[
 					}
 					err = d.DeleteEntry(cmnAppTs, db.Key{Comp: []string{tblKey}})
 					if err != nil {
-						switch e := err.(type) {
-						case tlerr.TranslibCVLFailure:
-							if cvl.CVLRetCode(e.Code) == cvl.CVL_SEMANTIC_KEY_NOT_EXIST {
-								log.Infof("Ignore delete that cannot be processed for table %v key %v that does not exist. err %v", tblNm, tblKey, e.CVLErrorInfo.ConstraintErrMsg)
-								err = nil
-							} else {
-								log.Warning("DELETE case - d.DeleteEntry() failure")
-								return err
-							}
-						default:
+						if cvl.CVLRetCode(err.(tlerr.TranslibCVLFailure).Code) == cvl.CVL_SEMANTIC_KEY_NOT_EXIST {
+							log.Infof("Ignore delete that cannot be processed for table %v key %v that does not exist. err %v", tblNm, tblKey, err.(tlerr.TranslibCVLFailure).CVLErrorInfo.ConstraintErrMsg)
+							err = nil
+						} else {
 							log.Warning("DELETE case - d.DeleteEntry() failure")
 							return err
 						}
@@ -1016,34 +1243,13 @@ func (app *CommonApp) cmnAppDelDbOpn(d *db.DB, opcode int, dbMap map[string]map[
 						log.Info("Table Entry from which the fields are to be deleted does not exist. Ignore error for non existant instance for idempotency")
 						continue
 					}
+
+					log.Info("Fields delete", cmnAppTs, db.Key{Comp: []string{tblKey}}, tblRw)
 					/* handle leaf-list merge if any leaf-list exists */
-					resTblRw := checkAndProcessLeafList(existingEntry, tblRw, DELETE, d, tblNm, tblKey)
-					log.Info("DELETE case - checkAndProcessLeafList() returned table row ", resTblRw)
-					if len(resTblRw.Field) > 0 {
-						if !app.deleteEmptyEntry {
-							/* add the NULL field if the last field gets deleted && deleteEmpyEntry is false */
-							deleteCount := 0
-							for field := range existingEntry.Field {
-								if resTblRw.Has(field) {
-									deleteCount++
-								}
-							}
-							if deleteCount == len(existingEntry.Field) {
-								nullTblRw := db.Value{Field: map[string]string{"NULL": "NULL"}}
-								log.Info("Last field gets deleted, add NULL field to keep an db entry")
-								err = d.ModEntry(cmnAppTs, db.Key{Comp: []string{tblKey}}, nullTblRw)
-								if err != nil {
-									log.Warning("UPDATE case - d.ModEntry() failure")
-									return err
-								}
-							}
-						}
-						/* deleted fields */
-						err := d.DeleteEntryFields(cmnAppTs, db.Key{Comp: []string{tblKey}}, resTblRw)
-						if err != nil {
-							log.Warning("DELETE case - d.DeleteEntryFields() failure")
-							return err
-						}
+					err = deleteFields(existingEntry, d, cmnAppTs, tblKey, tblRw, app.deleteEmptyEntry)
+					if err != nil {
+						log.Warning("DELETE case - deleteFields failure ")
+						return err
 					}
 				}
 			}

--- a/translib/db/db.go
+++ b/translib/db/db.go
@@ -333,6 +333,10 @@ func (d *DB) IsDirtified() bool {
 	return (len(d.txCmds) > 0)
 }
 
+func GetDBInstName(dbNo DBNum) string {
+	return getDBInstName(dbNo)
+}
+
 func getDBInstName(dbNo DBNum) string {
 	switch dbNo {
 	case ApplDB:

--- a/translib/db/db_config.go
+++ b/translib/db/db_config.go
@@ -159,3 +159,7 @@ func getDbPassword(dbName string) string {
 	}
 	return password
 }
+
+func GetDbConfigMap() map[string]interface{} {
+	return dbConfigMap
+}

--- a/translib/transformer/test/openconfig-test-xfmr-annot.yang
+++ b/translib/transformer/test/openconfig-test-xfmr-annot.yang
@@ -206,7 +206,6 @@ module openconfig-test-xfmr-annot {
     deviation /oc-test-xfmr:test-xfmr/oc-test-xfmr:test-ntp/oc-test-xfmr:test-ntp-keys/oc-test-xfmr:test-ntp-key {
       deviate add {
             sonic-ext:table-name "TEST_NTP_AUTHENTICATION_KEY";
-            //sonic-ext:key-transformer "test_ntp_authentication_key_xfmr";
       }
     }
 

--- a/translib/transformer/test/openconfig-test-xfmr-annot.yang
+++ b/translib/transformer/test/openconfig-test-xfmr-annot.yang
@@ -81,7 +81,7 @@ module openconfig-test-xfmr-annot {
     deviation /oc-test-xfmr:test-xfmr/oc-test-xfmr:test-sensor-groups/oc-test-xfmr:test-sensor-group/oc-test-xfmr:test-sensor-types/oc-test-xfmr:test-sensor-type/oc-test-xfmr:sensor-a-light-sensors {
       deviate add {
 	sonic-ext:table-name "NONE";
-        sonic-ext:get-validate "light_sensor_validate";
+        sonic-ext:validate-xfmr "light_sensor_validate";
       }
     }
 
@@ -108,6 +108,21 @@ module openconfig-test-xfmr-annot {
       deviate add {
             sonic-ext:table-name "TEST_SENSOR_ZONE_TABLE";
             sonic-ext:key-transformer "test_sensor_zone_key_xfmr";
+      }
+    }
+
+    deviation /oc-test-xfmr:test-xfmr/oc-test-xfmr:test-sets/oc-test-xfmr:system-zone-device-data {
+      deviate add {
+            sonic-ext:table-name "DEVICE_ZONE_METADATA";
+            sonic-ext:key-name "local-zonehost";
+            sonic-ext:table-owner "false";
+      }
+    }
+
+    deviation /oc-test-xfmr:test-xfmr/oc-test-xfmr:test-sets/oc-test-xfmr:transport-zone {
+      deviate add {
+            sonic-ext:table-name "TRANSPORT_ZONE";
+            sonic-ext:key-name "transport-host";
       }
     }
 
@@ -168,5 +183,101 @@ module openconfig-test-xfmr-annot {
         sonic-ext:key-name "global_sensor";
       }
     }
-}
 
+    deviation /oc-test-xfmr:test-xfmr/oc-test-xfmr:test-ntp {
+      deviate add {
+            sonic-ext:table-name "TEST_NTP";
+            sonic-ext:key-name "global";
+      }
+    }
+
+    deviation /oc-test-xfmr:test-xfmr/oc-test-xfmr:test-ntp/oc-test-xfmr:config/oc-test-xfmr:enable-ntp-auth {
+      deviate add {
+            sonic-ext:field-name "auth-enabled";
+      }
+    }
+
+    deviation /oc-test-xfmr:test-xfmr/oc-test-xfmr:test-ntp/oc-test-xfmr:test-ntp-keys {
+      deviate add {
+            sonic-ext:table-name "NONE";
+      }
+    }
+
+    deviation /oc-test-xfmr:test-xfmr/oc-test-xfmr:test-ntp/oc-test-xfmr:test-ntp-keys/oc-test-xfmr:test-ntp-key {
+      deviate add {
+            sonic-ext:table-name "TEST_NTP_AUTHENTICATION_KEY";
+            //sonic-ext:key-transformer "test_ntp_authentication_key_xfmr";
+      }
+    }
+
+    deviation /oc-test-xfmr:test-xfmr/oc-test-xfmr:test-ntp/oc-test-xfmr:test-ntp-keys/oc-test-xfmr:test-ntp-key/oc-test-xfmr:key-type {
+      deviate add {
+            sonic-ext:field-transformer "test_ntp_auth_key_type_xfmr";
+      }
+    }
+
+    deviation /oc-test-xfmr:test-xfmr/oc-test-xfmr:test-ntp/oc-test-xfmr:test-ntp-servers/oc-test-xfmr:test-ntp-server {
+      deviate add {
+            sonic-ext:table-name "TEST_NTP_SERVER";
+      }
+    }
+
+    deviation /oc-test-xfmr:test-xfmr/oc-test-xfmr:test-ni-instances/oc-test-xfmr:test-ni-instance {
+      deviate add {
+            sonic-ext:table-name "TEST_VRF";
+            sonic-ext:key-transformer "test_ni_instance_key_xfmr";
+      }
+    }
+
+    deviation /oc-test-xfmr:test-xfmr/oc-test-xfmr:test-ni-instances/oc-test-xfmr:test-ni-instance/oc-test-xfmr:test-protocols {
+      deviate add {
+            sonic-ext:table-name "NONE";
+      }
+    }
+
+    deviation /oc-test-xfmr:test-xfmr/oc-test-xfmr:test-ni-instances/oc-test-xfmr:test-ni-instance/oc-test-xfmr:test-protocols/oc-test-xfmr:test-protocol {
+      deviate add {
+            sonic-ext:table-transformer "test_ni_instance_protocol_table_xfmr";
+            sonic-ext:key-transformer "test_ni_instance_protocol_key_xfmr";
+      }
+    }
+
+    deviation /oc-test-xfmr:test-xfmr/oc-test-xfmr:test-ni-instances/oc-test-xfmr:test-ni-instance/oc-test-xfmr:test-protocols/oc-test-xfmr:test-protocol/oc-test-xfmr:bgp {
+      deviate add {
+            sonic-ext:validate-xfmr "validate_bgp_proto";
+      }
+    }
+
+    deviation /oc-test-xfmr:test-xfmr/oc-test-xfmr:test-ni-instances/oc-test-xfmr:test-ni-instance/oc-test-xfmr:test-protocols/oc-test-xfmr:test-protocol/oc-test-xfmr:bgp/oc-test-xfmr:network-cfgs/oc-test-xfmr:network-cfg {
+      deviate add {
+            sonic-ext:table-name "TEST_BGP_NETWORK_CFG";
+            sonic-ext:key-transformer "test_bgp_network_cfg_key_xfmr";
+      }
+    }
+
+    deviation /oc-test-xfmr:test-xfmr/oc-test-xfmr:test-ni-instances/oc-test-xfmr:test-ni-instance/oc-test-xfmr:test-protocols/oc-test-xfmr:test-protocol/oc-test-xfmr:ospfv2 {
+      deviate add {
+            sonic-ext:validate-xfmr "validate_ospfv2_proto";
+      }
+    }
+
+    deviation /oc-test-xfmr:test-xfmr/oc-test-xfmr:test-ni-instances/oc-test-xfmr:test-ni-instance/oc-test-xfmr:test-protocols/oc-test-xfmr:test-protocol/oc-test-xfmr:ospfv2/oc-test:global {
+      deviate add {
+            sonic-ext:table-name "TEST_OSPFV2_ROUTER";
+            sonic-ext:key-transformer "test_ospfv2_router_key_xfmr";
+      }
+    }
+
+    deviation /oc-test-xfmr:test-xfmr/oc-test-xfmr:test-ni-instances/oc-test-xfmr:test-ni-instance/oc-test-xfmr:test-protocols/oc-test-xfmr:test-protocol/oc-test-xfmr:ospfv2/oc-test:global/oc-test-xfmr:route-distribution-lists {
+      deviate add {
+            sonic-ext:table-name "NONE";
+      }
+    }
+
+    deviation /oc-test-xfmr:test-xfmr/oc-test-xfmr:test-ni-instances/oc-test-xfmr:test-ni-instance/oc-test-xfmr:test-protocols/oc-test-xfmr:test-protocol/oc-test-xfmr:ospfv2/oc-test:global/oc-test-xfmr:route-distribution-lists/oc-test-xfmr:route-distribution-list {
+      deviate add {
+            sonic-ext:table-name "TEST_OSPFV2_ROUTER_DISTRIBUTION";
+            sonic-ext:key-transformer "test_ospfv2_router_distribution_key_xfmr";
+      }
+    }
+}

--- a/translib/transformer/test/openconfig-test-xfmr.yang
+++ b/translib/transformer/test/openconfig-test-xfmr.yang
@@ -50,6 +50,23 @@ module openconfig-test-xfmr {
       "IP-layer test set with IPv6 addresses";
   }
 
+  identity TEST_NTP_AUTH_TYPE {
+    description
+      "Base identity for encryption schemes supported for NTP authentication keys";
+  }
+
+  identity TEST_NTP_AUTH_MD5 {
+    base TEST_NTP_AUTH_TYPE;
+    description
+      "MD5 encryption method";
+  }
+
+  identity TEST_NTP_AUTH_SHA {
+    base TEST_NTP_AUTH_TYPE;
+    description
+      "SHA encryption method";
+  }
+
   grouping test-sensor-group-top {
     description
       "Top level grouping for test-sensor-group configuration and operational
@@ -174,6 +191,59 @@ module openconfig-test-xfmr {
 
   // grouping statements
 
+  grouping system-zone {
+    description
+      "system-zone related data for test-sets";
+    container system-zone-device-data {  
+      container config {
+        leaf metric {
+          type uint32;
+        }
+        leaf hold-interval {
+          type uint32;
+        }
+      }
+      container state {
+        config false;
+        leaf metric {
+          type uint32;
+        }
+        leaf hold-interval {
+          type uint32;
+        }
+      }
+    }
+  }
+
+  grouping transport-zone-data {
+    container transport-zone {
+      container config {
+        leaf transport-keepalive-interval {
+          type uint32;
+        }
+        leaf restart-time {
+          type uint32;
+        }
+        leaf delay-time {
+          type uint32;
+          default 5;
+        }
+      }
+      container state {
+        config false;
+        leaf transport-keepalive-interval {
+          type uint32;
+        }
+        leaf restart-time {
+          type uint32;
+        }
+        leaf delay-time {
+          type uint32;
+        }
+      }
+    }
+  }
+
   grouping test-set-top {
     description
       "Access list entries variables top level container";
@@ -215,7 +285,9 @@ module openconfig-test-xfmr {
             "Test set  state information";
           uses test-set-config;
         }
-       }
+      }
+       uses system-zone;
+       uses transport-zone-data;
     }
   } 
 
@@ -655,6 +727,294 @@ module openconfig-test-xfmr {
           }
     }
   }
+
+  grouping bgp-data {
+    container bgp {
+      container network-cfgs {
+        list network-cfg {
+          key "network-id";
+          leaf network-id {
+            type leafref {
+              path "../config/network-id";
+            }
+          }
+          container config {
+            leaf network-id {
+              type uint32;
+            }
+            leaf policy-name {
+              type string;
+            }
+            leaf backdoor {
+              type boolean;
+            }
+          }
+          container state {
+            config false;
+            leaf network-id {
+              type uint32;
+            }
+            leaf policy-name {
+              type string;
+            }
+            leaf backdoor {
+              type boolean;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  grouping ospfv2-data {
+    container ospfv2 {
+      container global {
+        container config {
+          leaf enabled {
+            type boolean;
+          }
+          leaf write-multiplier {
+            type uint32;
+          }
+          leaf maximum-paths {
+            type uint32;
+          }
+        }
+        container state {
+          config false;
+          leaf enable {
+            type boolean;
+          }
+          leaf write-multiplier {
+            type uint32;
+          }
+          leaf maximum-paths {
+            type uint32;
+          }
+        } 
+        container timers {
+          container config {
+            leaf initial-delay {
+              type uint32;
+            }
+            leaf max-delay {
+              type uint32;
+            }
+          }
+          container state {
+            config false;
+            leaf initial-delay {
+              type uint32;
+            }
+            leaf max-delay {
+              type uint32;
+            }
+          }
+        }
+        container route-distribution-lists {
+          list route-distribution-list {
+            key "distribution-id";
+            leaf distribution-id {
+              type leafref {
+                path "../config/distribution-id";
+              }
+            }
+            container config {
+              leaf distribution-id {
+                type uint32;
+              }
+              leaf priority {
+                type uint32;
+              }
+              leaf table-id {
+                type uint32;
+              }
+            }
+            container state {
+              config false;
+              leaf distribution-id {
+                type uint32;
+              }
+              leaf priority {
+                type uint32;
+              }
+              leaf table-id {
+                type uint32;
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  grouping test-protocols-data {
+    container test-protocols {
+      list test-protocol {
+        key "name";
+        leaf name {
+          type leafref {
+            path "../config/name";
+          }
+        }
+        container config {
+          leaf name {
+            type string;
+          }
+        }
+        container state {
+          config false;
+          leaf name {
+            type string;
+          }
+        }
+
+        uses bgp-data;
+        uses ospfv2-data;
+      }
+    }
+  }
+
+  grouping test-ni-instance-data {
+    container test-ni-instances {
+      list test-ni-instance {
+        key "ni-name";
+        leaf ni-name {
+          type leafref {
+            path "../config/ni-name";
+          }
+          description
+            "Name of the test ni instance";
+        }
+        container config {
+          description
+            "Configuration parameters for the test ni instance";
+          leaf ni-name {
+            type string {
+              pattern "default|vrf-[a-zA-Z0-9]*";
+            }
+          }
+          leaf enabled {
+            type boolean;
+          }
+          leaf description {
+            type string;
+          }
+        }
+        container state {
+          config false;
+          leaf ni-name {
+            type string;
+          }
+          leaf enabled {
+            type boolean;
+          }
+          leaf description {
+            type string;
+          }
+        }
+        uses test-protocols-data;
+      }
+    }
+  }
+
+  grouping test-ntp-data {
+    container test-ntp {
+      container config {
+        leaf enable-ntp-auth {
+          type boolean;
+        }
+        leaf-list trusted-key {
+          type uint32;
+        }
+        leaf ni-name {
+          type string;
+        }
+      }
+      container state {
+        config false;
+        leaf enable-ntp-auth {
+          type boolean;
+        }
+        leaf-list trusted-key {
+          type uint32;
+        }
+        leaf ni-name {
+          type string;
+        }
+      }
+
+      container test-ntp-keys {
+        list test-ntp-key {
+          key "key-id";
+          leaf key-id {
+            type leafref {
+              path "../config/key-id";
+            }
+          }
+          container config {
+            leaf key-id {
+              type uint32;
+            }
+            leaf key-type {
+              type identityref {
+                base TEST_NTP_AUTH_TYPE;
+              }
+            }
+            leaf key-value {
+              type string;
+            }
+          }
+          container state {
+            config false;
+            leaf key-id {
+              type uint32;
+            }
+            leaf key-type {
+              type identityref {
+                base TEST_NTP_AUTH_TYPE;
+              }
+            }
+            leaf key-value {
+              type string;
+            }
+          }
+        }
+      }
+      container test-ntp-server {
+        list test-ntp-server {
+          key "server-id";
+          leaf server-id {
+            type leafref {
+              path "../config/server-id";
+            }
+          }
+          container config {
+            leaf server-id {
+              type uint32;
+            }
+            leaf key-id {
+              type uint32;
+            }
+            leaf min-poll {
+              type uint8;
+            }
+          }
+          container state {
+            config false;
+            leaf server-id {
+              type uint32;
+            }
+            leaf key-id {
+              type uint32;
+            }
+            leaf min-poll {
+              type uint8;
+            }
+          }
+        }
+      }
+    }
+  }
   ///////////////////
 
   // data definition statements
@@ -667,6 +1027,8 @@ module openconfig-test-xfmr {
     uses test-set-top;
     uses interfaces-top;
     uses test-global-sensor-config;
+    uses test-ni-instance-data;
+    uses test-ntp-data;
   }
   // augment statements
 

--- a/translib/transformer/test/sonic-test-xfmr.yang
+++ b/translib/transformer/test/sonic-test-xfmr.yang
@@ -19,6 +19,13 @@ module sonic-test-xfmr {
 			"Initial revision of Sonic transformer test yang.";
 	}
 
+        typedef ntp-key-type {
+                type enumeration {
+                        enum MD5; 
+                        enum SHA1;
+                }
+        }
+
 	container sonic-test-xfmr {
 
 		container TEST_SENSOR_GROUP {
@@ -339,6 +346,181 @@ module sonic-test-xfmr {
                                         }
                                 }
                         }
+                }
+
+                container DEVICE_ZONE_METADATA {
+                        container local-zonehost {
+                                 leaf metric {
+                                   type uint32;
+                                 }
+                                 leaf hold-interval {
+                                   type uint32;
+                                 }
+                                 leaf hwsku {
+                                   type string;                                         
+                                 }
+                                 leaf deployment-id {
+					type uint8;
+                                 }
+                        }
+                }
+
+                container TRANSPORT_ZONE {
+                        container transport-host {
+                                 leaf transport-keepalive-interval {
+                                   type uint32;
+                                 }
+                                 leaf restart-time {
+                                   type uint32;                                         
+                                 }
+                                 leaf delay-time {
+					type uint32;
+                                        default 5;
+                                 }
+                        }
+                }
+
+                container TEST_NTP {
+                        container global {
+                                 leaf auth-enabled {
+                                        type boolean;
+                                 }
+                                 leaf-list trusted-key {
+                                        type leafref {
+                                                path "/sonic-test-xfmr/TEST_NTP_AUTHENTICATION_KEY/NTP_AUTHENTICATION_KEY_LIST/id";
+                                        }                                         
+                                 }
+                                 leaf ni-name {
+                                        type string;
+                                 }
+                        }
+                }
+
+                container TEST_NTP_AUTHENTICATION_KEY {
+                         list NTP_AUTHENTICATION_KEY_LIST {
+                                key "id";
+
+                                leaf id {
+                                        type uint32;
+                                }                                
+                                leaf key-type {
+                                        mandatory true;
+                                        type ntp-key-type;
+                                }
+                                leaf key-value {
+                                        type string;
+                                }                               
+                          }
+                }
+
+                container TEST_NTP_SERVER {
+                         list NTP_SERVER_LIST {
+                                key "server-id";
+
+                                leaf server-id {
+                                        type uint32;
+                                }                                
+                                leaf key-id {
+                                        type leafref {
+                                                path "/sonic-test-xfmr/TEST_NTP_AUTHENTICATION_KEY/NTP_AUTHENTICATION_KEY_LIST/id";
+                                        } 
+                                }
+                                leaf min-poll {
+                                        type uint8 {
+                                                range "3..17";
+                                        }
+                                }                               
+                          }
+                }
+
+                container TEST_VRF {
+                         list TEST_VRF_LIST {
+                                key "test-vrf-name";
+
+                                leaf test-vrf-name {
+                                        type string {
+                                                pattern "default|Vrf_[a-zA-Z0-9]+" {
+                                                        error-message "Invalid VRF name";
+                                                        error-app-tag vrf-name-invalid;
+                                                }
+                                        }
+                                }                                
+                                leaf enabled {
+                                        type boolean;
+                                }
+                                leaf description {
+                                        type string;
+                                }                           
+                          }
+                }
+
+                container TEST_BGP_NETWORK_CFG {
+                         list TEST_BGP_NETWORK_CFG_LIST {
+                                key "test-vrf-name network-id";
+
+                                leaf test-vrf-name {
+                                        type leafref {
+                                                path "../../../TEST_VRF/TEST_VRF_LIST/test-vrf-name";
+                                        }
+                                }
+                                leaf network-id {
+                                        type uint32;
+                                }                                
+                                leaf backdoor {
+                                        type boolean;
+                                }                           
+                                leaf policy-name {
+                                        type string;
+                                }
+                          }
+                }
+
+                container TEST_OSPFV2_ROUTER {
+                         list TEST_OSPFV2_ROUTER_LIST {
+                                key "test-vrf-name";
+
+                                leaf test-vrf-name {
+                                        type leafref {
+                                                path "../../../TEST_VRF/TEST_VRF_LIST/test-vrf-name";
+                                        }
+                                }                             
+                                leaf enabled {
+                                        type boolean;
+                                }
+                                leaf write-multiplier {
+                                        type uint32;
+                                }
+                                leaf maximum-paths {
+                                        type uint32;
+                                } 
+                                leaf initial-delay {
+                                        type uint32;
+                                }
+                                leaf max-delay {
+                                        type uint32;
+                                }                          
+                          }
+                }
+
+                container TEST_OSPFV2_ROUTER_DISTRIBUTION {
+                         list TEST_OSPFV2_ROUTER_DISTRIBUTION_LIST {
+                                key "test-vrf-name distribution-id";
+
+                                leaf test-vrf-name {
+                                        type leafref {
+                                                path "../../../TEST_OSPFV2_ROUTER/TEST_OSPFV2_ROUTER_LIST/test-vrf-name";
+                                        }
+                                }                             
+                                leaf distribution-id {
+                                        type uint32;
+                                }
+                                leaf priority {
+                                        type uint32;
+                                }
+                                leaf table-id {
+                                        type uint32;
+                                }                  
+                         }
                 }
 	}
 }

--- a/translib/transformer/xfmr_interface.go
+++ b/translib/transformer/xfmr_interface.go
@@ -56,6 +56,7 @@ type XfmrParams struct {
 	pruneDone            *bool
 	invokeCRUSubtreeOnce *bool
 	ctxt                 context.Context
+	isNotTblOwner        *bool
 }
 
 // SubscProcType represents subcription process type identifying the type of subscription request made from translib.
@@ -197,8 +198,8 @@ type RpcCallpoint func(body []byte, dbs [db.MaxDB]*db.DB) ([]byte, error)
 // PostXfmrFunc type is defined to use for handling any default handling operations required as part of the CREATE
 // Transformer function definition.
 // Param: XfmrParams structure having database pointers, current db, operation, DB data in multidimensional map, YgotRoot, uri
-// Return: Multi dimensional map to hold the DB data Map (tblName, key and Fields), error
-type PostXfmrFunc func(inParams XfmrParams) (map[string]map[string]db.Value, error)
+// Return: error
+type PostXfmrFunc func(inParams XfmrParams) error
 
 // TableXfmrFunc type is defined to use for table transformer function for dynamic derviation of redis table.
 // Param: XfmrParams structure having database pointers, current db, operation, DB data in multidimensional map, YgotRoot, uri

--- a/translib/transformer/xfmr_intf.go
+++ b/translib/transformer/xfmr_intf.go
@@ -1574,10 +1574,9 @@ var DbToYang_intf_get_ether_counters_xfmr SubTreeXfmrDbToYang = func(inParams Xf
 	return populatePortCounters(inParams, eth_counters)
 }
 
-var intf_post_xfmr PostXfmrFunc = func(inParams XfmrParams) (map[string]map[string]db.Value, error) {
+var intf_post_xfmr PostXfmrFunc = func(inParams XfmrParams) error {
 
 	requestUriPath := (NewPathInfo(inParams.requestUri)).YangPath
-	retDbDataMap := (*inParams.dbDataMap)[inParams.curDb]
 	log.Info("Entering intf_post_xfmr")
 	log.Info(requestUriPath)
 	xpath, _, _ := XfmrRemoveXPATHPredicates(inParams.requestUri)
@@ -1588,7 +1587,7 @@ var intf_post_xfmr PostXfmrFunc = func(inParams XfmrParams) (map[string]map[stri
 		/* Preventing delete at IPv6 config level*/
 		if xpath == "/openconfig-interfaces:interfaces/interface/subinterfaces/subinterface/ipv6/config" {
 			log.Info("In interface Post transformer for DELETE op ==> URI : ", inParams.requestUri)
-			return retDbDataMap, tlerr.NotSupported(err_str)
+			return tlerr.NotSupported(err_str)
 		}
 
 		/* For delete request and for fields with default value, transformer adds subOp map with update operation (to update with default value).
@@ -1613,7 +1612,7 @@ var intf_post_xfmr PostXfmrFunc = func(inParams XfmrParams) (map[string]map[stri
 			}
 		}
 	}
-	return retDbDataMap, nil
+	return nil
 }
 
 var intf_pre_xfmr PreXfmrFunc = func(inParams XfmrParams) error {

--- a/translib/transformer/xfmr_testxfmr_callbacks.go
+++ b/translib/transformer/xfmr_testxfmr_callbacks.go
@@ -833,27 +833,6 @@ func light_sensor_validate(inParams XfmrParams) bool {
 	return traversal_valid
 }
 
-/*
-var YangToDb_test_ntp_authentication_key_xfmr KeyXfmrYangToDb = func(inParams XfmrParams) (string, error) {
-	log.Info("YangToDb_test_ntp_authentication_key_xfmr", inParams.uri)
-	pathInfo := NewPathInfo(inParams.uri)
-	auth_key := pathInfo.Var("key-id")
-	return auth_key, nil
-
-}
-
-var DbToYang_test_ntp_authentication_key_xfmr KeyXfmrDbToYang = func(inParams XfmrParams) (map[string]interface{}, error) {
-	log.Info("DbToYang_test_ntp_authentication_key_xfmr", inParams.uri)
-	var rmap map[string]interface{}
-	if inParams.key != "" {
-		rmap := make(map[string]interface{})
-		rmap["key-id"] = inParams.key
-	}
-	log.Info("DbToYang_test_ntp_authentication_key_xfmr returning ", rmap)
-	return rmap, nil
-}
-*/
-
 var YangToDb_test_ni_instance_key_xfmr KeyXfmrYangToDb = func(inParams XfmrParams) (string, error) {
 	var db_ni_name string
 	var err error

--- a/translib/transformer/xfmr_testxfmr_callbacks.go
+++ b/translib/transformer/xfmr_testxfmr_callbacks.go
@@ -41,6 +41,7 @@ func init() {
 
 	// Table transformer functions
 	XlateFuncBind("test_sensor_type_tbl_xfmr", test_sensor_type_tbl_xfmr)
+	XlateFuncBind("test_ni_instance_protocol_table_xfmr", test_ni_instance_protocol_table_xfmr)
 
 	// Key transformer functions
 	XlateFuncBind("YangToDb_test_sensor_type_key_xfmr", YangToDb_test_sensor_type_key_xfmr)
@@ -51,6 +52,17 @@ func init() {
 	XlateFuncBind("DbToYang_test_set_key_xfmr", DbToYang_test_set_key_xfmr)
 	XlateFuncBind("YangToDb_sensor_a_light_sensor_key_xfmr", YangToDb_sensor_a_light_sensor_key_xfmr)
 	XlateFuncBind("DbToYang_sensor_a_light_sensor_key_xfmr", DbToYang_sensor_a_light_sensor_key_xfmr)
+	//XlateFuncBind("YangToDb_test_ntp_authentication_key_xfmr", YangToDb_test_ntp_authentication_key_xfmr)
+	//XlateFuncBind("DbToYang_test_ntp_authentication_key_xfmr", DbToYang_test_ntp_authentication_key_xfmr)
+	XlateFuncBind("YangToDb_test_ni_instance_key_xfmr", YangToDb_test_ni_instance_key_xfmr)
+	XlateFuncBind("DbToYang_test_ni_instance_key_xfmr", DbToYang_test_ni_instance_key_xfmr)
+	XlateFuncBind("YangToDb_test_ni_instance_protocol_key_xfmr", YangToDb_test_ni_instance_protocol_key_xfmr)
+	XlateFuncBind("DbToYang_test_ni_instance_protocol_key_xfmr", DbToYang_test_ni_instance_protocol_key_xfmr)
+	XlateFuncBind("YangToDb_test_bgp_network_cfg_key_xfmr", YangToDb_test_bgp_network_cfg_key_xfmr)
+	XlateFuncBind("DbToYang_test_bgp_network_cfg_key_xfmr", DbToYang_test_bgp_network_cfg_key_xfmr)
+	XlateFuncBind("YangToDb_test_ospfv2_router_distribution_key_xfmr", YangToDb_test_ospfv2_router_distribution_key_xfmr)
+	XlateFuncBind("DbToYang_test_ospfv2_router_distribution_key_xfmr", DbToYang_test_ospfv2_router_distribution_key_xfmr)
+	XlateFuncBind("YangToDb_test_ospfv2_router_key_xfmr", YangToDb_test_ospfv2_router_key_xfmr)
 
 	// Key leafrefed Field transformer functions
 	XlateFuncBind("DbToYang_test_sensor_type_field_xfmr", DbToYang_test_sensor_type_field_xfmr)
@@ -71,6 +83,8 @@ func init() {
 
 	//validate transformer
 	XlateFuncBind("light_sensor_validate", light_sensor_validate)
+	XlateFuncBind("validate_bgp_proto", validate_bgp_proto)
+	XlateFuncBind("validate_ospfv2_proto", validate_ospfv2_proto)
 
 	// Sonic yang Key transformer functions
 	XlateFuncBind("DbToYang_test_sensor_mode_key_xfmr", DbToYang_test_sensor_mode_key_xfmr)
@@ -112,7 +126,7 @@ var test_pre_xfmr PreXfmrFunc = func(inParams XfmrParams) error {
 	return err
 }
 
-var test_post_xfmr PostXfmrFunc = func(inParams XfmrParams) (map[string]map[string]db.Value, error) {
+var test_post_xfmr PostXfmrFunc = func(inParams XfmrParams) error {
 
 	pathInfo := NewPathInfo(inParams.uri)
 	groupId := pathInfo.Var("id")
@@ -132,7 +146,7 @@ var test_post_xfmr PostXfmrFunc = func(inParams XfmrParams) (map[string]map[stri
 			inParams.subOpDataMap[CREATE] = &subOpCreateMap
 		}
 	}
-	return retDbDataMap, nil
+	return nil
 }
 
 var test_sensor_type_tbl_xfmr TableXfmrFunc = func(inParams XfmrParams) ([]string, error) {
@@ -171,7 +185,7 @@ var YangToDb_test_sensor_type_key_xfmr KeyXfmrYangToDb = func(inParams XfmrParam
 	pathInfo := NewPathInfo(inParams.uri)
 	groupId := pathInfo.Var("id")
 	sensorType := pathInfo.Var("type")
-	if groupId == "" || sensorType == "" {
+	if groupId == "" {
 		return sensor_type_key, err
 	}
 	if len(groupId) > 0 {
@@ -182,6 +196,8 @@ var YangToDb_test_sensor_type_key_xfmr KeyXfmrYangToDb = func(inParams XfmrParam
 		} else if strings.HasPrefix(sensorType, "sensorb_") {
 			sensor_type = strings.Replace(sensorType, "sensorb_", "sensor_type_b_", 1)
 			sensor_type_key = groupId + "|" + sensor_type
+		} else if sensorType == "" && (strings.HasSuffix(inParams.uri, "/test-sensor-type")) && (inParams.oper == GET || inParams.oper == DELETE) {
+			sensor_type_key = groupId
 		} else {
 			err_str := "Invalid key. Key not supported."
 			err = tlerr.NotSupported(err_str)
@@ -760,6 +776,8 @@ var YangToDb_sensor_a_light_sensor_key_xfmr KeyXfmrYangToDb = func(inParams Xfmr
 	sensorType := pathInfo.Var("type")
 	lightSensorTag := pathInfo.Var("tag")
 	if groupId == "" || sensorType == "" {
+		err_str := "Invalid key. Key not supported."
+		err = tlerr.NotSupported(err_str)
 		return light_sensor_key, err
 	}
 	sensor_type := ""
@@ -773,11 +791,10 @@ var YangToDb_sensor_a_light_sensor_key_xfmr KeyXfmrYangToDb = func(inParams Xfmr
 		err_str := "Invalid key. Key not supported."
 		err = tlerr.NotSupported(err_str)
 	}
-	if err == nil {
+	if err == nil && lightSensorTag != "" {
 		sensor_tag := strings.Replace(lightSensorTag, "lightsensor_", "light_sensor_", 1)
 		light_sensor_key += "|" + sensor_tag
 	}
-
 	log.Info("YangToDb_sensor_a_light_sensor_key_xfmr returns", light_sensor_key)
 	return light_sensor_key, err
 }
@@ -814,4 +831,269 @@ func light_sensor_validate(inParams XfmrParams) bool {
 	}
 	log.Info("light_sensor_validate returning ", traversal_valid)
 	return traversal_valid
+}
+
+/*
+var YangToDb_test_ntp_authentication_key_xfmr KeyXfmrYangToDb = func(inParams XfmrParams) (string, error) {
+	log.Info("YangToDb_test_ntp_authentication_key_xfmr", inParams.uri)
+	pathInfo := NewPathInfo(inParams.uri)
+	auth_key := pathInfo.Var("key-id")
+	return auth_key, nil
+
+}
+
+var DbToYang_test_ntp_authentication_key_xfmr KeyXfmrDbToYang = func(inParams XfmrParams) (map[string]interface{}, error) {
+	log.Info("DbToYang_test_ntp_authentication_key_xfmr", inParams.uri)
+	var rmap map[string]interface{}
+	if inParams.key != "" {
+		rmap := make(map[string]interface{})
+		rmap["key-id"] = inParams.key
+	}
+	log.Info("DbToYang_test_ntp_authentication_key_xfmr returning ", rmap)
+	return rmap, nil
+}
+*/
+
+var YangToDb_test_ni_instance_key_xfmr KeyXfmrYangToDb = func(inParams XfmrParams) (string, error) {
+	var db_ni_name string
+	var err error
+	log.Info("YangToDb_test_ni_instance_key_xfmr ", inParams.uri)
+	pathInfo := NewPathInfo(inParams.uri)
+	ni_name := pathInfo.Var("ni-name")
+
+	if strings.HasPrefix(ni_name, "vrf-") {
+		db_ni_name = strings.Replace(ni_name, "vrf-", "Vrf_", 1)
+	} else if strings.HasPrefix(ni_name, "default") {
+		db_ni_name = ni_name
+	} else if ni_name != "" {
+		err_str := "Invalid key. Key not supported."
+		err = tlerr.NotSupported(err_str)
+	}
+	log.Info("YangToDb_test_ni_instance_key_xfmr returning db_ni_name ", db_ni_name, " error ", err)
+	return db_ni_name, err
+}
+
+var DbToYang_test_ni_instance_key_xfmr KeyXfmrDbToYang = func(inParams XfmrParams) (map[string]interface{}, error) {
+	log.Info("DbToYang_test_ni_instance_key_xfmr ", inParams.uri)
+	var rmap map[string]interface{}
+	var ni_name string
+
+	if inParams.key == "default" {
+		ni_name = "default"
+	} else {
+		ni_name = strings.Replace(inParams.key, "Vrf_", "vrf-", 1)
+	}
+	rmap = make(map[string]interface{})
+	rmap["ni-name"] = ni_name
+
+	log.Info("DbToYang_test_ni_instance_key_xfmr returning ", rmap)
+	return rmap, nil
+}
+
+var test_ni_instance_protocol_table_xfmr TableXfmrFunc = func(inParams XfmrParams) ([]string, error) {
+	var tblList []string
+	var err error
+
+	log.Info("test_ni_instance_protocol_table_xfmr", inParams.uri)
+	if inParams.oper == GET || inParams.oper == DELETE {
+		pathInfo := NewPathInfo(inParams.uri)
+		ni_name := pathInfo.Var("ni-name")
+		proto_name := pathInfo.Var("name")
+		log.Info("test_ni_instance_protocol_table_xfmr ni-inatnce ", ni_name, " proto name ", proto_name)
+		cfg_tbl_updated := false
+		if inParams.dbDataMap != nil {
+			log.Info("test_ni_instance_protocol_table_xfmr  tblList dbDataMap ", (*inParams.dbDataMap)[db.ConfigDB])
+			if (ni_name == "default") || (strings.HasPrefix(ni_name, "vrf-")) {
+				if proto_name == "" { // inParams.uri at whole list level, hence add all child instances to be traversed
+					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"] = make(map[string]db.Value)
+					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"]["bgp"] = db.Value{Field: make(map[string]string)}
+					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"]["bgp"].Field["NULL"] = "NULL"
+					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"]["ospfv2"] = db.Value{Field: make(map[string]string)}
+					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"]["ospfv2"].Field["NULL"] = "NULL"
+					cfg_tbl_updated = true
+					log.Info("test_ni_instance_protocol_table_xfmr returning (*inParams.dbDataMap)[db.ConfigDB] ", (*inParams.dbDataMap)[db.ConfigDB])
+				} else if proto_name == "bgp" {
+					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"] = make(map[string]db.Value)
+					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"]["bgp"] = db.Value{Field: make(map[string]string)}
+					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"]["bgp"].Field["NULL"] = "NULL"
+					cfg_tbl_updated = true
+					log.Info("test_ni_instance_protocol_table_xfmr returning (*inParams.dbDataMap)[db.ConfigDB] ", (*inParams.dbDataMap)[db.ConfigDB])
+				} else if proto_name == "ospfv2" {
+					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"] = make(map[string]db.Value)
+					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"]["ospfv2"] = db.Value{Field: make(map[string]string)}
+					(*inParams.dbDataMap)[db.ConfigDB]["TEST_CFG_PROTO_TBL"]["ospfv2"].Field["NULL"] = "NULL"
+					cfg_tbl_updated = true
+					log.Info("test_ni_instance_protocol_table_xfmr returning (*inParams.dbDataMap)[db.ConfigDB] ", (*inParams.dbDataMap)[db.ConfigDB])
+				} else {
+					err_str := "Invalid protocol key. Key not supported."
+					err = tlerr.NotSupported(err_str)
+				}
+			} else {
+				err_str := "Invalid ni-instance key. Key not supported."
+				err = tlerr.NotSupported(err_str)
+			}
+		}
+		if cfg_tbl_updated {
+			tblList = append(tblList, "TEST_CFG_PROTO_TBL")
+		}
+	}
+	*inParams.isVirtualTbl = true
+	log.Info("test_ni_instance_protocol_table_xfmr returning tblList ", tblList, " error ", err)
+	return tblList, err
+}
+
+var YangToDb_test_ni_instance_protocol_key_xfmr KeyXfmrYangToDb = func(inParams XfmrParams) (string, error) {
+	var key string
+	var err error
+
+	if inParams.oper == GET || inParams.oper == DELETE {
+		pathInfo := NewPathInfo(inParams.uri)
+		ni_name := pathInfo.Var("ni-name")
+		proto_name := pathInfo.Var("name")
+		log.Info("YangToDb_test_ni_instance_protocol_key_xfmr received ni-instance ", ni_name, " protocol name ", proto_name)
+		if (ni_name == "default") || (strings.HasPrefix(ni_name, "vrf-")) {
+			if proto_name == "bgp" {
+				key = "bgp"
+			} else if proto_name == "ospfv2" {
+				key = "ospfv2"
+			} else if proto_name != "" {
+				err_str := "Invalid protocol key. Key not supported."
+				err = tlerr.NotSupported(err_str)
+			}
+		} else {
+			err_str := "Invalid ni-instance key. Key not supported."
+			err = tlerr.NotSupported(err_str)
+		}
+	}
+	log.Info("YangToDb_test_ni_instance_protocol_key_xfmr returning key ", key, " error ", err)
+	return key, err
+}
+
+var DbToYang_test_ni_instance_protocol_key_xfmr KeyXfmrDbToYang = func(inParams XfmrParams) (map[string]interface{}, error) {
+	rmap := make(map[string]interface{})
+	rmap["name"] = inParams.key
+	log.Info("DbToYang_test_ni_instance_protocol_key_xfmr returning ", rmap)
+	return rmap, nil
+}
+
+func checkNwInstanceProtocol(inParams XfmrParams, protoNm string) bool {
+	pathInfo := NewPathInfo(inParams.uri)
+	proto_name := pathInfo.Var("name")
+	log.Info("checkNwInstanceProtocol() through validate handler ", proto_name)
+	return proto_name == protoNm
+}
+
+func validate_bgp_proto(inParams XfmrParams) bool {
+	return checkNwInstanceProtocol(inParams, "bgp")
+}
+
+func validate_ospfv2_proto(inParams XfmrParams) bool {
+	return checkNwInstanceProtocol(inParams, "ospfv2")
+}
+
+var YangToDb_test_ospfv2_router_key_xfmr KeyXfmrYangToDb = func(inParams XfmrParams) (string, error) {
+	var ospfv2_db_key string
+	var err error
+	log.Info("YangToDb_test_ospfv2_router_key_xfmr ", inParams.uri)
+	pathInfo := NewPathInfo(inParams.uri)
+	ni_name := pathInfo.Var("ni-name")
+
+	if strings.HasPrefix(ni_name, "vrf-") {
+		ospfv2_db_key = strings.Replace(ni_name, "vrf-", "Vrf_", 1)
+	} else if strings.HasPrefix(ni_name, "default") {
+		ospfv2_db_key = ni_name
+	} else if ni_name != "" {
+		err_str := "Invalid network-instance key. Key not supported."
+		err = tlerr.NotSupported(err_str)
+	}
+	log.Info("YangToDb_test_ospfv2_router_key_xfmr returning ", ospfv2_db_key, " error ", err)
+	return ospfv2_db_key, err
+}
+
+var YangToDb_test_ospfv2_router_distribution_key_xfmr KeyXfmrYangToDb = func(inParams XfmrParams) (string, error) {
+	var db_ni_name, ospfv2_db_key string
+	var err error
+	log.Info("YangToDb_test_ospfv2_router_distribution_key_xfmr ", inParams.uri)
+	pathInfo := NewPathInfo(inParams.uri)
+	ni_name := pathInfo.Var("ni-name")
+	distribution_id := pathInfo.Var("distribution-id")
+
+	if strings.HasPrefix(ni_name, "vrf-") {
+		db_ni_name = strings.Replace(ni_name, "vrf-", "Vrf_", 1)
+	} else if strings.HasPrefix(ni_name, "default") {
+		db_ni_name = ni_name
+	} else if ni_name != "" {
+		err_str := "Invalid key. Key not supported."
+		err = tlerr.NotSupported(err_str)
+	}
+
+	if distribution_id != "" {
+		ospfv2_db_key = db_ni_name + "|" + distribution_id
+	} else {
+		ospfv2_db_key = db_ni_name
+	}
+
+	log.Info("YangToDb_test_ospfv2_router_distribution_key_xfmr returning ", ospfv2_db_key, " error ", err)
+	return ospfv2_db_key, err
+}
+
+var DbToYang_test_ospfv2_router_distribution_key_xfmr KeyXfmrDbToYang = func(inParams XfmrParams) (map[string]interface{}, error) {
+	log.Info("DbToYang_test_ospfv2_router_distribution_key_xfmr ", inParams.uri)
+	var rmap map[string]interface{}
+	var distribution_id string
+
+	if strings.Contains(inParams.key, "|") {
+		key_split := strings.SplitN(inParams.key, "|", 2)
+		if len(key_split) == 2 {
+			distribution_id = key_split[1]
+			rmap = make(map[string]interface{})
+			rmap["distribution-id"] = distribution_id
+		}
+	}
+	log.Info("DbToYang_test_ospfv2_router_distribution_key_xfmr returning ", rmap)
+	return rmap, nil
+}
+
+var YangToDb_test_bgp_network_cfg_key_xfmr KeyXfmrYangToDb = func(inParams XfmrParams) (string, error) {
+	var db_ni_name, bgp_cfg_db_key string
+	var err error
+	log.Info("YangToDb_test_bgp_network_cfg_key_xfmr ", inParams.uri)
+	pathInfo := NewPathInfo(inParams.uri)
+	ni_name := pathInfo.Var("ni-name")
+	network_id := pathInfo.Var("network-id")
+
+	if strings.HasPrefix(ni_name, "vrf-") {
+		db_ni_name = strings.Replace(ni_name, "vrf-", "Vrf_", 1)
+	} else if strings.HasPrefix(ni_name, "default") {
+		db_ni_name = ni_name
+	} else if ni_name != "" {
+		err_str := "Invalid key. Key not supported."
+		err = tlerr.NotSupported(err_str)
+	}
+
+	if network_id != "" {
+		bgp_cfg_db_key = db_ni_name + "|" + network_id
+	} else {
+		bgp_cfg_db_key = db_ni_name
+	}
+
+	log.Info("YangToDb_test_bgp_network_cfg_key_xfmr returning ", bgp_cfg_db_key, " error ", err)
+	return bgp_cfg_db_key, err
+}
+
+var DbToYang_test_bgp_network_cfg_key_xfmr KeyXfmrDbToYang = func(inParams XfmrParams) (map[string]interface{}, error) {
+	log.Info("DbToYang_test_bgp_network_cfg_key_xfmr ", inParams.uri)
+	var rmap map[string]interface{}
+	var network_id string
+
+	if strings.Contains(inParams.key, "|") {
+		key_split := strings.SplitN(inParams.key, "|", 2)
+		if len(key_split) == 2 {
+			network_id = key_split[1]
+			rmap = make(map[string]interface{})
+			rmap["network-id"] = network_id
+		}
+	}
+	log.Info("DbToYang_test_bgp_network_cfg_key_xfmr returning ", rmap)
+	return rmap, nil
 }

--- a/translib/transformer/xlate.go
+++ b/translib/transformer/xlate.go
@@ -612,7 +612,7 @@ func XlateFromDb(uri string, ygRoot *ygot.GoStruct, dbs [db.MaxDB]*db.DB, data R
 	qparams := inParamsForGet.queryParams
 	ygSchema := inParamsForGet.ygSchema
 	inParamsForGet = formXlateFromDbParams(dbs[cdb], dbs, cdb, ygRoot, uri, requestUri, xpath, GET, "", "",
-		&dbData, txCache, nil, false, qparams, inParamsForGet.reqCtxt, nil)
+		&dbData, txCache, nil, qparams, inParamsForGet.reqCtxt, nil)
 	inParamsForGet.dbTblKeyGetCache = dbTblKeyGetCache
 	inParamsForGet.xfmrDbTblKeyCache = tblXfmrCache
 	inParamsForGet.ygSchema = ygSchema

--- a/translib/transformer/xlate_datastructs.go
+++ b/translib/transformer/xlate_datastructs.go
@@ -72,10 +72,11 @@ type XfmrTranslateSubscribeInfo struct {
 }
 
 type xpathTblKeyExtractRet struct {
-	xpath        string
-	tableName    string
-	dbKey        string
-	isVirtualTbl bool
+	xpath         string
+	tableName     string
+	dbKey         string
+	isVirtualTbl  bool
+	isNotTblOwner bool
 }
 
 type xlateFromDbParams struct {
@@ -96,7 +97,6 @@ type xlateFromDbParams struct {
 	tbl               string
 	tblKey            string
 	resultMap         map[string]interface{}
-	validate          bool
 	xfmrDbTblKeyCache map[string]tblKeyCache
 	queryParams       QueryParams
 	dbTblKeyGetCache  map[db.DBNum]map[string]map[string]bool
@@ -114,6 +114,7 @@ type xlateToParams struct {
 	uri                     string
 	requestUri              string
 	xpath                   string
+	parentXpath             string
 	keyName                 string
 	jsonData                interface{}
 	resultMap               map[Operation]RedisDbMap
@@ -126,6 +127,7 @@ type xlateToParams struct {
 	name                    string
 	value                   interface{}
 	tableName               string
+	isNotTblOwner           bool
 	yangDefValMap           map[string]map[string]db.Value
 	yangAuxValMap           map[string]map[string]db.Value
 	xfmrDbTblKeyCache       map[string]tblKeyCache
@@ -148,6 +150,7 @@ type qpSubtreePruningErr struct {
 }
 
 type Operation int
+type subOpDataMapType map[Operation]*RedisDbMap
 
 type ContentType uint8
 

--- a/translib/transformer/xlate_del_to_db.go
+++ b/translib/transformer/xlate_del_to_db.go
@@ -159,8 +159,6 @@ func yangListDelData(xlateParams xlateToParams, dbDataMap *map[db.DBNum]map[stri
 	xfmrLogDebug("tblList(%v), tbl(%v), key(%v)  for URI (\"%v\")", tblList, xlateParams.tableName, xlateParams.keyName, xlateParams.uri)
 	for _, tbl := range tblList {
 		curDbDataMap, ferr := fillDbDataMapForTbl(xlateParams.uri, xlateParams.xpath, tbl, keyName, cdb, dbs, xlateParams.dbTblKeyGetCache, nil)
-		log.Info("********************************** ferr ", ferr, " curDbData ", curDbDataMap)
-		log.Info("*****************************  ", (*dbDataMap)[cdb])
 		if (ferr == nil) && len(curDbDataMap) > 0 {
 			mapCopy((*dbDataMap)[cdb], curDbDataMap[cdb])
 		}

--- a/translib/transformer/xlate_del_to_db.go
+++ b/translib/transformer/xlate_del_to_db.go
@@ -38,9 +38,7 @@ func tblKeyDataGet(xlateParams xlateToParams, dbDataMap *map[db.DBNum]map[string
 	isVirtualTbl := false
 
 	xfmrLogDebug("Get table data for  (\"%v\")", xlateParams.uri)
-	if (xYangSpecMap[xlateParams.xpath].tableName != nil) && (len(*xYangSpecMap[xlateParams.xpath].tableName) > 0) {
-		tblList = append(tblList, *xYangSpecMap[xlateParams.xpath].tableName)
-	} else if xYangSpecMap[xlateParams.xpath].xfmrTbl != nil {
+	if xYangSpecMap[xlateParams.xpath].xfmrTbl != nil {
 		xfmrTblFunc := *xYangSpecMap[xlateParams.xpath].xfmrTbl
 		if len(xfmrTblFunc) > 0 {
 			inParams := formXfmrInputRequest(xlateParams.d, dbs, cdb, xlateParams.ygRoot, xlateParams.uri, xlateParams.requestUri, xlateParams.oper, xlateParams.keyName, dbDataMap, nil, nil, xlateParams.txCache)
@@ -53,41 +51,47 @@ func tblKeyDataGet(xlateParams xlateToParams, dbDataMap *map[db.DBNum]map[string
 			}
 		}
 	}
-	tbl := xlateParams.tableName
-	if tbl != "" {
-		if !contains(tblList, tbl) {
-			tblList = append(tblList, tbl)
-		}
-	}
 	return tblList, isVirtualTbl, err
 }
 
-func subTreeXfmrDelDataGet(xlateParams xlateToParams, dbDataMap *map[db.DBNum]map[string]map[string]db.Value, cdb db.DBNum, spec *yangXpathInfo, chldSpec *yangXpathInfo, subTreeResMap *map[string]map[string]db.Value) error {
+func subTreeXfmrDelDataGet(xlateParams xlateToParams, dbDataMap *map[db.DBNum]map[string]map[string]db.Value, cdb db.DBNum, spec *yangXpathInfo, chldSpec *yangXpathInfo, subTreeResMap *map[string]map[string]db.Value) (bool, error) {
 	var dbs [db.MaxDB]*db.DB
 	dbs[cdb] = xlateParams.d
+	validate := true
 
 	xfmrLogDebug("Handle subtree for  (\"%v\")", xlateParams.uri)
-	if len(chldSpec.xfmrFunc) > 0 {
-		if (len(spec.xfmrFunc) == 0) || ((len(spec.xfmrFunc) > 0) &&
-			(spec.xfmrFunc != chldSpec.xfmrFunc)) {
-			inParams := formXfmrInputRequest(xlateParams.d, dbs, cdb, xlateParams.ygRoot, xlateParams.uri, xlateParams.requestUri, xlateParams.oper, "",
-				dbDataMap, xlateParams.subOpDataMap, nil, xlateParams.txCache)
-			retMap, err := xfmrHandler(inParams, chldSpec.xfmrFunc)
-			if err != nil {
-				xfmrLogDebug("Error returned by %v: %v", chldSpec.xfmrFunc, err)
-				return err
-			}
-			mapCopy(*subTreeResMap, retMap)
-			if xlateParams.pCascadeDelTbl != nil && len(*inParams.pCascadeDelTbl) > 0 {
-				for _, tblNm := range *inParams.pCascadeDelTbl {
-					if !contains(*xlateParams.pCascadeDelTbl, tblNm) {
-						*xlateParams.pCascadeDelTbl = append(*xlateParams.pCascadeDelTbl, tblNm)
-					}
-				}
+
+	// Evaluate validate xfmr if available for subtree
+	if (len(chldSpec.validateFunc) > 0) && (chldSpec.validateFunc != spec.validateFunc) {
+		xfmrLogDebug("Invoke validate Xfmr function %v for uri %v", spec.validateFunc, xlateParams.uri)
+		xpathKeyExtRet, err := xpathKeyExtract(xlateParams.d, xlateParams.ygRoot, xlateParams.oper, xlateParams.uri, xlateParams.requestUri, nil, xlateParams.subOpDataMap, xlateParams.txCache, xlateParams.xfmrDbTblKeyCache, dbs)
+		if err == nil {
+			inParams := formXfmrInputRequest(xlateParams.d, dbs, db.ConfigDB, xlateParams.ygRoot, xlateParams.uri, xlateParams.requestUri, xlateParams.oper, xpathKeyExtRet.dbKey, dbDataMap, xlateParams.subOpDataMap, nil, xlateParams.txCache)
+			res := validateHandlerFunc(inParams, chldSpec.validateFunc)
+			if !res {
+				// Return the validation status to caller to indicates further traversal not required
+				validate = res
+				return validate, err
 			}
 		}
 	}
-	return nil
+
+	inParams := formXfmrInputRequest(xlateParams.d, dbs, cdb, xlateParams.ygRoot, xlateParams.uri, xlateParams.requestUri, xlateParams.oper, "",
+		dbDataMap, xlateParams.subOpDataMap, nil, xlateParams.txCache)
+	retMap, err := xfmrHandler(inParams, chldSpec.xfmrFunc)
+	if err != nil {
+		xfmrLogDebug("Error returned by %v: %v", chldSpec.xfmrFunc, err)
+		return validate, err
+	}
+	mapCopy(*subTreeResMap, retMap)
+	if xlateParams.pCascadeDelTbl != nil && len(*inParams.pCascadeDelTbl) > 0 {
+		for _, tblNm := range *inParams.pCascadeDelTbl {
+			if !contains(*xlateParams.pCascadeDelTbl, tblNm) {
+				*xlateParams.pCascadeDelTbl = append(*xlateParams.pCascadeDelTbl, tblNm)
+			}
+		}
+	}
+	return validate, nil
 }
 
 func yangListDelData(xlateParams xlateToParams, dbDataMap *map[db.DBNum]map[string]map[string]db.Value, subTreeResMap *map[string]map[string]db.Value, isFirstCall bool) error {
@@ -96,7 +100,6 @@ func yangListDelData(xlateParams xlateToParams, dbDataMap *map[db.DBNum]map[stri
 	var tblList []string
 	xfmrLogDebug("yangListDelData Received xlateParams - %v \n dbDataMap - %v\n subTreeResMap - %v\n isFirstCall - %v", xlateParams, dbDataMap, subTreeResMap, isFirstCall)
 	fillFields := false
-	removedFillFields := false
 	virtualTbl := false
 	tblOwner := true
 	keyName := xlateParams.keyName
@@ -139,14 +142,25 @@ func yangListDelData(xlateParams xlateToParams, dbDataMap *map[db.DBNum]map[stri
 		xlateParams.keyName = keyName
 	}
 
-	tblList, virtualTbl, err = tblKeyDataGet(xlateParams, dbDataMap, cdb)
-	if err != nil {
+	if xYangSpecMap[xlateParams.xpath].xfmrTbl != nil {
+		tblList, virtualTbl, err = tblKeyDataGet(xlateParams, dbDataMap, cdb)
+		if err != nil {
+			return err
+		}
+	} else if len(xlateParams.tableName) > 0 {
+		tblList = append(tblList, xlateParams.tableName)
+	}
+
+	if len(tblList) == 0 {
+		xfmrLogInfo("Unable to traverse list as no table information available at URI %v. Please check if table mapping available", xlateParams.uri)
 		return err
 	}
 
 	xfmrLogDebug("tblList(%v), tbl(%v), key(%v)  for URI (\"%v\")", tblList, xlateParams.tableName, xlateParams.keyName, xlateParams.uri)
 	for _, tbl := range tblList {
 		curDbDataMap, ferr := fillDbDataMapForTbl(xlateParams.uri, xlateParams.xpath, tbl, keyName, cdb, dbs, xlateParams.dbTblKeyGetCache, nil)
+		log.Info("********************************** ferr ", ferr, " curDbData ", curDbDataMap)
+		log.Info("*****************************  ", (*dbDataMap)[cdb])
 		if (ferr == nil) && len(curDbDataMap) > 0 {
 			mapCopy((*dbDataMap)[cdb], curDbDataMap[cdb])
 		}
@@ -164,48 +178,66 @@ func yangListDelData(xlateParams xlateToParams, dbDataMap *map[db.DBNum]map[stri
 		xfmrLogDebug("Parent Uri - %v, ParentTbl - %v, parentKey - %v", parentUri, parentTbl, parentKey)
 	}
 
-	if len(tblList) == 0 {
-		xfmrLogInfo("Unable to traverse list as no table information available at URI %v. Please check if table mapping available", xlateParams.uri)
-	}
-
 	for _, tbl := range tblList {
 		tblData, ok := (*dbDataMap)[cdb][tbl]
 		xfmrLogDebug("Process Tbl - %v", tbl)
+		removedFillFields := false
 		var curTbl, curKey string
 		var cerr error
 		if ok {
 			for dbKey := range tblData {
 				xfmrLogDebug("Process Tbl - %v with dbKey - %v", tbl, dbKey)
-				_, curUri, _, kerr := dbKeyToYangDataConvert(xlateParams.uri, xlateParams.requestUri, xlateParams.xpath, tbl, xlateParams.d, dbs, dbDataMap, dbKey, separator, xlateParams.txCache, xlateParams.oper)
-				if kerr != nil {
+				rmap, curUri, _, kerr := dbKeyToYangDataConvert(xlateParams.uri, xlateParams.requestUri, xlateParams.xpath, tbl, xlateParams.d, dbs, dbDataMap, dbKey, separator, xlateParams.txCache, xlateParams.oper)
+				if kerr != nil || len(rmap) == 0 {
 					continue
 				}
-				if spec.virtualTbl != nil && *spec.virtualTbl {
-					virtualTbl = true
+				if spec.virtualTbl != nil {
+					virtualTbl = *spec.virtualTbl
+				}
+
+				var dbs [db.MaxDB]*db.DB
+				xpathKeyExtRet, xerr := xpathKeyExtract(xlateParams.d, xlateParams.ygRoot, xlateParams.oper, curUri, xlateParams.requestUri, nil, xlateParams.subOpDataMap, xlateParams.txCache, xlateParams.xfmrDbTblKeyCache, dbs)
+				curKey = xpathKeyExtRet.dbKey
+				curTbl = xpathKeyExtRet.tableName
+				if dbKey != curKey {
+					xfmrLogDebug("Mismatch in dbKey and key derived from uri. dbKey : %v, key from uri: %v. Cannot traverse instance at URI %v. Please check the key mapping", dbKey, curKey, curUri)
+					continue
 				}
 
 				// Not required to check for table inheritence case here as we have a subtree and subtree is already processed before we get here
 				// We only need to traverse nested subtrees here
 				if len(spec.xfmrFunc) == 0 {
-					var dbs [db.MaxDB]*db.DB
-					xpathKeyExtRet, xerr := xpathKeyExtract(xlateParams.d, xlateParams.ygRoot, xlateParams.oper, curUri, xlateParams.requestUri, nil, xlateParams.subOpDataMap, xlateParams.txCache, xlateParams.xfmrDbTblKeyCache, dbs)
-					curKey = xpathKeyExtRet.dbKey
-					curTbl = xpathKeyExtRet.tableName
+					if spec.virtualTbl == nil && xpathKeyExtRet.isVirtualTbl {
+						virtualTbl = xpathKeyExtRet.isVirtualTbl
+					}
+					if spec.tblOwner != nil {
+						tblOwner = *spec.tblOwner
+					} else {
+						tblOwner = !xpathKeyExtRet.isNotTblOwner
+					}
+
 					cerr = xerr
 					xfmrLogDebug("Current Uri - %v, CurrentTbl - %v, CurrentKey - %v", curUri, curTbl, curKey)
+					// Invoke the validate Xfmr function to evaluate if further processing is required
+					parentSpec, parentOk := xYangSpecMap[xlateParams.parentXpath]
 
-					if dbKey != curKey {
-						xfmrLogDebug("Mismatch in dbKey and key derived from uri. dbKey : %v, key from uri: %v. Cannot traverse instance at URI %v. Please check the key mapping", dbKey, curKey, curUri)
-						continue
+					if len(spec.validateFunc) > 0 && (isFirstCall ||
+						(parentOk && (spec.validateFunc != parentSpec.validateFunc))) {
+						xfmrLogDebug("Invoke validate Xfmr function %v for uri %v", spec.validateFunc, curUri)
+						inParams := formXfmrInputRequest(xlateParams.d, dbs, db.ConfigDB, xlateParams.ygRoot, curUri, xlateParams.requestUri, xlateParams.oper, curKey, dbDataMap, xlateParams.subOpDataMap, nil, xlateParams.txCache)
+						res := validateHandlerFunc(inParams, spec.validateFunc)
+						if !res {
+							continue
+						}
 					}
+
 					if isFirstCall {
 						if perr == nil && cerr == nil {
 							if len(curTbl) > 0 && parentTbl != curTbl {
 								/* Non-inhertited table case */
 								xfmrLogDebug("Non-inhertaed table case, URI - %v", curUri)
-								if spec.tblOwner != nil && !*spec.tblOwner {
+								if !tblOwner {
 									xfmrLogDebug("For URI - %v, table owner - %v", xlateParams.uri, *spec.tblOwner)
-									tblOwner = false
 									/* Fill only fields */
 									fillFields = true
 								}
@@ -216,17 +248,15 @@ func yangListDelData(xlateParams xlateToParams, dbDataMap *map[db.DBNum]map[stri
 									if parentKey == curKey { // List within list or List within container, where container map to entire table
 										xfmrLogDebug("Parent key is same as current key")
 										xfmrLogDebug("Request from NBI is at same level as that of current list - %v", curUri)
-										if spec.tblOwner != nil && !*spec.tblOwner {
-											xfmrLogDebug("For URI - %v, table owner - %v", xlateParams.uri, *spec.tblOwner)
-											tblOwner = false // since query is at this level, this will make sure to add instance to result
+										if !tblOwner {
+											xfmrLogDebug("For URI - %v, table owner - %v", xlateParams.uri, tblOwner)
 										}
 										/* Fill only fields */
 										fillFields = true
 									} else { /*same table but different keys */
 										xfmrLogDebug("Inherited table but parent key is NOT same as current key")
-										if spec.tblOwner != nil && !*spec.tblOwner {
+										if !tblOwner {
 											xfmrLogDebug("For URI - %v, table owner - %v", xlateParams.uri, *spec.tblOwner)
-											tblOwner = false
 											/* Fill only fields */
 											fillFields = true
 										}
@@ -234,116 +264,143 @@ func yangListDelData(xlateParams xlateToParams, dbDataMap *map[db.DBNum]map[stri
 								} else {
 									/*same table but no parent-key exists, parent must be a container wth just tableNm annot with no keyXfmr/Nm */
 									xfmrLogDebug("Inherited table but no parent key available")
-									if spec.tblOwner != nil && !*spec.tblOwner {
+									if !tblOwner {
 										xfmrLogDebug("For URI - %v, table owner - %v", xlateParams.uri, *spec.tblOwner)
-										tblOwner = false
 										/* Fill only fields */
 										fillFields = true
 
 									}
 								}
 							} else { //  len(curTbl) = 0
-								log.Warning("No table found for Uri - %v ", curUri)
+								log.Warning("No table found for Uri -  ", curUri)
 							}
 						}
 					} else {
 						/* if table instance already filled and there are no feilds present then it's instance level delete.
 						If fields present then its fields delet and not instance delete
 						*/
-						if tblData, tblDataOk := xlateParams.result[curTbl]; tblDataOk {
-							if fieldMap, fieldMapOk := tblData[curKey]; fieldMapOk {
-								xfmrLogDebug("Found table instance same as that of requestUri")
-								if len(fieldMap.Field) > 0 {
-									/* Fill only fields */
-									xfmrLogDebug("Found table instance same as that of requestUri with fields.")
-									fillFields = true
+						if !tblOwner {
+							xfmrLogDebug("For URI - %v, table owner - %v", xlateParams.uri, tblOwner)
+							/* Fill only fields */
+							fillFields = true
+						} else {
+							if tblData, tblDataOk := xlateParams.result[curTbl]; tblDataOk {
+								if fieldMap, fieldMapOk := tblData[curKey]; fieldMapOk {
+									xfmrLogDebug("Found table instance same as that of requestUri")
+									if len(fieldMap.Field) > 0 {
+										//* Fill only fields
+										xfmrLogDebug("Found table instance same as that of requestUri with fields.")
+										fillFields = true
+									}
 								}
 							}
 						}
-					} // end of if isFirstCall
-				} // end if !subtree case
-				xfmrLogDebug("For URI - %v , table-owner - %v, fillFields - %v", curUri, tblOwner, fillFields)
-				if fillFields || spec.hasChildSubTree || isFirstCall {
-					for yangChldName := range spec.yangEntry.Dir {
-						chldXpath := xlateParams.xpath + "/" + yangChldName
-						chldUri := curUri + "/" + yangChldName
-						chldSpec, ok := xYangSpecMap[chldXpath]
-						chldSpecYangEntry := spec.yangEntry.Dir[yangChldName]
-						if ok && ((chldSpecYangEntry != nil) && (!chldSpecYangEntry.ReadOnly())) {
-							chldYangType := chldSpec.yangType
-							curXlateParams := xlateParams
-							curXlateParams.uri = chldUri
-							curXlateParams.xpath = chldXpath
-							curXlateParams.tableName = ""
-							curXlateParams.keyName = ""
 
-							if (chldSpec.dbIndex == db.ConfigDB) && (len(chldSpec.xfmrFunc) > 0) {
-								err = subTreeXfmrDelDataGet(curXlateParams, dbDataMap, cdb, spec, chldSpec, subTreeResMap)
-								if err != nil {
-									return err
+					} // end of if isFirstCall
+				} else { // end if !subtree case
+					if !spec.hasChildSubTree {
+						return err
+					}
+				}
+
+				skipSibling := false
+
+				xfmrLogDebug("For URI - %v , table-owner - %v, fillFields - %v", curUri, tblOwner, fillFields)
+				for yangChldName := range spec.yangEntry.Dir {
+					chldXpath := xlateParams.xpath + "/" + yangChldName
+					chldUri := curUri + "/" + yangChldName
+					chldSpec, ok := xYangSpecMap[chldXpath]
+					chldSpecYangEntry := spec.yangEntry.Dir[yangChldName]
+					if ok && ((chldSpecYangEntry != nil) && (!chldSpecYangEntry.ReadOnly())) {
+						chldYangType := chldSpec.yangType
+						curXlateParams := xlateParams
+						curXlateParams.uri = chldUri
+						curXlateParams.xpath = chldXpath
+						curXlateParams.tableName = ""
+						curXlateParams.keyName = ""
+						curXlateParams.parentXpath = xlateParams.xpath
+
+						if (chldSpec.dbIndex == db.ConfigDB) && (len(chldSpec.xfmrFunc) > 0) {
+							if (len(spec.xfmrFunc) == 0) ||
+								((len(spec.xfmrFunc) > 0) && (spec.xfmrFunc != chldSpec.xfmrFunc)) {
+								validate, serr := subTreeXfmrDelDataGet(curXlateParams, dbDataMap, cdb, spec, chldSpec, subTreeResMap)
+								if serr != nil {
+									// Subtree returned error
+									return serr
+								} else if !validate {
+									// No error from subtree but validates to false
+									continue
 								}
 							}
-							if chldYangType == YANG_CONTAINER {
-								err = yangContainerDelData(curXlateParams, dbDataMap, subTreeResMap, false)
+							if !chldSpec.hasChildSubTree {
+								continue
+							}
+						}
+						if chldYangType == YANG_CONTAINER {
+							err = yangContainerDelData(curXlateParams, dbDataMap, subTreeResMap, false)
+							if err != nil {
+								return err
+							}
+						} else if chldYangType == YANG_LIST {
+							err = yangListDelData(curXlateParams, dbDataMap, subTreeResMap, false)
+							if err != nil {
+								return err
+							}
+						} else if (chldSpec.dbIndex == db.ConfigDB) && ((chldYangType == YANG_LEAF) || (chldYangType == YANG_LEAF_LIST)) && !virtualTbl && (len(chldSpec.xfmrFunc) == 0) {
+							/* Do not fill table in resultMap for virtual table and subtree cases */
+							if len(curTbl) == 0 {
+								continue
+							}
+							if len(curKey) == 0 { //at list level key should always be there
+								xfmrLogDebug("No key avaialble for URI - %v", curUri)
+								continue
+							}
+							if chldYangType == YANG_LEAF && chldSpec.isKey {
+								if _, tblDataOk := xlateParams.result[curTbl][curKey]; !tblDataOk {
+									if !tblOwner { //add dummy field to identify when to fill fields only at children traversal
+										addInstanceToDeleteMap(curTbl, curKey, curXlateParams.result, "FillFields", "true", xlateParams.pCascadeDelTbl)
+									} else {
+										addInstanceToDeleteMap(curTbl, curKey, curXlateParams.result, "", "", xlateParams.pCascadeDelTbl)
+									}
+								}
+							} else if fillFields && !skipSibling {
+								//strip off the leaf/leaf-list for mapFillDataUtil takes URI without it
+								curXlateParams.uri = xlateParams.uri
+								curXlateParams.name = chldSpecYangEntry.Name
+								curXlateParams.tableName = curTbl
+								curXlateParams.keyName = curKey
+								if chldYangType == YANG_LEAF_LIST {
+									curXlateParams.value = []interface{}{}
+								}
+
+								err = mapFillDataUtil(curXlateParams)
 								if err != nil {
-									return err
-								}
-							} else if chldYangType == YANG_LIST {
-								err = yangListDelData(curXlateParams, dbDataMap, subTreeResMap, false)
-								if err != nil {
-									return err
-								}
-							} else if (chldSpec.dbIndex == db.ConfigDB) && ((chldYangType == YANG_LEAF) || (chldYangType == YANG_LEAF_LIST)) && !virtualTbl {
-								if len(curTbl) == 0 {
-									continue
-								}
-								if len(curKey) == 0 { //at list level key should always be there
-									xfmrLogDebug("No key available for URI - %v", curUri)
-									continue
-								}
-								if chldYangType == YANG_LEAF && chldSpec.isKey {
-									if isFirstCall {
-										if !tblOwner { //add dummy field to identify when to fill fields only at children traversal
-											dataToDBMapAdd(curTbl, curKey, curXlateParams.result, "FillFields", "true")
-										} else {
-											dataToDBMapAdd(curTbl, curKey, curXlateParams.result, "", "")
+									xfmrLogDebug("Error received (\"%v\")", err)
+									switch e := err.(type) {
+									case tlerr.TranslibXfmrRetError:
+										ecode := e.XlateFailDelReq
+										log.Warningf("Error received (\"%v\"), ecode :%v", err, ecode)
+										if ecode {
+											return err
 										}
 									}
-								} else if fillFields {
-									//strip off the leaf/leaf-list for mapFillDataUtil takes URI without it
-									curXlateParams.uri = xlateParams.uri
-									curXlateParams.name = chldSpecYangEntry.Name
-									curXlateParams.tableName = curTbl
-									curXlateParams.keyName = curKey
-									err = mapFillDataUtil(curXlateParams)
-									if err != nil {
-										xfmrLogDebug("Error received (\"%v\")", err)
-										switch e := err.(type) {
-										case tlerr.TranslibXfmrRetError:
-											ecode := e.XlateFailDelReq
-											log.Warningf("Error received (\"%v\"), ecode :%v", err, ecode)
-											if ecode {
-												return err
-											}
-										}
-									}
-									if !removedFillFields {
-										if fieldMap, ok := curXlateParams.result[curTbl][curKey]; ok {
-											if len(fieldMap.Field) > 1 {
-												delete(curXlateParams.result[curTbl][curKey].Field, "FillFields")
+								}
+								if !removedFillFields {
+									if fieldMap, ok := curXlateParams.result[curTbl][curKey]; ok {
+										if len(fieldMap.Field) > 1 {
+											delete(curXlateParams.result[curTbl][curKey].Field, "FillFields")
+											removedFillFields = true
+										} else if len(fieldMap.Field) == 1 {
+											if _, ok := curXlateParams.result[curTbl][curKey].Field["FillFields"]; !ok {
 												removedFillFields = true
-											} else if len(fieldMap.Field) == 1 {
-												if _, ok := curXlateParams.result[curTbl][curKey].Field["FillFields"]; !ok {
-													removedFillFields = true
-												}
 											}
 										}
 									}
 								}
-							} // end of Leaf case
-						} // if rw
-					} // end of curUri children traversal loop
-				} // Child Subtree or fill fields
+							}
+						} // end of Leaf case
+					} // if rw
+				} // end of curUri children traversal loop
 			} // end of for dbKey loop
 		} // end of tbl in dbDataMap
 	} // end of for tbl loop
@@ -358,6 +415,8 @@ func yangContainerDelData(xlateParams xlateToParams, dbDataMap *map[db.DBNum]map
 	dbs[cdb] = xlateParams.d
 	removedFillFields := false
 	var curTbl, curKey string
+	virtualTbl := false
+	tblOwner := true
 
 	if !ok {
 		return err
@@ -374,7 +433,6 @@ func yangContainerDelData(xlateParams xlateToParams, dbDataMap *map[db.DBNum]map
 	xfmrLogDebug("Traverse container for DELETE at URI (\"%v\")", xlateParams.uri)
 
 	fillFields := false
-
 	// Not required to process parent and current table as subtree is already invoked before we get here
 	// We only need to traverse nested subtrees here
 	if len(spec.xfmrFunc) == 0 {
@@ -393,8 +451,19 @@ func yangContainerDelData(xlateParams xlateToParams, dbDataMap *map[db.DBNum]map
 				}
 			}
 		}
+		if spec.virtualTbl != nil {
+			virtualTbl = *spec.virtualTbl
+		} else if xpathKeyExtRet.isVirtualTbl {
+			virtualTbl = xpathKeyExtRet.isVirtualTbl
+		}
 
-		if isFirstCall {
+		if spec.tblOwner != nil {
+			tblOwner = *spec.tblOwner
+		} else {
+			tblOwner = !xpathKeyExtRet.isNotTblOwner
+		}
+
+		if isFirstCall && !virtualTbl {
 			parentUri := parentUriGet(xlateParams.uri)
 			var dbs [db.MaxDB]*db.DB
 			parentXpathKeyExtRet, perr := xpathKeyExtract(xlateParams.d, xlateParams.ygRoot, xlateParams.oper, parentUri, xlateParams.requestUri, nil, xlateParams.subOpDataMap, xlateParams.txCache, xlateParams.xfmrDbTblKeyCache, dbs)
@@ -405,133 +474,177 @@ func yangContainerDelData(xlateParams xlateToParams, dbDataMap *map[db.DBNum]map
 					xfmrLogDebug("DELETE handling at Container parentTbl %v, curTbl %v, curKey %v", parentTbl, curTbl, curKey)
 					if parentTbl != curTbl {
 						// Non inhertited table
-						if (spec.tblOwner != nil) && !(*spec.tblOwner) {
+						if !tblOwner {
 							// Fill fields only
 							xfmrLogDebug("DELETE handling at Container Non inhertited table and not table Owner")
-							dataToDBMapAdd(curTbl, curKey, xlateParams.result, "FillFields", "true")
+							addInstanceToDeleteMap(curTbl, curKey, xlateParams.result, "FillFields", "true", xlateParams.pCascadeDelTbl)
 							fillFields = true
-						} else if (spec.keyName != nil && len(*spec.keyName) > 0) || len(spec.xfmrKey) > 0 {
-							// Table owner && Key transformer present. Fill table instance
-							xfmrLogDebug("DELETE handling at Container Non inhertited table & table Owner")
-							dataToDBMapAdd(curTbl, curKey, xlateParams.result, "", "")
 						} else {
-							// Fallback case. Ideally should not enter here
-							fillFields = true
+							// Table owner and valid key present (either through inheritence or annotation). Hence mark the instance for delete
+							xfmrLogDebug("DELETE handling at Container Non inhertited table & table Owner")
+							addInstanceToDeleteMap(curTbl, curKey, xlateParams.result, "", "", xlateParams.pCascadeDelTbl)
 						}
 					} else {
 						if curKey != parentKey {
-							if (spec.tblOwner != nil) && !(*spec.tblOwner) {
+							if !tblOwner {
 								xfmrLogDebug("DELETE handling at Container inhertited table and not table Owner")
-								dataToDBMapAdd(curTbl, curKey, xlateParams.result, "FillFields", "true")
+								addInstanceToDeleteMap(curTbl, curKey, xlateParams.result, "FillFields", "true", xlateParams.pCascadeDelTbl)
 								fillFields = true
 							} else {
 								// Instance delete
 								xfmrLogDebug("DELETE handling at Container Non inhertited table & table Owner")
-								dataToDBMapAdd(curTbl, curKey, xlateParams.result, "", "")
+								addInstanceToDeleteMap(curTbl, curKey, xlateParams.result, "", "", xlateParams.pCascadeDelTbl)
 							}
 						} else {
-							// if Instance already filled do not fill fields
 							xfmrLogDebug("DELETE handling at Container Inherited table")
 							//Fill fields only
-							if len(curTbl) > 0 && len(curKey) > 0 {
-								dataToDBMapAdd(curTbl, curKey, xlateParams.result, "FillFields", "true")
-								fillFields = true
-							}
+							addInstanceToDeleteMap(curTbl, curKey, xlateParams.result, "FillFields", "true", xlateParams.pCascadeDelTbl)
+							fillFields = true
 						}
 					}
 				} else {
-					if (spec.tblOwner != nil) && !(*spec.tblOwner) {
+					if !tblOwner {
 						// Fill fields only
 						xfmrLogDebug("DELETE handling at Container Non inhertited table and not table Owner No Key available. table: %v, key: %v", curTbl, curKey)
 					} else {
 						// Table owner && Key transformer present. Fill table instance
 						xfmrLogDebug("DELETE handling at Container Non inhertited table & table Owner. No Key Delete complete TABLE : %v", curTbl)
-						dataToDBMapAdd(curTbl, curKey, xlateParams.result, "", "")
+						addInstanceToDeleteMap(curTbl, curKey, xlateParams.result, "", "", xlateParams.pCascadeDelTbl)
 					}
 				}
 			} else {
+				// Unable to determine table key entry mapped at this level. traverse to children.
 				xfmrLogDebug("perr: %v cerr: %v curTbl: %v, curKey: %v", perr, cerr, curTbl, curKey)
 			}
-		} else {
-			// Inherited Table. We always expect the curTbl entry in xlateParams.result
-			// if Instance already filled do not fill fields
-			xfmrLogDebug("DELETE handling at Container Inherited table curTbl: %v, curKey %v", curTbl, curKey)
-			if tblMap, ok := xlateParams.result[curTbl]; ok {
-				if fieldMap, ok := tblMap[curKey]; ok {
-					if len(fieldMap.Field) == 0 {
-						xfmrLogDebug("Inhertited table & Instance delete case. Skip fields fill")
+		} else if !isFirstCall {
+			// Invoke the validate transformer if available. Not required for firstCall as its called at entry point
+			parentSpec, parentOk := xYangSpecMap[xlateParams.parentXpath]
+			if (len(spec.validateFunc) > 0) && (parentOk && (spec.validateFunc != parentSpec.validateFunc)) {
+				xfmrLogDebug("Invoke validate Xfmr function %v fo uri %v", spec.validateFunc, xlateParams.uri)
+				inParams := formXfmrInputRequest(xlateParams.d, dbs, db.ConfigDB, xlateParams.ygRoot, xlateParams.uri, xlateParams.requestUri, xlateParams.oper, curKey, nil, xlateParams.subOpDataMap, nil, xlateParams.txCache)
+				res := validateHandlerFunc(inParams, spec.validateFunc)
+				if !res {
+					return err
+				}
+			}
+			if !virtualTbl {
+				xfmrLogDebug("DELETE handling at Container Inherited table curTbl: %v, curKey %v", curTbl, curKey)
+				// We always expect table mapped to container to have a valid key.
+				if !tblOwner {
+					xfmrLogDebug("Non table owner child node handling. Fields fill for table :%v", curTbl)
+					if len(curTbl) > 0 && len(curKey) > 0 {
+						if fldMap, ok := xlateParams.result[curTbl][curKey]; !ok {
+							addInstanceToDeleteMap(curTbl, curKey, xlateParams.result, "FillFields", "true", xlateParams.pCascadeDelTbl)
+							fillFields = true
+						} else {
+							if len(fldMap.Field) > 0 {
+								fillFields = true
+							}
+						}
+					}
+				} else if len(curTbl) > 0 {
+					xfmrLogDebug("DELETE handling at child container mapped table curTbl: %v, curKey %v", curTbl, curKey)
+					// Mark the instance for delete if its a table owner. For derived tables from parent, entry should already exist during parent traversal.
+					if len(curKey) > 0 {
+						if fieldMap, ok := xlateParams.result[curTbl][curKey]; ok {
+							// Identify if DB instance existence check is required. If exists add to resultMap else ignore and continue traversal.
+							if len(fieldMap.Field) > 0 {
+								fillFields = true
+							}
+						} else {
+							addInstanceToDeleteMap(curTbl, curKey, xlateParams.result, "", "", xlateParams.pCascadeDelTbl)
+						}
 					} else {
-						xfmrLogDebug("Inhertited table & fields fill for table :%v", curTbl)
-						fillFields = true
+						// We expect a valid key always. If key not present it will be considered as complete table delete
+						// TODO: Identify if DB instance existence check is required. If exists add to resultMap else ignore and continue traversal.
+						addInstanceToDeleteMap(curTbl, curKey, xlateParams.result, "", "", xlateParams.pCascadeDelTbl)
 					}
 				}
 			}
 		}
-
+	} else {
+		if !spec.hasChildSubTree {
+			return err
+		}
 	}
+
 	xfmrLogDebug("URI %v fillFields %v, hasChildSubtree  %v, isFirstCall %v", xlateParams.uri, fillFields, spec.hasChildSubTree, isFirstCall)
 
-	if fillFields || spec.hasChildSubTree || isFirstCall {
-		for yangChldName := range spec.yangEntry.Dir {
-			chldXpath := xlateParams.xpath + "/" + yangChldName
-			chldUri := xlateParams.uri + "/" + yangChldName
-			chldSpec, ok := xYangSpecMap[chldXpath]
-			chldSpecYangEntry := spec.yangEntry.Dir[yangChldName]
-			if ok && ((chldSpecYangEntry != nil) && (!chldSpecYangEntry.ReadOnly())) {
-				chldYangType := chldSpec.yangType
-				curXlateParams := xlateParams
-				curXlateParams.uri = chldUri
-				curXlateParams.xpath = chldXpath
-				curXlateParams.tableName = curTbl
-				curXlateParams.keyName = curKey
+	skipSibling := false
+	for yangChldName := range spec.yangEntry.Dir {
+		chldXpath := xlateParams.xpath + "/" + yangChldName
+		chldUri := xlateParams.uri + "/" + yangChldName
+		chldSpec, ok := xYangSpecMap[chldXpath]
+		chldSpecYangEntry := spec.yangEntry.Dir[yangChldName]
+		if ok && ((chldSpecYangEntry != nil) && (!chldSpecYangEntry.ReadOnly())) {
+			chldYangType := chldSpec.yangType
+			curXlateParams := xlateParams
+			curXlateParams.uri = chldUri
+			curXlateParams.xpath = chldXpath
+			curXlateParams.tableName = curTbl
+			curXlateParams.keyName = curKey
+			curXlateParams.parentXpath = xlateParams.xpath
 
-				if (chldSpec.dbIndex == db.ConfigDB) && (len(chldSpec.xfmrFunc) > 0) {
-					err = subTreeXfmrDelDataGet(curXlateParams, dbDataMap, cdb, spec, chldSpec, subTreeResMap)
-					if err != nil {
-						return err
+			if (chldSpec.dbIndex == db.ConfigDB) && (len(chldSpec.xfmrFunc) > 0) {
+				if (len(spec.xfmrFunc) == 0) || ((len(spec.xfmrFunc) > 0) &&
+					(spec.xfmrFunc != chldSpec.xfmrFunc)) {
+
+					validate, serr := subTreeXfmrDelDataGet(curXlateParams, dbDataMap, cdb, spec, chldSpec, subTreeResMap)
+					if serr != nil {
+						// Return the subtree error
+						return serr
+					} else if !validate {
+						// No error from subtree but validates to false
+						return nil
 					}
 				}
-				if chldYangType == YANG_CONTAINER {
-					err = yangContainerDelData(curXlateParams, dbDataMap, subTreeResMap, false)
-					if err != nil {
-						return err
-					}
-				} else if chldYangType == YANG_LIST {
-					err = yangListDelData(curXlateParams, dbDataMap, subTreeResMap, false)
-					if err != nil {
-						return err
-					}
-				} else if (chldSpec.dbIndex == db.ConfigDB) && (chldYangType == YANG_LEAF || chldYangType == YANG_LEAF_LIST) && fillFields {
-					//strip off the leaf/leaf-list for mapFillDataUtil takes URI without it
-					curXlateParams.uri = xlateParams.uri
-					curXlateParams.name = chldSpecYangEntry.Name
-					err = mapFillDataUtil(curXlateParams)
-					if err != nil {
-						xfmrLogDebug("Error received during leaf fill (\"%v\")", err)
-						switch e := err.(type) {
-						case tlerr.TranslibXfmrRetError:
-							ecode := e.XlateFailDelReq
-							log.Warningf("Error received (\"%v\"), ecode :%v", err, ecode)
-							if ecode {
-								return err
-							}
+				if !chldSpec.hasChildSubTree {
+					continue
+				}
+			}
+			if chldYangType == YANG_CONTAINER {
+				err = yangContainerDelData(curXlateParams, dbDataMap, subTreeResMap, false)
+				if err != nil {
+					return err
+				}
+			} else if chldYangType == YANG_LIST {
+				err = yangListDelData(curXlateParams, dbDataMap, subTreeResMap, false)
+				if err != nil {
+					return err
+				}
+			} else if (chldSpec.dbIndex == db.ConfigDB) && (chldYangType == YANG_LEAF || chldYangType == YANG_LEAF_LIST) && fillFields && !skipSibling {
+				//strip off the leaf/leaf-list for mapFillDataUtil takes URI without it
+				curXlateParams.uri = xlateParams.uri
+				curXlateParams.name = chldSpecYangEntry.Name
+				if chldYangType == YANG_LEAF_LIST {
+					curXlateParams.value = []interface{}{}
+				}
+				err = mapFillDataUtil(curXlateParams)
+				if err != nil {
+					xfmrLogDebug("Error received during leaf fill (\"%v\")", err)
+					switch e := err.(type) {
+					case tlerr.TranslibXfmrRetError:
+						ecode := e.XlateFailDelReq
+						log.Warningf("Error received (\"%v\"), ecode :%v", err, ecode)
+						if ecode {
+							return err
 						}
 					}
-					if !removedFillFields {
-						if fieldMap, ok := curXlateParams.result[curTbl][curKey]; ok {
-							if len(fieldMap.Field) > 1 {
-								delete(curXlateParams.result[curTbl][curKey].Field, "FillFields")
+				}
+				if !removedFillFields {
+					if fieldMap, ok := curXlateParams.result[curTbl][curKey]; ok {
+						if len(fieldMap.Field) > 1 {
+							delete(curXlateParams.result[curTbl][curKey].Field, "FillFields")
+							removedFillFields = true
+						} else if len(fieldMap.Field) == 1 {
+							if _, ok := curXlateParams.result[curTbl][curKey].Field["FillFields"]; !ok {
 								removedFillFields = true
-							} else if len(fieldMap.Field) == 1 {
-								if _, ok := curXlateParams.result[curTbl][curKey].Field["FillFields"]; !ok {
-									removedFillFields = true
-								}
 							}
 						}
 					}
-				} else {
-					xfmrLogDebug("%v", "Instance Fill case. Have filled the result table with table and key")
 				}
+			} else {
+				xfmrLogDebug("%v", "Instance Fill case. Have filled the result table with table and key")
 			}
 		}
 	}
@@ -564,6 +677,7 @@ func allChildTblGetToDelete(xlateParams xlateToParams) (map[string]map[string]db
 	if ok && spec.yangEntry != nil {
 		xlateParams.uri = xlateParams.requestUri
 		xlateParams.xpath = xpath
+		xlateParams.parentXpath = parentXpathGet(xpath)
 		yangType := spec.yangType
 		if yangType == YANG_LIST {
 			err = yangListDelData(xlateParams, &dbDataMap, &subTreeResMap, isFirstCall)
@@ -585,19 +699,15 @@ func dbMapDelete(d *db.DB, ygRoot *ygot.GoStruct, oper Operation, uri string, re
 	var cascadeDelTbl []string
 
 	/* Check if the parent table exists for RFC compliance */
-	var exists bool
 	var dbs [db.MaxDB]*db.DB
 	subOpMapDiscard := make(map[Operation]*RedisDbMap)
-	exists, err = verifyParentTable(d, dbs, ygRoot, oper, uri, nil, txCache, subOpMapDiscard, nil)
-	xfmrLogDebug("verifyParentTable() returned - exists - %v, err - %v", exists, err)
-	if err != nil {
-		if exists {
-			// Special case when we delete at container that does exist. Not required to do translation. Do not return error either.
-			return nil
-		}
-		log.Warningf("Cannot perform Operation %v on URI %v due to - %v", oper, uri, err)
-		return err
+	exists, parChkErr := verifyParentTable(d, dbs, ygRoot, oper, uri, nil, txCache, subOpMapDiscard, nil)
+	xfmrLogDebug("verifyParentTable() returned - exists - %v, err - %v", exists, parChkErr)
+	if parChkErr != nil && !exists {
+		log.Warningf("Cannot perform Operation %v on URI %v due to - %v", oper, uri, parChkErr)
+		return parChkErr
 	}
+	// Special case: If Resource not found in DB when we delete at container node(requestUri - parChkErr != nil && exists), continue to traverse to get child tables. Also identify a leaf case having default value when table does not exist to skip default value setting for non existent entry.
 	if !exists {
 		errStr := fmt.Sprintf("Parent table does not exist for uri(%v)", uri)
 		return tlerr.InternalError{Format: errStr}
@@ -641,11 +751,16 @@ func dbMapDelete(d *db.DB, ygRoot *ygot.GoStruct, oper Operation, uri string, re
 				}
 			}
 
-			if spec.cascadeDel == XFMR_ENABLE && xpathKeyExtRet.tableName != "" && xpathKeyExtRet.tableName != XFMR_NONE_STRING {
-				if !contains(cascadeDelTbl, xpathKeyExtRet.tableName) {
-					cascadeDelTbl = append(cascadeDelTbl, xpathKeyExtRet.tableName)
+			if len(xYangSpecMap[xpathKeyExtRet.xpath].validateFunc) > 0 && specYangType != YANG_LIST {
+				// For list cases evaluate for every instance to make sure the validation is done for the current instance
+				inParams := formXfmrInputRequest(d, dbs, db.ConfigDB, ygRoot, uri, requestUri, oper, xpathKeyExtRet.dbKey, nil, subOpDataMap, nil, txCache)
+				res := validateHandlerFunc(inParams, xYangSpecMap[xpathKeyExtRet.xpath].validateFunc)
+				if !res {
+					// Validate xfmr returns not valid hence, no further traversal required. return here
+					return nil
 				}
 			}
+
 			curXlateParams := formXlateToDbParam(d, ygRoot, oper, uri, requestUri, xpathKeyExtRet.xpath, xpathKeyExtRet.dbKey, jsonData, resultMap, result, txCache, nil, subOpDataMap, &cascadeDelTbl, &xfmrErr, "", "", xpathKeyExtRet.tableName, nil, nil, nil)
 			curXlateParams.xfmrDbTblKeyCache = make(map[string]tblKeyCache)
 			if len(spec.xfmrFunc) > 0 {
@@ -658,14 +773,15 @@ func dbMapDelete(d *db.DB, ygRoot *ygot.GoStruct, oper Operation, uri string, re
 				} else {
 					return err
 				}
-				// TODO: Nested subtree invoke
-				curResult, cerr := allChildTblGetToDelete(curXlateParams)
-				if cerr != nil {
-					return cerr
-				} else {
-					mapCopy(result, curResult)
+				// Traverse the tree only if the yang tree has a nested subtree
+				if spec.hasChildSubTree {
+					curResult, cerr := allChildTblGetToDelete(curXlateParams)
+					if cerr != nil {
+						return cerr
+					} else {
+						mapCopy(result, curResult)
+					}
 				}
-
 				if inParams.pCascadeDelTbl != nil && len(*inParams.pCascadeDelTbl) > 0 {
 					for _, tblNm := range *inParams.pCascadeDelTbl {
 						if !contains(cascadeDelTbl, tblNm) {
@@ -674,20 +790,22 @@ func dbMapDelete(d *db.DB, ygRoot *ygot.GoStruct, oper Operation, uri string, re
 					}
 				}
 			} else if specYangType == YANG_LEAF || specYangType == YANG_LEAF_LIST {
-				if len(xpathKeyExtRet.tableName) > 0 && len(xpathKeyExtRet.dbKey) > 0 {
+				xpath := xpathKeyExtRet.xpath
+				_, ok := xYangSpecMap[xpath]
+				if parChkErr != nil && exists && specYangType == YANG_LEAF && ok && len(xYangSpecMap[xpath].defVal) > 0 {
+					xfmrLogDebug("Do not reset to default for DELETE on leaf having default but maps to a table annotated at container that does not exist.")
+				} else if len(xpathKeyExtRet.tableName) > 0 && len(xpathKeyExtRet.dbKey) > 0 {
 					dataToDBMapAdd(xpathKeyExtRet.tableName, xpathKeyExtRet.dbKey, result, "", "")
-					xpath := xpathKeyExtRet.xpath
 					pathList := strings.Split(xpath, "/")
 					uriItemList := splitUri(strings.TrimSuffix(uri, "/"))
 					uriItemListLen := len(uriItemList)
 					var luri string
 					if uriItemListLen > 0 {
-						luri = strings.Join(uriItemList[:uriItemListLen-1], "/") //strip off the leaf/leaf-list for mapFillDataUtil takes URI without it
+						luri = "/" + strings.Join(uriItemList[:uriItemListLen-1], "/") //strip off the leaf/leaf-list for mapFillDataUtil takes URI without it
 
 					}
 
 					if specYangType == YANG_LEAF {
-						_, ok := xYangSpecMap[xpath]
 						if ok && len(xYangSpecMap[xpath].defVal) > 0 {
 							// Do not fill def value if leaf does not map to any redis field
 							dbSpecXpath := xpathKeyExtRet.tableName + "/" + xYangSpecMap[xpath].fieldName
@@ -760,15 +878,6 @@ func dbMapDelete(d *db.DB, ygRoot *ygot.GoStruct, oper Operation, uri string, re
 					mapCopy(result, curResult)
 				}
 				xfmrLogDebug("allChildTblGetToDelete result: %v  subtree curResult: %v", result, curResult)
-				// Add the child tables to delete when table at request URI is not available or its complete table delete request (not specific instance)
-				chResult := make(map[string]map[string]db.Value)
-				if (len(xpathKeyExtRet.tableName) == 0 || (len(xpathKeyExtRet.tableName) > 0 && len(xpathKeyExtRet.dbKey) == 0)) && len(spec.childTable) > 0 {
-					for _, child := range spec.childTable {
-						chResult[child] = make(map[string]db.Value)
-					}
-					xfmrLogDebug("Before adding children result: %v  result with child tables: %v", result, chResult)
-				}
-				mapCopy(result, chResult)
 			}
 
 			if xYangModSpecMap != nil {
@@ -782,7 +891,7 @@ func dbMapDelete(d *db.DB, ygRoot *ygot.GoStruct, oper Operation, uri string, re
 					var dbresult = make(RedisDbMap)
 					dbresult[db.ConfigDB] = result
 					inParams := formXfmrInputRequest(d, dbs, db.ConfigDB, ygRoot, uri, requestUri, oper, "", &dbresult, subOpDataMap, nil, txCache)
-					result, err = postXfmrHandlerFunc(xfmrPost, inParams)
+					err = postXfmrHandlerFunc(xfmrPost, inParams)
 					if err != nil {
 						return err
 					}
@@ -969,6 +1078,18 @@ func sonicYangReqToDbMapDelete(xlateParams xlateToParams) error {
 	}
 	xlateParams.resultMap[oper][db.ConfigDB] = xlateParams.result
 	return nil
+}
+
+func addInstanceToDeleteMap(tableName string, dbKey string, result map[string]map[string]db.Value, field string, value string, pCascadeDelTbl *[]string) {
+	dataToDBMapAdd(tableName, dbKey, result, field, value)
+	/* Add table to cascade delete list if annotation is available only for complete instance Delete case. */
+	if len(field) == 0 {
+		if tblSpecInfo, ok := xDbSpecMap[tableName]; ok && tblSpecInfo.cascadeDel == XFMR_ENABLE {
+			if pCascadeDelTbl != nil && !contains(*pCascadeDelTbl, tableName) {
+				*pCascadeDelTbl = append(*pCascadeDelTbl, tableName)
+			}
+		}
+	}
 }
 
 func checkAndProcessSonicYangNesetedListDelete(xlateParams xlateToParams, parentListNm string, nestedChildNm string) error {

--- a/translib/transformer/xlate_xfmr_handler.go
+++ b/translib/transformer/xlate_xfmr_handler.go
@@ -339,36 +339,25 @@ func keyXfmrHandler(inParams XfmrParams, xfmrFuncNm string) (string, error) {
 }
 
 /* Invoke the post tansformer */
-func postXfmrHandlerFunc(xfmrPost string, inParams XfmrParams) (map[string]map[string]db.Value, error) {
-	const (
-		POST_XFMR_RET_ARGS     = 2
-		POST_XFMR_RET_VAL_INDX = 0
-		POST_XFMR_RET_ERR_INDX = 1
-	)
-	retData := make(map[string]map[string]db.Value)
+func postXfmrHandlerFunc(xfmrPost string, inParams XfmrParams) error {
+	const POST_XFMR_RET_ERR_INDX = 0
 	xfmrLogDebug("Before calling post xfmr %v, inParams %v", xfmrPost, inParams)
 	ret, err := XlateFuncCall(xfmrPost, inParams)
 	xfmrLogDebug("After calling post xfmr %v, inParams %v", xfmrPost, inParams)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	if (ret != nil) && (len(ret) > 0) {
-		if len(ret) == POST_XFMR_RET_ARGS {
-			// post xfmr returns err as second value in return data list from <xfmr_func>.Call()
-			if ret[POST_XFMR_RET_ERR_INDX].Interface() != nil {
-				err = ret[POST_XFMR_RET_ERR_INDX].Interface().(error)
-				if err != nil {
-					log.Warningf("Transformer function(\"%v\") returned error - %v.", xfmrPost, err)
-					return retData, err
-				}
+		// post xfmr returns err as the only value in return data list from <xfmr_func>.Call()
+		if ret[POST_XFMR_RET_ERR_INDX].Interface() != nil {
+			err = ret[POST_XFMR_RET_ERR_INDX].Interface().(error)
+			if err != nil {
+				log.Warningf("Transformer function(\"%v\") returned error - %v.", xfmrPost, err)
+				return err
 			}
 		}
-		if ret[POST_XFMR_RET_VAL_INDX].Interface() != nil {
-			retData = ret[POST_XFMR_RET_VAL_INDX].Interface().(map[string]map[string]db.Value)
-			xfmrLogDebug("Post xfmr function : %v retData : %v", xfmrPost, retData)
-		}
 	}
-	return retData, err
+	return err
 }
 
 /* Invoke the pre tansformer */


### PR DESCRIPTION
This enhancement to the transformer component in management framework will support DELETE operations using OpenConfig YANG models, enabling configuration data deletion through YANG data tree traversal.
Refer - https://github.com/sonic-net/SONiC/pull/1950  for more details.

The DELETE operation will remove data resources under the specified target resource, identified by the RESTCONF target resource URI, which can be at any depth within a YANG data model.

Previously, deleting data resources with the DELETE operation at any depth of a YANG model was challenging, and support was limited to removing the target resource, not the hierarchy beneath it. This feature aims to address this issues by supporting DELETE operation at any YANG depth.

This enhancement will be the base or prerequisite for supporting PUT/REPLACE operations at any yang depth, the support for the same will be brought in as a subsequent PR.