### PR TITLE
model based replace/put operation handling in transformer infra for openconfig yangs

### DIFF
--- a/translib/common_app.go
+++ b/translib/common_app.go
@@ -921,7 +921,7 @@ func deleteFields(existingEntry db.Value, d *db.DB, cmnAppTs *db.TableSpec, tblK
 			}
 			if deleteCount == len(existingEntry.Field) {
 				nullTblRw := db.Value{Field: map[string]string{"NULL": "NULL"}}
-				log.Info("Last field gets deleted, add NULL field to keep an db entry")
+				log.V(4).Infof("All existing fields(%v) getting deleted, add NULL field to keep the db entry/instance(%v)", existingEntry.Field, tblNm+"|"+tblKey)
 				err = d.ModEntry(cmnAppTs, db.Key{Comp: []string{tblKey}}, nullTblRw)
 				if err != nil {
 					log.Warning("UPDATE case - d.ModEntry() failure")
@@ -978,7 +978,7 @@ func (app *CommonApp) processTableDeleteForReplace(d *db.DB, parentTblNm string,
 			continue
 		}
 		markChildTablesToCleanFromTranslatedResult(d, dbMap[db.ConfigDB], childTblToCleanMap, parentTblNm, moduleNm)
-		if log.V(3) {
+		if log.V(4) {
 			log.Infof("populated child tables that might need cleanup after processing result tables for oper %v is %v", oper, childTblToCleanMap)
 		}
 	}
@@ -1194,7 +1194,7 @@ func (app *CommonApp) handleChildDeleteForOcReplaceAndDelete(d *db.DB, sortedDel
 						log.Info("Table Entry from which the fields are to be deleted does not exist. Ignore error for non existant instance for idempotency")
 						continue
 					}
-					if log.V(3) {
+					if log.V(4) {
 						log.Info("Fields delete", cmnAppTs, db.Key{Comp: []string{tblKey}}, tblRw)
 					}
 					err = deleteFields(existingEntry, d, cmnAppTs, tblKey, tblRw, app.deleteEmptyEntry)

--- a/translib/common_app.go
+++ b/translib/common_app.go
@@ -740,7 +740,12 @@ func (app *CommonApp) cmnAppCRUCommonDbOpn(d *db.DB, opcode int, dbMap map[strin
 						A leaf-list field in redis has "@" suffix as per swsssdk convention.
 						*/
 						resTblRw := db.Value{Field: map[string]string{}}
-						resTblRw = checkAndProcessLeafList(existingEntry, tblRw, UPDATE, d, tblNm, tblKey)
+						/* for north-bound REPLACE request always swap the whole leaf-list */
+						if app.cmnAppOpcode == REPLACE {
+							resTblRw = tblRw
+						} else {
+							resTblRw = checkAndProcessLeafList(existingEntry, tblRw, UPDATE, d, tblNm, tblKey)
+						}
 						log.Info("Processing Table row ", resTblRw)
 						err = d.ModEntry(cmnAppTs, db.Key{Comp: []string{tblKey}}, resTblRw)
 						if err != nil {
@@ -773,7 +778,12 @@ func (app *CommonApp) cmnAppCRUCommonDbOpn(d *db.DB, opcode int, dbMap map[strin
 						A leaf-list field in redis has "@" suffix as per swsssdk convention.
 						*/
 						resTblRw := db.Value{Field: map[string]string{}}
-						resTblRw = checkAndProcessLeafList(existingEntry, tblRw, UPDATE, d, tblNm, tblKey)
+						/* for north-bound REPLACE request always swap the whole leaf-list */
+						if app.cmnAppOpcode == REPLACE {
+							resTblRw = tblRw
+						} else {
+							resTblRw = checkAndProcessLeafList(existingEntry, tblRw, UPDATE, d, tblNm, tblKey)
+						}
 						err = d.ModEntry(cmnAppTs, db.Key{Comp: []string{tblKey}}, resTblRw)
 						if err != nil {
 							log.Warning("UPDATE case - d.ModEntry() failure")
@@ -911,7 +921,7 @@ func deleteFields(existingEntry db.Value, d *db.DB, cmnAppTs *db.TableSpec, tblK
 			}
 			if deleteCount == len(existingEntry.Field) {
 				nullTblRw := db.Value{Field: map[string]string{"NULL": "NULL"}}
-				log.V(4).Infof("All existing fields(%v) getting deleted, add NULL field to keep the db entry/instance(%v)", existingEntry.Field, tblNm+"|"+tblKey)
+				log.Info("Last field gets deleted, add NULL field to keep an db entry")
 				err = d.ModEntry(cmnAppTs, db.Key{Comp: []string{tblKey}}, nullTblRw)
 				if err != nil {
 					log.Warning("UPDATE case - d.ModEntry() failure")
@@ -929,9 +939,186 @@ func deleteFields(existingEntry db.Value, d *db.DB, cmnAppTs *db.TableSpec, tblK
 	return err
 }
 
+func (app *CommonApp) processTableDeleteForReplace(d *db.DB, parentTblNm string, parentTblSpec *db.TableSpec, moduleNm string, cvlSess *cvl.CVL, ordParentTblKeys []string) error {
+	var err error
+	var childTblToCleanMap map[string]bool
+	var parentTblKeyMap map[string]db.Value
+	var parentTblKeys []db.Key
+	var getKeysErr error
+
+	replaceDbMap, replaceOk := app.cmnAppTableMap[REPLACE][db.ConfigDB]
+
+	/* non-table owners are filled in update by infra, subtrees can fill anywhere
+	   map-consolidation at the end of infra translation before hitting common_app
+	   should merge the data if table-instance present across operations.
+	*/
+	updateDbMap, updateOk := app.cmnAppTableMap[UPDATE][db.ConfigDB]
+	createDbMap, createOk := app.cmnAppTableMap[CREATE][db.ConfigDB]
+	if !replaceOk && !updateOk && !createOk {
+		log.V(4).Info("No data in REPLACE, UPDATE and CREATE result map.")
+		return nil
+	}
+	if len(ordParentTblKeys) == 0 {
+		parentTblKeys, getKeysErr = d.GetKeys(parentTblSpec)
+		if getKeysErr != nil {
+			log.Warningf("GetKeys() failed for parent table - %v - error - %v", parentTblNm, getKeysErr)
+		}
+		if len(parentTblKeys) == 0 {
+			log.V(4).Info("No DB data found so no action to take for parent table ", parentTblNm)
+			return nil
+		}
+	}
+
+	log.Infof("processDeleteForReplace: parent table %v", parentTblNm)
+
+	childTblToCleanMap = make(map[string]bool)
+	for oper, dbMap := range app.cmnAppTableMap {
+		//table/instances passed as input param to this function belong to DELETE resultmap
+		if (oper == DELETE) || (len(dbMap) == 0) || (len(dbMap[db.ConfigDB]) == 0) {
+			continue
+		}
+		markChildTablesToCleanFromTranslatedResult(d, dbMap[db.ConfigDB], childTblToCleanMap, parentTblNm, moduleNm)
+		if log.V(3) {
+			log.Infof("populated child tables that might need cleanup after processing result tables for oper %v is %v", oper, childTblToCleanMap)
+		}
+	}
+
+	if len(childTblToCleanMap) == 0 {
+		log.Info("No child tables, mapped to/under target URI yang hierarchy remaining for cleanup.")
+		return nil
+	}
+
+	if len(ordParentTblKeys) == 0 {
+		parentTblKeyMap = make(map[string]db.Value)
+		log.V(4).Info("parent table keys - ", parentTblKeys)
+		for _, parentKey := range parentTblKeys {
+			parentTblKeyMap[strings.Join(parentKey.Comp, "|")] = db.Value{}
+		}
+		log.V(4).Info("parent table key map - ", parentTblKeyMap)
+		ordParentTblKeys = transformer.SortSncTableDbKeys(parentTblNm, parentTblKeyMap)
+	}
+	log.V(4).Info("Sorted parent table keys - ", ordParentTblKeys)
+
+	for _, parentKey := range ordParentTblKeys {
+		log.V(4).Info("processing parentKey: ", parentKey)
+		parentInst := parentTblNm + "|" + parentKey
+		depDataList := cvlSess.GetDepDataForDelete(parentInst)
+		log.V(4).Info("depList: ", depDataList)
+		for idx := len(depDataList) - 1; idx >= 0; idx-- { //CVL gives in parent first order
+			depEntry := depDataList[idx]
+			log.V(4).Infof("Processing depEntry for item %v in depDataList ", depEntry.RefKey)
+			for depInst, depInstFieldMap := range depEntry.Entry {
+				log.V(4).Info("Processing depInst:depFields ", depInst, depInstFieldMap)
+				childTblAndKey := strings.SplitN(depInst, "|", 2)
+				if len(childTblAndKey) != 2 {
+					log.Warning("Child table/key not found in depInst: ", depInst)
+					continue
+				}
+				childTblNm := childTblAndKey[0]
+				childTblKey := childTblAndKey[1]
+				if !childTblToCleanMap[childTblNm] {
+					continue
+				}
+
+				/*  Child table mapped in the yang hierarchy from request URI will be present either
+				    in REPLACE/UPDATE/CREATE result-map(payload/direct map to request URI) based on
+					table ownership, or in DELETE result-map(since a GET like traversal is done).
+				    If present in DELETE result-map then its already processed being a child table
+				    and no clean-up needed before cleaning parent.Clean-up needed only when present
+				    in REPLACE/UPDATE/CREATE
+				*/
+				tblOwner := true //if instance found in REPLACE map then table owner
+				nonTblOwnerInstRwInResultMap := db.Value{}
+				nonTblOwnerInstRwInResultMap.Field = make(map[string]string)
+				var instInReplaceMap, instInUpdateMap, instInCreateMap bool
+				if _, instInReplaceMap = replaceDbMap[childTblNm][childTblKey]; !instInReplaceMap {
+					if nonTblOwnerInstRwInResultMap, instInUpdateMap = updateDbMap[childTblNm][childTblKey]; !instInUpdateMap {
+						if nonTblOwnerInstRwInResultMap, instInCreateMap = createDbMap[childTblNm][childTblKey]; !instInCreateMap {
+							log.V(4).Info("Table instance not found in REPLACE/UPDATE/CREATE result map.")
+							continue
+						}
+					}
+					tblOwner = false
+					log.V(4).Infof("Table instance %v found in UPDATE/CREATE result map with fields %v", childTblAndKey, nonTblOwnerInstRwInResultMap)
+				}
+
+				//cleanup depending on table-ownership and key vs non-key based relationship between the parent and child table
+				childTblSpec := &db.TableSpec{Name: childTblNm}
+				if len(depInstFieldMap) > 0 {
+					// non-key based realtionship so clean-up only dependent fields
+					var fieldRw db.Value
+					fieldRw.Field = make(map[string]string)
+					for field, val := range depInstFieldMap {
+						fieldRw.Field[field] = val
+					}
+					if !tblOwner {
+						/* for non-table owner if dependent data has a field not mapped to/under the
+						   target URI yang hierarchy then abort since CVL will not allow parent to be deleted
+						   without dependency being cleaned.
+						*/
+						cleanUp, cleanUpErr := checkNonTblOwnerDepChildNeedsCleanUp(fieldRw, nonTblOwnerInstRwInResultMap,
+							parentInst, depInst, app.pathInfo.Path)
+						if cleanUpErr != nil {
+							return cleanUpErr
+						}
+						if !cleanUp {
+							continue
+						}
+					}
+					err = d.DeleteEntryFields(childTblSpec, db.Key{Comp: []string{childTblKey}}, fieldRw)
+					if err != nil {
+						log.Warning("DELETE for REPLACE case d.DeleteEntryFields() failure")
+						return err
+					}
+				} else {
+					//key based relation between parent and child so complete child instance can be deleted
+					if !tblOwner {
+						/* for non-table owner entire child instance cannot be deleted
+						   if that instance in DB has a field not mapped to/under the
+						   target URI yang hierarchy.
+						*/
+						existingEntry, existingEntryErr := d.GetEntry(childTblSpec, db.Key{Comp: []string{childTblKey}})
+						if existingEntryErr != nil {
+							log.Warning("DELETE case for REPLACE - d.GetEntry() failure")
+							return err
+						}
+						if existingEntry.IsPopulated() {
+							cleanUp, cleanUpErr := checkNonTblOwnerDepChildNeedsCleanUp(existingEntry, nonTblOwnerInstRwInResultMap,
+								parentInst, depInst, app.pathInfo.Path)
+							if cleanUpErr != nil {
+								return cleanUpErr
+							}
+							if !cleanUp {
+								continue
+							}
+						}
+					}
+					err = d.DeleteEntry(childTblSpec, db.Key{Comp: []string{childTblKey}})
+					if err != nil {
+						log.Warning("DELETE for REPLACE case - d.DeleteEntry() failure")
+						return err
+					}
+				}
+			}
+		} // end of depData List loop
+	} //end of parent table keys loop
+
+	return nil
+}
+
 func (app *CommonApp) handleChildDeleteForOcReplaceAndDelete(d *db.DB, sortedDelTblLst []string, moduleNm string) error {
 	/* resultTblLst has child first, parent later order */
+	var cvlSess *cvl.CVL
 	var err error
+
+	if app.cmnAppOpcode == REPLACE {
+		cvlSess, err = d.NewValidationSession()
+		if err != nil || cvlSess == nil {
+			log.Info("getCVLDepDataForDelete : cvl.ValidationSessOpen failed")
+			return err
+		}
+		defer cvl.ValidationSessClose(cvlSess)
+	}
 
 	for _, tblNm := range sortedDelTblLst {
 		log.V(4).Info("In Yang to DB map returned from transformer looking for table = ", tblNm)
@@ -940,7 +1127,7 @@ func (app *CommonApp) handleChildDeleteForOcReplaceAndDelete(d *db.DB, sortedDel
 			cmnAppTs := &db.TableSpec{Name: tblNm}
 			if len(tblVal) == 0 {
 				log.Info("No table instances/rows found hence mark entire table to be deleted = ", tblNm)
-				/* handle child table cleanup when North Bound oper is REPLACE- TODO.
+				/* handle child table cleanup when North Bound oper is REPLACE
 				   For north bound DELETE child yang hierarchy traversal for target/request
 				   URI will populate the relevant child tables in the result map and
 				   SortAsPerTblDeps() on the tables in result map will take care of child table getting
@@ -949,11 +1136,16 @@ func (app *CommonApp) handleChildDeleteForOcReplaceAndDelete(d *db.DB, sortedDel
 				*/
 				if app.cmnAppOpcode == REPLACE {
 					log.V(4).Info("process Table level Delete For North Bound Replace oper")
-					/* TODO - For North Bound REPLACE operation payload translation can result in
+					/* For North Bound REPLACE operation payload translation can result in
 					   data being populated in UPDATE map based on table ownership and also the
 					   scope of db-mapping at the target URL.DELETE map will contain whats not present
 					   in the payload in yang hiercharchy beneath the target URL.Thus data needs to be
-					   processed in order resolving dependencies to achieve the end result */
+					   processed in order resolving dependencies to achieve the end result.
+					*/
+					err = app.processTableDeleteForReplace(d, tblNm, cmnAppTs, moduleNm, cvlSess, parentKeysList)
+					if err != nil {
+						return err
+					}
 				}
 				log.Info("deleting table = ", tblNm)
 				err = d.DeleteTable(cmnAppTs)
@@ -1014,7 +1206,23 @@ func (app *CommonApp) handleChildDeleteForOcReplaceAndDelete(d *db.DB, sortedDel
 			}
 			/* Delete the dependent entries for all keys in parentKeysList in case of REPLACE */
 			if app.cmnAppOpcode == REPLACE && len(parentKeysList) > 0 {
-				// TODO as mentioned in above comment
+				err = app.processTableDeleteForReplace(d, tblNm, cmnAppTs, moduleNm, cvlSess, parentKeysList)
+				if err != nil {
+					return err
+				}
+			}
+			for _, tableKey := range parentKeysList {
+				log.V(4).Info("Delete parent entry ", cmnAppTs, db.Key{Comp: []string{tableKey}})
+				err = d.DeleteEntry(cmnAppTs, db.Key{Comp: []string{tableKey}})
+				if err != nil {
+					if cvl.CVLRetCode(err.(tlerr.TranslibCVLFailure).Code) == cvl.CVL_SEMANTIC_KEY_NOT_EXIST {
+						log.V(4).Infof("Ignore delete that cannot be processed for table %v key %v that does not exist. err %v", tblNm, tableKey, err.(tlerr.TranslibCVLFailure).CVLErrorInfo.ConstraintErrMsg)
+						err = nil
+					} else {
+						log.Warning("DELETE case - d.DeleteEntry() failure")
+						return err
+					}
+				}
 			}
 		}
 	}
@@ -1379,4 +1587,50 @@ func isPartialReplace(exstRw db.Value, replTblRw db.Value, auxRw db.Value) bool 
 	}
 	log.Info("returning partialReplace - ", partialReplace)
 	return partialReplace
+}
+
+func checkNonTblOwnerDepChildNeedsCleanUp(entryTocheckAgainst db.Value, resultMapEntry db.Value, parentTblInst string, childTblInst string, targetPath string) (bool, error) {
+	foundfieldNotMapped := false
+	fieldNm := ""
+	log.Info("checkNonTblOwnerDepChildNeedsCleanUp() - entryTocheckAgainst", entryTocheckAgainst, "resultMapEntry", resultMapEntry)
+	for field := range entryTocheckAgainst.Field {
+		if !resultMapEntry.Has(field) {
+			foundfieldNotMapped = true
+			fieldNm = field
+			break
+		}
+	}
+	if foundfieldNotMapped {
+		fieldNm = strings.TrimSuffix(fieldNm, "@")
+		log.Warningf("Found field %v not mapped to/under target URI yang hierarchy in child instance %v so cannot delete the child instance.", fieldNm, childTblInst)
+		errStr := fmt.Sprintf("Instance %v is in use by %v for field %v(not mapped in target yang hierarchy) and cannot be deleted.", parentTblInst, childTblInst, fieldNm)
+		return false, tlerr.InternalError{Format: errStr, Path: targetPath}
+	}
+
+	return true, nil
+}
+
+func markChildTablesToCleanFromTranslatedResult(d *db.DB, resultDbMap map[string]map[string]db.Value, childTblToCleanMap map[string]bool, parentTblNm string, moduleNm string) {
+	for tblNm := range resultDbMap {
+		if tblNm == parentTblNm {
+			continue
+		}
+		if childTblToCleanMap[tblNm] {
+			log.Info("Table already marked for cleaning ", tblNm)
+			continue
+		}
+		tblSpec := &db.TableSpec{Name: tblNm}
+		tblKeys, getKeysErr := d.GetKeys(tblSpec)
+		if getKeysErr != nil {
+			log.Infof("GetKeys() failed for table - %v - error - %v", tblNm, getKeysErr)
+		}
+		if len(tblKeys) == 0 {
+			log.Info("No DB data found so no action to take for table ", tblNm)
+			continue
+		}
+		if !transformer.IsDependentChildTable(tblNm, parentTblNm, moduleNm) {
+			continue
+		}
+		childTblToCleanMap[tblNm] = true
+	}
 }

--- a/translib/transformer/xfmr_testxfmr_callbacks.go
+++ b/translib/transformer/xfmr_testxfmr_callbacks.go
@@ -52,8 +52,6 @@ func init() {
 	XlateFuncBind("DbToYang_test_set_key_xfmr", DbToYang_test_set_key_xfmr)
 	XlateFuncBind("YangToDb_sensor_a_light_sensor_key_xfmr", YangToDb_sensor_a_light_sensor_key_xfmr)
 	XlateFuncBind("DbToYang_sensor_a_light_sensor_key_xfmr", DbToYang_sensor_a_light_sensor_key_xfmr)
-	//XlateFuncBind("YangToDb_test_ntp_authentication_key_xfmr", YangToDb_test_ntp_authentication_key_xfmr)
-	//XlateFuncBind("DbToYang_test_ntp_authentication_key_xfmr", DbToYang_test_ntp_authentication_key_xfmr)
 	XlateFuncBind("YangToDb_test_ni_instance_key_xfmr", YangToDb_test_ni_instance_key_xfmr)
 	XlateFuncBind("DbToYang_test_ni_instance_key_xfmr", DbToYang_test_ni_instance_key_xfmr)
 	XlateFuncBind("YangToDb_test_ni_instance_protocol_key_xfmr", YangToDb_test_ni_instance_protocol_key_xfmr)
@@ -110,7 +108,7 @@ var test_pre_xfmr PreXfmrFunc = func(inParams XfmrParams) error {
 	rejectReplaceNodes := []string{"/openconfig-test-xfmr:test-xfmr/interfaces",
 		"/openconfig-test-xfmr:test-xfmr/test-sensor-groups",
 		"/openconfig-test-xfmr:test-xfmr/test-sensor-types",
-		"/openconfig-test-xfmr:test-xfmr/test-sets",
+		"/openconfig-test-xfmr:test-xfmr",
 	}
 	targetUriPath, _ := getYangPathFromUri(pathInfo.Path)
 

--- a/translib/transformer/xlate_datastructs.go
+++ b/translib/transformer/xlate_datastructs.go
@@ -79,6 +79,34 @@ type xpathTblKeyExtractRet struct {
 	isNotTblOwner bool
 }
 
+type replaceProcessingInfo struct {
+	/* used to differentiate DELETE flow for REPLACE vs normal DELETE */
+	isDeleteForReplace bool
+
+	/* Add current uri when subtree invoked first time in payload processing.
+	   Used in DELETE flow for REPLACE
+	*/
+	subtreeVisitedCache map[string]bool
+
+	/* subOpDataMap filled only by infra during Replace request/target URI or
+	   payload processing for nontable owner cases identified by non table owner
+	   annotation(static/dynamic) or inherited table case(applies for target URI level only).
+	*/
+	subOpDataMap map[Operation]*RedisDbMap
+
+	/* set to true for request URI node having child complex-node(list/container) else
+	   set to false IFF request URI is leaf/leaf-list/terminal-container/terminal-list */
+	targetHasNonTerminalNode bool
+
+	/* Boolean pointer that is used to indicate if sibling fields traversal is required
+	   during delete if field found in non REPLACE resultMap*/
+	skipFieldSiblingTraversalForDelete *bool
+
+	/*used to identify if default value processing is being done for Non-table owner data
+	  populated in subOpDataMap[UPDATE]*/
+	isNonTblOwnerDefaultValProcess bool
+}
+
 type xlateFromDbParams struct {
 	d          *db.DB //current db
 	dbs        [db.MaxDB]*db.DB
@@ -133,6 +161,7 @@ type xlateToParams struct {
 	xfmrDbTblKeyCache       map[string]tblKeyCache
 	dbTblKeyGetCache        map[db.DBNum]map[string]map[string]bool
 	invokeCRUSubtreeOnceMap map[string]map[string]bool
+	replaceInfo             *replaceProcessingInfo
 }
 
 type contentQPSpecMapInfo struct {

--- a/translib/transformer/xlate_from_db.go
+++ b/translib/transformer/xlate_from_db.go
@@ -2027,6 +2027,13 @@ func dbDataToYangJsonCreate(inParamsForGet xlateFromDbParams) (string, bool, err
 							}
 							inParamsForGet.ygRoot = ygRoot
 							break
+						} else if (yangType == YANG_LEAF_LIST) && ((strings.HasSuffix(uri, "]")) || (strings.HasSuffix(uri, "]/"))) {
+							/*GET on leaf-list instance with subtree annotatiion.
+							  Translib pre-populates ygRoot with leaf-list instance specified in GET URL
+							*/
+							jsonMapData, _ := json.Marshal(resultMap)
+							jsonData = fmt.Sprintf("%v", string(jsonMapData))
+							return jsonData, false, nil
 						}
 					} else {
 						tbl, key, _ := tableNameAndKeyFromDbMapGet((*dbDataMap)[cdb], xpathKeyExtRet.tableName)

--- a/translib/transformer/xlate_replace_utils.go
+++ b/translib/transformer/xlate_replace_utils.go
@@ -1,0 +1,895 @@
+////////////////////////////////////////////////////////////////////////////////
+//                                                                            //
+//  Copyright 2024 Dell, Inc.                                                 //
+//                                                                            //
+//  Licensed under the Apache License, Version 2.0 (the "License");           //
+//  you may not use this file except in compliance with the License.          //
+//  You may obtain a copy of the License at                                   //
+//                                                                            //
+//  http://www.apache.org/licenses/LICENSE-2.0                                //
+//                                                                            //
+//  Unless required by applicable law or agreed to in writing, software       //
+//  distributed under the License is distributed on an "AS IS" BASIS,         //
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  //
+//  See the License for the specific language governing permissions and       //
+//  limitations under the License.                                            //
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+
+package transformer
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Azure/sonic-mgmt-common/translib/db"
+	"github.com/Azure/sonic-mgmt-common/translib/tlerr"
+	log "github.com/golang/glog"
+)
+
+func processTargetUriForReplace(xlateParams xlateToParams, skipDelete *bool) error {
+	/* This function identifies if the sonic table mapped to the request URI is owned by the node or not and decide if
+	   the DB table key entry should be in UPDATE map or REPLACE map so that related payload(leaf/leaf-list) can go in correct
+	   operation map.This function also decides if DELETE processing is to be skipped following a REPLACE when request URI
+	   is Leaf or Leaf-list or list instance that  doesn't exist in DB or a subtree-xfmr is present at request URI with
+	   no nested child subtree-xfmr.
+	*/
+
+	isTblOwner := true
+	var dbs [db.MaxDB]*db.DB
+
+	// Check for subtree at request URI
+	xpath, _, _ := XfmrRemoveXPATHPredicates(xlateParams.requestUri)
+	spec, ok := xYangSpecMap[xpath]
+	if !ok {
+		errStr := fmt.Sprintf("Invalid yang-path(\"%v\").", xpath)
+		return tlerr.InternalError{Format: errStr}
+	}
+	if len(spec.xfmrFunc) > 0 {
+		if !spec.hasChildSubTree {
+			if skipDelete != nil {
+				*skipDelete = true
+				xfmrLogDebug("Request URI has subtree annotated with no child subtree hence skip DELETE after REPLACE.")
+			}
+		}
+		return nil
+	}
+
+	/* skip Delete and follow regular REPLACE flow for request URI thats a :
+	   a) leaf
+	   b) leaf-list
+	   c) terminal container(having only leaves/leaf-list(s) children).Infra handles partial-relace
+	      at terminal container using Aux map & common_app flow appropriately
+	*/
+	if spec.yangType == YANG_LEAF || spec.yangType == YANG_LEAF_LIST {
+		xlateParams.replaceInfo.targetHasNonTerminalNode = false
+		if skipDelete != nil {
+			*skipDelete = true
+			xfmrLogDebug("Request URI is leaf/leaf-list hence skip DELETE after REPLACE.")
+		}
+		return nil
+	}
+	if spec.yangType == YANG_CONTAINER && !spec.hasNonTerminalNode {
+		xlateParams.replaceInfo.targetHasNonTerminalNode = false
+		if skipDelete != nil {
+			*skipDelete = true
+		}
+		xfmrLogDebug("Request URI is terminal container hence skip DELETE after REPLACE.")
+		return nil
+	}
+
+	/* whole list case at request URI,so no table-instance.*/
+	if spec.yangType == YANG_LIST {
+		if !spec.hasNonTerminalNode {
+			xlateParams.replaceInfo.targetHasNonTerminalNode = false
+		}
+		if !(strings.HasSuffix(xlateParams.requestUri, "]") || strings.HasSuffix(xlateParams.requestUri, "]/")) {
+			return nil
+		} else if !spec.hasNonTerminalNode {
+			/*if the request URI list-instance belongs to a terminal list
+			  then the aux-map/partial-replace handling in common_app will do
+			  the needful so DELETE traversal can be skipped.
+			*/
+			if skipDelete != nil {
+				*skipDelete = true
+			}
+			xfmrLogDebug("Request URI is terminal list instance hence skip DELETE after REPLACE.")
+			return nil
+		}
+	}
+
+	/*skip further processing if virtual table annotated*/
+	if spec.virtualTbl != nil && *spec.virtualTbl {
+		xfmrLogDebug("Request URI has virtual table annotated.")
+		return nil
+	}
+
+	// Check the table owner flag if annotated
+	checkTblOwnerThruInheritance := true
+	if spec.tblOwner != nil {
+		if !*spec.tblOwner {
+			isTblOwner = false
+		}
+		checkTblOwnerThruInheritance = false
+		xfmrLogDebug("Target uri contains table owner annoatation with value %v.", *spec.tblOwner)
+	}
+
+	xpathKeyExtRet, cerr := xpathKeyExtract(xlateParams.d, xlateParams.ygRoot, xlateParams.oper, xlateParams.uri, xlateParams.requestUri, nil, xlateParams.subOpDataMap,
+		xlateParams.txCache, xlateParams.xfmrDbTblKeyCache, dbs)
+	if cerr != nil {
+		return cerr
+	}
+	curKey := xpathKeyExtRet.dbKey
+	curTbl := xpathKeyExtRet.tableName
+	if len(curTbl) == 0 || len(curKey) == 0 {
+		xfmrLogDebug("Target uri didn't translate to a table or key so proceed to payload processing.")
+		return nil
+	}
+	if xpathKeyExtRet.isVirtualTbl {
+		xfmrLogDebug("Target uri table transformer reported virtual table.")
+		return nil
+	}
+	if xpathKeyExtRet.isNotTblOwner {
+		checkTblOwnerThruInheritance = false
+		xfmrLogDebug("Target uri table transformer reported not table owner.")
+	}
+
+	if checkTblOwnerThruInheritance {
+		xfmrLogDebug("Checking table ownership through inheritance.")
+		parentUri := parentUriGet(xlateParams.requestUri)
+		parentXpathKeyExtRet, perr := xpathKeyExtract(xlateParams.d, xlateParams.ygRoot, xlateParams.oper, parentUri, xlateParams.requestUri, nil, xlateParams.subOpDataMap,
+			xlateParams.txCache, xlateParams.xfmrDbTblKeyCache, dbs)
+		parentTbl := parentXpathKeyExtRet.tableName
+		parentKey := parentXpathKeyExtRet.dbKey
+
+		if perr != nil {
+			return perr
+		}
+
+		if parentTbl == curTbl && curKey == parentKey {
+			// Parent and current node mapped to same instance
+			isTblOwner = false
+			xfmrLogDebug("Target uri inherits table and key from parent so its not table owner.")
+		}
+	}
+
+	/*check for target URI resource existance */
+	_, derr := dbTableExists(xlateParams.d, curTbl, curKey, xlateParams.oper)
+
+	/* dbTableExists() returns Resource Not found(NotFoundError) error along with other error.
+	   In order to skip Delete after Replace for list instance target URI, it should be
+	   correctly known whether Tbl instance doesn't exists, which is when dbTableExists()
+	   returns tlerr.NotFoundError error.Also if target URI is container that has complex child
+	   nodes then that resource needs get created if it doesn't exist, in case there is payload for it.
+	*/
+	resourceExist := false
+	if derr != nil {
+		if _, ok := derr.(tlerr.NotFoundError); ok && strings.Contains(derr.Error(), "Resource not found") {
+			xfmrLogDebug("Resource doesn't exist in DB.(%v)", derr.Error())
+		} else {
+			xfmrLogDebug("Resource existance in DB couldn't be determined.(%v)", derr)
+		}
+	} else {
+		resourceExist = true
+	}
+
+	/* Handle list instance case, whole list already handled above. */
+	if spec.yangType == YANG_LIST && !resourceExist && skipDelete != nil {
+		/*skip DELETE after REPLACE processing if instance doesn't exist in DB*/
+		*skipDelete = true
+		xfmrLogDebug("List instance doesn't exist in DB hence skip DELETE after REPLACE.")
+	}
+
+	if isTblOwner || ((spec.yangType == YANG_LIST) && (!resourceExist)) {
+		/* Table owner can REPLACE the instance.So add it to result(map where REPLACE result is
+		   added when payload processing).For NON table-owner if resource doesn't exist, the instance
+		   can still be added to result(REPLACE), so that cases where applications use the presence of that
+		   instance in global default value map(inParams.yangDefValMap - filled for instances in result) to
+		   add all defaults for a SONIC table-instance.eg.BGP_GLOBALS post-xfmr.
+		*/
+		xlateParams.result[curTbl] = map[string]db.Value{curKey: {Field: map[string]string{"NULL": "NULL"}}}
+	} else {
+		/*If resource exists then Non table owner should update the instance not replace/swap it hence put it in UPDATE map*/
+		allocateSubOpDataMapForOper(xlateParams.replaceInfo.subOpDataMap, UPDATE)
+		subOpUpdateMap, updateOk := xlateParams.replaceInfo.subOpDataMap[UPDATE]
+		if updateOk {
+			if _, curTblOk := (*subOpUpdateMap)[db.ConfigDB][curTbl]; !curTblOk {
+				(*subOpUpdateMap)[db.ConfigDB][curTbl] = make(map[string]db.Value)
+			}
+			if _, curKeyOk := (*subOpUpdateMap)[db.ConfigDB][curTbl][curKey]; !curKeyOk {
+				(*subOpUpdateMap)[db.ConfigDB][curTbl][curKey] = db.Value{Field: map[string]string{"NULL": "NULL"}}
+			}
+		}
+	}
+
+	//Add the uri to default value cacahe to have the defaults filled once payload processing is done
+	// tblXpathMap used for default value processing for a given request
+	if tblUriMapVal, tblUriMapOk := xlateParams.tblXpathMap[curTbl][curKey]; !tblUriMapOk {
+		if _, tblOk := xlateParams.tblXpathMap[curTbl]; !tblOk {
+			xlateParams.tblXpathMap[curTbl] = make(map[string]map[string]bool)
+		}
+		tblUriMapVal = map[string]bool{xlateParams.requestUri: true}
+		xlateParams.tblXpathMap[curTbl][curKey] = tblUriMapVal
+	} else {
+		if tblUriMapVal == nil {
+			tblUriMapVal = map[string]bool{xlateParams.requestUri: true}
+		} else {
+			tblUriMapVal[xlateParams.requestUri] = true
+		}
+		xlateParams.tblXpathMap[curTbl][curKey] = tblUriMapVal
+	}
+
+	return nil
+}
+
+func dataToDBMapForReplace(xlateParams xlateToParams, field string, value string) {
+	var updateOk, sendSubOpMapUpdate bool
+	var subOpUpdateMap *RedisDbMap
+
+	curTbl := xlateParams.tableName
+	curKey := xlateParams.keyName
+
+	if xlateParams.replaceInfo == nil { //ideally will never happen, just added for safety
+		xfmrLogInfo("replace processing info not set.")
+		return
+	}
+
+	xfmrLogDebug("Received uri: %v, Table: %v, Key: %v, Field: %v, Value: %v, Resultmap(REPLACE oper): %v, "+
+		"replaceInfo.subOpDataMap: %v", xlateParams.uri, curTbl, curKey, field, value,
+		xlateParams.result, subOpDataMapType(xlateParams.replaceInfo.subOpDataMap))
+
+	/* This function processes payload and translates it to appropriate operation DB result map.*/
+	subOpUpdateMap, updateOk = xlateParams.replaceInfo.subOpDataMap[UPDATE]
+	if updateOk && subOpUpdateMap != nil {
+		if tblRw, ok := (*subOpUpdateMap)[db.ConfigDB][curTbl][curKey]; ok {
+			for fld := range tblRw.Field {
+				if fld == field {
+					xfmrLogDebug("Field %v already present in subOpMapData under UPDATE operation so no need to refill.", field)
+					return
+				}
+			}
+			sendSubOpMapUpdate = true
+		}
+	}
+	xpathInfo, ok := xYangSpecMap[xlateParams.xpath]
+	if !ok {
+		xfmrLogInfo("Invalid yang-path(\"%v\").", xlateParams.xpath)
+		return
+	}
+
+	tblOwner := !xlateParams.isNotTblOwner
+	if xpathInfo.tblOwner != nil {
+		tblOwner = *xpathInfo.tblOwner
+	}
+
+	/*if the request URI(identified using replaceInfo.targetHasNonTerminalNode) is
+	  leaf/leaf-list/terminal container/terminal list then the aux-map/partial-replace
+	  handling in common_app will do the needful for non-table owner cases too
+	  so no need to add to subOpData UPDATE.
+	*/
+	if !sendSubOpMapUpdate && xlateParams.replaceInfo.targetHasNonTerminalNode && !tblOwner {
+		configDbOk := false
+		if updateOk && subOpUpdateMap != nil {
+			_, configDbOk = (*subOpUpdateMap)[db.ConfigDB]
+		}
+		if !updateOk || subOpUpdateMap == nil || !configDbOk {
+			allocateSubOpDataMapForOper(xlateParams.replaceInfo.subOpDataMap, UPDATE)
+			subOpUpdateMap = xlateParams.replaceInfo.subOpDataMap[UPDATE]
+		}
+		sendSubOpMapUpdate = true
+	}
+
+	if sendSubOpMapUpdate {
+		dataToDBMapAdd(curTbl, curKey, (*subOpUpdateMap)[db.ConfigDB], field, value)
+	} else {
+		dataToDBMapAdd(curTbl, curKey, xlateParams.result, field, value)
+	}
+	xfmrLogDebug("After processing uri: %v, Table: %v, Key: %v, Field: %v, Value: %v, "+
+		"Resultmap(REPLACE oper): %v, replaceInfo.subOpDataMap: %v", xlateParams.uri, curTbl, curKey, field, value,
+		xlateParams.result, subOpDataMapType(xlateParams.replaceInfo.subOpDataMap))
+
+}
+
+func dbMapDefaultFieldValFillForReplace(xlateParams xlateToParams, tblUriList []string) error {
+	var result, yangDefValMap, yangAuxValMap map[string]map[string]db.Value
+
+	/* In REPLACE flow non-table-owner nodes' payload data is added to subOpDataMap[UPDATE] */
+	if xlateParams.replaceInfo != nil && xlateParams.replaceInfo.isNonTblOwnerDefaultValProcess {
+		/* Defaults for leaves inside non-table-owner nodes must be reset even if instance exists
+		   in DB so transfer them to result.Non-default leaves inside non-table-owner nodes
+		   which were not present in payload should be deleted, so transfer them from auxValmap to
+		   original/global DELETE subOpDataMap.
+		*/
+		result = (*xlateParams.replaceInfo.subOpDataMap[UPDATE])[db.ConfigDB]
+		yangDefValMap = (*xlateParams.replaceInfo.subOpDataMap[UPDATE])[db.ConfigDB]
+		yangAuxValMap = (*xlateParams.replaceInfo.subOpDataMap[DELETE])[db.ConfigDB]
+	} else {
+		result = xlateParams.result
+		yangDefValMap = xlateParams.yangDefValMap
+		yangAuxValMap = xlateParams.yangAuxValMap
+	}
+
+	tblData := result[xlateParams.tableName]
+	var dbs [db.MaxDB]*db.DB
+	tblName := xlateParams.tableName
+	isNotTblOwner := xlateParams.isNotTblOwner
+	dbKey := xlateParams.keyName
+	defSubOpDataMap := make(map[Operation]*RedisDbMap)
+	for _, tblUri := range tblUriList {
+		xfmrLogDebug("Processing URI %v for default value filling(Table - %v, dbKey - %v)", tblUri, tblName, dbKey)
+		yangXpath, _, prdErr := XfmrRemoveXPATHPredicates(tblUri)
+		if prdErr != nil {
+			continue
+		}
+		yangNode, ok := xYangSpecMap[yangXpath]
+		if ok && yangNode.yangEntry != nil {
+			for childName := range yangNode.yangEntry.Dir {
+				childXpath := yangXpath + "/" + childName
+				childUri := tblUri + "/" + childName
+				childNode, ok := xYangSpecMap[childXpath]
+				if ok {
+					if len(childNode.xfmrFunc) > 0 {
+						xfmrLogDebug("Skip default filling since a subtree Xfmr found for path - %v", childXpath)
+						continue
+					}
+					yangType := childNode.yangType
+					childNodeYangEntry := yangNode.yangEntry.Dir[childName]
+					if childNodeYangEntry == nil {
+						xfmrLogDebug("yang entry is nil for xpath %v", childXpath)
+						continue
+					}
+					if ((yangType == YANG_LIST) || (yangType == YANG_CONTAINER)) && (!childNodeYangEntry.ReadOnly()) {
+						var tblList []string
+						if childNode.tableName != nil && *childNode.tableName != tblName {
+							continue
+						}
+						if childNode.xfmrTbl != nil {
+							if len(*childNode.xfmrTbl) > 0 {
+								inParamsTblXfmr := formXfmrInputRequest(xlateParams.d, dbs, db.MaxDB, xlateParams.ygRoot, childUri, xlateParams.requestUri, xlateParams.oper, "", nil, defSubOpDataMap, "", xlateParams.txCache)
+								chldTblNm, ctErr := tblNameFromTblXfmrGet(*childNode.xfmrTbl, inParamsTblXfmr, xlateParams.xfmrDbTblKeyCache)
+								xfmrLogDebug("Table transformer %v for xpath %v returned table %v", *childNode.xfmrTbl, childXpath, chldTblNm)
+								if ctErr != nil || chldTblNm != tblName {
+									continue
+								}
+							}
+						}
+						tblList = append(tblList, childUri)
+						err := dbMapDefaultFieldValFillForReplace(xlateParams, tblList)
+						if err != nil {
+							return err
+						}
+					}
+					/*terminal-node/leaf case*/
+					_, ok := tblData[dbKey].Field[childName]
+					if !ok {
+						if len(childNode.xfmrField) > 0 {
+							childYangDataType := childNodeYangEntry.Type.Kind
+							var param interface{}
+							oper := xlateParams.oper
+							if len(childNode.defVal) > 0 {
+								xfmrLogDebug("Update(\"%v\") default: tbl[\"%v\"]key[\"%v\"]fld[\"%v\"] = val(\"%v\").",
+									childXpath, tblName, dbKey, childNode.fieldName, childNode.defVal)
+								_, defValPtr, err := DbToYangType(childYangDataType, childXpath, childNode.defVal, xlateParams.oper)
+								if err == nil && defValPtr != nil {
+									param = defValPtr
+								} else {
+									xfmrLogDebug("Failed to update(\"%v\") default: tbl[\"%v\"]key[\"%v\"]fld[\"%v\"] = val(\"%v\").",
+										childXpath, tblName, dbKey, childNode.fieldName, childNode.defVal)
+								}
+							} else {
+								// non-default field not part of translated result should be deleted so add it to auxValMap
+								oper = DELETE
+							}
+							inParams := formXfmrInputRequest(xlateParams.d, dbs, db.MaxDB, xlateParams.ygRoot, tblUri+"/"+childName, xlateParams.requestUri, oper, "", nil, defSubOpDataMap, param, xlateParams.txCache)
+							retData, err := leafXfmrHandler(inParams, childNode.xfmrField)
+							if err != nil {
+								log.Warningf("Default/AuxMap Value filling. Received error %v from %v", err, childNode.xfmrField)
+							}
+							if retData != nil {
+								xfmrLogDebug("xfmr function : %v Xpath: %v retData: %v", childNode.xfmrField, childXpath, retData)
+								for f, v := range retData {
+									// Fill default value only if value is not available in result Map
+									// else we overwrite the value filled in resultMap with default value
+									_, ok := result[tblName][dbKey].Field[f]
+									if !ok {
+										if len(childNode.defVal) > 0 {
+											dataToDBMapAdd(tblName, dbKey, yangDefValMap, f, v)
+										} else {
+											// Fill the yangAuxValMap with all fields that are not in either resultMap or defaultValue Map
+											dataToDBMapAdd(tblName, dbKey, yangAuxValMap, f, "")
+										}
+									}
+								}
+							}
+						} else if len(childNode.fieldName) > 0 {
+							var xfmrErr error
+							if xDbSpecInfo, ok := xDbSpecMap[tblName+"/"+childNode.fieldName]; ok && (xDbSpecInfo != nil) && (!xDbSpecInfo.isKey) {
+								// Fill default value only if value is not available in result Map
+								// else we overwrite the value filled in resultMap with default value
+								dbFieldNm := childNode.fieldName
+								if xDbSpecInfo.yangType == YANG_LEAF_LIST {
+									dbFieldNm += "@"
+								}
+								_, ok = result[tblName][dbKey].Field[dbFieldNm]
+								if !ok {
+									if len(childNode.defVal) > 0 {
+										curXlateParams := formXlateToDbParam(xlateParams.d, xlateParams.ygRoot, xlateParams.oper, xlateParams.uri, xlateParams.requestUri, childXpath, dbKey, xlateParams.jsonData, xlateParams.resultMap, yangDefValMap, xlateParams.txCache, xlateParams.tblXpathMap, defSubOpDataMap, xlateParams.pCascadeDelTbl, &xfmrErr, childName, childNode.defVal, tblName, isNotTblOwner, xlateParams.invokeCRUSubtreeOnceMap, nil, nil, xlateParams.replaceInfo)
+										err := mapFillDataUtil(curXlateParams, true)
+										if err != nil {
+											log.Warningf("Default/AuxMap Value filling. Received error %v from %v", err, childNode.fieldName)
+										}
+									} else {
+										dataToDBMapAdd(tblName, dbKey, yangAuxValMap, dbFieldNm, "")
+									}
+								}
+							}
+						} else if childNode.isRefByKey {
+							/* this case occurs only for static table-name, table-xfmr always has field-name
+							   assigned by infra when there no explicit annotation from user.
+							   Also key-leaf in config container has no default value, so here we handle only
+							   REPLACE yangAuxValMap filling */
+							_, ok := result[tblName][dbKey].Field["NULL"]
+							if !ok {
+								dataToDBMapAdd(tblName, dbKey, yangAuxValMap, "NULL", "")
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func dbMapDefaultValFillForReplace(xlateParams xlateToParams) error {
+
+	xfmrLogDebug("Before default value processing of result for REPLACE xlateParams.result %v, xlateParams.subOpDataMap %v, xlateParams.yangDefValMap %v", xlateParams.result, subOpDataMapType(xlateParams.subOpDataMap), xlateParams.yangDefValMap)
+	for tbl, tblData := range xlateParams.result {
+		if _, tblOk := xlateParams.tblXpathMap[tbl]; !tblOk {
+			continue
+		}
+		for dbKey := range tblData {
+			var yxpathList []string //contains all uris(with keys) that were traversed for a table while processing the incoming request
+			if tblUriMapVal, ok := xlateParams.tblXpathMap[tbl][dbKey]; !ok {
+				continue
+			} else {
+				for tblUri := range tblUriMapVal {
+					yxpathList = append(yxpathList, tblUri)
+				}
+			}
+			if len(yxpathList) == 0 {
+				continue
+			}
+
+			curXlateParams := xlateParams
+			curXlateParams.tableName = tbl
+			curXlateParams.keyName = dbKey
+			err := dbMapDefaultFieldValFillForReplace(curXlateParams, yxpathList)
+			if err != nil {
+				return err
+			}
+			tblInstDefaultFields, deflvalOk := xlateParams.yangDefValMap[tbl][dbKey]
+			if !deflvalOk {
+				tblInstDefaultFields = db.Value{}
+			}
+			removeTblInstMappedtoContainer(xlateParams.result, tbl, dbKey, tblInstDefaultFields, yxpathList)
+		}
+	}
+	xfmrLogDebug("After default value processing of result for REPLACE xlateParams.result %v, xlateParams.subOpDataMap %v,"+
+		" xlateParams.yangDefValMap %v, xlateParams.yangAuxValMap %v", xlateParams.result, subOpDataMapType(xlateParams.subOpDataMap),
+		xlateParams.yangDefValMap, xlateParams.yangAuxValMap)
+
+	// non-table owner infra handled cases are filled in erplaceInfo.subOpDataMap.Perform default value processing for them.
+	if (xlateParams.replaceInfo == nil) || (!xlateParams.replaceInfo.targetHasNonTerminalNode) {
+		return nil
+	}
+
+	var subOpUpdateMap *RedisDbMap
+	var updateDbDataMap map[string]map[string]db.Value
+	var updateOk, cfgOk, subOpDelMapAllocated bool
+	if subOpUpdateMap, updateOk = xlateParams.replaceInfo.subOpDataMap[UPDATE]; !updateOk || subOpUpdateMap == nil {
+		return nil
+	}
+	if updateDbDataMap, cfgOk = (*subOpUpdateMap)[db.ConfigDB]; !cfgOk || (len(updateDbDataMap) == 0) {
+		return nil
+	}
+	xfmrLogDebug("Before default value processing of result for UPDATE(non table owners filled by infra) replaceInfo.subOpDataMap %v", subOpDataMapType(xlateParams.replaceInfo.subOpDataMap))
+	xlateParams.replaceInfo.isNonTblOwnerDefaultValProcess = true
+	for tbl, tblData := range updateDbDataMap {
+		if _, tblOk := xlateParams.tblXpathMap[tbl]; !tblOk {
+			continue
+		}
+		for dbKey := range tblData {
+			var yxpathList []string
+			if tblUriMapVal, ok := xlateParams.tblXpathMap[tbl][dbKey]; !ok {
+				continue
+			} else {
+				for tblUri := range tblUriMapVal {
+					yxpathList = append(yxpathList, tblUri)
+				}
+			}
+
+			if len(yxpathList) == 0 {
+				continue
+			}
+
+			if !subOpDelMapAllocated {
+				allocateSubOpDataMapForOper(xlateParams.replaceInfo.subOpDataMap, DELETE)
+				subOpDelMapAllocated = true
+			}
+			/* check if the same instance has been processed above as part of REPLACE result map instance processing.
+			   Same instance might get added into result of REPLACE by subtree, since during payload processing immediately
+			   after every subtree call the subtree returned result is consolidated into infra replace result map.
+			   The default value cache(xlateParams.tblXpathMap) is indexed based on table-key,so all infra-handled yang-paths
+			   mapped against it are already processed in above default value processing and the global yangDefValMap and yangAuxValMap filled accordingly.
+			   So transfer data from global yangDefValMap for the instance into replaceInfo.subOpDataMap[UPDATE]
+			   after cross checking against what was filled from infra-handled payload into replaceInfo.subOpDataMap[UPDATE].
+			   replaceInfo.subOpDataMap[UPDATE] will be consolidated with Replace result map later.
+			   Also since the instance is going to be replaced clear off the instance from global yangAuxvalMap.
+			*/
+
+			if _, instanceFoundInReplaceResultMap := xlateParams.result[tbl][dbKey]; instanceFoundInReplaceResultMap {
+				if defValMapInstanceFields, instanceYangDefValMapOk := xlateParams.yangDefValMap[tbl][dbKey]; instanceYangDefValMapOk {
+					for field, val := range defValMapInstanceFields.Field {
+						if _, fldOk := updateDbDataMap[tbl][dbKey].Field[field]; !fldOk {
+							updateDbDataMap[tbl][dbKey].Field[field] = val
+						}
+					}
+					delete(xlateParams.yangDefValMap[tbl], dbKey)
+					if len(xlateParams.yangDefValMap[tbl]) == 0 {
+						delete(xlateParams.yangDefValMap, tbl)
+					}
+				}
+				if _, instanceYangAuxValMapOk := xlateParams.yangAuxValMap[tbl][dbKey]; instanceYangAuxValMapOk {
+					delete(xlateParams.yangAuxValMap[tbl], dbKey)
+					if len(xlateParams.yangAuxValMap[tbl]) == 0 {
+						delete(xlateParams.yangAuxValMap, tbl)
+					}
+				}
+				xfmrLogDebug("Skipping default value processing for instance [%v][%v] as it is already processed in REPLACE result map."+
+					" xlateParams.replaceInfo.subOpDataMap %v, xlateParams.yangDefValMap %v, xlateParams.yangAuxValMap %v",
+					tbl, dbKey, subOpDataMapType(xlateParams.replaceInfo.subOpDataMap), xlateParams.yangDefValMap, xlateParams.yangAuxValMap)
+				removeTblInstMappedtoContainer(updateDbDataMap, tbl, dbKey, db.Value{}, yxpathList)
+				continue
+			}
+
+			curXlateParams := xlateParams
+			curXlateParams.tableName = tbl
+			curXlateParams.isNotTblOwner = true
+			curXlateParams.keyName = dbKey
+
+			err := dbMapDefaultFieldValFillForReplace(curXlateParams, yxpathList)
+			if err != nil {
+				return err
+			}
+			removeTblInstMappedtoContainer(updateDbDataMap, tbl, dbKey, db.Value{}, yxpathList)
+		}
+	}
+
+	xfmrLogDebug("Returning from default value processing for REPLACE xlateParams.result(Replace oper result) %v, xlateParams.subOpDataMap %v,"+
+		"xlateParams.yangDefValMap %v, xlateParams.yangAuxValMap %v, xlateParams.replaceInfo.subOpDataMap %v", xlateParams.result,
+		subOpDataMapType(xlateParams.subOpDataMap), xlateParams.yangDefValMap, xlateParams.yangAuxValMap, subOpDataMapType(xlateParams.replaceInfo.subOpDataMap))
+	return nil
+}
+
+func addToDeleteForReplaceMap(tableName string, dbKey string, field string, replaceResultMap map[Operation]RedisDbMap) (bool, bool) {
+	// This function is called only for isDeleteForReplace case and checks if the table,dbKey and field is already present in replaceResultMap
+	//Inputs - table, dbKey and fieldName that needs to be verified if available in replaceResultMap, resultMap (having consolidated result and subOpMap from REPLACE
+	// Output - bool indicating add to delete resultMap required or not, bool to indicate skipSiblingTraversal for the field in input param
+	addToMap := true
+	skipSiblingTraversal := false
+
+	// Check if table instance exists in replace resultMap
+	for op, redisMap := range replaceResultMap {
+		for _, tblMap := range redisMap {
+			for tbl, instMap := range tblMap {
+				if tbl != tableName {
+					// If table not found continue to loop to chk if tableName exists in replaceResultMap
+					continue
+				} else {
+					for key, fieldVal := range instMap {
+						if key != dbKey {
+							// If instance not found continue to loop to check if dbKey exists in replaceResultMap
+							continue
+						} else {
+							// Instance found in replaceResultMap
+							// If no field and value is found in input args it is a table instance, mark instance to be not added to delete resultMap
+							if field == "" {
+								addToMap = false
+							} else if field == "FillFields" {
+								// For non table owners add FillFields to identify fields to be deleted from the yang tree
+								addToMap = true
+							} else {
+								// Check for field availability
+								// If the instance is found in REPLACE resultMap for field level fill, then do not add to delete result as its a complete instance replace
+								if op == REPLACE {
+									addToMap = false
+									skipSiblingTraversal = true
+								}
+								for fld := range fieldVal.Field {
+									if fld == field {
+										// If field found in replaceResultMap for non REPLACE operations, do not add field to deleteMap
+										addToMap = false
+										break
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	return addToMap, skipSiblingTraversal
+}
+
+func processDeleteForReplace(xlateParams xlateToParams) error {
+	var dbs [db.MaxDB]*db.DB
+	var xfmrErr error
+	jsonData := make(map[string]interface{})
+
+	xfmrLogDebug("Before merging REPLACE before going to DELETE xlateParams.resultMap - %v xlateParams.result %v xlateParams.subOpDataMap %v", xlateParams.resultMap, xlateParams.result, subOpDataMapType(xlateParams.subOpDataMap))
+	/*merge REPLACE result and subOpMap into resultMap to pass to DELETE flow*/
+	mergeSubOpMapWithResultForReplace(xlateParams.resultMap, xlateParams.result, xlateParams.subOpDataMap)
+
+	xfmrLogDebug("After merging REPLACE before going to DELETE xlateParams.resultMap - %v ", xlateParams.resultMap)
+
+	/*pass empty result and subOpDataMap as it would be for normal DELETE procesing*/
+	result := make(map[string]map[string]db.Value)
+	subOpDataMap := make(map[Operation]*RedisDbMap)
+	xpathKeyExtRet, err := xpathKeyExtract(xlateParams.d, xlateParams.ygRoot, DELETE, xlateParams.uri, xlateParams.requestUri, nil, xlateParams.subOpDataMap, xlateParams.txCache, nil, dbs)
+	if err != nil {
+		return err
+	}
+	xfmrLogInfo("Delete req for Replace: uri(\"%v\"), key(\"%v\"), xpath(\"%v\"), tableName(\"%v\").", xlateParams.uri, xpathKeyExtRet.dbKey, xpathKeyExtRet.xpath, xpathKeyExtRet.tableName)
+
+	xlateParamsForDelete := formXlateToDbParam(xlateParams.d, xlateParams.ygRoot, DELETE, xlateParams.uri, xlateParams.requestUri, xpathKeyExtRet.xpath, xpathKeyExtRet.dbKey, jsonData,
+		xlateParams.resultMap, result, xlateParams.txCache, xlateParams.tblXpathMap, subOpDataMap, xlateParams.pCascadeDelTbl, &xfmrErr, "", "", xpathKeyExtRet.tableName,
+		xlateParams.isNotTblOwner, nil, nil, nil, xlateParams.replaceInfo)
+	curResult, cerr := allChildTblGetToDelete(xlateParamsForDelete)
+	if cerr != nil {
+		err = cerr
+		return err
+	} else {
+		xfmrLogDebug("allChildTblGetToDelete Before subtree result merge result: %v  subtree curResult: %v subtree subOpDataMap: %v", result, curResult, subOpDataMapType(subOpDataMap))
+		// merge the DELETE translated maps by infra and subtrees
+		mapCopy(result, curResult)
+		xfmrLogDebug("allChildTblGetToDelete DELETE merged result: %v ", result)
+	}
+
+	// Merge the xlateParams.result and xlateParams.subOpDataMap having result of delete traversal for Replace into the resultMap generated for replace payload.
+	mergeDeleteResultMaptoReplaceResultMap(xlateParamsForDelete)
+
+	xfmrLogDebug("After merging DELETE result and subop with REPLACE xlateParams.resultMap - %v \n", xlateParamsForDelete.resultMap)
+
+	/* Reset the result and subOpDataMap with data from resultMap for REPLACE flow since post-xfmr and regular REPLACE flow expects that way*/
+	for op, redisMap := range xlateParamsForDelete.resultMap {
+		// Reset the subopMap to empty Map as it's current data has already been merged to xlateParams.resultMap
+		// Copy into subOpMap data from merged xlateParams.resultMap
+		allocateSubOpDataMapForOper(xlateParams.subOpDataMap, op)
+		operMap := make(RedisDbMap)
+		operMap = redisMap
+		xlateParams.subOpDataMap[op] = &operMap
+
+		if op == REPLACE {
+			xlateParams.result = redisMap[db.ConfigDB]
+			continue
+		}
+
+		if op == DELETE {
+			// Add Delete tables in resultMap to cascade delete table list
+			for tbNm, dbKeyMap := range redisMap[db.ConfigDB] {
+				for _, fieldVal := range dbKeyMap {
+					// Cascade delete supported for instance level delete only
+					if len(fieldVal.Field) == 0 {
+						if tblSpecInfo, ok := xDbSpecMap[tbNm]; ok && tblSpecInfo.cascadeDel == XFMR_ENABLE {
+							if !contains(*xlateParams.pCascadeDelTbl, tbNm) {
+								*xlateParams.pCascadeDelTbl = append(*xlateParams.pCascadeDelTbl, tbNm)
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	xfmrLogDebug("After rearraging resultMap for post xfmr xlateParams.resultMap - %v xlateParams.result - %v, xlateParams.subOpDataMap - %v", xlateParamsForDelete.resultMap, xlateParams.result, subOpDataMapType(xlateParams.subOpDataMap))
+
+	return nil
+}
+
+func mergeDeleteResultMaptoReplaceResultMap(xlateParams xlateToParams) {
+	/* Cross Check & Consolidate REPLACE and DELETE data at end of DELETE for internal REPLACEDELETE:
+	   Cross-check and consolidate data into resultMap["DELETE"] from xlateParams.result(includes DELETE data from infra as well as subtree returned result for DELETE).
+	   Priority is given to resultMap data since it was created from REPLACE payload and should be retained.*/
+
+	if _, ok := xlateParams.resultMap[DELETE]; ok {
+		if _, ok := xlateParams.resultMap[DELETE][db.ConfigDB]; !ok {
+			xlateParams.resultMap[DELETE][db.ConfigDB] = make(map[string]map[string]db.Value)
+		}
+	} else {
+		xlateParams.resultMap[DELETE] = make(RedisDbMap)
+		xlateParams.resultMap[DELETE][db.ConfigDB] = make(map[string]map[string]db.Value)
+	}
+
+	mapMergeAcrossOperations(xlateParams.resultMap, xlateParams.result, DELETE)
+
+	/*Cross-check and consolidate into resultMap data from subOpMap built at the end of DELETE for each oper,tbl,key,field against each
+	  oper,tbl,key,field in resultMap. Priority to be given to REPLACE resultMap in case of conflicts.*/
+
+	operList := []Operation{REPLACE, UPDATE, CREATE, DELETE}
+	for _, op := range operList {
+		if redisMapPtr, ok := xlateParams.subOpDataMap[op]; ok && redisMapPtr != nil {
+			for dbNum, dbMap := range *redisMapPtr {
+				if dbNum != db.ConfigDB {
+					continue
+				}
+				if _, ok := xlateParams.resultMap[op]; !ok {
+					xlateParams.resultMap[op] = make(RedisDbMap)
+				}
+				if _, ok := xlateParams.resultMap[op][dbNum]; !ok {
+					xlateParams.resultMap[op][dbNum] = make(map[string]map[string]db.Value)
+				}
+				mapMergeAcrossOperations(xlateParams.resultMap, dbMap, op)
+			}
+		}
+	}
+}
+
+func mapMergeAcrossOperations(resultMap map[Operation]RedisDbMap, dbMap map[string]map[string]db.Value, op Operation) {
+	for tbl, instMap := range dbMap {
+		for key, fieldVal := range instMap {
+			instFound := false
+			var operFound Operation
+			instFound, operFound = instanceExistsinResultMap(tbl, key, resultMap)
+			if !instFound {
+				// If the instance is not found in resultMap, add them to resultMap
+				if _, ok := resultMap[op][db.ConfigDB][tbl]; !ok {
+					resultMap[op][db.ConfigDB][tbl] = make(map[string]db.Value)
+				}
+				resultMap[op][db.ConfigDB][tbl][key] = db.Value{Field: make(map[string]string)}
+			}
+			// If instance is found check if the fields are present in resultMap for this instance
+			for fld, val := range fieldVal.Field {
+				_, fieldOk := fieldExistsinResultMap(tbl, key, fld, resultMap, instFound, operFound)
+				if op == DELETE {
+					// For DELETE oper if whole instance found in SubOpMap do not merge that instance.
+					// If the field for this instance exists in other oper other than DELETE, then too merge is not required. This field can be ignored.
+					// If instance is found in resultMap and found for REPLACE Operation no merge is required as the whole instance is being replaced
+					// If the instance is found in other opers (CREATE/UPDATE/DELETE) in ReplaceResultMap and field for this instance is not available in other oper in resultMap,
+					// then it can be merged as it may target a specific field delete.
+					if !instFound {
+						resultMap[op][db.ConfigDB][tbl][key].Field[fld] = val
+					} else if instFound && operFound != REPLACE && !fieldOk {
+						// Merge Leaves into the resultMap for Delete operation
+						if _, ok := resultMap[op][db.ConfigDB][tbl]; !ok {
+							resultMap[op][db.ConfigDB][tbl] = make(map[string]db.Value)
+						}
+						if _, ok := resultMap[op][db.ConfigDB][tbl][key]; !ok {
+							resultMap[op][db.ConfigDB][tbl][key] = db.Value{Field: make(map[string]string)}
+						}
+						resultMap[op][db.ConfigDB][tbl][key].Field[fld] = val
+					}
+				} else {
+					if instFound && !fieldOk {
+						// Merge Leaves into the resultMap for Update/Create operation
+						if _, ok := resultMap[operFound][db.ConfigDB][tbl][key]; !ok {
+							// Allocate memory for fields if empty
+							resultMap[operFound][db.ConfigDB][tbl][key] = db.Value{Field: make(map[string]string)}
+						}
+						resultMap[operFound][db.ConfigDB][tbl][key].Field[fld] = val
+					} else if !instFound {
+						resultMap[op][db.ConfigDB][tbl][key].Field[fld] = val
+					}
+				}
+			}
+		}
+	}
+}
+
+func replcePayloadContainerProcessing(xlateParams xlateToParams) {
+
+	// tblXpathMap used for default value processing for a given request
+	if tblUriMapVal, tblUriMapOk := xlateParams.tblXpathMap[xlateParams.tableName][xlateParams.keyName]; !tblUriMapOk {
+		if _, tblOk := xlateParams.tblXpathMap[xlateParams.tableName]; !tblOk {
+			xlateParams.tblXpathMap[xlateParams.tableName] = make(map[string]map[string]bool)
+		}
+		tblUriMapVal = map[string]bool{xlateParams.uri: true}
+		xlateParams.tblXpathMap[xlateParams.tableName][xlateParams.keyName] = tblUriMapVal
+	} else {
+		if tblUriMapVal == nil {
+			tblUriMapVal = map[string]bool{xlateParams.uri: true}
+		} else {
+			tblUriMapVal[xlateParams.uri] = true
+		}
+		xlateParams.tblXpathMap[xlateParams.tableName][xlateParams.keyName] = tblUriMapVal
+	}
+
+	//Add table-instance to translated result
+	dataToDBMapForReplace(xlateParams, "NULL", "NULL")
+}
+
+func combineGlobalSubOpMapWithReplaceInfoSubOpMap(subOpDataMapGlobal map[Operation]*RedisDbMap, subOpDataMapFromReplaceInfo map[Operation]*RedisDbMap) {
+	/* This funtion will transfer UPDATE and DELETE oper data, generated by infra-handled non table owner cases during payload and
+		   default value processing, into global subOpMapData UPDATE and DELETE oper data respectively, filled by app callbacks during Replace payload processing.
+	       If there is same field then app callback field is taken just like mapCopy() does
+	*/
+	var operMapGlobal RedisDbMap
+	var subOpMapPtr *RedisDbMap
+	var operOkGlobal bool
+	replaceInfoSubOper := []Operation{DELETE, UPDATE}
+
+	xfmrLogDebug("Received subOpDataMapGlobal: %v, subOpDataMapFromReplaceInfo : %v", subOpDataMapType(subOpDataMapGlobal), subOpDataMapType(subOpDataMapFromReplaceInfo))
+	for _, oper := range replaceInfoSubOper {
+		if operMap, operOk := subOpDataMapFromReplaceInfo[oper]; operOk && operMap != nil {
+			if operDbData, cfgOk := (*operMap)[db.ConfigDB]; cfgOk && (len(operDbData) != 0) {
+				for tbl, tblData := range operDbData {
+					if subOpMapPtr, operOkGlobal = subOpDataMapGlobal[oper]; !operOkGlobal {
+						operMapGlobal = make(RedisDbMap)
+						subOpMapPtr = &operMapGlobal
+						subOpDataMapGlobal[oper] = subOpMapPtr
+					}
+					if _, configDbOk := (*subOpMapPtr)[db.ConfigDB]; !configDbOk {
+						(*subOpMapPtr)[db.ConfigDB] = make(map[string]map[string]db.Value)
+					}
+
+					_, ok := (*subOpMapPtr)[db.ConfigDB][tbl]
+					if !ok {
+						(*subOpMapPtr)[db.ConfigDB][tbl] = make(map[string]db.Value)
+					}
+					for rule, ruleData := range tblData {
+						_, ok = (*subOpMapPtr)[db.ConfigDB][tbl][rule]
+						if !ok || (len((*subOpMapPtr)[db.ConfigDB][tbl][rule].Field) == 0) {
+							(*subOpMapPtr)[db.ConfigDB][tbl][rule] = db.Value{Field: make(map[string]string)}
+						}
+						for field, value := range ruleData.Field {
+							/*Do not overwrite field into global subOpMapData if it already exists.Give preference
+							  to app callback filled data like mapCopy()
+							*/
+							if _, fldOk := (*subOpMapPtr)[db.ConfigDB][tbl][rule].Field[field]; !fldOk {
+								(*subOpMapPtr)[db.ConfigDB][tbl][rule].Field[field] = value
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	subOpDataMapFromReplaceInfo = nil
+	xfmrLogDebug("Returning subOpDataMapGlobal: %v", subOpDataMapType(subOpDataMapGlobal))
+
+}
+
+func removeTblInstMappedtoContainer(tblInstMap map[string]map[string]db.Value, tblNm string, dbkey string, tblInstDefaultFields db.Value, yangXpathListMappedFortable []string) {
+	/* Enclosing Containers in payload mapping to a unique table instance should not get created or replaced with NULL:NULL entry
+	   if no default values are found as well as no actual payload/leaf.So this function will remove such  table instance from infra
+	   translated result(both table owners and non table owners) during REPLACE processing.yangXpathListMappedFortable contains all
+	   yang complex node paths that were found mapped to a table instance during replace payload processing that need to be traversed
+	   during default value processing.
+	*/
+	xfmrLogDebug("Received table-instance map %v, table name %v, key %v, tblInstDefFields %v, yangXpathList %v", tblInstMap, tblNm, dbkey, tblInstDefaultFields, yangXpathListMappedFortable)
+	if tblInstMap == nil || tblInstMap[tblNm] == nil || len(yangXpathListMappedFortable) == 0 {
+		xfmrLogDebug("Table %v, key %v not found in tblInstMap or yangXpathList is empty %v", tblNm, dbkey, len(yangXpathListMappedFortable))
+		return
+	}
+	tblInstFields := tblInstMap[tblNm][dbkey]
+	if len(tblInstFields.Field) == 1 && tblInstFields.Has("NULL") {
+		if len(tblInstDefaultFields.Field) == 0 {
+			removeInstMappedToContainer := true
+			for _, path := range yangXpathListMappedFortable {
+				if strings.HasSuffix(path, "]") { // Check to make sure only containers are mapped to this instance
+					removeInstMappedToContainer = false
+					break
+				}
+			}
+			if removeInstMappedToContainer {
+				if len(tblInstMap[tblNm]) == 1 {
+					delete(tblInstMap, tblNm)
+				} else {
+					delete(tblInstMap[tblNm], dbkey)
+				}
+			}
+		}
+	}
+	xfmrLogDebug("Returning tblInstMap after processing %v", tblInstMap)
+}

--- a/translib/transformer/xlate_utils.go
+++ b/translib/transformer/xlate_utils.go
@@ -1179,17 +1179,25 @@ func xpathKeyExtractForGet(d *db.DB, ygRoot *ygot.GoStruct, oper Operation, path
 	return retData, err
 }
 
-func dbTableFromUriGet(d *db.DB, ygRoot *ygot.GoStruct, oper Operation, uri string, requestUri string, subOpDataMap map[Operation]*RedisDbMap, txCache interface{}, xfmrTblKeyCache map[string]tblKeyCache) (string, error) {
+func dbTableFromUriGet(d *db.DB, ygRoot *ygot.GoStruct, oper Operation, xpath string, uri string, requestUri string, subOpDataMap map[Operation]*RedisDbMap, txCache interface{}, xfmrTblKeyCache map[string]tblKeyCache) (string, error) {
 	tableName := ""
 	var err error
 	cdb := db.ConfigDB
 	var dbs [db.MaxDB]*db.DB
 
-	xPath, _, _ := XfmrRemoveXPATHPredicates(uri)
-	xpathInfo, ok := xYangSpecMap[xPath]
-	if !ok {
-		log.Warningf("No entry found in xYangSpecMap for xpath %v.", xPath)
+	if len(xpath) == 0 && len(uri) > 0 {
+		xpath, _, _ = XfmrRemoveXPATHPredicates(uri)
+	}
+	xpathInfo, ok := xYangSpecMap[xpath]
+	if !ok || xpathInfo == nil {
+		log.Warningf("No entry found in xYangSpecMap for xpath %v.", xpath)
 		return tableName, err
+	}
+
+	// Static virtual table annotated. Hence return empty table name
+	if xpathInfo.virtualTbl != nil && *xpathInfo.virtualTbl {
+		xfmrLogDebug("virtual table case for uri - %v", uri)
+		return "", nil
 	}
 
 	tblPtr := xpathInfo.tableName
@@ -1198,7 +1206,14 @@ func dbTableFromUriGet(d *db.DB, ygRoot *ygot.GoStruct, oper Operation, uri stri
 	} else if xpathInfo.xfmrTbl != nil {
 		inParams := formXfmrInputRequest(d, dbs, cdb, ygRoot, uri, requestUri, oper, "", nil, subOpDataMap, nil, txCache)
 		tableName, err = tblNameFromTblXfmrGet(*xpathInfo.xfmrTbl, inParams, xfmrTblKeyCache)
+		if inParams.isVirtualTbl != nil && *(inParams.isVirtualTbl) {
+			return "", nil
+		}
+		if err != nil {
+			return "", err
+		}
 	}
+	xfmrLogDebug("returning table-name %v for uri %v", tableName, uri)
 	return tableName, err
 }
 
@@ -1534,7 +1549,7 @@ func formXlateFromDbParams(d *db.DB, dbs [db.MaxDB]*db.DB, cdb db.DBNum, ygRoot 
 	return inParamsForGet
 }
 
-func formXlateToDbParam(d *db.DB, ygRoot *ygot.GoStruct, oper Operation, uri string, requestUri string, xpathPrefix string, keyName string, jsonData interface{}, resultMap map[Operation]RedisDbMap, result map[string]map[string]db.Value, txCache interface{}, tblXpathMap map[string]map[string]map[string]bool, subOpDataMap map[Operation]*RedisDbMap, pCascadeDelTbl *[]string, xfmrErr *error, name string, value interface{}, tableName string, invokeSubtreeOnceMap map[string]map[string]bool, yangDefValMap map[string]map[string]db.Value, yangAuxValMap map[string]map[string]db.Value) xlateToParams {
+func formXlateToDbParam(d *db.DB, ygRoot *ygot.GoStruct, oper Operation, uri string, requestUri string, xpathPrefix string, keyName string, jsonData interface{}, resultMap map[Operation]RedisDbMap, result map[string]map[string]db.Value, txCache interface{}, tblXpathMap map[string]map[string]map[string]bool, subOpDataMap map[Operation]*RedisDbMap, pCascadeDelTbl *[]string, xfmrErr *error, name string, value interface{}, tableName string, isNotTblOwner bool, invokeSubtreeOnceMap map[string]map[string]bool, yangDefValMap map[string]map[string]db.Value, yangAuxValMap map[string]map[string]db.Value, replaceInfo *replaceProcessingInfo) xlateToParams {
 	var inParamsForSet xlateToParams
 	inParamsForSet.d = d
 	inParamsForSet.ygRoot = ygRoot
@@ -1554,9 +1569,11 @@ func formXlateToDbParam(d *db.DB, ygRoot *ygot.GoStruct, oper Operation, uri str
 	inParamsForSet.name = name
 	inParamsForSet.value = value
 	inParamsForSet.tableName = tableName
+	inParamsForSet.isNotTblOwner = isNotTblOwner
 	inParamsForSet.invokeCRUSubtreeOnceMap = invokeSubtreeOnceMap
 	inParamsForSet.yangDefValMap = yangDefValMap
 	inParamsForSet.yangAuxValMap = yangAuxValMap
+	inParamsForSet.replaceInfo = replaceInfo
 	return inParamsForSet
 }
 
@@ -3026,4 +3043,151 @@ func applyValueXfmronDbMapForNestedList(tblName string, fld string, val string, 
 		resultMap[oper][dbNum][tblName][dbKey].Field[keyRetVal] = nonKeyRetVal
 	}
 	return nil
+}
+
+func (subOpDataMap subOpDataMapType) String() string {
+	subOpDataMapStr := ""
+	if subOpDataMap == nil {
+		subOpDataMapStr = "subOpDataMap - nil"
+		return subOpDataMapStr
+	}
+	for oper, subOpMap := range subOpDataMap {
+		if _, configDbOk := (*subOpMap)[db.ConfigDB]; configDbOk {
+			subOpDataMapStr += fmt.Sprintf("subOpDataMap[%v][configDB] - %v ", oper, (*subOpMap)[db.ConfigDB])
+		}
+	}
+	return subOpDataMapStr
+}
+
+func allocateSubOpDataMapForOper(subOpDataMap map[Operation]*RedisDbMap, oper Operation) {
+	var operMap RedisDbMap
+	var subOpMap *RedisDbMap
+	var operOk bool
+
+	if subOpDataMap == nil {
+		xfmrLogInfo("subOpDataMap is not allocated.")
+		return
+	}
+	if subOpMap, operOk = subOpDataMap[oper]; !operOk {
+		operMap = make(RedisDbMap)
+		subOpMap = &operMap
+		subOpDataMap[oper] = subOpMap
+	}
+	if _, configDbOk := (*subOpMap)[db.ConfigDB]; !configDbOk {
+		(*subOpMap)[db.ConfigDB] = make(map[string]map[string]db.Value)
+	}
+}
+
+func instanceExistsinResultMap(tableName string, dbKey string, resultMap map[Operation]RedisDbMap) (bool, Operation) {
+	// This function is called only for isDeleteForReplace case and checks if the table,dbKey and field is already present in replaceResultMap
+	//Inputs - table, dbKey and fieldName that needs to be verified if available in replaceResultMap, resultMap (having consolidated result and subOpMap from REPLACE
+	// Output - bool indicating add to delete resultMap required or not, bool to indicate skipSiblingTraversal for the field in input param
+	instFound := false
+	var opFound Operation
+
+	// Check if table instance exists in resultMap
+	for op, redisMap := range resultMap {
+		for dbNum, dbMap := range redisMap {
+			if dbNum != db.ConfigDB {
+				continue
+			}
+			// Check if dbKey instance exists in resultMap
+			for tbl, instMap := range dbMap {
+				if tbl != tableName {
+					// If table not found continue to loop to chk if tableName exists for other opers in replaceResultMap
+					continue
+				} else {
+					for key := range instMap {
+						if key != dbKey {
+							// If instance not found continue to loop to check if dbKey exists for other instnces replaceResultMap
+							continue
+						} else {
+							// Instance found in replaceResultMap
+							instFound = true
+							opFound = op
+							break
+						}
+					}
+				}
+			}
+		}
+	}
+	return instFound, opFound
+}
+
+func fieldExistsinResultMap(tableName string, dbKey string, field string, resultMap map[Operation]RedisDbMap, instExists bool, opFound Operation) (bool, bool) {
+	// This function is called only for isDeleteForReplace case and checks if the table,dbKey and field is already present in replaceResultMap
+	//Inputs - table, dbKey and fieldName that needs to be verified if available in replaceResultMap, resultMap (having consolidated result and subOpMap from REPLACE
+	// Output - bool indicating add to delete resultMap required or not, bool to indicate skipSiblingTraversal for the field in input param
+	instFound := false
+	fieldFound := false
+	var op Operation
+	if !instExists {
+		instFound, op = instanceExistsinResultMap(tableName, dbKey, resultMap)
+	} else {
+		instFound = instExists
+		op = opFound
+	}
+	if instFound {
+		fieldVal := resultMap[op][db.ConfigDB][tableName][dbKey]
+		for fld := range fieldVal.Field {
+			if fld == field {
+				fieldFound = true
+				break
+			}
+		}
+	} else {
+		return false, false
+	}
+	return instFound, fieldFound
+}
+
+func mergeSubOpMapWithResultForReplace(resultMap map[Operation]RedisDbMap, result map[string]map[string]db.Value, subOpDataMap map[Operation]*RedisDbMap) {
+	//This function merges the subopMap and inifra generated replace payload infra generated map into the resultMap
+	if len(result) > 0 || len(subOpDataMap) > 0 {
+		// Initially copy the result generated after REPLACE payload processing to resultMap[REPLACE]
+		if _, ok := resultMap[REPLACE]; !ok { //ideally will never be pre-allocated but stil adding safety check
+			resultMap[REPLACE] = make(RedisDbMap)
+		}
+		resultMap[REPLACE][db.ConfigDB] = result
+
+		// Merge the SubopMap data generated after Replace payload processsing into resultMap
+		// First merge the REPLACE maps. If conflicting data found, subopMap data as filled by the applications will be given preference. Hence mapCopy is done here.
+		// Replace data merging is done first to consolidate the results before merging of other operations.
+
+		for op, redisMapPtr := range subOpDataMap {
+			if redisMapPtr != nil {
+				for dbNum, dbMap := range *redisMapPtr {
+					if dbNum != db.ConfigDB {
+						continue
+					}
+					if op == REPLACE {
+						mapCopy(resultMap[REPLACE][db.ConfigDB], dbMap)
+					} else {
+						continue
+					}
+				}
+			}
+		}
+
+		// Merge the subopMap to the resultMap for CREATE, UPDATE and DELETE operations
+		// Replace data merging is taken care above. Hence skip it.
+		var operList []Operation = []Operation{UPDATE, CREATE, DELETE}
+		for _, op := range operList {
+			if redisMapPtr, ok := subOpDataMap[op]; ok && redisMapPtr != nil {
+				for dbNum, dbMap := range *redisMapPtr {
+					if dbNum != db.ConfigDB {
+						continue
+					}
+					if _, ok := resultMap[op]; !ok {
+						resultMap[op] = make(RedisDbMap)
+					}
+					if _, ok := resultMap[op][dbNum]; !ok {
+						resultMap[op][dbNum] = make(map[string]map[string]db.Value)
+					}
+					mapMergeAcrossOperations(resultMap, dbMap, op)
+				}
+			}
+		}
+	}
 }

--- a/translib/transformer/xspec.go
+++ b/translib/transformer/xspec.go
@@ -296,14 +296,16 @@ func yangToDbMapFill(keyLevel uint8, xYangSpecMap map[string]*yangXpathInfo, ent
 		curXpathFull = xpath
 		if xpathPrefix != xpathFull {
 			curXpathFull = xpathFull + "/" + entry.Name
+			xpathData := new(yangXpathInfo)
+			xpathData.subscribeMinIntvl = XFMR_INVALID
+			xpathData.dbIndex = db.ConfigDB // default value
 			if annotNode, ok := xYangSpecMap[curXpathFull]; ok {
-				xpathData := new(yangXpathInfo)
-				xpathData.subscribeMinIntvl = XFMR_INVALID
-				xpathData.dbIndex = db.ConfigDB // default value
 				xYangSpecMap[xpath] = xpathData
 				copyYangXpathSpecData(xYangSpecMap[xpath], annotNode)
-				updateChoiceCaseXpath = true
+			} else {
+				xYangSpecMap[curXpathFull] = xpathData
 			}
+			updateChoiceCaseXpath = true
 		}
 
 		xpathData, ok := xYangSpecMap[xpath]


### PR DESCRIPTION
This enhancement to the transformer component in management framework will support REPLACE/PUT operation using OpenConfig YANG models, enabling configuration data replacement through YANG data tree traversal.
Refer - [sonic-net/SONiC#1950](https://github.com/sonic-net/SONiC/pull/1950) for more details.

The PUT/REPLACE RESTCONF method, equivalent to the NETCONF “create” or “replace” operations, can create non-existing data resources or replace existing ones, with the request payload, for a specified resource, identified by the RESTCONF target resource URI.
Previously, replacing data resources with the PUT/REPLACE operation at any depth of a YANG model was challenging, and support was limited to replacing only the data translated from the request payload rather than the entire data resource.
This feature aims to address these issues by supporting PUT/REPLACE  targeted at any YANG depth.

The prerequisite for supporting PUT/REPLACE operations at any yang depth was merged as part of model based DELETE [PR](https://github.com/sonic-net/sonic-mgmt-common/pull/166).