### PR TITLE
Adding transformer support for OCYANG VLAN interfaces

### DIFF
--- a/config/transformer/models_list
+++ b/config/transformer/models_list
@@ -8,6 +8,6 @@ openconfig-interfaces.yang
 openconfig-interfaces-annot.yang
 openconfig-if-ip.yang
 openconfig-if-aggregate.yang
-openconfig-interfaces-annot.yang
 openconfig-mclag.yang
 openconfig-mclag-annot.yang
+openconfig-vlan.yang

--- a/models/yang/annotations/openconfig-interfaces-annot.yang
+++ b/models/yang/annotations/openconfig-interfaces-annot.yang
@@ -7,12 +7,20 @@ module openconfig-interfaces-annot {
 
     import sonic-extensions { prefix sonic-ext; }
     import openconfig-interfaces { prefix oc-intf; }
+    import openconfig-vlan {prefix oc-vlan; }
     import openconfig-if-ip {prefix oc-ip; }
+    import openconfig-if-aggregate { prefix oc-lag; }
 
     deviation /oc-intf:interfaces/oc-intf:interface {
         deviate add {
             sonic-ext:key-transformer "intf_tbl_key_xfmr";
             sonic-ext:table-transformer "intf_table_xfmr";
+        }
+    }
+
+    deviation /oc-intf:interfaces/oc-intf:interface/oc-intf:config/oc-intf:name {
+        deviate add {
+            sonic-ext:field-transformer "intf_name_xfmr";
         }
     }
 
@@ -90,6 +98,12 @@ module openconfig-interfaces-annot {
       }
     }
 
+    deviation /oc-intf:interfaces/oc-intf:interface/oc-intf:state/oc-intf:name {
+        deviate add {
+            sonic-ext:field-transformer "intf_name_xfmr";
+        }
+    }
+
     deviation /oc-intf:interfaces/oc-intf:interface/oc-intf:state/oc-intf:enabled {
         deviate add {
             sonic-ext:field-transformer "intf_enabled_xfmr";
@@ -110,6 +124,20 @@ module openconfig-interfaces-annot {
             sonic-ext:db-name "COUNTERS_DB";
             sonic-ext:subtree-transformer "intf_get_ether_counters_xfmr";
             sonic-ext:subscribe-on-change "disable";
+        }
+    }
+
+    deviation /oc-intf:interfaces/oc-intf:interface/oc-lag:aggregation/oc-vlan:switched-vlan {
+        deviate add {
+            sonic-ext:subtree-transformer "sw_vlans_xfmr";
+            sonic-ext:path-transformer "sw_vlans_path_xfmr";
+        }
+    }
+
+     deviation /oc-intf:interfaces/oc-intf:interface/oc-eth:ethernet/oc-vlan:switched-vlan {
+        deviate add {
+            sonic-ext:subtree-transformer "sw_vlans_xfmr";
+            sonic-ext:path-transformer "sw_vlans_path_xfmr";
         }
     }
     
@@ -196,4 +224,57 @@ module openconfig-interfaces-annot {
             sonic-ext:field-transformer "ipv6_enabled_xfmr";
         }
     }
+
+    deviation /oc-intf:interfaces/oc-intf:interface/oc-vlan:routed-vlan {
+        deviate add {
+	    sonic-ext:path-transformer "intf_ip_path_xfmr";
+        }
+    }
+
+    deviation /oc-intf:interfaces/oc-intf:interface/oc-vlan:routed-vlan/oc-vlan:config/oc-vlan:vlan {
+        deviate add {
+             sonic-ext:field-transformer "intf_routed_vlan_name_xfmr";
+        }
+    }
+
+    deviation /oc-intf:interfaces/oc-intf:interface/oc-vlan:routed-vlan/oc-vlan:state/oc-vlan:vlan {
+        deviate add {
+            sonic-ext:field-transformer "intf_routed_vlan_name_xfmr";
+        }
+    }
+
+    deviation /oc-intf:interfaces/oc-intf:interface/oc-vlan:routed-vlan/oc-ip:ipv4/oc-ip:addresses {
+        deviate add {
+            sonic-ext:table-name "NONE";
+            sonic-ext:subtree-transformer "routed_vlan_ip_addr_xfmr";
+        }
+    }
+
+    deviation /oc-intf:interfaces/oc-intf:interface/oc-vlan:routed-vlan/oc-ip:ipv6/oc-ip:addresses {
+        deviate add {
+            sonic-ext:table-name "NONE";
+            sonic-ext:subtree-transformer "routed_vlan_ip_addr_xfmr";
+        }
+    }
+
+    deviation /oc-intf:interfaces/oc-intf:interface/oc-vlan:routed-vlan/oc-ip:ipv6/oc-ip:state {
+        deviate add {
+            sonic-ext:db-name "APPL_DB";
+        }
+    }
+
+    deviation /oc-intf:interfaces/oc-intf:interface/oc-vlan:routed-vlan/oc-ip:ipv6/oc-ip:config/oc-ip:enabled {
+        deviate add {
+            sonic-ext:field-transformer "ipv6_enabled_xfmr";
+            sonic-ext:field-name "ipv6_use_link_local_only";
+        }
+    }
+
+    deviation /oc-intf:interfaces/oc-intf:interface/oc-vlan:routed-vlan/oc-ip:ipv6/oc-ip:state/oc-ip:enabled {
+        deviate add {
+            sonic-ext:field-transformer "ipv6_enabled_xfmr";
+            sonic-ext:field-name "ipv6_use_link_local_only";
+        }
+    }
+
 }

--- a/models/yang/extensions/openconfig-interfaces-deviation.yang
+++ b/models/yang/extensions/openconfig-interfaces-deviation.yang
@@ -247,14 +247,6 @@ module openconfig-interfaces-deviation {
     deviate not-supported;
   }
 
-  deviation /oc-intf:interfaces/oc-intf:interface/oc-eth:ethernet/oc-vlan:switched-vlan {
-    deviate not-supported;
-  }
-  
-  deviation /oc-intf:interfaces/oc-intf:interface/oc-lag:aggregation/oc-vlan:switched-vlan {
-    deviate not-supported;
-  }
-
   deviation /oc-intf:interfaces/oc-intf:interface/oc-lag:aggregation/oc-lag:config/oc-lag:lag-type {
     deviate not-supported;
   }
@@ -307,8 +299,16 @@ module openconfig-interfaces-deviation {
     deviate not-supported;
   }
 
-  deviation /oc-intf:interfaces/oc-intf:interface/oc-vlan:routed-vlan {
-    deviate not-supported;
+  deviation /oc-intf:interfaces/oc-intf:interface/oc-lag:aggregation/oc-vlan:switched-vlan/oc-vlan:config/oc-vlan:native-vlan {
+      deviate not-supported;
+  }
+
+  deviation /oc-intf:interfaces/oc-intf:interface/oc-lag:aggregation/oc-vlan:switched-vlan/oc-vlan:state/oc-vlan:native-vlan {
+      deviate not-supported;
+  }
+
+  deviation /oc-intf:interfaces/oc-intf:interface/oc-vlan:routed-vlan/oc-ip:ipv6/oc-ip:unnumbered {
+        deviate not-supported;
   }
  
 }

--- a/models/yang/openconfig-if-ip.yang
+++ b/models/yang/openconfig-if-ip.yang
@@ -44,7 +44,13 @@ module openconfig-if-ip {
     Section 4.c of the IETF Trust's Legal Provisions Relating
     to IETF Documents (http://trustee.ietf.org/license-info).";
 
-  oc-ext:openconfig-version "2.3.1";
+  oc-ext:openconfig-version "3.0.0";
+
+  revision "2019-01-08" {
+    description
+      "Eliminate use of the 'empty' type.";
+    reference "3.0.0";
+  }
 
   revision "2018-11-21" {
     description
@@ -601,7 +607,7 @@ module openconfig-if-ip {
         "The origin of this neighbor entry.";
     }
     leaf is-router {
-      type empty;
+      type boolean;
       description
         "Indicates that the neighbor node acts as a router.";
     }

--- a/models/yang/sonic/import.mk
+++ b/models/yang/sonic/import.mk
@@ -9,6 +9,7 @@ SONICYANG_IMPORTS += sonic-sflow.yang
 SONICYANG_IMPORTS += sonic-interface.yang
 SONICYANG_IMPORTS += sonic-port.yang
 SONICYANG_IMPORTS += sonic-portchannel.yang
+SONICYANG_IMPORTS += sonic-vlan.yang
 SONICYANG_IMPORTS += sonic-mclag.yang
 SONICYANG_IMPORTS += sonic-types.yang
 SONICYANG_IMPORTS += sonic-vrf.yang

--- a/translib/transformer/sw_portchannel.go
+++ b/translib/transformer/sw_portchannel.go
@@ -98,6 +98,12 @@ func deleteLagIntfAndMembers(inParams *XfmrParams, lagName *string) error {
 		return nil
 	}
 
+	/* Restrict deletion if iface configured as member-port of any existing Vlan */
+	err = validateIntfAssociatedWithExistingVlan(inParams.d, lagName)
+	if err != nil {
+		return err
+	}
+
 	/* Validate L3 Configuration only operation is not Delete */
 	if inParams.oper != DELETE {
 		err = validateL3ConfigExists(inParams.d, lagName)

--- a/translib/transformer/sw_vlan.go
+++ b/translib/transformer/sw_vlan.go
@@ -1,0 +1,1860 @@
+////////////////////////////////////////////////////////////////////////////////
+//                                                                            //
+//  Copyright 2019 Dell, Inc.                                                 //
+//                                                                            //
+//  Licensed under the Apache License, Version 2.0 (the "License");           //
+//  you may not use this file except in compliance with the License.          //
+//  You may obtain a copy of the License at                                   //
+//                                                                            //
+//  http://www.apache.org/licenses/LICENSE-2.0                                //
+//                                                                            //
+//  Unless required by applicable law or agreed to in writing, software       //
+//  distributed under the License is distributed on an "AS IS" BASIS,         //
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  //
+//  See the License for the specific language governing permissions and       //
+//  limitations under the License.                                            //
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+
+package transformer
+
+import (
+	"errors"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/Azure/sonic-mgmt-common/translib/db"
+	"github.com/Azure/sonic-mgmt-common/translib/ocbinds"
+	"github.com/Azure/sonic-mgmt-common/translib/tlerr"
+	"github.com/Azure/sonic-mgmt-common/translib/utils"
+	log "github.com/golang/glog"
+	"github.com/openconfig/ygot/ygot"
+)
+
+type intfModeType int
+
+const (
+	MODE_UNSET intfModeType = iota
+	ACCESS
+	TRUNK
+	ALL
+)
+
+type intfModeReq struct {
+	ifName string
+	mode   intfModeType
+}
+
+type ifVlan struct {
+	ifName *string
+	mode   intfModeType
+	//accessVlan *string
+	trunkVlans []string
+}
+
+type swVlanMemberPort_t struct {
+	swEthMember         *ocbinds.OpenconfigInterfaces_Interfaces_Interface_Ethernet_SwitchedVlan
+	swPortChannelMember *ocbinds.OpenconfigInterfaces_Interfaces_Interface_Aggregation_SwitchedVlan
+}
+
+func init() {
+	XlateFuncBind("YangToDb_sw_vlans_xfmr", YangToDb_sw_vlans_xfmr)
+	XlateFuncBind("DbToYang_sw_vlans_xfmr", DbToYang_sw_vlans_xfmr)
+	XlateFuncBind("DbToYangPath_sw_vlans_path_xfmr", DbToYangPath_sw_vlans_path_xfmr)
+}
+
+/*
+Param: port/portchannel name
+
+	Return: tagged & untagged vlan list config for given port/portchannel
+*/
+func getIntfVlanConfig(d *db.DB, tblName string, ifName string) ([]string, string, error) {
+	var taggedVlanList []string
+	var untaggedVlan string
+	vlanMemberKeys, err := d.GetKeysByPattern(&db.TableSpec{Name: tblName}, "*"+ifName)
+	if err != nil {
+		return nil, "", err
+	}
+	for _, vlanMember := range vlanMemberKeys {
+		vlanId := vlanMember.Get(0)
+		entry, err := d.GetEntry(&db.TableSpec{Name: tblName}, db.Key{Comp: []string{vlanId, ifName}})
+		if err != nil {
+			return nil, "", err
+		}
+		tagMode := entry.Field["tagging_mode"]
+		if tagMode == "tagged" {
+			taggedVlanList = append(taggedVlanList, vlanId)
+		} else {
+			untaggedVlan = vlanId
+		}
+	}
+	return taggedVlanList, untaggedVlan, nil
+}
+
+/* Validate whether VLAN exists in DB */
+func validateVlanExists(d *db.DB, vlanName *string) error {
+	if len(*vlanName) == 0 {
+		return errors.New("Length of VLAN name is zero")
+	}
+	entry, err := d.GetEntry(&db.TableSpec{Name: VLAN_TN}, db.Key{Comp: []string{*vlanName}})
+	if err != nil || !entry.IsPopulated() {
+		errStr := "Vlan:" + *vlanName + " does not exist!"
+		log.V(3).Info(errStr)
+		return errors.New(errStr)
+	}
+	return nil
+}
+
+/* Validates whether physical interface or port-channel interface configured as member of any existing VLAN */
+func validateIntfAssociatedWithExistingVlan(d *db.DB, ifName *string) error {
+	var err error
+
+	if len(*ifName) == 0 {
+		return errors.New("Interface name is empty!")
+	}
+	var vlanKeys []db.Key
+	vlanKeys, err = d.GetKeysByPattern(&db.TableSpec{Name: VLAN_MEMBER_TN}, "*"+*ifName)
+
+	if err != nil {
+		return errors.New("Failed to get keys from table: " + VLAN_MEMBER_TN)
+	}
+	log.Infof("Interface member of %d Vlan(s)", len(vlanKeys))
+	if len(vlanKeys) > 0 {
+		errStr := "Vlan configuration exists on interface: " + *ifName
+		log.Error(errStr)
+		return tlerr.InvalidArgsError{Format: errStr}
+	}
+	return err
+}
+
+/* Check member port exists in the list and get Interface mode */
+func checkMemberPortExistsInListAndGetMode(d *db.DB, memberPortsList []string, memberPort *string, vlanName *string, ifMode *intfModeType) bool {
+	for _, port := range memberPortsList {
+		if *memberPort == port {
+			tagModeEntry, err := d.GetEntry(&db.TableSpec{Name: VLAN_MEMBER_TN}, db.Key{Comp: []string{*vlanName, *memberPort}})
+			if err != nil {
+				return false
+			}
+			tagMode := tagModeEntry.Field["tagging_mode"]
+			convertTaggingModeToInterfaceModeType(&tagMode, ifMode)
+			return true
+		}
+	}
+	return false
+}
+
+/* Convert tagging mode to Interface Mode type */
+func convertTaggingModeToInterfaceModeType(tagMode *string, ifMode *intfModeType) {
+	switch *tagMode {
+	case "untagged":
+		*ifMode = ACCESS
+	case "tagged":
+		*ifMode = TRUNK
+	}
+}
+
+/* Validate whether Port has any Untagged VLAN Config existing */
+func validateUntaggedVlanCfgredForIf(d *db.DB, vlanMemberTs *string, ifName *string, accessVlan *string) (bool, error) {
+	var err error
+
+	var vlanMemberKeys []db.Key
+
+	vlanMemberKeys, err = d.GetKeysPattern(&db.TableSpec{Name: *vlanMemberTs}, db.Key{Comp: []string{"*", *ifName}})
+	if err != nil {
+		return false, err
+	}
+
+	log.Infof("Found %d Vlan Member table keys", len(vlanMemberKeys))
+
+	for _, vlanMember := range vlanMemberKeys {
+		if len(vlanMember.Comp) < 2 {
+			continue
+		}
+		memberPortEntry, err := d.GetEntry(&db.TableSpec{Name: *vlanMemberTs}, vlanMember)
+		if err != nil || !memberPortEntry.IsPopulated() {
+			errStr := "Get from VLAN_MEMBER table for Vlan: + " + vlanMember.Get(0) + " Interface:" + *ifName + " failed!"
+			log.Error(errStr)
+			return false, errors.New(errStr)
+		}
+		tagMode, ok := memberPortEntry.Field["tagging_mode"]
+		if !ok {
+			errStr := "tagging_mode entry is not present for VLAN: " + vlanMember.Get(0) + " Interface: " + *ifName
+			log.Error(errStr)
+			return false, errors.New(errStr)
+		}
+		if tagMode == "untagged" {
+			*accessVlan = vlanMember.Get(0)
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+/* Fills all the trunk-vlans part of physical or port-channel interface */
+func fillTrunkVlansForInterface(d *db.DB, ifName *string, ifVlanInfo *ifVlan) error {
+	var err error
+	var vlanKeys []db.Key
+
+	vlanKeys, err = d.GetKeysByPattern(&db.TableSpec{Name: VLAN_MEMBER_TN}, "*"+*ifName)
+	if err != nil {
+		return err
+	}
+
+	for _, vlanKey := range vlanKeys {
+		if len(vlanKey.Comp) < 2 {
+			continue
+		}
+		if vlanKey.Get(1) == *ifName {
+			memberPortEntry, err := d.GetEntry(&db.TableSpec{Name: VLAN_MEMBER_TN}, vlanKey)
+			if err != nil {
+				log.Errorf("Error found on fetching Vlan member info from App DB for Interface Name : %s", *ifName)
+				return err
+			}
+			tagInfo, ok := memberPortEntry.Field["tagging_mode"]
+			if ok {
+				if tagInfo == "tagged" {
+					ifVlanInfo.trunkVlans = append(ifVlanInfo.trunkVlans, vlanKey.Get(0))
+				}
+			}
+		}
+	}
+	return err
+}
+
+/* Remove tagged port associated with VLAN and update VLAN_MEMBER table */
+func removeTaggedVlanAndUpdateVlanMembTbl(d *db.DB, trunkVlan *string, ifName *string,
+	vlanMemberMap map[string]db.Value) error {
+	var err error
+
+	memberPortEntry, err := d.GetEntry(&db.TableSpec{Name: VLAN_MEMBER_TN}, db.Key{Comp: []string{*trunkVlan, *ifName}})
+	if err != nil || !memberPortEntry.IsPopulated() {
+		errStr := "Tagged Vlan configuration: " + *trunkVlan + " doesn't exist for Interface: " + *ifName
+		log.V(3).Info(errStr)
+		return tlerr.InvalidArgsError{Format: errStr}
+	}
+	tagMode, ok := memberPortEntry.Field["tagging_mode"]
+	if !ok {
+		errStr := "tagging_mode entry is not present for VLAN: " + *trunkVlan + " Interface: " + *ifName
+		log.V(3).Info(errStr)
+		return errors.New(errStr)
+	}
+	vlanName := *trunkVlan
+	if tagMode == "tagged" {
+		vlanMemberKey := *trunkVlan + "|" + *ifName
+		vlanMemberMap[vlanMemberKey] = db.Value{Field: map[string]string{}}
+	} else {
+		vlanId := vlanName[len("Vlan"):]
+		errStr := "Tagged VLAN: " + vlanId + " configuration doesn't exist for Interface: " + *ifName
+		log.V(3).Info(errStr)
+		return tlerr.InvalidArgsError{Format: errStr}
+	}
+	return err
+}
+
+/* Remove untagged port associated with VLAN and update VLAN_MEMBER table */
+func removeUntaggedVlanAndUpdateVlanMembTbl(d *db.DB, ifName *string,
+	vlanMemberMap map[string]db.Value) (*string, error) {
+	if len(*ifName) == 0 {
+		return nil, errors.New("Interface name is empty for fetching list of VLANs!")
+	}
+
+	var vlanMemberKeys []db.Key
+	var err error
+
+	vlanMemberKeys, err = d.GetKeysByPattern(&db.TableSpec{Name: VLAN_MEMBER_TN}, "*"+*ifName)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Infof("Found %d Vlan Member table keys", len(vlanMemberKeys))
+
+	for _, vlanMember := range vlanMemberKeys {
+		if len(vlanMember.Comp) < 2 {
+			continue
+		}
+		if vlanMember.Get(1) != *ifName {
+			continue
+		}
+		memberPortEntry, err := d.GetEntry(&db.TableSpec{Name: VLAN_MEMBER_TN}, vlanMember)
+		if err != nil || !memberPortEntry.IsPopulated() {
+			errStr := "Get from VLAN_MEMBER table for Vlan: + " + vlanMember.Get(0) + " Interface:" + *ifName + " failed!"
+			return nil, errors.New(errStr)
+		}
+		tagMode, ok := memberPortEntry.Field["tagging_mode"]
+		if !ok {
+			errStr := "tagging_mode entry is not present for VLAN: " + vlanMember.Get(0) + " Interface: " + *ifName
+			return nil, errors.New(errStr)
+		}
+		vlanName := vlanMember.Get(0)
+		vlanMemberKey := vlanName + "|" + *ifName
+		if tagMode == "untagged" {
+			vlanMemberMap[vlanMemberKey] = db.Value{Field: map[string]string{}}
+			return &vlanName, nil
+		}
+	}
+	errStr := "Untagged VLAN configuration doesn't exist for Interface: " + *ifName
+	log.Info(errStr)
+	return nil, tlerr.InvalidArgsError{Format: errStr}
+}
+
+func removeAllVlanMembrsForIfAndGetVlans(d *db.DB, ifName *string, ifMode intfModeType, vlanMemberMap map[string]db.Value) error {
+	var err error
+	var vlanKeys []db.Key
+
+	vlanKeys, err = d.GetKeysByPattern(&db.TableSpec{Name: VLAN_MEMBER_TN}, "*"+*ifName)
+	if err != nil {
+		return err
+	}
+
+	for _, vlanKey := range vlanKeys {
+		if len(vlanKeys) < 2 {
+			continue
+		}
+		if vlanKey.Get(1) == *ifName {
+			memberPortEntry, err := d.GetEntry(&db.TableSpec{Name: VLAN_MEMBER_TN}, vlanKey)
+			if err != nil {
+				log.Errorf("Error found on fetching Vlan member info from App DB for Interface Name : %s", *ifName)
+				return err
+			}
+			tagInfo, ok := memberPortEntry.Field["tagging_mode"]
+			if ok {
+				switch ifMode {
+				case ACCESS:
+					if tagInfo != "tagged" {
+						continue
+					}
+				case TRUNK:
+					if tagInfo != "untagged" {
+						continue
+					}
+				}
+				vlanMemberKey := vlanKey.Get(0) + "|" + *ifName
+				vlanMemberMap[vlanMemberKey] = db.Value{Field: make(map[string]string)}
+				vlanMemberMap[vlanMemberKey] = memberPortEntry
+			}
+		}
+	}
+	return err
+}
+
+func sortVlanList(vlanList []string) []string {
+	var vlanIds []int
+
+	for _, vlanStr := range vlanList {
+		vlanIdStr := strings.TrimPrefix(vlanStr, "Vlan")
+		vlanId, _ := strconv.Atoi(vlanIdStr)
+		vlanIds = append(vlanIds, vlanId)
+	}
+	sort.Ints(vlanIds)
+	sortedVlans := make([]string, len(vlanIds))
+	for i, vlanId := range vlanIds {
+		sortedVlans[i] = "Vlan" + strconv.Itoa(vlanId)
+	}
+	return sortedVlans
+}
+
+func intfAccessModeReqConfig(d *db.DB, ifName *string,
+	vlanMap map[string]db.Value,
+	vlanMemberMap map[string]db.Value) error {
+	var err error
+	if len(*ifName) == 0 {
+		return errors.New("Empty Interface name received!")
+	}
+
+	err = removeAllVlanMembrsForIfAndGetVlans(d, ifName, ACCESS, vlanMemberMap)
+	if err != nil {
+		return err
+	}
+
+	return err
+}
+
+func intfModeReqConfig(d *db.DB, mode intfModeReq,
+	vlanMap map[string]db.Value,
+	vlanMemberMap map[string]db.Value) error {
+	var err error
+	switch mode.mode {
+	case ACCESS:
+		err := intfAccessModeReqConfig(d, &mode.ifName, vlanMap, vlanMemberMap)
+		if err != nil {
+			return err
+		}
+	case TRUNK:
+	case MODE_UNSET:
+		break
+	}
+	return err
+}
+
+/* Adding member to VLAN requires updation of VLAN Table and VLAN Member Table */
+func processIntfVlanMemberAdd(d *db.DB, vlanMembersMap map[string]map[string]db.Value, vlanMap map[string]db.Value,
+	vlanMemberMap map[string]db.Value) error {
+	var err error
+
+	/* Updating the VLAN member table */
+	for vlanName, ifEntries := range vlanMembersMap {
+		log.V(3).Info("Processing VLAN: ", vlanName)
+
+		vlanEntry, _ := d.GetEntry(&db.TableSpec{Name: VLAN_TN}, db.Key{Comp: []string{vlanName}})
+		if !vlanEntry.IsPopulated() {
+			errStr := "Failed to retrieve memberPorts info of VLAN : " + vlanName
+			log.Error(errStr)
+			return errors.New(errStr)
+		}
+
+		for ifName, ifEntry := range ifEntries {
+			log.V(3).Infof("Processing Interface: %s for VLAN: %s", ifName, vlanName)
+
+			vlanMemberKey := vlanName + "|" + ifName
+			vlanMemberMap[vlanMemberKey] = db.Value{Field: make(map[string]string)}
+			vlanMemberMap[vlanMemberKey].Field["tagging_mode"] = ifEntry.Field["tagging_mode"]
+			log.V(3).Infof("Updated Vlan Member Map with vlan member key: %s and tagging-mode: %s", vlanMemberKey, ifEntry.Field["tagging_mode"])
+		}
+		vlanMap[vlanName] = db.Value{Field: make(map[string]string)}
+	}
+
+	return err
+}
+
+func processIntfVlanMemberRemoval(inParams *XfmrParams, ifVlanInfoList []*ifVlan, vlanMap map[string]db.Value,
+	vlanMemberMap map[string]db.Value) error {
+	var err error
+
+	d := inParams.d
+
+	if len(ifVlanInfoList) == 0 {
+		log.Info("No VLAN Info present for membership removal!")
+		return nil
+	}
+
+	for _, ifVlanInfo := range ifVlanInfoList {
+		if ifVlanInfo.ifName == nil {
+			return errors.New("No Interface name present for membership removal from VLAN!")
+		}
+
+		ifName := ifVlanInfo.ifName
+		ifMode := ifVlanInfo.mode
+		trunkVlans := ifVlanInfo.trunkVlans
+
+		switch ifMode {
+		case ACCESS:
+			/* Handling Access Vlan delete */
+			log.Info("Access VLAN Delete!")
+			_, err = removeUntaggedVlanAndUpdateVlanMembTbl(d, ifName, vlanMemberMap)
+			if err != nil {
+				return err
+			}
+		case TRUNK:
+			/* Handling trunk-vlans delete */
+			log.Info("Trunk VLAN Delete!")
+			cfgredTrunkVlanList, _, err := getIntfVlanConfig(inParams.d, VLAN_MEMBER_TN, *ifName)
+			if err != nil {
+				return err
+			}
+			sort.Strings(cfgredTrunkVlanList)
+			sort.Strings(trunkVlans)
+			for _, trunkVlan := range trunkVlans {
+				idx := sort.SearchStrings(cfgredTrunkVlanList, trunkVlan)
+				//If Vlan Not exists in the Configured Tagged Vlan List then ignore
+				if idx >= len(cfgredTrunkVlanList) || cfgredTrunkVlanList[idx] != trunkVlan {
+					errStr := "Tagged Vlan : " + trunkVlan + " doesn't exist for Interface: " + *ifName
+					log.V(3).Info(errStr)
+					continue
+				}
+				if log.V(3) {
+					log.Info("Tagged Vlan :", trunkVlan, " exists for the Interface", *ifName)
+				}
+				rerr := removeTaggedVlanAndUpdateVlanMembTbl(d, &trunkVlan, ifName, vlanMemberMap)
+				if rerr != nil {
+					//If trunkVlan config not present for ifname continue to next trunkVlan in list
+					continue
+				}
+			}
+		// Mode set to ALL, if you want to delete both access and trunk
+		case ALL:
+			log.Info("Handling All Access and Trunk VLAN delete!")
+			//Access Vlan Delete
+			_, _ = removeUntaggedVlanAndUpdateVlanMembTbl(d, ifName, vlanMemberMap)
+			//Trunk Vlan Delete
+			cfgredTrunkVlanList, _, err := getIntfVlanConfig(inParams.d, VLAN_MEMBER_TN, *ifName)
+			if err != nil {
+				return err
+			}
+			if len(cfgredTrunkVlanList) > 0 {
+				if log.V(3) {
+					log.Info("Configured Tagged Vlan list , cfgredTaggedVlan: ", cfgredTrunkVlanList)
+				}
+				for _, trunkVlan := range cfgredTrunkVlanList {
+					rerr := removeTaggedVlanAndUpdateVlanMembTbl(d, &trunkVlan, ifName, vlanMemberMap)
+					if rerr != nil {
+						//If trunkVlan config not present for ifname continue to next trunkVlan in list
+						continue
+					}
+				}
+			} else {
+				log.Info("Tagged Vlan doesn't exist for the interface :", *ifName)
+			}
+		}
+	}
+	return nil
+}
+
+/* Function performs VLAN Member removal from Interface */
+/* Handles 4 cases
+   case 1: Deletion of top-level container / list
+   case 2: Deletion of entire leaf-list trunk-vlans
+   case 3: Deletion of access-vlan leaf
+   case 4: Deletion of trunk-vlan (leaf-list with instance)  */
+func intfVlanMemberRemoval(swVlanConfig *swVlanMemberPort_t,
+	inParams *XfmrParams, ifName *string,
+	vlanMap map[string]db.Value,
+	vlanMemberMap map[string]db.Value,
+	intfType E_InterfaceType) error {
+	var err error
+	var ifVlanInfo ifVlan
+	var ifVlanInfoList []*ifVlan
+
+	targetUriPath := (NewPathInfo(inParams.uri)).YangPath
+	log.Info("Target URI Path = ", targetUriPath)
+	switch intfType {
+	case IntfTypeEthernet:
+		if swVlanConfig.swPortChannelMember != nil {
+			errStr := "Wrong yang path is used for member " + *ifName + " disassociation from vlan"
+			log.Errorf(errStr)
+			return errors.New(errStr)
+		}
+		//case 1
+		if swVlanConfig.swEthMember == nil || swVlanConfig.swEthMember.Config == nil ||
+			(swVlanConfig.swEthMember.Config.AccessVlan == nil && swVlanConfig.swEthMember.Config.TrunkVlans == nil) {
+
+			log.Info("Container/list level delete for Interface: ", *ifName)
+			ifVlanInfo.mode = ALL
+			//case 2
+			if targetUriPath == "/openconfig-interfaces:interfaces/interface/openconfig-if-ethernet:ethernet/openconfig-vlan:switched-vlan/config/trunk-vlans" {
+				ifVlanInfo.mode = TRUNK
+			}
+			//Fill Trunk Vlans for interface
+			err = fillTrunkVlansForInterface(inParams.d, ifName, &ifVlanInfo)
+			if err != nil {
+				return err
+			}
+
+			ifVlanInfo.ifName = ifName
+			ifVlanInfoList = append(ifVlanInfoList, &ifVlanInfo)
+
+			err = processIntfVlanMemberRemoval(inParams, ifVlanInfoList, vlanMap, vlanMemberMap)
+			if err != nil {
+				log.Errorf("Interface VLAN member removal for Interface: %s failed!", *ifName)
+				return err
+			}
+			return err
+		}
+		//case 3
+		if swVlanConfig.swEthMember.Config.AccessVlan != nil {
+			ifVlanInfo.mode = ACCESS
+		}
+		//case 4
+		if swVlanConfig.swEthMember.Config.TrunkVlans != nil {
+			trunkVlansUnionList := swVlanConfig.swEthMember.Config.TrunkVlans
+			ifVlanInfo.mode = TRUNK
+
+			for _, trunkVlanUnion := range trunkVlansUnionList {
+				trunkVlanUnionType := reflect.TypeOf(trunkVlanUnion).Elem()
+
+				switch trunkVlanUnionType {
+
+				case reflect.TypeOf(ocbinds.OpenconfigInterfaces_Interfaces_Interface_Ethernet_SwitchedVlan_Config_TrunkVlans_Union_String{}):
+					val := (trunkVlanUnion).(*ocbinds.OpenconfigInterfaces_Interfaces_Interface_Ethernet_SwitchedVlan_Config_TrunkVlans_Union_String)
+					vlansList := strings.Split(val.String, ",")
+					for _, vlan := range vlansList {
+						/* Handle case if multiple/range of VLANs given */
+						if strings.Contains(vlan, "..") { //e.g vlan - 1..100
+							err = utils.ExtractVlanIdsFromRange(vlan, &ifVlanInfo.trunkVlans)
+							if err != nil {
+								return err
+							}
+						} else {
+							vlanName := "Vlan" + vlan
+							err = validateVlanExists(inParams.d, &vlanName)
+							if err != nil {
+								return err
+							}
+							ifVlanInfo.trunkVlans = append(ifVlanInfo.trunkVlans, vlanName)
+						}
+					}
+				case reflect.TypeOf(ocbinds.OpenconfigInterfaces_Interfaces_Interface_Ethernet_SwitchedVlan_Config_TrunkVlans_Union_Uint16{}):
+					val := (trunkVlanUnion).(*ocbinds.OpenconfigInterfaces_Interfaces_Interface_Ethernet_SwitchedVlan_Config_TrunkVlans_Union_Uint16)
+					ifVlanInfo.trunkVlans = append(ifVlanInfo.trunkVlans, "Vlan"+strconv.Itoa(int(val.Uint16)))
+				}
+			}
+		}
+	case IntfTypePortChannel:
+		if swVlanConfig.swEthMember != nil {
+			errStr := "Wrong yang path is used for Interface " + *ifName + " disassociation from Port-Channel Interface"
+			log.Error(errStr)
+			return errors.New(errStr)
+		}
+		//case 1
+		if swVlanConfig.swPortChannelMember == nil || swVlanConfig.swPortChannelMember.Config == nil ||
+			(swVlanConfig.swPortChannelMember.Config.AccessVlan == nil && swVlanConfig.swPortChannelMember.Config.TrunkVlans == nil) {
+
+			log.Info("Container/list level delete for Interface: ", *ifName)
+			ifVlanInfo.mode = ALL
+			//case 2
+			if targetUriPath == "/openconfig-interfaces:interfaces/interface/openconfig-if-aggregate:aggregation/openconfig-vlan:switched-vlan/config/trunk-vlans" {
+				ifVlanInfo.mode = TRUNK
+			}
+
+			//Fill Trunk Vlans for interface
+			err = fillTrunkVlansForInterface(inParams.d, ifName, &ifVlanInfo)
+			if err != nil {
+				return err
+			}
+
+			ifVlanInfo.ifName = ifName
+			ifVlanInfoList = append(ifVlanInfoList, &ifVlanInfo)
+
+			err = processIntfVlanMemberRemoval(inParams, ifVlanInfoList, vlanMap, vlanMemberMap)
+			if err != nil {
+				log.Errorf("Interface VLAN member removal for Interface: %s failed!", *ifName)
+				return err
+			}
+			return err
+		}
+		//case 3
+		if swVlanConfig.swPortChannelMember.Config.AccessVlan != nil {
+			ifVlanInfo.mode = ACCESS
+		}
+		// case 4: Note:- Deletion request is for trunk-vlans with an instance
+		if swVlanConfig.swPortChannelMember.Config.TrunkVlans != nil {
+			trunkVlansUnionList := swVlanConfig.swPortChannelMember.Config.TrunkVlans
+			ifVlanInfo.mode = TRUNK
+
+			for _, trunkVlanUnion := range trunkVlansUnionList {
+				trunkVlanUnionType := reflect.TypeOf(trunkVlanUnion).Elem()
+
+				switch trunkVlanUnionType {
+
+				case reflect.TypeOf(ocbinds.OpenconfigInterfaces_Interfaces_Interface_Aggregation_SwitchedVlan_Config_TrunkVlans_Union_String{}):
+					val := (trunkVlanUnion).(*ocbinds.OpenconfigInterfaces_Interfaces_Interface_Aggregation_SwitchedVlan_Config_TrunkVlans_Union_String)
+					vlansList := strings.Split(val.String, ",")
+					for _, vlan := range vlansList {
+						/* Handle case if multiple/range of VLANs given */
+						if strings.Contains(vlan, "..") {
+							err = utils.ExtractVlanIdsFromRange(vlan, &ifVlanInfo.trunkVlans)
+							if err != nil {
+								return err
+							}
+						} else {
+							vlanName := "Vlan" + vlan
+							err = validateVlanExists(inParams.d, &vlanName)
+							if err != nil {
+								return err
+							}
+							ifVlanInfo.trunkVlans = append(ifVlanInfo.trunkVlans, vlanName)
+						}
+					}
+				case reflect.TypeOf(ocbinds.OpenconfigInterfaces_Interfaces_Interface_Aggregation_SwitchedVlan_Config_TrunkVlans_Union_Uint16{}):
+					val := (trunkVlanUnion).(*ocbinds.OpenconfigInterfaces_Interfaces_Interface_Aggregation_SwitchedVlan_Config_TrunkVlans_Union_Uint16)
+					ifVlanInfo.trunkVlans = append(ifVlanInfo.trunkVlans, "Vlan"+strconv.Itoa(int(val.Uint16)))
+				}
+			}
+		}
+	}
+	if ifVlanInfo.mode != MODE_UNSET {
+		ifVlanInfo.ifName = ifName
+		ifVlanInfoList = append(ifVlanInfoList, &ifVlanInfo)
+	}
+	err = processIntfVlanMemberRemoval(inParams, ifVlanInfoList, vlanMap, vlanMemberMap)
+	if err != nil {
+		log.Errorf("Interface VLAN member removal for Interface: %s failed!", *ifName)
+		return err
+	}
+	return err
+}
+
+/* Function performs VLAN Member addition to Interface */
+func intfVlanMemberAdd(swVlanConfig *swVlanMemberPort_t,
+	inParams *XfmrParams, ifName *string,
+	uriIfName *string,
+	vlanMap map[string]db.Value,
+	vlanMemberMap map[string]db.Value, intfType E_InterfaceType) error {
+
+	var err error
+	var accessVlanId uint16 = 0
+	var trunkVlanSlice []string
+	var accessVlan string
+	var ifMode ocbinds.E_OpenconfigVlan_VlanModeType
+
+	accessVlanFound := false
+	trunkVlanFound := false
+
+	intTbl := IntfTypeTblMap[IntfTypeVlan]
+
+	vlanMembersListMap := make(map[string]map[string]db.Value)
+
+	switch intfType {
+	case IntfTypeEthernet:
+		/* Retrieve the Access VLAN Id */
+		if swVlanConfig.swEthMember == nil || swVlanConfig.swEthMember.Config == nil {
+			errStr := "Not supported switched-vlan request for Interface: " + *ifName
+			log.Error(errStr)
+			return errors.New(errStr)
+		}
+		if swVlanConfig.swEthMember.Config.AccessVlan != nil {
+			accessVlanId = *swVlanConfig.swEthMember.Config.AccessVlan
+			log.Infof("Vlan id : %d observed for Untagged Member port addition configuration!", accessVlanId)
+			accessVlanFound = true
+		}
+
+		/* Retrieve the list of trunk-vlans */
+		if swVlanConfig.swEthMember.Config.TrunkVlans != nil {
+			vlanUnionList := swVlanConfig.swEthMember.Config.TrunkVlans
+			if len(vlanUnionList) != 0 {
+				trunkVlanFound = true
+			}
+			for _, vlanUnion := range vlanUnionList {
+				vlanUnionType := reflect.TypeOf(vlanUnion).Elem()
+
+				switch vlanUnionType {
+
+				case reflect.TypeOf(ocbinds.OpenconfigInterfaces_Interfaces_Interface_Ethernet_SwitchedVlan_Config_TrunkVlans_Union_String{}):
+					val := (vlanUnion).(*ocbinds.OpenconfigInterfaces_Interfaces_Interface_Ethernet_SwitchedVlan_Config_TrunkVlans_Union_String)
+					err = utils.ExtractVlanIdsFromRange(val.String, &trunkVlanSlice)
+					if err != nil {
+						return err
+					}
+				case reflect.TypeOf(ocbinds.OpenconfigInterfaces_Interfaces_Interface_Ethernet_SwitchedVlan_Config_TrunkVlans_Union_Uint16{}):
+					val := (vlanUnion).(*ocbinds.OpenconfigInterfaces_Interfaces_Interface_Ethernet_SwitchedVlan_Config_TrunkVlans_Union_Uint16)
+					trunkVlanSlice = append(trunkVlanSlice, "Vlan"+strconv.Itoa(int(val.Uint16)))
+				}
+			}
+		}
+		if swVlanConfig.swEthMember.Config.InterfaceMode != ocbinds.OpenconfigVlan_VlanModeType_UNSET {
+			ifMode = swVlanConfig.swEthMember.Config.InterfaceMode
+		}
+	case IntfTypePortChannel:
+		/* Retrieve the Access VLAN Id */
+		if swVlanConfig.swPortChannelMember == nil || swVlanConfig.swPortChannelMember.Config == nil {
+			errStr := "Not supported switched-vlan request for Interface: " + *ifName
+			log.Error(errStr)
+			return errors.New(errStr)
+		}
+		if swVlanConfig.swPortChannelMember.Config.AccessVlan != nil {
+			accessVlanId = *swVlanConfig.swPortChannelMember.Config.AccessVlan
+			log.Infof("Vlan id : %d observed for Untagged Member port addition configuration!", accessVlanId)
+			accessVlanFound = true
+		}
+
+		/* Retrieve the list of trunk-vlans */
+		if swVlanConfig.swPortChannelMember.Config.TrunkVlans != nil {
+			vlanUnionList := swVlanConfig.swPortChannelMember.Config.TrunkVlans
+			if len(vlanUnionList) != 0 {
+				trunkVlanFound = true
+			}
+			for _, vlanUnion := range vlanUnionList {
+				vlanUnionType := reflect.TypeOf(vlanUnion).Elem()
+
+				switch vlanUnionType {
+
+				case reflect.TypeOf(ocbinds.OpenconfigInterfaces_Interfaces_Interface_Aggregation_SwitchedVlan_Config_TrunkVlans_Union_String{}):
+					val := (vlanUnion).(*ocbinds.OpenconfigInterfaces_Interfaces_Interface_Aggregation_SwitchedVlan_Config_TrunkVlans_Union_String)
+					err = utils.ExtractVlanIdsFromRange(val.String, &trunkVlanSlice)
+					if err != nil {
+						return err
+					}
+				case reflect.TypeOf(ocbinds.OpenconfigInterfaces_Interfaces_Interface_Aggregation_SwitchedVlan_Config_TrunkVlans_Union_Uint16{}):
+					val := (vlanUnion).(*ocbinds.OpenconfigInterfaces_Interfaces_Interface_Aggregation_SwitchedVlan_Config_TrunkVlans_Union_Uint16)
+					trunkVlanSlice = append(trunkVlanSlice, "Vlan"+strconv.Itoa(int(val.Uint16)))
+				}
+			}
+		}
+		if swVlanConfig.swPortChannelMember.Config.InterfaceMode != ocbinds.OpenconfigVlan_VlanModeType_UNSET {
+			ifMode = swVlanConfig.swPortChannelMember.Config.InterfaceMode
+		}
+	}
+	/* Update the DS based on access-vlan/trunk-vlans config */
+	if accessVlanFound {
+		accessVlan = "Vlan" + strconv.Itoa(int(accessVlanId))
+		var cfgredAccessVlan string
+		log.Info(accessVlan)
+
+		exists, err := validateUntaggedVlanCfgredForIf(inParams.d, &intTbl.cfgDb.memberTN, ifName, &cfgredAccessVlan)
+		if err != nil {
+			return err
+		}
+		if exists {
+			if cfgredAccessVlan == accessVlan {
+				log.Infof("Untagged VLAN: %s already configured, not updating the cache!", accessVlan)
+				goto TRUNKCONFIG
+			}
+			//Replace existing untagged vlan config(cfgredAccessVlan) with new config
+			del_res_map := make(map[string]map[string]db.Value)
+			vlanMapDel := make(map[string]db.Value)
+			vlanMemberMapDel := make(map[string]db.Value)
+			_, err := removeUntaggedVlanAndUpdateVlanMembTbl(inParams.d, ifName, vlanMemberMapDel)
+			if err != nil {
+				return err
+			}
+
+			if len(vlanMemberMapDel) != 0 {
+				del_res_map[VLAN_MEMBER_TN] = vlanMemberMapDel
+			}
+			if len(vlanMapDel) != 0 {
+				del_res_map[VLAN_TN] = vlanMapDel
+			}
+			vlanId := cfgredAccessVlan[len("Vlan"):]
+
+			if inParams.subOpDataMap[DELETE] != nil && (*inParams.subOpDataMap[DELETE])[db.ConfigDB] != nil {
+				if map_val, exists := (*inParams.subOpDataMap[DELETE])[db.ConfigDB][VLAN_TN]; exists {
+					for vlanName := range vlanMapDel {
+						if _, ok := map_val[vlanName]; !ok {
+							map_val[vlanName] = db.Value{Field: make(map[string]string)}
+						}
+					}
+					del_res_map[VLAN_TN] = map_val
+				}
+				mapCopy((*inParams.subOpDataMap[DELETE])[db.ConfigDB], del_res_map)
+			} else {
+				del_subOpMap := make(map[db.DBNum]map[string]map[string]db.Value)
+				del_subOpMap[db.ConfigDB] = del_res_map
+				inParams.subOpDataMap[DELETE] = &del_subOpMap
+			}
+			log.Info("Removing existing untagged VLAN: "+vlanId+" configuration, vlan delete subopmap:", (*inParams.subOpDataMap[DELETE])[db.ConfigDB])
+
+		}
+		err = validateVlanExists(inParams.d, &accessVlan)
+		if err == nil {
+			//If VLAN exists add to vlanMembersListMap
+			if vlanMembersListMap[accessVlan] == nil {
+				vlanMembersListMap[accessVlan] = make(map[string]db.Value)
+			}
+			vlanMembersListMap[accessVlan][*ifName] = db.Value{Field: make(map[string]string)}
+			vlanMembersListMap[accessVlan][*ifName].Field["tagging_mode"] = "untagged"
+		}
+	}
+
+TRUNKCONFIG:
+	if trunkVlanFound {
+		memberPortEntryMap := make(map[string]string)
+		memberPortEntry := db.Value{Field: memberPortEntryMap}
+		memberPortEntry.Field["tagging_mode"] = "tagged"
+		for _, vlanId := range trunkVlanSlice {
+			vlanName := vlanId
+			log.Infof("%s", vlanName)
+
+			err = validateVlanExists(inParams.d, &vlanId)
+			if err == nil {
+				if vlanMembersListMap[vlanId] == nil {
+					vlanMembersListMap[vlanId] = make(map[string]db.Value)
+				}
+				vlanMembersListMap[vlanId][*ifName] = db.Value{Field: make(map[string]string)}
+				vlanMembersListMap[vlanId][*ifName].Field["tagging_mode"] = "tagged"
+			}
+		}
+	}
+
+	if accessVlanFound || trunkVlanFound {
+		err = processIntfVlanMemberAdd(inParams.d, vlanMembersListMap, vlanMap, vlanMemberMap)
+		if err != nil {
+			log.Info("Processing Interface VLAN addition failed!")
+			return err
+		}
+		return err
+	}
+
+	if ifMode == ocbinds.OpenconfigVlan_VlanModeType_UNSET {
+		return nil
+	}
+	/* Handling the request just for setting Interface Mode */
+	log.Info("Request is for Configuring just the Mode for Interface: ", *ifName)
+	var mode intfModeReq
+
+	switch ifMode {
+	case ocbinds.OpenconfigVlan_VlanModeType_ACCESS:
+		/* Configuring Interface Mode as ACCESS only without VLAN info*/
+		mode = intfModeReq{ifName: *ifName, mode: ACCESS}
+		log.Info("Access Mode Config for Interface: ", *ifName)
+	case ocbinds.OpenconfigVlan_VlanModeType_TRUNK:
+	}
+	/* Switchport access/trunk mode config without VLAN */
+	/* This mode will be set in the translate fn, when request is just for mode without VLAN info. */
+	if mode.mode != MODE_UNSET {
+		err = intfModeReqConfig(inParams.d, mode, vlanMap, vlanMemberMap)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+/* Function performs VLAN Member replace to Interface */
+func intfVlanMemberReplace(swVlanConfig *swVlanMemberPort_t,
+	inParams *XfmrParams, ifName *string,
+	vlanMap map[string]db.Value,
+	vlanMemberMap map[string]db.Value,
+	intfType E_InterfaceType) error {
+
+	var err error
+	var accessVlanId uint16 = 0
+	var trunkVlanSlice []string
+	var accessVlan string
+
+	accessVlanFound := false
+	trunkVlanFound := false
+
+	vlanMembersListMap := make(map[string]map[string]db.Value)
+
+	var cfgredTaggedVlan []string
+	var cfgredAccessVlan string
+
+	accessVlanInPath := true
+	trunkVlanInPath := true
+
+	// check the request uri path to see if need to handle accessVlan or trunkVlan under switched-vlan
+	xpath, _, _ := XfmrRemoveXPATHPredicates(inParams.requestUri)
+	log.V(3).Info("intfVlanMemberReplace, xpath: ", xpath)
+
+	if (xpath == "/openconfig-interfaces:interfaces/interface/ethernet/switched-vlan/config/access-vlan") ||
+		(xpath == "/openconfig-interfaces:interfaces/interface/aggregation/switched-vlan/config/access-vlan") {
+		trunkVlanInPath = false
+	}
+	if (xpath == "/openconfig-interfaces:interfaces/interface/ethernet/switched-vlan/config/trunk-vlans") ||
+		(xpath == "/openconfig-interfaces:interfaces/interface/aggregation/switched-vlan/config/trunk-vlans") {
+		accessVlanInPath = false
+	}
+
+	switch intfType {
+	case IntfTypeEthernet:
+		/* Retrieve the Access VLAN Id */
+		if swVlanConfig.swEthMember == nil || swVlanConfig.swEthMember.Config == nil {
+			errStr := "Not supported switched-vlan request for Interface: " + *ifName
+			log.Error(errStr)
+			return errors.New(errStr)
+		}
+		if swVlanConfig.swEthMember.Config.AccessVlan != nil {
+			accessVlanId = *swVlanConfig.swEthMember.Config.AccessVlan
+			log.Infof("Vlan id : %d observed for Untagged Member port addition configuration!", accessVlanId)
+			accessVlanFound = true
+		}
+
+		/* Retrieve the list of trunk-vlans */
+		if swVlanConfig.swEthMember.Config.TrunkVlans != nil {
+			vlanUnionList := swVlanConfig.swEthMember.Config.TrunkVlans
+			if len(vlanUnionList) != 0 {
+				trunkVlanFound = true
+			}
+			for _, vlanUnion := range vlanUnionList {
+				vlanUnionType := reflect.TypeOf(vlanUnion).Elem()
+
+				switch vlanUnionType {
+
+				case reflect.TypeOf(ocbinds.OpenconfigInterfaces_Interfaces_Interface_Ethernet_SwitchedVlan_Config_TrunkVlans_Union_String{}):
+					val := (vlanUnion).(*ocbinds.OpenconfigInterfaces_Interfaces_Interface_Ethernet_SwitchedVlan_Config_TrunkVlans_Union_String)
+					err = utils.ExtractVlanIdsFromRange(val.String, &trunkVlanSlice)
+					if err != nil {
+						return err
+					}
+				case reflect.TypeOf(ocbinds.OpenconfigInterfaces_Interfaces_Interface_Ethernet_SwitchedVlan_Config_TrunkVlans_Union_Uint16{}):
+					val := (vlanUnion).(*ocbinds.OpenconfigInterfaces_Interfaces_Interface_Ethernet_SwitchedVlan_Config_TrunkVlans_Union_Uint16)
+					trunkVlanSlice = append(trunkVlanSlice, "Vlan"+strconv.Itoa(int(val.Uint16)))
+				}
+			}
+		}
+	case IntfTypePortChannel:
+		/* Retrieve the Access VLAN Id */
+		if swVlanConfig.swPortChannelMember == nil || swVlanConfig.swPortChannelMember.Config == nil {
+			errStr := "Not supported switched-vlan request for Interface: " + *ifName
+			log.Error(errStr)
+			return errors.New(errStr)
+		}
+		if swVlanConfig.swPortChannelMember.Config.AccessVlan != nil {
+			accessVlanId = *swVlanConfig.swPortChannelMember.Config.AccessVlan
+			log.Infof("Vlan id : %d observed for Untagged Member port addition configuration!", accessVlanId)
+			accessVlanFound = true
+		}
+
+		/* Retrieve the list of trunk-vlans */
+		if swVlanConfig.swPortChannelMember.Config.TrunkVlans != nil {
+			vlanUnionList := swVlanConfig.swPortChannelMember.Config.TrunkVlans
+			if len(vlanUnionList) != 0 {
+				trunkVlanFound = true
+			}
+			for _, vlanUnion := range vlanUnionList {
+				vlanUnionType := reflect.TypeOf(vlanUnion).Elem()
+
+				switch vlanUnionType {
+
+				case reflect.TypeOf(ocbinds.OpenconfigInterfaces_Interfaces_Interface_Aggregation_SwitchedVlan_Config_TrunkVlans_Union_String{}):
+					val := (vlanUnion).(*ocbinds.OpenconfigInterfaces_Interfaces_Interface_Aggregation_SwitchedVlan_Config_TrunkVlans_Union_String)
+					err = utils.ExtractVlanIdsFromRange(val.String, &trunkVlanSlice)
+					if err != nil {
+						return err
+					}
+				case reflect.TypeOf(ocbinds.OpenconfigInterfaces_Interfaces_Interface_Aggregation_SwitchedVlan_Config_TrunkVlans_Union_Uint16{}):
+					val := (vlanUnion).(*ocbinds.OpenconfigInterfaces_Interfaces_Interface_Aggregation_SwitchedVlan_Config_TrunkVlans_Union_Uint16)
+					trunkVlanSlice = append(trunkVlanSlice, "Vlan"+strconv.Itoa(int(val.Uint16)))
+				}
+			}
+		}
+	}
+
+	log.V(3).Infof("intfVlanMemberReplace, accessVlanId: %v, trunkVlanSlice:%v", accessVlanId, trunkVlanSlice)
+
+	//Get existing tagged and untagged vlan config on interface
+	if !accessVlanInPath {
+		cfgredTaggedVlan, _, err = getIntfVlanConfig(inParams.d, VLAN_MEMBER_TN, *ifName)
+	} else if !trunkVlanInPath {
+		_, cfgredAccessVlan, err = getIntfVlanConfig(inParams.d, VLAN_MEMBER_TN, *ifName)
+	} else {
+		cfgredTaggedVlan, cfgredAccessVlan, err = getIntfVlanConfig(inParams.d, VLAN_MEMBER_TN, *ifName)
+	}
+	if err != nil {
+		return err
+	}
+
+	log.V(3).Infof("intfVlanMemberReplace, cfgredAccessVlan: %v, cfgredTaggedVlan: %v", cfgredAccessVlan, cfgredTaggedVlan)
+
+	delTrunkVlansList := utils.VlanDifference(cfgredTaggedVlan, trunkVlanSlice)
+	log.V(3).Info("REPLACE oper - delTrunkVlansList: ", delTrunkVlansList)
+	addTrunkVlansList := utils.VlanDifference(trunkVlanSlice, cfgredTaggedVlan)
+	log.V(3).Info("REPLACE oper - addTrunkVlansList: ", addTrunkVlansList)
+
+	vlanMapDel := make(map[string]db.Value)
+	vlanMemberMapDel := make(map[string]db.Value)
+
+	del_res_map := make(map[string]map[string]db.Value)
+	add_res_map := make(map[string]map[string]db.Value)
+
+	if accessVlanInPath {
+		newAccessVlanFound := cfgredAccessVlan == ""
+		accessVlan = ""
+
+		if accessVlanFound {
+			accessVlan = "Vlan" + strconv.Itoa(int(accessVlanId))
+
+			err = validateVlanExists(inParams.d, &accessVlan)
+			if err == nil {
+				if cfgredAccessVlan != accessVlan {
+					newAccessVlanFound = true
+				}
+				if newAccessVlanFound {
+					// If new accessVlanExist, add it
+					//Adding VLAN to be configured(accessVlan) to the vlanMembersListMap
+					if vlanMembersListMap[accessVlan] == nil {
+						vlanMembersListMap[accessVlan] = make(map[string]db.Value)
+					}
+					vlanMembersListMap[accessVlan][*ifName] = db.Value{Field: make(map[string]string)}
+					vlanMembersListMap[accessVlan][*ifName].Field["tagging_mode"] = "untagged"
+				}
+			}
+		}
+		if cfgredAccessVlan != "" {
+			if cfgredAccessVlan == accessVlan {
+				log.Infof("Untagged VLAN: %s already configured, not updating the cache!", accessVlan)
+				goto TRUNKCONFIG
+			}
+
+			//Delete existing untagged vlan config(cfgredAccessVlan)
+			_, err := removeUntaggedVlanAndUpdateVlanMembTbl(inParams.d, ifName, vlanMemberMapDel)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+TRUNKCONFIG:
+
+	if trunkVlanInPath {
+		memberPortEntryMap := make(map[string]string)
+		memberPortEntry := db.Value{Field: memberPortEntryMap}
+		memberPortEntry.Field["tagging_mode"] = "tagged"
+		//Update vlanMembersListMap with trunk vlans to be configured
+		for _, vlanName := range addTrunkVlansList {
+			err = validateVlanExists(inParams.d, &vlanName)
+			if err == nil && accessVlan != vlanName {
+				//Update vlanMembersListMap if the VLAN exists and there is no conflicting untagged configuration.
+				if vlanMembersListMap[vlanName] == nil {
+					vlanMembersListMap[vlanName] = make(map[string]db.Value)
+				}
+				vlanMembersListMap[vlanName][*ifName] = db.Value{Field: make(map[string]string)}
+				vlanMembersListMap[vlanName][*ifName].Field["tagging_mode"] = "tagged"
+			}
+		}
+
+		//Delete existing Vlans already configured and are not in VLANs to be configured list
+		if len(cfgredTaggedVlan) != 0 {
+			//Not including the vlans to be configured in the delete map
+			for _, vlan := range delTrunkVlansList {
+				err = removeTaggedVlanAndUpdateVlanMembTbl(inParams.d, &vlan, ifName, vlanMemberMapDel)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	if len(vlanMemberMapDel) != 0 {
+		del_res_map[VLAN_MEMBER_TN] = vlanMemberMapDel
+	}
+	if len(vlanMapDel) != 0 {
+		del_res_map[VLAN_TN] = vlanMapDel
+	}
+
+	del_subOpMap := make(map[db.DBNum]map[string]map[string]db.Value)
+	del_subOpMap[db.ConfigDB] = del_res_map
+	inParams.subOpDataMap[DELETE] = &del_subOpMap
+	log.V(3).Info("REPLACE oper - vlan delete subopmap:", del_subOpMap)
+
+	if accessVlanFound || trunkVlanFound {
+		err = processIntfVlanMemberAdd(inParams.d, vlanMembersListMap, vlanMap, vlanMemberMap)
+		if err != nil {
+			log.Error("Processing Interface VLAN addition failed!")
+			return err
+		}
+		if len(vlanMemberMap) != 0 {
+			add_res_map[VLAN_MEMBER_TN] = vlanMemberMap
+		}
+		if len(vlanMap) != 0 {
+			add_res_map[VLAN_TN] = vlanMap
+		}
+
+		add_subOpMap := make(map[db.DBNum]map[string]map[string]db.Value)
+		add_subOpMap[db.ConfigDB] = add_res_map
+		inParams.subOpDataMap[UPDATE] = &add_subOpMap
+		return err
+	}
+
+	return nil
+}
+
+/* Function to delete VLAN and all its member ports */
+func deleteVlanIntfAndMembers(inParams *XfmrParams, vlanName *string) error {
+	var err error
+	subOpMap := make(map[db.DBNum]map[string]map[string]db.Value)
+	resMap := make(map[string]map[string]db.Value)
+	vlanMap := make(map[string]db.Value)
+	vlanIntfMap := make(map[string]db.Value)
+	vlanMemberMap := make(map[string]db.Value)
+
+	intTbl := IntfTypeTblMap[IntfTypeVlan]
+	vlanMap[*vlanName] = db.Value{Field: map[string]string{}}
+	subOpMap[db.ConfigDB] = resMap
+	inParams.subOpDataMap[DELETE] = &subOpMap
+
+	_, err = inParams.d.GetEntry(&db.TableSpec{Name: VLAN_TN}, db.Key{Comp: []string{*vlanName}})
+	if err != nil {
+		errStr := "Retrieving data from VLAN table for VLAN: " + *vlanName + " failed!"
+		log.Error(errStr)
+		// Not returning error from here since mgmt infra will return "Resource not found" error in case of non existence entries
+		return nil
+	}
+	/* Validation is needed, if oper is not DELETE. Cleanup for sub-interfaces is done as part of Delete. */
+	if inParams.oper != DELETE {
+		err = validateL3ConfigExists(inParams.d, vlanName)
+		if err != nil {
+			return err
+		}
+	}
+
+	/* Handle VLAN_MEMBER TABLE */
+	var flag bool = false
+	ts := db.TableSpec{Name: intTbl.cfgDb.memberTN + inParams.d.Opts.KeySeparator + *vlanName}
+	memberKeys, err := inParams.d.GetKeys(&ts)
+	if err == nil {
+		for key := range memberKeys {
+			flag = true
+			log.Info("Member port", memberKeys[key].Get(1))
+			memberKey := *vlanName + "|" + memberKeys[key].Get(1)
+			vlanMemberMap[memberKey] = db.Value{Field: map[string]string{}}
+		}
+		if flag {
+			resMap[VLAN_MEMBER_TN] = vlanMemberMap
+		}
+	}
+
+	/* Handle VLAN_INTERFACE TABLE */
+	processIntfTableRemoval(inParams.d, *vlanName, VLAN_INTERFACE_TN, vlanIntfMap)
+	if len(vlanIntfMap) != 0 {
+		resMap[VLAN_INTERFACE_TN] = vlanIntfMap
+	}
+
+	if len(vlanMap) != 0 {
+		resMap[VLAN_TN] = vlanMap
+	}
+	subOpMap[db.ConfigDB] = resMap
+	inParams.subOpDataMap[DELETE] = &subOpMap
+	return err
+}
+
+// YangToDb_sw_vlans_xfmr is a Yang to DB Subtree transformer supports CREATE, UPDATE and DELETE operations
+var YangToDb_sw_vlans_xfmr SubTreeXfmrYangToDb = func(inParams XfmrParams) (map[string]map[string]db.Value, error) {
+	var err error
+	res_map := make(map[string]map[string]db.Value)
+	vlanMap := make(map[string]db.Value)
+	vlanMemberMap := make(map[string]db.Value)
+	log.Info("YangToDb_sw_vlans_xfmr: ", inParams.uri)
+
+	var swVlanConfig swVlanMemberPort_t
+	pathInfo := NewPathInfo(inParams.uri)
+	uriIfName := pathInfo.Var("name")
+	ifName := uriIfName
+
+	deviceObj := (*inParams.ygRoot).(*ocbinds.Device)
+	intfObj := deviceObj.Interfaces
+
+	log.Info("Switched vlans request for ", ifName)
+	intf := intfObj.Interface[uriIfName]
+
+	intfType, _, err := getIntfTypeByName(ifName)
+	if err != nil {
+		errStr := "Extraction of Interface type from Interface: " + ifName + " failed!"
+		return nil, errors.New(errStr)
+	}
+	if intfType != IntfTypeEthernet && intfType != IntfTypePortChannel {
+		return nil, nil
+	}
+
+	/* Set invokeCRUSubtreeOnce flag to invoke subtree once */
+	if inParams.invokeCRUSubtreeOnce != nil {
+		*inParams.invokeCRUSubtreeOnce = true
+	}
+
+	if (inParams.oper == DELETE) && ((intf.Ethernet == nil || intf.Ethernet.SwitchedVlan == nil ||
+		intf.Ethernet.SwitchedVlan.Config == nil) && (intf.Aggregation == nil || intf.Aggregation.SwitchedVlan == nil ||
+		intf.Aggregation.SwitchedVlan.Config == nil)) {
+		err = intfVlanMemberRemoval(&swVlanConfig, &inParams, &ifName, vlanMap, vlanMemberMap, intfType)
+		if err != nil {
+			log.Errorf("Interface VLAN member port removal failed for Interface: %s!", ifName)
+			return nil, err
+		}
+		if len(vlanMemberMap) != 0 {
+			res_map[VLAN_MEMBER_TN] = vlanMemberMap
+		}
+		if len(vlanMap) != 0 {
+			res_map[VLAN_TN] = vlanMap
+		}
+		return res_map, err
+	}
+
+	if intf.Ethernet == nil && intf.Aggregation == nil {
+		return nil, errors.New("Wrong Config Request")
+	}
+	if intf.Ethernet != nil {
+		if intf.Ethernet.SwitchedVlan == nil || intf.Ethernet.SwitchedVlan.Config == nil {
+			return nil, errors.New("Wrong config request for Ethernet!")
+		}
+		swVlanConfig.swEthMember = intf.Ethernet.SwitchedVlan
+		if inParams.oper == REPLACE || inParams.oper == UPDATE {
+			if swVlanConfig.swEthMember.Config.TrunkVlans != nil {
+				vlanUnionList := swVlanConfig.swEthMember.Config.TrunkVlans
+				if len(vlanUnionList) == 0 {
+					log.Errorf("patch/replace operation not supported with empty trunk vlans ; ifname %s!", ifName)
+					return nil, errors.New("patch/replace operation not supported with empty trunk vlans !")
+				}
+			}
+		}
+	}
+	if intf.Aggregation != nil {
+		if intf.Aggregation.SwitchedVlan == nil || intf.Aggregation.SwitchedVlan.Config == nil {
+			return nil, errors.New("Wrong Config Request for Port Channel")
+		}
+		swVlanConfig.swPortChannelMember = intf.Aggregation.SwitchedVlan
+		if inParams.oper == REPLACE || inParams.oper == UPDATE {
+			if swVlanConfig.swPortChannelMember.Config.TrunkVlans != nil {
+				vlanUnionList := swVlanConfig.swPortChannelMember.Config.TrunkVlans
+				if len(vlanUnionList) == 0 {
+					log.Errorf("patch/replace operation not supported with empty trunk vlans ; ifname %s!", ifName)
+					return nil, errors.New("patch/replace operation not supported with empty trunk vlans !")
+				}
+			}
+		}
+	}
+
+	switch inParams.oper {
+	case REPLACE:
+		err = intfVlanMemberReplace(&swVlanConfig, &inParams, &ifName, vlanMap, vlanMemberMap, intfType)
+		if err != nil {
+			log.Errorf("Interface VLAN member port replace failed for Interface: %s!", ifName)
+			return nil, err
+		}
+
+	case CREATE:
+		fallthrough
+	case UPDATE:
+		err = intfVlanMemberAdd(&swVlanConfig, &inParams, &ifName, &uriIfName, vlanMap, vlanMemberMap, intfType)
+		if err != nil {
+			log.Errorf("Interface VLAN member port addition failed for Interface: %s!", ifName)
+			return nil, err
+		}
+		if len(vlanMap) != 0 {
+			res_map[VLAN_TN] = vlanMap
+			if inParams.subOpDataMap[inParams.oper] != nil && (*inParams.subOpDataMap[inParams.oper])[db.ConfigDB] != nil {
+				map_val := (*inParams.subOpDataMap[inParams.oper])[db.ConfigDB][VLAN_TN]
+				for vlanName := range vlanMap {
+					if _, ok := map_val[vlanName]; !ok {
+						map_val[vlanName] = db.Value{Field: make(map[string]string)}
+					}
+				}
+			} else {
+				subOpMap := make(map[db.DBNum]map[string]map[string]db.Value)
+				subOpMap[db.ConfigDB] = res_map
+				inParams.subOpDataMap[inParams.oper] = &subOpMap
+			}
+		}
+
+		if len(vlanMemberMap) != 0 { //make sure this map filled only with vlans existing
+			res_map[VLAN_MEMBER_TN] = vlanMemberMap
+		}
+
+	case DELETE:
+		err = intfVlanMemberRemoval(&swVlanConfig, &inParams, &ifName, vlanMap, vlanMemberMap, intfType)
+		if err != nil {
+			log.Errorf("Interface VLAN member port removal failed for Interface: %s!", ifName)
+			return nil, err
+		}
+		if len(vlanMemberMap) != 0 {
+			res_map[VLAN_MEMBER_TN] = vlanMemberMap
+		}
+		if len(vlanMap) != 0 {
+			res_map[VLAN_TN] = vlanMap
+		}
+	}
+	log.Info("YangToDb_sw_vlans_xfmr: vlan res map:", res_map)
+	log.Info("YangToDb_sw_vlans_xfmr: inParams.subOpDataMap UPDATE: ", inParams.subOpDataMap[UPDATE])
+	log.Info("YangToDb_sw_vlans_xfmr: inParams.subOpDataMap DELETE: ", inParams.subOpDataMap[DELETE])
+	log.Info("YangToDb_sw_vlans_xfmr: inParams.subOpDataMap REPLACE: ", inParams.subOpDataMap[REPLACE])
+	return res_map, err
+}
+
+func fillDBSwitchedVlanInfoForIntf(d *db.DB, ifName *string, vlanMemberMap map[string]map[string]db.Value) error {
+	if log.V(5) {
+		log.Info("fillDBSwitchedVlanInfoForIntf() called!")
+	}
+	var err error
+
+	vlanMemberKeys, err := d.GetKeysByPattern(&db.TableSpec{Name: VLAN_MEMBER_TN}, "*"+*ifName)
+	if err != nil {
+		return err
+	}
+	if log.V(5) {
+		log.Infof("Found %d vlan-member-table keys", len(vlanMemberKeys))
+	}
+
+	for _, vlanMember := range vlanMemberKeys {
+		if len(vlanMember.Comp) < 2 {
+			continue
+		}
+		vlanId := vlanMember.Get(0)
+		ifName := vlanMember.Get(1)
+		if log.V(5) {
+			log.Infof("Received Vlan: %s for Interface: %s", vlanId, ifName)
+		}
+
+		memberPortEntry, err := d.GetEntry(&db.TableSpec{Name: VLAN_MEMBER_TN}, vlanMember)
+		if err != nil {
+			return err
+		}
+		if !memberPortEntry.IsPopulated() {
+			errStr := "Tagging Info not present for Vlan: " + vlanId + " Interface: " + ifName + " from VLAN_MEMBER_TABLE"
+			return errors.New(errStr)
+		}
+
+		/* vlanMembersTableMap is used as DS for ifName to list of VLANs */
+		if vlanMemberMap[ifName] == nil {
+			vlanMemberMap[ifName] = make(map[string]db.Value)
+			vlanMemberMap[ifName][vlanId] = memberPortEntry
+		} else {
+			vlanMemberMap[ifName][vlanId] = memberPortEntry
+		}
+	}
+	if log.V(5) {
+		log.Infof("Updated the vlan-member-table ds for Interface: %s", *ifName)
+	}
+	return err
+}
+
+func getIntfVlanAttr(ifName *string, ifMode intfModeType, vlanMemberMap map[string]map[string]db.Value) ([]string, *string, error) {
+
+	if log.V(5) {
+		log.Info("getIntfVlanAttr() called")
+	}
+	vlanEntries, ok := vlanMemberMap[*ifName]
+	if !ok {
+		errStr := "Cannot find info for Interface: " + *ifName + " from VLAN_MEMBERS_TABLE!"
+		log.Info(errStr)
+		return nil, nil, nil
+	}
+	switch ifMode {
+	case ACCESS:
+		for vlanKey, tagEntry := range vlanEntries {
+			tagMode, ok := tagEntry.Field["tagging_mode"]
+			if ok {
+				if tagMode == "untagged" {
+					log.Info("Untagged VLAN found!")
+					return nil, &vlanKey, nil
+				}
+			}
+		}
+	case TRUNK:
+		var trunkVlans []string
+		for vlanKey, tagEntry := range vlanEntries {
+			tagMode, ok := tagEntry.Field["tagging_mode"]
+			if ok {
+				if tagMode == "tagged" {
+					trunkVlans = append(trunkVlans, vlanKey)
+				}
+			}
+		}
+		return sortVlanList(trunkVlans), nil, nil
+	}
+	return nil, nil, nil
+}
+
+func getSpecificSwitchedVlanStateAttr(targetUriPath *string, ifKey *string,
+	vlanMemberMap map[string]map[string]db.Value,
+	swVlan *swVlanMemberPort_t, intfType E_InterfaceType) (bool, error) {
+	log.Info("Specific Switched-vlan attribute!")
+	var config bool = true
+	switch *targetUriPath {
+	case "/openconfig-interfaces:interfaces/interface/openconfig-if-ethernet:ethernet/openconfig-vlan:switched-vlan/state/access-vlan":
+		fallthrough
+	case "/openconfig-interfaces:interfaces/interface/openconfig-if-aggregate:aggregation/openconfig-vlan:switched-vlan/state/access-vlan":
+		config = false
+		fallthrough
+	case "/openconfig-interfaces:interfaces/interface/openconfig-if-ethernet:ethernet/openconfig-vlan:switched-vlan/config/access-vlan":
+		fallthrough
+	case "/openconfig-interfaces:interfaces/interface/openconfig-if-aggregate:aggregation/openconfig-vlan:switched-vlan/config/access-vlan":
+
+		_, accessVlanName, e := getIntfVlanAttr(ifKey, ACCESS, vlanMemberMap)
+		if e != nil {
+			return true, e
+		}
+		if accessVlanName == nil {
+			return true, nil
+		}
+		log.Info("Access VLAN - ", accessVlanName)
+		vlanName := *accessVlanName
+		vlanIdStr := vlanName[len("Vlan"):]
+		vlanId, err := strconv.Atoi(vlanIdStr)
+		if err != nil {
+			errStr := "Conversion of string to int failed for " + vlanIdStr
+			return true, errors.New(errStr)
+		}
+		vlanIdCast := uint16(vlanId)
+
+		switch intfType {
+		case IntfTypeEthernet:
+			if config {
+				swVlan.swEthMember.Config.AccessVlan = &vlanIdCast
+			} else {
+				if swVlan.swEthMember.State == nil {
+					ygot.BuildEmptyTree(swVlan.swEthMember)
+				}
+				swVlan.swEthMember.State.AccessVlan = &vlanIdCast
+			}
+		case IntfTypePortChannel:
+			if config {
+				swVlan.swPortChannelMember.Config.AccessVlan = &vlanIdCast
+			} else {
+				if swVlan.swPortChannelMember.State == nil {
+					ygot.BuildEmptyTree(swVlan.swPortChannelMember)
+				}
+				swVlan.swPortChannelMember.State.AccessVlan = &vlanIdCast
+			}
+		}
+		return true, nil
+	case "/openconfig-interfaces:interfaces/interface/openconfig-if-ethernet:ethernet/openconfig-vlan:switched-vlan/state/trunk-vlans":
+		fallthrough
+	case "/openconfig-interfaces:interfaces/interface/openconfig-if-aggregate:aggregation/openconfig-vlan:switched-vlan/state/trunk-vlans":
+		config = false
+		fallthrough
+	case "/openconfig-interfaces:interfaces/interface/openconfig-if-ethernet:ethernet/openconfig-vlan:switched-vlan/config/trunk-vlans":
+		fallthrough
+	case "/openconfig-interfaces:interfaces/interface/openconfig-if-aggregate:aggregation/openconfig-vlan:switched-vlan/config/trunk-vlans":
+
+		trunkVlans, _, e := getIntfVlanAttr(ifKey, TRUNK, vlanMemberMap)
+		if e != nil {
+			return true, e
+		}
+
+		switch intfType {
+		case IntfTypeEthernet:
+
+			for _, vlanName := range trunkVlans {
+				log.Info("Trunk VLAN - ", vlanName)
+				vlanIdStr := vlanName[len("Vlan"):]
+				vlanId, err := strconv.Atoi(vlanIdStr)
+				if err != nil {
+					errStr := "Conversion of string to int failed for " + vlanIdStr
+					return true, errors.New(errStr)
+				}
+				vlanIdCast := uint16(vlanId)
+				if config {
+					trunkVlan, _ := swVlan.swEthMember.Config.To_OpenconfigInterfaces_Interfaces_Interface_Ethernet_SwitchedVlan_Config_TrunkVlans_Union(vlanIdCast)
+					swVlan.swEthMember.Config.TrunkVlans = append(swVlan.swEthMember.Config.TrunkVlans, trunkVlan)
+				} else {
+					trunkVlan, _ := swVlan.swEthMember.State.To_OpenconfigInterfaces_Interfaces_Interface_Ethernet_SwitchedVlan_State_TrunkVlans_Union(vlanIdCast)
+					swVlan.swEthMember.State.TrunkVlans = append(swVlan.swEthMember.State.TrunkVlans, trunkVlan)
+				}
+			}
+		case IntfTypePortChannel:
+			for _, vlanName := range trunkVlans {
+				log.Info("Trunk VLAN - ", vlanName)
+				vlanIdStr := vlanName[len("Vlan"):]
+				vlanId, err := strconv.Atoi(vlanIdStr)
+				if err != nil {
+					errStr := "Conversion of string to int failed for " + vlanIdStr
+					return true, errors.New(errStr)
+				}
+				vlanIdCast := uint16(vlanId)
+				if config {
+					trunkVlan, _ := swVlan.swPortChannelMember.Config.To_OpenconfigInterfaces_Interfaces_Interface_Aggregation_SwitchedVlan_Config_TrunkVlans_Union(vlanIdCast)
+					swVlan.swPortChannelMember.Config.TrunkVlans = append(swVlan.swPortChannelMember.Config.TrunkVlans, trunkVlan)
+				} else {
+					trunkVlan, _ := swVlan.swPortChannelMember.State.To_OpenconfigInterfaces_Interfaces_Interface_Aggregation_SwitchedVlan_State_TrunkVlans_Union(vlanIdCast)
+					swVlan.swPortChannelMember.State.TrunkVlans = append(swVlan.swPortChannelMember.State.TrunkVlans, trunkVlan)
+				}
+			}
+		}
+		return true, nil
+	case "/openconfig-interfaces:interfaces/interface/openconfig-if-ethernet:ethernet/openconfig-vlan:switched-vlan/state/interface-mode":
+		fallthrough
+	case "/openconfig-interfaces:interfaces/interface/openconfig-if-aggregate:aggregation/openconfig-vlan:switched-vlan/state/interface-mode":
+		config = false
+		fallthrough
+	case "/openconfig-interfaces:interfaces/interface/openconfig-if-ethernet:ethernet/openconfig-vlan:switched-vlan/config/interface-mode":
+		fallthrough
+	case "/openconfig-interfaces:interfaces/interface/openconfig-if-aggregate:aggregation/openconfig-vlan:switched-vlan/config/interface-mode":
+
+		_, accessVlanName, e := getIntfVlanAttr(ifKey, ACCESS, vlanMemberMap)
+		if e != nil {
+			return true, e
+		}
+
+		trunkVlans, _, e := getIntfVlanAttr(ifKey, TRUNK, vlanMemberMap)
+		if e != nil {
+			return true, e
+		}
+
+		switch intfType {
+		case IntfTypeEthernet:
+			if accessVlanName != nil {
+				if config {
+					swVlan.swEthMember.Config.InterfaceMode = ocbinds.OpenconfigVlan_VlanModeType_ACCESS
+				} else {
+					swVlan.swEthMember.State.InterfaceMode = ocbinds.OpenconfigVlan_VlanModeType_ACCESS
+				}
+			}
+			if len(trunkVlans) > 0 {
+				if config {
+					swVlan.swEthMember.Config.InterfaceMode = ocbinds.OpenconfigVlan_VlanModeType_TRUNK
+				} else {
+					swVlan.swEthMember.State.InterfaceMode = ocbinds.OpenconfigVlan_VlanModeType_TRUNK
+				}
+			}
+		case IntfTypePortChannel:
+			if accessVlanName != nil {
+				if config {
+					swVlan.swPortChannelMember.Config.InterfaceMode = ocbinds.OpenconfigVlan_VlanModeType_ACCESS
+				} else {
+					swVlan.swPortChannelMember.State.InterfaceMode = ocbinds.OpenconfigVlan_VlanModeType_ACCESS
+				}
+			}
+			if len(trunkVlans) > 0 {
+				if config {
+					swVlan.swPortChannelMember.Config.InterfaceMode = ocbinds.OpenconfigVlan_VlanModeType_TRUNK
+				} else {
+					swVlan.swPortChannelMember.State.InterfaceMode = ocbinds.OpenconfigVlan_VlanModeType_TRUNK
+				}
+			}
+		}
+		return true, nil
+	}
+	return false, nil
+}
+
+func getSwitchedVlanState(ifKey *string, vlanMemberMap map[string]map[string]db.Value,
+	swVlan *swVlanMemberPort_t, intfType E_InterfaceType, config bool) error {
+	/* Get Access VLAN info for Interface */
+	_, accessVlanName, e := getIntfVlanAttr(ifKey, ACCESS, vlanMemberMap)
+	if e != nil {
+		return e
+	}
+
+	/* Get Trunk VLAN info for Interface */
+	trunkVlans, _, e := getIntfVlanAttr(ifKey, TRUNK, vlanMemberMap)
+	if e != nil {
+		return e
+	}
+
+	switch intfType {
+	case IntfTypeEthernet:
+
+		if swVlan.swEthMember.State == nil {
+			ygot.BuildEmptyTree(swVlan.swEthMember)
+		}
+
+		if accessVlanName != nil {
+			vlanName := *accessVlanName
+			vlanIdStr := vlanName[len("Vlan"):]
+			vlanId, err := strconv.Atoi(vlanIdStr)
+			if err != nil {
+				errStr := "Conversion of string to int failed for " + vlanIdStr
+				return errors.New(errStr)
+			}
+			vlanIdCast := uint16(vlanId)
+			if config {
+				swVlan.swEthMember.Config.AccessVlan = &vlanIdCast
+				swVlan.swEthMember.Config.InterfaceMode = ocbinds.OpenconfigVlan_VlanModeType_ACCESS
+			} else {
+				swVlan.swEthMember.State.AccessVlan = &vlanIdCast
+				swVlan.swEthMember.State.InterfaceMode = ocbinds.OpenconfigVlan_VlanModeType_ACCESS
+			}
+		}
+		for _, vlanName := range trunkVlans {
+			vlanIdStr := vlanName[len("Vlan"):]
+			vlanId, err := strconv.Atoi(vlanIdStr)
+			if err != nil {
+				errStr := "Conversion of string to int failed for " + vlanIdStr
+				return errors.New(errStr)
+			}
+			vlanIdCast := uint16(vlanId)
+
+			if config {
+				trunkVlan, _ := swVlan.swEthMember.Config.To_OpenconfigInterfaces_Interfaces_Interface_Ethernet_SwitchedVlan_Config_TrunkVlans_Union(vlanIdCast)
+				swVlan.swEthMember.Config.TrunkVlans = append(swVlan.swEthMember.Config.TrunkVlans, trunkVlan)
+				swVlan.swEthMember.Config.InterfaceMode = ocbinds.OpenconfigVlan_VlanModeType_TRUNK
+			} else {
+				trunkVlan, _ := swVlan.swEthMember.State.To_OpenconfigInterfaces_Interfaces_Interface_Ethernet_SwitchedVlan_State_TrunkVlans_Union(vlanIdCast)
+				swVlan.swEthMember.State.TrunkVlans = append(swVlan.swEthMember.State.TrunkVlans, trunkVlan)
+				swVlan.swEthMember.State.InterfaceMode = ocbinds.OpenconfigVlan_VlanModeType_TRUNK
+			}
+		}
+	case IntfTypePortChannel:
+
+		if swVlan.swPortChannelMember.State == nil {
+			ygot.BuildEmptyTree(swVlan.swPortChannelMember)
+		}
+
+		if accessVlanName != nil {
+			vlanName := *accessVlanName
+			vlanIdStr := vlanName[len("Vlan"):]
+			vlanId, err := strconv.Atoi(vlanIdStr)
+			if err != nil {
+				errStr := "Conversion of string to int failed for " + vlanIdStr
+				return errors.New(errStr)
+			}
+			vlanIdCast := uint16(vlanId)
+			if config {
+				swVlan.swPortChannelMember.Config.AccessVlan = &vlanIdCast
+				swVlan.swPortChannelMember.Config.InterfaceMode = ocbinds.OpenconfigVlan_VlanModeType_ACCESS
+			} else {
+				swVlan.swPortChannelMember.State.AccessVlan = &vlanIdCast
+				swVlan.swPortChannelMember.State.InterfaceMode = ocbinds.OpenconfigVlan_VlanModeType_ACCESS
+			}
+		}
+		for _, vlanName := range trunkVlans {
+			vlanIdStr := vlanName[len("Vlan"):]
+			vlanId, err := strconv.Atoi(vlanIdStr)
+			if err != nil {
+				errStr := "Conversion of string to int failed for " + vlanIdStr
+				return errors.New(errStr)
+			}
+
+			vlanIdCast := uint16(vlanId)
+			if config {
+				trunkVlan, _ := swVlan.swPortChannelMember.Config.To_OpenconfigInterfaces_Interfaces_Interface_Aggregation_SwitchedVlan_Config_TrunkVlans_Union(vlanIdCast)
+				swVlan.swPortChannelMember.Config.TrunkVlans = append(swVlan.swPortChannelMember.Config.TrunkVlans, trunkVlan)
+				swVlan.swPortChannelMember.Config.InterfaceMode = ocbinds.OpenconfigVlan_VlanModeType_TRUNK
+			} else {
+				trunkVlan, _ := swVlan.swPortChannelMember.State.To_OpenconfigInterfaces_Interfaces_Interface_Aggregation_SwitchedVlan_State_TrunkVlans_Union(vlanIdCast)
+				swVlan.swPortChannelMember.State.TrunkVlans = append(swVlan.swPortChannelMember.State.TrunkVlans, trunkVlan)
+				swVlan.swPortChannelMember.State.InterfaceMode = ocbinds.OpenconfigVlan_VlanModeType_TRUNK
+			}
+		}
+	}
+	return nil
+}
+
+// DbToYang_sw_vlans_xfmr is a DB to Yang Subtree transformer method handles GET operation
+var DbToYang_sw_vlans_xfmr SubTreeXfmrDbToYang = func(inParams XfmrParams) error {
+	var err error
+	var swVlan swVlanMemberPort_t
+	intfsObj := getIntfsRoot(inParams.ygRoot)
+	if intfsObj == nil {
+		errStr := "Nil root object received for Ethernet-Switched VLAN Get!"
+		log.Errorf(errStr)
+		return errors.New(errStr)
+	}
+	pathInfo := NewPathInfo(inParams.uri)
+
+	uriIfName := pathInfo.Var("name")
+	ifName := uriIfName
+
+	if log.V(5) {
+		log.Infof("Ethernet-Switched Vlan Get observed for Interface: %s", ifName)
+	}
+	intfType, _, err := getIntfTypeByName(ifName)
+	if intfType != IntfTypeEthernet && intfType != IntfTypePortChannel || err != nil {
+		intfTypeStr := strconv.Itoa(int(intfType))
+		errStr := "TableXfmrFunc - Invalid interface type" + intfTypeStr
+		log.Warning(errStr)
+		return errors.New(errStr)
+	}
+
+	if (strings.Contains(inParams.uri, "ethernet") && (intfType == IntfTypePortChannel)) ||
+		(strings.Contains(inParams.uri, "aggregation") && (intfType == IntfTypeEthernet)) {
+		return nil
+	}
+	targetUriPath := pathInfo.YangPath
+	if log.V(5) {
+		log.Info("targetUriPath is ", targetUriPath)
+	}
+
+	intfObj := intfsObj.Interface[uriIfName]
+	if intfObj == nil {
+		intfObj, _ = intfsObj.NewInterface(uriIfName)
+		ygot.BuildEmptyTree(intfObj)
+	}
+
+	if intfObj.Ethernet == nil && intfObj.Aggregation == nil {
+		return errors.New("Wrong GET request for switched-vlan!")
+	}
+	if intfObj.Ethernet != nil {
+		if intfObj.Ethernet.SwitchedVlan == nil {
+			ygot.BuildEmptyTree(intfObj.Ethernet)
+		}
+		swVlan.swEthMember = intfObj.Ethernet.SwitchedVlan
+	}
+	if intfObj.Aggregation != nil {
+		if intfObj.Aggregation.SwitchedVlan == nil {
+			ygot.BuildEmptyTree(intfObj.Aggregation)
+		}
+		swVlan.swPortChannelMember = intfObj.Aggregation.SwitchedVlan
+	}
+	switch intfType {
+	case IntfTypeEthernet:
+		if intfObj.Ethernet == nil {
+			errStr := "Switched-vlan state tree not built correctly for Interface: " + ifName
+			log.Error(errStr)
+			return errors.New(errStr)
+		}
+		if intfObj.Ethernet.SwitchedVlan == nil {
+			ygot.BuildEmptyTree(intfObj.Ethernet)
+		}
+
+		vlanMemberMap := make(map[string]map[string]db.Value)
+		err = fillDBSwitchedVlanInfoForIntf(inParams.d, &ifName, vlanMemberMap)
+		if err != nil {
+			log.Errorf("Filiing Switched Vlan Info for Interface: %s failed!", ifName)
+			return err
+		}
+		if log.V(5) {
+			log.Info("Succesfully completed DB population for Ethernet!")
+		}
+
+		attrPresent, err := getSpecificSwitchedVlanStateAttr(&targetUriPath, &ifName, vlanMemberMap, &swVlan, intfType)
+		if err != nil {
+			return err
+		}
+		if !attrPresent {
+			if log.V(5) {
+				log.Infof("Get is for Switched Vlan State Container!")
+			}
+			switch targetUriPath {
+			case "/openconfig-interfaces:interfaces/interface/openconfig-if-ethernet:ethernet/openconfig-vlan:switched-vlan/config":
+				err = getSwitchedVlanState(&ifName, vlanMemberMap, &swVlan, intfType, true)
+				if err != nil {
+					return err
+				}
+			case "/openconfig-interfaces:interfaces/interface/openconfig-if-ethernet:ethernet/openconfig-vlan:switched-vlan/state":
+				err = getSwitchedVlanState(&ifName, vlanMemberMap, &swVlan, intfType, false)
+				if err != nil {
+					return err
+				}
+			case "/openconfig-interfaces:interfaces/interface/openconfig-if-ethernet:ethernet/openconfig-vlan:switched-vlan":
+				fallthrough
+			case "/openconfig-interfaces:interfaces/interface/openconfig-if-ethernet:ethernet/switched-vlan":
+				fallthrough
+			case "/openconfig-interfaces:interfaces/interface/ethernet/switched-vlan":
+				err = getSwitchedVlanState(&ifName, vlanMemberMap, &swVlan, intfType, true)
+				if err != nil {
+					return err
+				}
+				err = getSwitchedVlanState(&ifName, vlanMemberMap, &swVlan, intfType, false)
+				if err != nil {
+					return err
+				}
+			}
+		}
+
+	case IntfTypePortChannel:
+		if intfObj.Aggregation == nil {
+			errStr := "Switched-vlan state tree not built correctly for Interface: " + ifName
+			log.Error(errStr)
+			return errors.New(errStr)
+		}
+
+		if intfObj.Aggregation.SwitchedVlan == nil {
+			ygot.BuildEmptyTree(intfObj.Aggregation)
+		}
+
+		vlanMemberMap := make(map[string]map[string]db.Value)
+		err = fillDBSwitchedVlanInfoForIntf(inParams.d, &ifName, vlanMemberMap)
+		if err != nil {
+			log.Errorf("Filiing Switched Vlan Info for Interface: %s failed!", ifName)
+			return err
+		}
+		log.Info("Succesfully completed DB population for Port-Channel!")
+		attrPresent, err := getSpecificSwitchedVlanStateAttr(&targetUriPath, &ifName, vlanMemberMap, &swVlan, intfType)
+		if err != nil {
+			return err
+		}
+		if !attrPresent {
+			log.Infof("Get is for Switched Vlan State Container!")
+			switch targetUriPath {
+			case "/openconfig-interfaces:interfaces/interface/openconfig-if-aggregate:aggregation/openconfig-vlan:switched-vlan/config":
+				err = getSwitchedVlanState(&ifName, vlanMemberMap, &swVlan, intfType, true)
+				if err != nil {
+					return err
+				}
+			case "/openconfig-interfaces:interfaces/interface/openconfig-if-aggregate:aggregation/openconfig-vlan:switched-vlan/state":
+				err = getSwitchedVlanState(&ifName, vlanMemberMap, &swVlan, intfType, false)
+				if err != nil {
+					return err
+				}
+			case "/openconfig-interfaces:interfaces/interface/openconfig-if-aggregate:aggregation/openconfig-vlan:switched-vlan":
+				fallthrough
+			case "/openconfig-interfaces:interfaces/interface/openconfig-if-aggregate:aggregation/switched-vlan":
+				fallthrough
+			case "/openconfig-interfaces:interfaces/interface/aggregation/switched-vlan":
+				err = getSwitchedVlanState(&ifName, vlanMemberMap, &swVlan, intfType, true)
+				if err != nil {
+					return err
+				}
+				err = getSwitchedVlanState(&ifName, vlanMemberMap, &swVlan, intfType, false)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return err
+}
+
+var DbToYangPath_sw_vlans_path_xfmr PathXfmrDbToYangFunc = func(params XfmrDbToYgPathParams) error {
+	log.Info("DbToYangPath_sw_vlans_path_xfmr : params ", params)
+
+	if (params.tblName != "PORT") &&
+		(params.tblName != "PORTCHANNEL") {
+		log.Info("DbToYangPath_sw_vlans_path_xfmr: unsupported table: ", params.tblName)
+		return nil
+	}
+
+	log.Info("DbToYangPath_sw_vlans_path_xfmr : params.ygPathkeys: ", params.ygPathKeys)
+
+	return nil
+}

--- a/translib/transformer/vlan_openconfig_test.go
+++ b/translib/transformer/vlan_openconfig_test.go
@@ -1,0 +1,1045 @@
+////////////////////////////////////////////////////////////////////////////////
+//                                                                            //
+//  Copyright 2025 Dell, Inc.                                                 //
+//                                                                            //
+//  Licensed under the Apache License, Version 2.0 (the "License");           //
+//  you may not use this file except in compliance with the License.          //
+//  You may obtain a copy of the License at                                   //
+//                                                                            //
+//     http://www.apache.org/licenses/LICENSE-2.0                             //
+//                                                                            //
+//  Unless required by applicable law or agreed to in writing, software       //
+//  distributed under the License is distributed on an "AS IS" BASIS,         //
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  //
+//  See the License for the specific language governing permissions and       //
+//  limitations under the License.                                            //
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+
+//go:build testapp
+// +build testapp
+
+package transformer_test
+
+import (
+	"github.com/Azure/sonic-mgmt-common/translib/db"
+	"github.com/Azure/sonic-mgmt-common/translib/tlerr"
+	"testing"
+	"time"
+)
+
+func Test_openconfig_vlan_interface(t *testing.T) {
+	var url, url_input_body_json string
+
+	t.Log("\n\n++++++++++++ CREATING VLAN INTERFACE ++++++++++++")
+
+	t.Log("\n\n--- PATCH to Create VLAN 10 ---")
+	url = "/openconfig-interfaces:interfaces"
+	url_input_body_json = "{\"openconfig-interfaces:interfaces\":{\"interface\":[{\"name\":\"Vlan10\",\"config\":{\"name\":\"Vlan10\",\"mtu\":9000,\"enabled\":true}}]}}"
+	t.Run("Test Create VLAN 10", processSetRequest(url, url_input_body_json, "PATCH", false, nil))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify VLAN Creation (PATCH) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan10]/config"
+	expected_get_json := "{\"openconfig-interfaces:config\": {\"enabled\": true, \"mtu\": 9000, \"name\": \"Vlan10\"}}"
+	t.Run("Test GET VLAN interface creation config ", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- PATCH to Create VLAN 20, 30, and 40 ---")
+	url = "/openconfig-interfaces:interfaces"
+	url_input_body_json = "{\"openconfig-interfaces:interfaces\":{\"interface\":[{\"name\":\"Vlan20\",\"config\":{\"name\":\"Vlan20\",\"mtu\":9000,\"enabled\":true}}, {\"name\":\"Vlan30\",\"config\":{\"name\":\"Vlan30\",\"mtu\":9100,\"enabled\":true}}, {\"name\":\"Vlan40\",\"config\":{\"name\":\"Vlan40\",\"mtu\":9100,\"enabled\":true}}]}}"
+	t.Run("Test Create VLAN 20,30,40", processSetRequest(url, url_input_body_json, "PATCH", false, nil))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify VLAN Creations (PATCH) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan20]/config"
+	expected_get_json = "{\"openconfig-interfaces:config\": {\"enabled\": true, \"mtu\": 9000, \"name\": \"Vlan20\"}}"
+	t.Run("Test GET VLAN interface creation config ", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify VLAN Creations (PATCH) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan30]/config"
+	expected_get_json = "{\"openconfig-interfaces:config\": {\"enabled\": true, \"mtu\": 9100, \"name\": \"Vlan30\"}}"
+	t.Run("Test GET VLAN interface creation config ", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify VLAN Creations (PATCH) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan40]/config"
+	expected_get_json = "{\"openconfig-interfaces:config\": {\"enabled\": true, \"mtu\": 9100, \"name\": \"Vlan40\"}}"
+	t.Run("Test GET VLAN interface creation config ", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- POST to Create VLAN 50 ---")
+	url = "/openconfig-interfaces:interfaces"
+	url_input_body_json = "{\"openconfig-interfaces:interface\":[{\"name\":\"Vlan50\",\"config\":{\"name\":\"Vlan50\",\"mtu\":9000,\"enabled\":true}}]}"
+	t.Run("Test Create VLAN 50", processSetRequest(url, url_input_body_json, "POST", false, nil))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify VLAN Creation (POST) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan50]/config"
+	expected_get_json = "{\"openconfig-interfaces:config\": {\"enabled\": true, \"mtu\": 9000, \"name\": \"Vlan50\"}}"
+	t.Run("Test GET VLAN interface creation config ", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- POST to Create VLAN 60, 70, and 80 ---")
+	url = "/openconfig-interfaces:interfaces"
+	url_input_body_json = "{\"openconfig-interfaces:interface\":[{\"name\":\"Vlan60\",\"config\":{\"name\":\"Vlan60\",\"mtu\":9000,\"enabled\":true}}, {\"name\":\"Vlan70\",\"config\":{\"name\":\"Vlan70\",\"mtu\":9100,\"enabled\":true}}, {\"name\":\"Vlan80\",\"config\":{\"name\":\"Vlan80\",\"mtu\":9100,\"enabled\":true}}]}"
+	t.Run("Test Create VLAN 60,70,80", processSetRequest(url, url_input_body_json, "POST", false, nil))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify VLAN Creations (POST) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan60]/config"
+	expected_get_json = "{\"openconfig-interfaces:config\": {\"enabled\": true, \"mtu\": 9000, \"name\": \"Vlan60\"}}"
+	t.Run("Test GET VLAN interface creation config ", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify VLAN Creations (POST) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan70]/config"
+	expected_get_json = "{\"openconfig-interfaces:config\": {\"enabled\": true, \"mtu\": 9100, \"name\": \"Vlan70\"}}"
+	t.Run("Test GET VLAN interface creation config ", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify VLAN Creations (POST) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan80]/config"
+	expected_get_json = "{\"openconfig-interfaces:config\": {\"enabled\": true, \"mtu\": 9100, \"name\": \"Vlan80\"}}"
+	t.Run("Test GET VLAN interface creation config ", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n++++++++++++ GET LEVELS ON VLAN INTERFACE ++++++++++++")
+
+	t.Log("\n\n--- GET VLAN (interface level) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan10]"
+	expected_get_json = "{\"openconfig-interfaces:interface\":[{\"config\":{\"enabled\":true,\"mtu\":9000,\"name\":\"Vlan10\"},\"name\":\"Vlan10\",\"openconfig-vlan:routed-vlan\":{\"openconfig-if-ip:ipv6\":{\"config\":{\"enabled\":false},\"state\":{\"enabled\":false}}},\"state\":{\"name\":\"Vlan10\"},\"subinterfaces\":{\"subinterface\":[{\"config\":{\"index\":0},\"index\":0,\"openconfig-if-ip:ipv6\":{\"config\":{\"enabled\":false},\"state\":{\"enabled\":false}},\"state\":{\"index\":0}}]}}]}"
+	t.Run("Test GET VLAN interface creation config ", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- GET VLAN (leaf level mtu) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan10]/config/mtu"
+	expected_get_json = "{\"openconfig-interfaces:mtu\":9000}"
+	t.Run("Test GET VLAN interface creation config ", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- GET VLAN (leaf level enabled) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan10]/config/enabled"
+	expected_get_json = "{\"openconfig-interfaces:enabled\":true}"
+	t.Run("Test GET VLAN interface creation config ", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n++++++++++++ UPDATE VLAN INTERFACE ++++++++++++")
+
+	t.Log("\n\n--- PATCH VLAN interface (leaf) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan10]/config/mtu"
+	url_input_body_json = "{\"openconfig-interfaces:mtu\":9100}"
+	t.Run("Test modify VLAN 10", processSetRequest(url, url_input_body_json, "PATCH", false, nil))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify VLAN modification ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan10]/config"
+	expected_get_json = "{\"openconfig-interfaces:config\": {\"enabled\": true, \"mtu\": 9100, \"name\": \"Vlan10\"}}"
+	t.Run("Test GET VLAN interface creation config ", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- PATCH VLAN interface (config) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan10]/config"
+	url_input_body_json = "{\"openconfig-interfaces:config\":{\"name\":\"Vlan10\",\"mtu\":9000,\"enabled\":false}}"
+	t.Run("Test modify VLAN 10", processSetRequest(url, url_input_body_json, "PATCH", false, nil))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify VLAN modification ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan10]/config"
+	expected_get_json = "{\"openconfig-interfaces:config\": {\"enabled\": false, \"mtu\": 9000, \"name\": \"Vlan10\"}}"
+	t.Run("Test GET VLAN interface creation config ", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- POST VLAN interface ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan10]"
+	url_input_body_json = "{\"openconfig-interfaces:config\":{\"name\":\"Vlan10\",\"mtu\":9100,\"enabled\":false}}"
+	t.Run("Test modify VLAN 10", processSetRequest(url, url_input_body_json, "POST", false, nil))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify VLAN modification ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan10]/config"
+	expected_get_json = "{\"openconfig-interfaces:config\": {\"enabled\": false, \"mtu\": 9100, \"name\": \"Vlan10\"}}"
+	t.Run("Test GET VLAN interface creation config ", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- PUT VLAN interface ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan10]"
+	url_input_body_json = "{\"openconfig-interfaces:interface\":[{\"name\":\"Vlan10\",\"config\":{\"name\":\"Vlan10\",\"mtu\":9000,\"enabled\":true}}]}"
+	t.Run("Test replace VLAN 10", processSetRequest(url, url_input_body_json, "PUT", false, nil))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify VLAN modification ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan10]/config"
+	expected_get_json = "{\"openconfig-interfaces:config\": {\"enabled\": true, \"mtu\": 9000, \"name\": \"Vlan10\"}}"
+	t.Run("Test GET VLAN interface creation config ", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n++++++++++++ CHECK STATE ATTRIBUTES ++++++++++++")
+
+	cleanuptbl := map[string]interface{}{"VLAN_TABLE": map[string]interface{}{"Vlan10": ""}}
+	unloadDB(db.ApplDB, cleanuptbl)
+	pre_req_map := map[string]interface{}{"VLAN_TABLE": map[string]interface{}{"Vlan10": map[string]interface{}{"admin_status": "up", "mtu": "9000", "enabled": "true"}}}
+	loadDB(db.ApplDB, pre_req_map)
+
+	t.Log("\n\n--- GET VLAN (state level) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan10]/state"
+	expected_get_json = "{\"openconfig-interfaces:state\":{\"admin-status\":\"UP\",\"enabled\":true,\"mtu\":9000,\"name\":\"Vlan10\"}}"
+	t.Run("Test GET VLAN interface state config ", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- GET VLAN (leaf level admin status) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan10]/state/admin-status"
+	expected_get_json = "{\"openconfig-interfaces:admin-status\":\"UP\"}"
+	t.Run("Test GET VLAN interface state config ", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	unloadDB(db.ApplDB, cleanuptbl)
+}
+
+func Test_openconfig_vlan_member(t *testing.T) {
+	var url, url_input_body_json string
+
+	t.Log("\n\n++++++++++++ ADD VLAN MEMBERS ++++++++++++")
+
+	t.Log("\n\n--- PATCH to add VLAN member (Eth, access) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Ethernet0]/openconfig-if-ethernet:ethernet/openconfig-vlan:switched-vlan/config"
+	url_input_body_json = "{\"openconfig-vlan:config\":{\"interface-mode\":\"ACCESS\",\"access-vlan\":10}}"
+	t.Run("Test add VLAN member", processSetRequest(url, url_input_body_json, "PATCH", false, nil))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify VLAN member (Eth, access) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Ethernet0]/openconfig-if-ethernet:ethernet/openconfig-vlan:switched-vlan"
+	expected_get_json := "{\"openconfig-vlan:switched-vlan\":{\"config\":{\"access-vlan\":10,\"interface-mode\":\"ACCESS\"},\"state\":{\"access-vlan\":10,\"interface-mode\":\"ACCESS\"}}}"
+	t.Run("Test GET VLAN member config ", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- PATCH to add VLAN member (Eth, trunk) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Ethernet0]/openconfig-if-ethernet:ethernet/openconfig-vlan:switched-vlan/config"
+	url_input_body_json = "{\"openconfig-vlan:config\":{\"interface-mode\":\"TRUNK\",\"trunk-vlans\":[30,40]}}"
+	t.Run("Test add VLAN member", processSetRequest(url, url_input_body_json, "PATCH", false, nil))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify VLAN member (Eth, trunk) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Ethernet0]/openconfig-if-ethernet:ethernet/openconfig-vlan:switched-vlan"
+	expected_get_json = "{\"openconfig-vlan:switched-vlan\":{\"config\":{\"access-vlan\":10,\"interface-mode\":\"TRUNK\",\"trunk-vlans\":[30,40]},\"state\":{\"access-vlan\":10,\"interface-mode\":\"TRUNK\",\"trunk-vlans\":[30,40]}}}"
+	t.Run("Test GET VLAN member config ", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- PUT to create PortChannel interface ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=PortChannel12]"
+	url_input_body_json = "{\"openconfig-interfaces:interface\":[{\"name\":\"PortChannel12\",\"config\":{\"name\":\"PortChannel12\",\"mtu\":9000,\"description\":\"tst_pc\",\"enabled\":true},\"openconfig-if-aggregate:aggregation\":{\"config\":{\"min-links\":3}}}]}"
+	t.Run("Test create PC interface", processSetRequest(url, url_input_body_json, "PUT", false, nil))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- PATCH to add VLAN member (PC, trunk) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=PortChannel12]/openconfig-if-aggregate:aggregation/openconfig-vlan:switched-vlan/config"
+	url_input_body_json = "{\"openconfig-vlan:config\":{\"interface-mode\":\"TRUNK\",\"trunk-vlans\":[10,30]}}"
+	t.Run("Test add VLAN member", processSetRequest(url, url_input_body_json, "PATCH", false, nil))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify VLAN member (PC, trunk) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=PortChannel12]/openconfig-if-aggregate:aggregation/openconfig-vlan:switched-vlan/config"
+	expected_get_json = "{\"openconfig-vlan:config\":{\"interface-mode\":\"TRUNK\",\"trunk-vlans\":[10,30]}}"
+	t.Run("Test GET VLAN member config ", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- PATCH to add VLAN member (PC, access) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=PortChannel12]/openconfig-if-aggregate:aggregation/openconfig-vlan:switched-vlan/config"
+	url_input_body_json = "{\"openconfig-vlan:config\":{\"access-vlan\":20}}"
+	t.Run("Test add VLAN member", processSetRequest(url, url_input_body_json, "PATCH", false, nil))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify VLAN member (PC, trunk) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=PortChannel12]/openconfig-if-aggregate:aggregation/openconfig-vlan:switched-vlan/config"
+	expected_get_json = "{\"openconfig-vlan:config\":{\"access-vlan\":20,\"interface-mode\":\"TRUNK\",\"trunk-vlans\":[10,30]}}"
+	t.Run("Test GET VLAN member config ", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n++++++++++++ UPDATE VLAN MEMBERS ++++++++++++")
+
+	t.Log("\n\n--- PATCH VLAN member (Eth, access-vlan leaf) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Ethernet0]/openconfig-if-ethernet:ethernet/openconfig-vlan:switched-vlan/config/access-vlan"
+	url_input_body_json = "{\"openconfig-vlan:access-vlan\":20}"
+	t.Run("Test update VLAN member", processSetRequest(url, url_input_body_json, "PATCH", false, nil))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify VLAN member (Eth, access-vlan leaf) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Ethernet0]/openconfig-if-ethernet:ethernet/openconfig-vlan:switched-vlan/config/access-vlan"
+	expected_get_json = "{\"openconfig-vlan:access-vlan\":20}"
+	t.Run("Test GET VLAN member config ", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- PUT VLAN member (Eth, access-vlan leaf) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Ethernet0]/openconfig-if-ethernet:ethernet/openconfig-vlan:switched-vlan/config/access-vlan"
+	url_input_body_json = "{\"openconfig-vlan:access-vlan\":10}"
+	t.Run("Test replace VLAN member", processSetRequest(url, url_input_body_json, "PUT", false, nil))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify VLAN member (Eth, access-vlan leaf) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Ethernet0]/openconfig-if-ethernet:ethernet/openconfig-vlan:switched-vlan/config/access-vlan"
+	expected_get_json = "{\"openconfig-vlan:access-vlan\":10}"
+	t.Run("Test GET VLAN member config ", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- PUT VLAN member (Eth, trunk-vlans leaf) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Ethernet0]/openconfig-if-ethernet:ethernet/openconfig-vlan:switched-vlan/config/trunk-vlans"
+	url_input_body_json = "{\"openconfig-vlan:trunk-vlans\":[20,30]}"
+	t.Run("Test replace VLAN member", processSetRequest(url, url_input_body_json, "PUT", false, nil))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify VLAN member (Eth, trunk-vlans leaf) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Ethernet0]/openconfig-if-ethernet:ethernet/openconfig-vlan:switched-vlan/config/trunk-vlans"
+	expected_get_json = "{\"openconfig-vlan:trunk-vlans\":[20,30]}"
+	t.Run("Test GET VLAN member config ", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- PATCH VLAN member (Eth, trunk-vlans leaf) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Ethernet0]/openconfig-if-ethernet:ethernet/openconfig-vlan:switched-vlan/config/trunk-vlans"
+	url_input_body_json = "{\"openconfig-vlan:trunk-vlans\":[40]}"
+	t.Run("Test update VLAN member", processSetRequest(url, url_input_body_json, "PATCH", false, nil))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify VLAN member (Eth, trunk-vlans leaf) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Ethernet0]/openconfig-if-ethernet:ethernet/openconfig-vlan:switched-vlan/config/trunk-vlans"
+	expected_get_json = "{\"openconfig-vlan:trunk-vlans\":[20,30,40]}"
+	t.Run("Test GET VLAN member config ", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- PATCH VLAN member (PC, trunk-vlans leaf) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=PortChannel12]/openconfig-if-aggregate:aggregation/openconfig-vlan:switched-vlan/config/trunk-vlans"
+	url_input_body_json = "{\"openconfig-vlan:trunk-vlans\":[40]}"
+	t.Run("Test update VLAN member", processSetRequest(url, url_input_body_json, "PATCH", false, nil))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify VLAN member (PC, trunk-vlans leaf) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=PortChannel12]/openconfig-if-aggregate:aggregation/openconfig-vlan:switched-vlan/config/trunk-vlans"
+	expected_get_json = "{\"openconfig-vlan:trunk-vlans\":[10,30,40]}"
+	t.Run("Test GET VLAN member config ", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- PUT VLAN member (PC, trunk-vlans leaf) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=PortChannel12]/openconfig-if-aggregate:aggregation/openconfig-vlan:switched-vlan/config/trunk-vlans"
+	url_input_body_json = "{\"openconfig-vlan:trunk-vlans\":[10,30]}"
+	t.Run("Test replace VLAN member", processSetRequest(url, url_input_body_json, "PUT", false, nil))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify VLAN member (PC, trunk-vlans leaf) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=PortChannel12]/openconfig-if-aggregate:aggregation/openconfig-vlan:switched-vlan/config/trunk-vlans"
+	expected_get_json = "{\"openconfig-vlan:trunk-vlans\":[10,30]}"
+	t.Run("Test GET VLAN member config ", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- PATCH VLAN member (PC, trunk-vlans leaf) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=PortChannel12]/openconfig-if-aggregate:aggregation/openconfig-vlan:switched-vlan/config/trunk-vlans"
+	url_input_body_json = "{\"openconfig-vlan:trunk-vlans\":[40]}"
+	t.Run("Test update VLAN member", processSetRequest(url, url_input_body_json, "PATCH", false, nil))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify VLAN member (PC, trunk-vlans leaf) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=PortChannel12]/openconfig-if-aggregate:aggregation/openconfig-vlan:switched-vlan/config/trunk-vlans"
+	expected_get_json = "{\"openconfig-vlan:trunk-vlans\":[10,30,40]}"
+	t.Run("Test GET VLAN member config ", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	// Verify that changing to ACCESS mode with trunk VLANs configured does nothing
+	t.Log("\n\n--- PATCH VLAN member (Eth, interface-mode leaf) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Ethernet0]/openconfig-if-ethernet:ethernet/openconfig-vlan:switched-vlan/config/interface-mode"
+	url_input_body_json = "{\"openconfig-vlan:interface-mode\":\"ACCESS\"}"
+	t.Run("Test update VLAN member", processSetRequest(url, url_input_body_json, "PATCH", false, nil))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify VLAN member (Eth, interface-mode leaf) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Ethernet0]/openconfig-if-ethernet:ethernet/openconfig-vlan:switched-vlan/config/interface-mode"
+	expected_get_json = "{\"openconfig-vlan:interface-mode\":\"TRUNK\"}"
+	t.Run("Test GET VLAN member config ", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	// Verify that changing to TRUNK mode with only access VLAN configured does nothing
+	t.Log("\n\n--- PUT to replace VLAN member (Eth, switched-vlan) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Ethernet0]/openconfig-if-ethernet:ethernet/openconfig-vlan:switched-vlan"
+	url_input_body_json = "{\"openconfig-vlan:switched-vlan\":{\"config\":{\"interface-mode\":\"ACCESS\",\"access-vlan\":10}}}"
+	t.Run("Test replace VLAN member", processSetRequest(url, url_input_body_json, "PUT", false, nil))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- PATCH VLAN member (Eth, interface-mode leaf) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Ethernet0]/openconfig-if-ethernet:ethernet/openconfig-vlan:switched-vlan/config/interface-mode"
+	url_input_body_json = "{\"openconfig-vlan:interface-mode\":\"TRUNK\"}"
+	t.Run("Test update VLAN member", processSetRequest(url, url_input_body_json, "PATCH", false, nil))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify VLAN member (Eth, interface-mode leaf) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Ethernet0]/openconfig-if-ethernet:ethernet/openconfig-vlan:switched-vlan/config/interface-mode"
+	expected_get_json = "{\"openconfig-vlan:interface-mode\":\"ACCESS\"}"
+	t.Run("Test GET VLAN member config ", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n++++++++++++ DELETE VLAN MEMBERS ++++++++++++")
+
+	// Reset VLAN config
+	t.Log("\n\n--- PUT to replace VLAN member (Eth, switched-vlan) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Ethernet0]/openconfig-if-ethernet:ethernet/openconfig-vlan:switched-vlan"
+	url_input_body_json = "{\"openconfig-vlan:switched-vlan\":{\"config\":{\"interface-mode\":\"TRUNK\",\"access-vlan\":10, \"trunk-vlans\":[20,30,40]}}}"
+	t.Run("Test replace VLAN member", processSetRequest(url, url_input_body_json, "PUT", false, nil))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- DELETE VLAN member (Eth, access) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Ethernet0]/openconfig-if-ethernet:ethernet/openconfig-vlan:switched-vlan/config/access-vlan"
+	t.Run("Test delete VLAN member", processDeleteRequest(url, true))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify deleted VLAN member (Eth, access) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Ethernet0]/openconfig-if-ethernet:ethernet/openconfig-vlan:switched-vlan"
+	expected_get_json = "{\"openconfig-vlan:switched-vlan\":{\"config\":{\"interface-mode\":\"TRUNK\",\"trunk-vlans\":[20,30,40]},\"state\":{\"interface-mode\":\"TRUNK\",\"trunk-vlans\":[20,30,40]}}}"
+	t.Run("Test GET VLAN member config ", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify deleted resource at VLAN member (Eth, access) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Ethernet0]/openconfig-if-ethernet:ethernet/openconfig-vlan:switched-vlan/config/access-vlan"
+	err_str := "Resource not found"
+	expected_err_invalid := tlerr.NotFoundError{Format: err_str}
+	t.Run("Test GET on deleted VLAN member", processGetRequest(url, nil, "", true, expected_err_invalid))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- DELETE VLAN member (Eth, one trunk) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Ethernet0]/openconfig-if-ethernet:ethernet/openconfig-vlan:switched-vlan/config/trunk-vlans[trunk-vlans=40]"
+	t.Run("Test delete VLAN member", processDeleteRequest(url, true))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify deleted VLAN member (Eth, one trunk) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Ethernet0]/openconfig-if-ethernet:ethernet/openconfig-vlan:switched-vlan"
+	expected_get_json = "{\"openconfig-vlan:switched-vlan\":{\"config\":{\"interface-mode\":\"TRUNK\",\"trunk-vlans\":[20,30]},\"state\":{\"interface-mode\":\"TRUNK\",\"trunk-vlans\":[20,30]}}}"
+	t.Run("Test GET VLAN member config ", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- DELETE VLAN member (Eth, all trunk) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Ethernet0]/openconfig-if-ethernet:ethernet/openconfig-vlan:switched-vlan/config/trunk-vlans"
+	t.Run("Test delete VLAN member", processDeleteRequest(url, true))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify deleted VLAN member (Eth, all trunk) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Ethernet0]/openconfig-if-ethernet:ethernet/openconfig-vlan:switched-vlan"
+	expected_get_json = "{}"
+	t.Run("Test GET VLAN member config ", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify deleted resource at VLAN member (Eth, trunk) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Ethernet0]/openconfig-if-ethernet:ethernet/openconfig-vlan:switched-vlan/config/trunk-vlans"
+	expected_get_json = "{}"
+	t.Run("Test GET on deleted VLAN member", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- DELETE VLAN member (PC, one trunk) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=PortChannel12]/openconfig-if-aggregate:aggregation/openconfig-vlan:switched-vlan/config/trunk-vlans[trunk-vlans=10]"
+	t.Run("Test delete VLAN member", processDeleteRequest(url, true))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify deleted VLAN member (PC, one trunk) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=PortChannel12]/openconfig-if-aggregate:aggregation/openconfig-vlan:switched-vlan"
+	expected_get_json = "{\"openconfig-vlan:switched-vlan\":{\"config\":{\"interface-mode\":\"TRUNK\",\"access-vlan\":20,\"trunk-vlans\":[30,40]},\"state\":{\"interface-mode\":\"TRUNK\",\"access-vlan\":20,\"trunk-vlans\":[30,40]}}}"
+	t.Run("Test GET VLAN member config ", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- DELETE VLAN member (PC, all trunk) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=PortChannel12]/openconfig-if-aggregate:aggregation/openconfig-vlan:switched-vlan/config/trunk-vlans"
+	t.Run("Test delete VLAN member", processDeleteRequest(url, true))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify deleted VLAN member (PC, all trunk) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=PortChannel12]/openconfig-if-aggregate:aggregation/openconfig-vlan:switched-vlan"
+	expected_get_json = "{\"openconfig-vlan:switched-vlan\":{\"config\":{\"access-vlan\":20,\"interface-mode\":\"ACCESS\"},\"state\":{\"access-vlan\":20,\"interface-mode\":\"ACCESS\"}}}"
+	t.Run("Test GET VLAN member config ", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify deleted resource at VLAN member (PC, trunk) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=PortChannel12]/openconfig-if-aggregate:aggregation/openconfig-vlan:switched-vlan/config/trunk-vlans"
+	expected_get_json = "{}"
+	t.Run("Test GET on deleted VLAN member", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- DELETE VLAN member (PC, access) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=PortChannel12]/openconfig-if-aggregate:aggregation/openconfig-vlan:switched-vlan/config/access-vlan"
+	t.Run("Test delete VLAN member", processDeleteRequest(url, true))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify deleted resource at VLAN member (PC, access) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=PortChannel12]/openconfig-if-aggregate:aggregation/openconfig-vlan:switched-vlan/config/access-vlan"
+	err_str = "Resource not found"
+	expected_err_invalid = tlerr.NotFoundError{Format: err_str}
+	t.Run("Test GET on deleted VLAN member", processGetRequest(url, nil, "", true, expected_err_invalid))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify deleted VLAN member (Eth, access) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=PortChannel12]/openconfig-if-aggregate:aggregation/openconfig-vlan:switched-vlan"
+	expected_get_json = "{}"
+	t.Run("Test GET VLAN member config ", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n++++++++++++ DELETE VLAN MEMBERS (container level) ++++++++++++")
+
+	t.Log("\n\n--- PATCH to add VLAN member (Eth, switched-vlan) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Ethernet0]/openconfig-if-ethernet:ethernet/openconfig-vlan:switched-vlan"
+	url_input_body_json = "{\"openconfig-vlan:switched-vlan\":{\"config\":{\"interface-mode\":\"TRUNK\",\"access-vlan\":10,\"trunk-vlans\":[20,30,40]}}}"
+	t.Run("Test add VLAN member", processSetRequest(url, url_input_body_json, "PATCH", false, nil))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- PUT to add VLAN member (Eth, switched-vlan) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Ethernet0]/openconfig-if-ethernet:ethernet/openconfig-vlan:switched-vlan"
+	url_input_body_json = "{\"openconfig-vlan:switched-vlan\":{\"config\":{\"interface-mode\":\"TRUNK\",\"access-vlan\":10,\"trunk-vlans\":[20,40]}}}"
+	t.Run("Test replace VLAN member", processSetRequest(url, url_input_body_json, "PUT", false, nil))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify VLAN member (Eth, switched-vlan) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Ethernet0]/openconfig-if-ethernet:ethernet/openconfig-vlan:switched-vlan"
+	expected_get_json = "{\"openconfig-vlan:switched-vlan\":{\"config\":{\"access-vlan\":10,\"interface-mode\":\"TRUNK\",\"trunk-vlans\":[20,40]},\"state\":{\"access-vlan\":10,\"interface-mode\":\"TRUNK\",\"trunk-vlans\":[20,40]}}}"
+	t.Run("Test GET VLAN member config ", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- DELETE all VLAN members (Eth, config) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Ethernet0]/openconfig-if-ethernet:ethernet/openconfig-vlan:switched-vlan/config"
+	t.Run("Test delete all VLAN members", processDeleteRequest(url, true))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify deleted VLAN members (Eth, switched-vlan) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Ethernet0]/openconfig-if-ethernet:ethernet/openconfig-vlan:switched-vlan"
+	expected_get_json = "{}"
+	t.Run("Test GET VLAN member config ", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- PATCH to add VLAN member (PC, switched-vlan) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=PortChannel12]/openconfig-if-aggregate:aggregation/openconfig-vlan:switched-vlan"
+	url_input_body_json = "{\"openconfig-vlan:switched-vlan\":{\"config\":{\"interface-mode\":\"TRUNK\",\"access-vlan\":30,\"trunk-vlans\":[10,20]}}}"
+	t.Run("Test add VLAN member", processSetRequest(url, url_input_body_json, "PATCH", false, nil))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- PUT to add VLAN member (PC, switched-vlan) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=PortChannel12]/openconfig-if-aggregate:aggregation/openconfig-vlan:switched-vlan"
+	url_input_body_json = "{\"openconfig-vlan:switched-vlan\":{\"config\":{\"interface-mode\":\"TRUNK\",\"access-vlan\":30,\"trunk-vlans\":[10,20,40]}}}"
+	t.Run("Test replace VLAN member", processSetRequest(url, url_input_body_json, "PUT", false, nil))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify VLAN member (PC, switched-vlan) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=PortChannel12]/openconfig-if-aggregate:aggregation/openconfig-vlan:switched-vlan"
+	expected_get_json = "{\"openconfig-vlan:switched-vlan\":{\"config\":{\"access-vlan\":30,\"interface-mode\":\"TRUNK\",\"trunk-vlans\":[10,20,40]},\"state\":{\"access-vlan\":30,\"interface-mode\":\"TRUNK\",\"trunk-vlans\":[10,20,40]}}}"
+	t.Run("Test GET VLAN member config ", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- DELETE all VLAN members (PC, switched-vlan) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=PortChannel12]/openconfig-if-aggregate:aggregation/openconfig-vlan:switched-vlan"
+	t.Run("Test delete all VLAN members", processDeleteRequest(url, true))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify deleted VLAN members (PC, switched-vlan config) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=PortChannel12]/openconfig-if-aggregate:aggregation/openconfig-vlan:switched-vlan/config"
+	expected_get_json = "{}"
+	t.Run("Test GET VLAN member config ", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+}
+
+func Test_openconfig_vlan_interface_ip(t *testing.T) {
+	var url, url_input_body_json string
+
+	t.Log("\n\n++++++++++++ CONFIGURE IPv4 VLAN INTERFACE ++++++++++++")
+
+	t.Log("\n\n--- PATCH VLAN interface IPv4 address ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan10]/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv4/addresses"
+	url_input_body_json = "{\"openconfig-if-ip:addresses\":{\"address\":[{\"ip\":\"2.2.2.2\",\"config\":{\"ip\":\"2.2.2.2\",\"prefix-length\":24}}]}}"
+	t.Run("Test configure VLAN IPv4", processSetRequest(url, url_input_body_json, "PATCH", false, nil))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify VLAN interface IPv4 address ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan10]/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv4/addresses/address[ip=2.2.2.2]"
+	expected_get_json := "{\"openconfig-if-ip:address\":[{\"config\":{\"ip\":\"2.2.2.2\",\"prefix-length\":24},\"ip\":\"2.2.2.2\"}]}"
+	t.Run("Test GET VLAN interface IPv4 config ", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- PUT VLAN interface IPv4 address ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan10]/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv4/addresses"
+	url_input_body_json = "{\"openconfig-if-ip:addresses\":{\"address\":[{\"ip\":\"4.4.5.1\",\"config\":{\"ip\":\"4.4.5.1\",\"prefix-length\":24}}]}}"
+	t.Run("Test configure VLAN IPv4", processSetRequest(url, url_input_body_json, "PUT", false, nil))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify VLAN interface IPv4 address ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan10]/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv4/addresses/address[ip=4.4.5.1]"
+	expected_get_json = "{\"openconfig-if-ip:address\":[{\"config\":{\"ip\":\"4.4.5.1\",\"prefix-length\":24},\"ip\":\"4.4.5.1\"}]}"
+	t.Run("Test GET VLAN interface IPv4 config ", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- POST VLAN interface IPv4 address ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan10]/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv4/addresses"
+	url_input_body_json = "{\"openconfig-if-ip:address\":[{\"ip\":\"2.2.2.2\",\"config\":{\"ip\":\"2.2.2.2\",\"prefix-length\":24}}]}"
+	t.Run("Test configure VLAN IPv4", processSetRequest(url, url_input_body_json, "POST", false, nil))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify VLAN interface IPv4 address ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan10]/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv4/addresses"
+	expected_get_json = "{\"openconfig-if-ip:addresses\":{\"address\":[{\"config\":{\"ip\":\"2.2.2.2\",\"prefix-length\":24},\"ip\":\"2.2.2.2\"}]}}"
+	t.Run("Test GET VLAN interface IPv4 config ", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- PATCH VLAN interface IPv4 address (routed-vlan container) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan20]/openconfig-vlan:routed-vlan"
+	url_input_body_json = "{\"openconfig-vlan:routed-vlan\": {\"config\": {\"vlan\": \"Vlan20\" },\"openconfig-if-ip:ipv4\": {\"addresses\": {\"address\": [{\"ip\": \"16.16.16.16\", \"config\": {\"ip\": \"16.16.16.16\", \"prefix-length\": 24}}]}}}}"
+	t.Run("Test configure VLAN IPv4", processSetRequest(url, url_input_body_json, "PATCH", false, nil))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify VLAN interface IPv4 address ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan20]/openconfig-vlan:routed-vlan"
+	expected_get_json = "{\"openconfig-vlan:routed-vlan\":{\"config\":{\"vlan\":\"Vlan20\"},\"openconfig-if-ip:ipv4\":{\"addresses\":{\"address\":[{\"config\":{\"ip\":\"16.16.16.16\",\"prefix-length\":24},\"ip\":\"16.16.16.16\"}]}},\"openconfig-if-ip:ipv6\":{\"config\":{\"enabled\":false},\"state\":{\"enabled\":false}},\"state\":{\"vlan\":\"Vlan20\"}}}"
+	t.Run("Test GET VLAN interface IPv4 config ", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify VLAN interface ID (config)---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan20]/openconfig-vlan:routed-vlan/config"
+	expected_get_json = "{\"openconfig-vlan:config\":{\"vlan\":\"Vlan20\"}}"
+	t.Run("Test GET VLAN interface ID (config) ", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- PATCH VLAN interface IPv4 address (IPv4 container) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan30]/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv4"
+	url_input_body_json = "{\"openconfig-if-ip:ipv4\":{\"addresses\":{\"address\":[{\"ip\":\"8.8.8.8\",\"config\":{\"ip\":\"8.8.8.8\",\"prefix-length\":24}}]}}}"
+	t.Run("Test configure VLAN IPv4", processSetRequest(url, url_input_body_json, "PATCH", false, nil))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify VLAN interface IPv4 address ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan30]/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv4"
+	expected_get_json = "{\"openconfig-if-ip:ipv4\":{\"addresses\":{\"address\":[{\"config\":{\"ip\":\"8.8.8.8\",\"prefix-length\":24},\"ip\":\"8.8.8.8\"}]}}}"
+	t.Run("Test GET VLAN interface IPv4 config ", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- PATCH VLAN interface IPv4 address ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan10]/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv4/addresses"
+	url_input_body_json = "{\"openconfig-if-ip:addresses\":{\"address\":[{\"ip\":\"4.4.5.1\",\"config\":{\"ip\":\"4.4.5.1\",\"prefix-length\":32}}]}}"
+	t.Run("Test configure VLAN IPv4", processSetRequest(url, url_input_body_json, "PATCH", false, nil))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- PATCH VLAN interface IPv4 address (prefix-length leaf) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan10]/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv4/addresses/address[ip=4.4.5.1]/config/prefix-length"
+	url_input_body_json = "{\"openconfig-if-ip:prefix-length\":24}"
+	t.Run("Test configure VLAN IPv4", processSetRequest(url, url_input_body_json, "PATCH", false, nil))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify VLAN interface IPv4 address (prefix-length leaf) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan10]/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv4/addresses/address[ip=4.4.5.1]/config/prefix-length"
+	expected_get_json = "{\"openconfig-if-ip:prefix-length\":24}"
+	t.Run("Test GET VLAN interface IPv4 config ", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- POST VLAN interface IPv4 address (address config level) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan10]/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv4/addresses/address[ip=4.4.5.1]/config"
+	url_input_body_json = "{\"openconfig-if-ip:prefix-length\":32}"
+	t.Run("Test configure VLAN IPv4", processSetRequest(url, url_input_body_json, "POST", false, nil))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify VLAN interface IPv4 address (address config level) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan10]/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv4/addresses/address[ip=4.4.5.1]/config"
+	expected_get_json = "{\"openconfig-if-ip:config\":{\"ip\":\"4.4.5.1\",\"prefix-length\":32}}"
+	t.Run("Test GET VLAN interface IPv4 config ", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n++++++++++++ CONFIGURE IPv6 VLAN INTERFACE ++++++++++++")
+
+	t.Log("\n\n--- PATCH VLAN interface IPv6 enabled ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan20]/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv6/config/enabled"
+	url_input_body_json = "{\"openconfig-if-ip:enabled\":true}"
+	t.Run("Test configure VLAN IPv6", processSetRequest(url, url_input_body_json, "PATCH", false, nil))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify VLAN interface IPv6 enabled ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan20]/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv6/config/enabled"
+	expected_get_json = "{\"openconfig-if-ip:enabled\":true}"
+	t.Run("Test GET VLAN interface IPv6 config ", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- PUT VLAN interface IPv6 enabled ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan20]/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv6/config/enabled"
+	url_input_body_json = "{\"openconfig-if-ip:enabled\":false}"
+	t.Run("Test configure VLAN IPv6", processSetRequest(url, url_input_body_json, "PUT", false, nil))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify VLAN interface IPv6 enabled ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan20]/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv6/config/enabled"
+	expected_get_json = "{\"openconfig-if-ip:enabled\":false}"
+	t.Run("Test GET VLAN interface IPv6 config ", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- POST VLAN interface IPv6 enabled (config level) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan20]/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv6/config"
+	url_input_body_json = "{\"openconfig-if-ip:enabled\":true}"
+	t.Run("Test configure VLAN IPv6", processSetRequest(url, url_input_body_json, "POST", false, nil))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify VLAN interface IPv6 enabled ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan20]/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv6/config"
+	expected_get_json = "{\"openconfig-if-ip:config\":{\"enabled\":true}}"
+	t.Run("Test GET VLAN interface IPv6 config ", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- PATCH VLAN interface IPv6 address ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan10]/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv6/addresses"
+	url_input_body_json = "{\"openconfig-if-ip:addresses\":{\"address\":[{\"ip\":\"2001:4860:4860::8888\",\"config\":{\"ip\":\"2001:4860:4860::8888\",\"prefix-length\":64}}]}}"
+	t.Run("Test configure VLAN IPv6 address", processSetRequest(url, url_input_body_json, "PATCH", false, nil))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify VLAN interface IPv6 address ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan10]/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv6/addresses/address[ip=2001:4860:4860::8888]"
+	expected_get_json = "{\"openconfig-if-ip:address\":[{\"config\":{\"ip\":\"2001:4860:4860::8888\",\"prefix-length\":64},\"ip\":\"2001:4860:4860::8888\"}]}"
+	t.Run("Test GET VLAN interface IPv6 config ", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- PUT VLAN interface IPv6 address ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan10]/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv6/addresses"
+	url_input_body_json = "{\"openconfig-if-ip:addresses\":{\"address\":[{\"ip\":\"2001:4860:4860::8844\",\"config\":{\"ip\":\"2001:4860:4860::8844\",\"prefix-length\":64}}]}}"
+	t.Run("Test configure VLAN IPv6 address", processSetRequest(url, url_input_body_json, "PUT", false, nil))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify VLAN interface IPv6 address ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan10]/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv6/addresses/address[ip=2001:4860:4860::8844]"
+	expected_get_json = "{\"openconfig-if-ip:address\":[{\"config\":{\"ip\":\"2001:4860:4860::8844\",\"prefix-length\":64},\"ip\":\"2001:4860:4860::8844\"}]}"
+	t.Run("Test GET VLAN interface IPv6 config ", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- POST VLAN interface IPv6 address ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan10]/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv6/addresses"
+	url_input_body_json = "{\"openconfig-if-ip:address\":[{\"ip\":\"2001:4860:4860::8888\",\"config\":{\"ip\":\"2001:4860:4860::8888\",\"prefix-length\":64}}]}"
+	t.Run("Test configure VLAN IPv6 address", processSetRequest(url, url_input_body_json, "POST", false, nil))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify VLAN interface IPv6 address ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan10]/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv6/addresses"
+	expected_get_json = "{\"openconfig-if-ip:addresses\":{\"address\":[{\"config\":{\"ip\":\"2001:4860:4860::8844\",\"prefix-length\":64},\"ip\":\"2001:4860:4860::8844\"},{\"config\":{\"ip\":\"2001:4860:4860::8888\",\"prefix-length\":64},\"ip\":\"2001:4860:4860::8888\"}]}}"
+	t.Run("Test GET VLAN interface IPv6 config ", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- PATCH VLAN interface IPv6 address (routed-vlan container) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan30]/openconfig-vlan:routed-vlan"
+	url_input_body_json = "{\"openconfig-vlan:routed-vlan\":{\"config\":{\"vlan\":\"Vlan30\"},\"openconfig-if-ip:ipv6\":{\"addresses\":{\"address\":[{\"ip\":\"2606:4700:4700::1111\",\"config\":{\"ip\":\"2606:4700:4700::1111\",\"prefix-length\":64}}]}}}}"
+	t.Run("Test configure VLAN IPv6 address", processSetRequest(url, url_input_body_json, "PATCH", false, nil))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify VLAN interface IPv6 address (routed-vlan container)---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan30]/openconfig-vlan:routed-vlan"
+	expected_get_json = "{\"openconfig-vlan:routed-vlan\":{\"config\":{\"vlan\":\"Vlan30\"},\"openconfig-if-ip:ipv4\":{\"addresses\":{\"address\":[{\"config\":{\"ip\":\"8.8.8.8\",\"prefix-length\":24},\"ip\":\"8.8.8.8\"}]}},\"openconfig-if-ip:ipv6\":{\"addresses\":{\"address\":[{\"config\":{\"ip\":\"2606:4700:4700::1111\",\"prefix-length\":64},\"ip\":\"2606:4700:4700::1111\"}]},\"config\":{\"enabled\":false},\"state\":{\"enabled\":false}},\"state\":{\"vlan\":\"Vlan30\"}}}"
+	t.Run("Test GET VLAN interface IPv6 config", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- PATCH VLAN interface IPv6 address (IPv6 container) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan30]/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv6"
+	url_input_body_json = "{\"openconfig-if-ip:ipv6\":{\"addresses\":{\"address\":[{\"ip\":\"2606:4700:4700::1001\",\"config\":{\"ip\":\"2606:4700:4700::1001\",\"prefix-length\":64}}]}}}"
+	t.Run("Test configure VLAN IPv6 address", processSetRequest(url, url_input_body_json, "PATCH", false, nil))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify VLAN interface IPv6 address (IPv6 container)---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan30]/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv6"
+	expected_get_json = "{\"openconfig-if-ip:ipv6\":{\"addresses\":{\"address\":[{\"config\":{\"ip\":\"2606:4700:4700::1001\",\"prefix-length\":64},\"ip\":\"2606:4700:4700::1001\"},{\"config\":{\"ip\":\"2606:4700:4700::1111\",\"prefix-length\":64},\"ip\":\"2606:4700:4700::1111\"}]},\"config\":{\"enabled\":false},\"state\":{\"enabled\":false}}}"
+	t.Run("Test GET VLAN interface IPv6 config", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n++++++++++++ CHECK STATE ATTRIBUTES ++++++++++++")
+
+	cleanuptbl := map[string]interface{}{"INTF_TABLE": map[string]interface{}{"Vlan10": ""}}
+	unloadDB(db.ApplDB, cleanuptbl)
+	pre_req_map := map[string]interface{}{"INTF_TABLE": map[string]interface{}{"Vlan10": map[string]interface{}{"vlan": "Vlan10"}}}
+	loadDB(db.ApplDB, pre_req_map)
+
+	t.Log("\n\n--- GET VLAN (state level) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan10]/openconfig-vlan:routed-vlan/state"
+	expected_get_json = "{\"openconfig-vlan:state\":{\"vlan\":\"Vlan10\"}}"
+	t.Run("Test GET VLAN interface state config ", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+	unloadDB(db.ApplDB, cleanuptbl)
+
+	cleanuptbl = map[string]interface{}{"INTF_TABLE": map[string]interface{}{"Vlan10:4.4.5.1/32": ""}}
+	unloadDB(db.ApplDB, cleanuptbl)
+	pre_req_map = map[string]interface{}{"INTF_TABLE": map[string]interface{}{"Vlan10:4.4.5.1/32": map[string]interface{}{"ip": "4.4.5.1", "prefix-length": 32}}}
+	loadDB(db.ApplDB, pre_req_map)
+
+	t.Log("\n\n--- GET VLAN (state level) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan10]/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv4/addresses/address[ip=4.4.5.1]/state"
+	expected_get_json = "{\"openconfig-if-ip:state\":{\"ip\":\"4.4.5.1\",\"prefix-length\":32}}"
+	t.Run("Test GET VLAN interface IPv4 state", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+	unloadDB(db.ApplDB, cleanuptbl)
+
+	cleanuptbl = map[string]interface{}{"INTF_TABLE": map[string]interface{}{"Vlan10:2001:4860:4860::8844/64": ""}}
+	unloadDB(db.ApplDB, cleanuptbl)
+	pre_req_map = map[string]interface{}{"INTF_TABLE": map[string]interface{}{"Vlan10:2001:4860:4860::8844/64": map[string]interface{}{"ip": "2001:4860:4860::8844", "prefix-length": 64}}}
+	loadDB(db.ApplDB, pre_req_map)
+
+	t.Log("\n\n--- GET VLAN (state level) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan10]/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv6/addresses/address[ip=2001:4860:4860::8844]/state"
+	expected_get_json = "{\"openconfig-if-ip:state\":{\"ip\":\"2001:4860:4860::8844\",\"prefix-length\":64}}"
+	t.Run("Test GET VLAN interface IPv6 state", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+	unloadDB(db.ApplDB, cleanuptbl)
+
+	t.Log("\n\n++++++++++++ CLEAN UP VLAN INTERFACES IP CONFIG ++++++++++++")
+
+	t.Log("\n\n--- DELETE VLAN interface IPv4 (prefix-length leaf) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan30]/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv4/addresses/address[ip=8.8.8.8]/config/prefix-length"
+	t.Run("Test delete VLAN interface IP config", processDeleteRequest(url, true))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify deleted VLAN interface IP (prefix-length leaf) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan30]/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv4/addresses/address[ip=8.8.8.8]/config/prefix-length"
+	expected_get_json = "{\"openconfig-if-ip:prefix-length\":0}"
+	t.Run("Test GET deleted VLAN interface IP config ", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- DELETE VLAN interface IPv4 (specify address) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan10]/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv4/addresses/address[ip=4.4.4.4]"
+	t.Run("Test delete VLAN interface IP config", processDeleteRequest(url, true))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify deleted VLAN interface IP (specify address) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan10]/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv4/addresses/address[ip=4.4.4.4]"
+	expected_get_json = "{\"openconfig-if-ip:address\":[{\"ip\":\"4.4.4.4\"}]}"
+	t.Run("Test GET deleted VLAN interface IP config ", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- DELETE VLAN interface IPv4 (all addresses level) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan20]/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv4/addresses"
+	t.Run("Test delete VLAN interface IP config", processDeleteRequest(url, true))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify deleted VLAN interface IP (all addresses level) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan20]/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv4/addresses"
+	expected_get_json = "{}"
+	t.Run("Test GET deleted VLAN interface IP config ", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- PATCH VLAN interface IPv4 (temp) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan10]/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv4/addresses"
+	url_input_body_json = "{\"openconfig-if-ip:addresses\":{\"address\":[{\"ip\":\"2.2.2.2\",\"config\":{\"ip\":\"2.2.2.2\",\"prefix-length\":24}}]}}"
+	t.Run("Test configure VLAN IPv4 address", processSetRequest(url, url_input_body_json, "PATCH", false, nil))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify VLAN interface IPv4 (temp) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan10]/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv4/addresses/address[ip=2.2.2.2]"
+	expected_get_json = "{\"openconfig-if-ip:address\":[{\"config\":{\"ip\":\"2.2.2.2\",\"prefix-length\":24},\"ip\":\"2.2.2.2\"}]}"
+	t.Run("Test GET VLAN interface IPv4", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- DELETE VLAN interface IPv4 (IPv4 level) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan10]/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv4"
+	t.Run("Test delete VLAN interface IP config", processDeleteRequest(url, true))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify deleted VLAN interface IPv4 (IPv4 level) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan10]/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv4"
+	expected_get_json = "{}"
+	t.Run("Test GET deleted VLAN interface IP config ", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- DELETE VLAN interface IPv6 (prefix-length leaf) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan30]/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv6/addresses/address[ip=2606:4700:4700::1111]/config/prefix-length"
+	t.Run("Test delete VLAN interface IP config", processDeleteRequest(url, true))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify deleted VLAN interface IPv6 (prefix-length leaf) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan30]/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv6/addresses/address[ip=2606:4700:4700::1111]/config/prefix-length"
+	expected_get_json = "{\"openconfig-if-ip:prefix-length\":0}"
+	t.Run("Test GET deleted VLAN interface IP config ", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- PATCH VLAN interface IPv6 (temp) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan30]/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv6/addresses"
+	url_input_body_json = "{\"openconfig-if-ip:addresses\":{\"address\":[{\"ip\":\"2606:4700:4700::1111\",\"config\":{\"ip\":\"2606:4700:4700::1111\",\"prefix-length\":64}}]}}"
+	t.Run("Test configure VLAN IPv6 address (temp)", processSetRequest(url, url_input_body_json, "PATCH", false, nil))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify VLAN interface IPv6 (temp) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan30]/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv6/addresses"
+	expected_get_json = "{\"openconfig-if-ip:addresses\":{\"address\":[{\"config\":{\"ip\":\"2606:4700:4700::1001\",\"prefix-length\":64},\"ip\":\"2606:4700:4700::1001\"},{\"config\":{\"ip\":\"2606:4700:4700::1111\",\"prefix-length\":64},\"ip\":\"2606:4700:4700::1111\"}]}}"
+	t.Run("Test GET VLAN interface IPv6", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- DELETE VLAN interface IPv6 (specify address) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan30]/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv6/addresses/address[ip=2606:4700:4700::1111]"
+	t.Run("Test delete VLAN interface IP config", processDeleteRequest(url, true))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify deleted VLAN interface IPv6 (specify address) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan30]/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv6/addresses"
+	expected_get_json = "{\"openconfig-if-ip:addresses\":{\"address\":[{\"config\":{\"ip\":\"2606:4700:4700::1001\",\"prefix-length\":64},\"ip\":\"2606:4700:4700::1001\"}]}}"
+	t.Run("Test GET deleted VLAN interface IP config ", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- DELETE VLAN interface IPv6 (all addresses level) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan30]/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv6/addresses"
+	t.Run("Test delete VLAN interface IP config", processDeleteRequest(url, true))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify deleted VLAN interface IPv6 (all addresses level) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan30]/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv6/addresses"
+	expected_get_json = "{}"
+	t.Run("Test GET deleted VLAN interface IP config ", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- DELETE VLAN interface IPv6 (IPv6 level) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan10]/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv6"
+	t.Run("Test delete VLAN interface IP config", processDeleteRequest(url, true))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify deleted VLAN interface IPv6 (IPv6 level) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan10]/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv6"
+	expected_get_json = "{\"openconfig-if-ip:ipv6\":{\"config\":{\"enabled\":false},\"state\":{\"enabled\":false}}}"
+	t.Run("Test GET deleted VLAN interface IP config ", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- PATCH VLAN interface IPv6 (temp) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan10]/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv6/addresses"
+	url_input_body_json = "{\"openconfig-if-ip:addresses\":{\"address\":[{\"ip\":\"2001:4860:4860::8888\",\"config\":{\"ip\":\"2001:4860:4860::8888\",\"prefix-length\":64}}]}}"
+	t.Run("Test configure VLAN IPv6 address (temp)", processSetRequest(url, url_input_body_json, "PATCH", false, nil))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- PATCH VLAN interface IPv6 (temp) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan10]/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv6/addresses"
+	url_input_body_json = "{\"openconfig-if-ip:addresses\":{\"address\":[{\"ip\":\"2606:4700:4700::1111\",\"config\":{\"ip\":\"2606:4700:4700::1111\",\"prefix-length\":64}}]}}"
+	t.Run("Test configure VLAN IPv6 address (temp)", processSetRequest(url, url_input_body_json, "PATCH", false, nil))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- PATCH VLAN interface IPv4 (temp) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan10]/openconfig-vlan:routed-vlan"
+	url_input_body_json = "{\"openconfig-vlan:routed-vlan\": {\"config\": {\"vlan\": \"Vlan20\" },\"openconfig-if-ip:ipv4\": {\"addresses\": {\"address\": [{\"ip\": \"16.16.16.16\", \"config\": {\"ip\": \"16.16.16.16\", \"prefix-length\": 32}}]}}}}"
+	t.Run("Test configure VLAN IPv4 address (temp)", processSetRequest(url, url_input_body_json, "PATCH", false, nil))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify VLAN interface IPv6 (temp) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan10]/openconfig-vlan:routed-vlan"
+	expected_get_json = "{\"openconfig-vlan:routed-vlan\":{\"config\":{\"vlan\":\"Vlan10\"},\"openconfig-if-ip:ipv4\":{\"addresses\":{\"address\":[{\"config\":{\"ip\":\"16.16.16.16\",\"prefix-length\":32},\"ip\":\"16.16.16.16\"}]}},\"openconfig-if-ip:ipv6\":{\"addresses\":{\"address\":[{\"config\":{\"ip\":\"2001:4860:4860::8888\",\"prefix-length\":64},\"ip\":\"2001:4860:4860::8888\"},{\"config\":{\"ip\":\"2606:4700:4700::1111\",\"prefix-length\":64},\"ip\":\"2606:4700:4700::1111\"}]},\"config\":{\"enabled\":false},\"state\":{\"enabled\":false}},\"state\":{\"vlan\":\"Vlan10\"}}}"
+	t.Run("Test GET VLAN interface IP (temp)", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- DELETE VLAN interface all IP (routed-vlan level) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan10]/openconfig-vlan:routed-vlan"
+	t.Run("Test delete VLAN interface IP config", processDeleteRequest(url, true))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify deleted VLAN interface all IP (routed-vlan level) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan10]/openconfig-vlan:routed-vlan"
+	expected_get_json = "{\"openconfig-vlan:routed-vlan\":{\"openconfig-if-ip:ipv6\":{\"config\":{\"enabled\":false},\"state\":{\"enabled\":false}}}}"
+	t.Run("Test GET deleted VLAN interface IP config ", processGetRequest(url, nil, expected_get_json, false))
+	time.Sleep(1 * time.Second)
+}
+
+func Test_openconfig_vlan_interface_delete(t *testing.T) {
+	var url, url_input_body_json string
+
+	t.Log("\n\n++++++++++++ DELETE VLAN INTERFACE ++++++++++++")
+
+	t.Log("\n\n--- POST to Update Vlan 10 ---")
+	url = "/openconfig-interfaces:interfaces"
+	url_input_body_json = "{\"openconfig-interfaces:interface\":[{\"name\":\"Vlan10\",\"config\":{\"name\":\"Vlan10\",\"mtu\":9000,\"enabled\":true, \"description\":\"test_vlan\"}}]}"
+	t.Run("Test Update VLAN 10", processSetRequest(url, url_input_body_json, "POST", false, nil))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- DELETE VLAN interface attribute (description) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan10]/config/description"
+	t.Run("Test delete VLAN interface attribute", processDeleteRequest(url, true))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify deleted VLAN interface attribute (mtu) ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan10]/config/description"
+	err_str := "Resource not found"
+	expected_err_invalid := tlerr.NotFoundError{Format: err_str}
+	t.Run("Test GET on deleted VLAN interface attribute", processGetRequest(url, nil, "", true, expected_err_invalid))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Delete Vlan 10 ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan10]"
+	t.Run("Test delete VLAN interface", processDeleteRequest(url, true))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify deleted VLAN interface ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan10]"
+	err_str = "Resource not found"
+	expected_err_invalid = tlerr.NotFoundError{Format: err_str}
+	t.Run("Test GET on deleted VLAN interface", processGetRequest(url, nil, "", true, expected_err_invalid))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Delete Vlan 20 ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan20]"
+	t.Run("Test delete VLAN interface", processDeleteRequest(url, true))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify deleted VLAN interface ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan20]"
+	err_str = "Resource not found"
+	expected_err_invalid = tlerr.NotFoundError{Format: err_str}
+	t.Run("Test GET on deleted VLAN interface", processGetRequest(url, nil, "", true, expected_err_invalid))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Delete Vlan 30 ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan30]"
+	t.Run("Test delete VLAN interface", processDeleteRequest(url, true))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify deleted VLAN interface ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan30]"
+	err_str = "Resource not found"
+	expected_err_invalid = tlerr.NotFoundError{Format: err_str}
+	t.Run("Test GET on deleted VLAN interface", processGetRequest(url, nil, "", true, expected_err_invalid))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Delete Vlan 40 ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan40]"
+	t.Run("Test delete VLAN interface", processDeleteRequest(url, true))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify deleted VLAN interface ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan40]"
+	err_str = "Resource not found"
+	expected_err_invalid = tlerr.NotFoundError{Format: err_str}
+	t.Run("Test GET on deleted VLAN interface", processGetRequest(url, nil, "", true, expected_err_invalid))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Delete Vlan 50 ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan50]"
+	t.Run("Test delete VLAN interface", processDeleteRequest(url, true))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify deleted VLAN interface ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan50]"
+	err_str = "Resource not found"
+	expected_err_invalid = tlerr.NotFoundError{Format: err_str}
+	t.Run("Test GET on deleted VLAN interface", processGetRequest(url, nil, "", true, expected_err_invalid))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Delete Vlan 60 ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan60]"
+	t.Run("Test delete VLAN interface", processDeleteRequest(url, true))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify deleted VLAN interface ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan60]"
+	err_str = "Resource not found"
+	expected_err_invalid = tlerr.NotFoundError{Format: err_str}
+	t.Run("Test GET on deleted VLAN interface", processGetRequest(url, nil, "", true, expected_err_invalid))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Delete Vlan 70 ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan70]"
+	t.Run("Test delete VLAN interface", processDeleteRequest(url, true))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify deleted VLAN interface ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan70]"
+	err_str = "Resource not found"
+	expected_err_invalid = tlerr.NotFoundError{Format: err_str}
+	t.Run("Test GET on deleted VLAN interface", processGetRequest(url, nil, "", true, expected_err_invalid))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Delete Vlan 80 ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan80]"
+	t.Run("Test delete VLAN interface", processDeleteRequest(url, true))
+	time.Sleep(1 * time.Second)
+
+	t.Log("\n\n--- Verify deleted VLAN interface ---")
+	url = "/openconfig-interfaces:interfaces/interface[name=Vlan80]"
+	err_str = "Resource not found"
+	expected_err_invalid = tlerr.NotFoundError{Format: err_str}
+	t.Run("Test GET on deleted VLAN interface", processGetRequest(url, nil, "", true, expected_err_invalid))
+	time.Sleep(1 * time.Second)
+}

--- a/translib/transformer/xfmr_intf.go
+++ b/translib/transformer/xfmr_intf.go
@@ -21,6 +21,7 @@ package transformer
 import (
 	"errors"
 	"fmt"
+	"net"
 	"reflect"
 	"regexp"
 	"sort"
@@ -40,6 +41,8 @@ func init() {
 	XlateFuncBind("intf_table_xfmr", intf_table_xfmr)
 	XlateFuncBind("YangToDb_intf_tbl_key_xfmr", YangToDb_intf_tbl_key_xfmr)
 	XlateFuncBind("DbToYang_intf_tbl_key_xfmr", DbToYang_intf_tbl_key_xfmr)
+	XlateFuncBind("YangToDb_intf_name_xfmr", YangToDb_intf_name_xfmr)
+	XlateFuncBind("DbToYang_intf_name_xfmr", DbToYang_intf_name_xfmr)
 	XlateFuncBind("YangToDb_intf_mtu_xfmr", YangToDb_intf_mtu_xfmr)
 	XlateFuncBind("DbToYang_intf_mtu_xfmr", DbToYang_intf_mtu_xfmr)
 	XlateFuncBind("DbToYang_intf_admin_status_xfmr", DbToYang_intf_admin_status_xfmr)
@@ -72,6 +75,7 @@ func init() {
 	XlateFuncBind("DbToYang_subif_index_xfmr", DbToYang_subif_index_xfmr)
 	XlateFuncBind("DbToYangPath_intf_ip_path_xfmr", DbToYangPath_intf_ip_path_xfmr)
 	XlateFuncBind("Subscribe_intf_ip_addr_xfmr", Subscribe_intf_ip_addr_xfmr)
+	XlateFuncBind("Subscribe_routed_vlan_ip_addr_xfmr", Subscribe_routed_vlan_ip_addr_xfmr)
 
 	XlateFuncBind("YangToDb_subintf_ipv6_tbl_key_xfmr", YangToDb_subintf_ipv6_tbl_key_xfmr)
 	XlateFuncBind("DbToYang_subintf_ipv6_tbl_key_xfmr", DbToYang_subintf_ipv6_tbl_key_xfmr)
@@ -81,6 +85,10 @@ func init() {
 	XlateFuncBind("intf_post_xfmr", intf_post_xfmr)
 	XlateFuncBind("intf_pre_xfmr", intf_pre_xfmr)
 
+	XlateFuncBind("DbToYang_intf_routed_vlan_name_xfmr", DbToYang_intf_routed_vlan_name_xfmr)
+	XlateFuncBind("YangToDb_intf_routed_vlan_name_xfmr", YangToDb_intf_routed_vlan_name_xfmr)
+	XlateFuncBind("YangToDb_routed_vlan_ip_addr_xfmr", YangToDb_routed_vlan_ip_addr_xfmr)
+	XlateFuncBind("DbToYang_routed_vlan_ip_addr_xfmr", DbToYang_routed_vlan_ip_addr_xfmr)
 }
 
 const (
@@ -91,6 +99,11 @@ const (
 	PORTCHANNEL_INTERFACE_TN = "PORTCHANNEL_INTERFACE"
 	PORTCHANNEL_MEMBER_TN    = "PORTCHANNEL_MEMBER"
 	DEFAULT_MTU              = "9100"
+
+	INTF_TABLE_TN     = "INTF_TABLE"
+	VLAN_TN           = "VLAN"
+	VLAN_MEMBER_TN    = "VLAN_MEMBER"
+	VLAN_INTERFACE_TN = "VLAN_INTERFACE"
 )
 
 const (
@@ -98,6 +111,7 @@ const (
 	COLON       = ":"
 	ETHERNET    = "Eth"
 	PORTCHANNEL = "PortChannel"
+	VLAN        = "Vlan"
 )
 
 type TblData struct {
@@ -134,10 +148,14 @@ var IntfTypeTblMap = map[E_InterfaceType]IntfTblData{
 		appDb:   TblData{portTN: "LAG_TABLE", intfTN: "INTF_TABLE", keySep: COLON, memberTN: "LAG_MEMBER_TABLE"},
 		stateDb: TblData{portTN: "LAG_TABLE", intfTN: "INTERFACE_TABLE", keySep: PIPE},
 	},
+	IntfTypeVlan: IntfTblData{
+		cfgDb: TblData{portTN: "VLAN", memberTN: "VLAN_MEMBER", intfTN: "VLAN_INTERFACE", keySep: PIPE},
+		appDb: TblData{portTN: "VLAN_TABLE", memberTN: "VLAN_MEMBER_TABLE", intfTN: "INTF_TABLE", keySep: COLON},
+	},
 }
 
 var dbIdToTblMap = map[db.DBNum][]string{
-	db.ConfigDB: {"PORT", "PORTCHANNEL"},
+	db.ConfigDB: {"PORT", "PORTCHANNEL", "VLAN"},
 	db.ApplDB:   {"PORT_TABLE", "LAG_TABLE"},
 	db.StateDB:  {"PORT_TABLE", "LAG_TABLE"},
 }
@@ -164,6 +182,7 @@ const (
 	IntfTypeUnset       E_InterfaceType = 0
 	IntfTypeEthernet    E_InterfaceType = 1
 	IntfTypePortChannel E_InterfaceType = 2
+	IntfTypeVlan        E_InterfaceType = 3
 )
 
 type E_InterfaceSubType int64
@@ -179,6 +198,8 @@ func getIntfTypeByName(name string) (E_InterfaceType, E_InterfaceSubType, error)
 		return IntfTypeEthernet, IntfSubTypeUnset, err
 	} else if strings.HasPrefix(name, PORTCHANNEL) {
 		return IntfTypePortChannel, IntfSubTypeUnset, err
+	} else if strings.HasPrefix(name, VLAN) {
+		return IntfTypeVlan, IntfSubTypeUnset, err
 	} else {
 		err = errors.New("Interface name prefix not matched with supported types")
 		return IntfTypeUnset, IntfSubTypeUnset, err
@@ -218,6 +239,14 @@ func performIfNameKeyXfmrOp(inParams *XfmrParams, requestUriPath *string, ifName
 
 		if *requestUriPath == "/openconfig-interfaces:interfaces/interface" {
 			switch ifType {
+			case IntfTypeVlan:
+				/* VLAN Interface Delete Handling */
+				/* Update the map for VLAN and VLAN MEMBER table */
+				err := deleteVlanIntfAndMembers(inParams, ifName)
+				if err != nil {
+					log.Warningf("Deleting VLAN: %s failed! Err:%v", *ifName, err)
+					return tlerr.InvalidArgsError{Format: err.Error()}
+				}
 			case IntfTypePortChannel:
 				err := deleteLagIntfAndMembers(inParams, ifName)
 				if err != nil {
@@ -251,20 +280,17 @@ func performIfNameKeyXfmrOp(inParams *XfmrParams, requestUriPath *string, ifName
 			}
 			if inParams.oper == REPLACE {
 				if strings.Contains(*requestUriPath, "/openconfig-interfaces:interfaces/interface") {
-					// OC interfaces yang does not have attributes to set Physical interface critical attributes like speed.
-					// Replace/PUT request without the critical attributes would end up in deletion of the same in PORT table, which cannot be allowed.
-					// Hence block the Replace/PUT request for Physical interfaces alone.
-					err_str := "Replace/PUT request not allowed for Physical interfaces"
-					return tlerr.NotSupported(err_str)
-				}
-			}
-		}
-		if ifType == IntfTypePortChannel {
-			if (inParams.oper == UPDATE) || (inParams.oper == REPLACE) {
-				err = validateIntfExists(inParams.d, IntfTypeTblMap[IntfTypePortChannel].cfgDb.portTN, *ifName)
-				if err != nil { //No Matching PortChannel to UPDATE/REPLACE
-					errStr := "PortChannel: " + *ifName + " does not exist"
-					return tlerr.InvalidArgsError{Format: errStr}
+					if strings.Contains(*requestUriPath, "openconfig-if-ethernet:ethernet/openconfig-vlan:switched-vlan") {
+						if log.V(3) {
+							log.Infof("allow replace operation for switched-vlan")
+						}
+					} else {
+						// OC interfaces yang does not have attributes to set Physical interface critical attributes like speed, alias, lanes, index.
+						// Replace/PUT request without the critical attributes would end up in deletion of the same in PORT table, which cannot be allowed.
+						// Hence block the Replace/PUT request for Physical interfaces alone.
+						err_str := "Replace/PUT request not allowed for Physical interfaces"
+						return tlerr.NotSupported(err_str)
+					}
 				}
 			}
 		}
@@ -342,15 +368,28 @@ func getDbToYangSpeed(speed string) (ocbinds.E_OpenconfigIfEthernet_ETHERNET_SPE
 	return portSpeed, err
 }
 
+// getNormalizedIpStr takes an IP address as a string and returns a normalized version of the IP address.
+// For e.g. It converts (fd:aa:0:0:01 ==> fd:aa::1), (12.01.01.02 ==> 12.1.1.2)
+// If the input IP is not a valid IP address, the function returns an error.
+func getNormalizedIpStr(ip string) (string, error) {
+	ipAddr := net.ParseIP(ip)
+	if ipAddr == nil {
+		return "", errors.New("Invalid IP : " + ip)
+	}
+	return ipAddr.String(), nil
+}
+
 var intf_table_xfmr TableXfmrFunc = func(inParams XfmrParams) ([]string, error) {
 	var tblList []string
 	var err error
 
 	pathInfo := NewPathInfo(inParams.uri)
+
 	targetUriPath := pathInfo.YangPath
 	targetUriXpath, _, _ := XfmrRemoveXPATHPredicates(targetUriPath)
 
 	ifName := pathInfo.Var("name")
+
 	if ifName == "" {
 		log.Info("TableXfmrFunc - intf_table_xfmr Intf key is not present")
 
@@ -368,9 +407,15 @@ var intf_table_xfmr TableXfmrFunc = func(inParams XfmrParams) ([]string, error) 
 		log.Info("intf_table_xfmr * ifName subscribe with targetUriPath ", targetUriPath)
 
 		if strings.HasPrefix(targetUriPath, "/openconfig-interfaces:interfaces/interface/config") {
-			tblList = append(tblList, "PORT")
+			tblList = append(tblList, "PORT", "PORTCHANNEL", "VLAN")
 		} else if strings.HasPrefix(targetUriPath, "/openconfig-interfaces:interfaces/interface/state") {
-			tblList = append(tblList, "PORT_TABLE")
+			tblList = append(tblList, "PORT_TABLE", "LAG_TABLE", "VLAN_TABLE")
+		} else if strings.HasPrefix(targetUriPath, "/openconfig-interfaces:interfaces/interface/openconfig-if-aggregate:aggregation/config") {
+			tblList = append(tblList, "PORTCHANNEL")
+		} else if strings.HasPrefix(targetUriPath, "/openconfig-interfaces:interfaces/interface/openconfig-vlan:routed-vlan/openconfig-ip:ipv6/config") {
+			tblList = append(tblList, "VLAN_INTERFACE")
+		} else if strings.HasPrefix(targetUriPath, "/openconfig-interfaces:interfaces/interface/openconfig-vlan:routed-vlan/openconfig-ip:ipv6/state") {
+			tblList = append(tblList, "VLAN_INTERFACE")
 		} else if strings.HasPrefix(targetUriPath, "/openconfig-interfaces:interfaces/interface/openconfig-if-ethernet:ethernet/state") {
 			tblList = append(tblList, "PORT_TABLE")
 		} else {
@@ -398,6 +443,16 @@ var intf_table_xfmr TableXfmrFunc = func(inParams XfmrParams) ([]string, error) 
 		log.Info("TableXfmrFunc - targetUriXpath : ", targetUriXpath)
 	}
 
+	if intfType == IntfTypeVlan {
+		if strings.Contains(inParams.requestUri, "subinterfaces") {
+			return tblList, errors.New("subinterfaces subtree is not valid for Vlan interface")
+		}
+	} else {
+		if strings.Contains(inParams.requestUri, "openconfig-vlan:routed-vlan") {
+			return tblList, errors.New("routed-vlan subtree is not valid for non-Vlan interface")
+		}
+	}
+
 	if inParams.oper == DELETE && (targetUriXpath == "/openconfig-interfaces:interfaces/interface/subinterfaces/subinterface/ipv4" ||
 		targetUriXpath == "/openconfig-interfaces:interfaces/interface/subinterfaces/subinterface/ipv6") {
 		errStr := "DELETE operation not allowed on this container"
@@ -413,6 +468,10 @@ var intf_table_xfmr TableXfmrFunc = func(inParams XfmrParams) ([]string, error) 
 	} else if intfType != IntfTypePortChannel &&
 		strings.HasPrefix(targetUriPath, "/openconfig-interfaces:interfaces/interface/openconfig-if-aggregate:aggregation") {
 		//Checking interface type at container level, if not PortChannel type return nil
+		return nil, nil
+	} else if intfType != IntfTypeVlan &&
+		strings.HasPrefix(targetUriPath, "/openconfig-interfaces:interfaces/interface/openconfig-vlan:routed-vlan") {
+		//Checking interface type at container level, if not Vlan type return nil
 		return nil, nil
 	} else if strings.HasPrefix(targetUriPath, "/openconfig-interfaces:interfaces/interface/state/counters") {
 		tblList = append(tblList, "NONE")
@@ -442,6 +501,30 @@ var intf_table_xfmr TableXfmrFunc = func(inParams XfmrParams) ([]string, error) 
 	} else if inParams.oper == GET && strings.HasPrefix(targetUriXpath, "/openconfig-interfaces:interfaces/interface/subinterfaces/subinterface/ipv4/neighbors") ||
 		strings.HasPrefix(targetUriXpath, "/openconfig-interfaces:interfaces/interface/subinterfaces/subinterface/ipv6/neighbors") {
 		tblList = append(tblList, "NONE")
+	} else if strings.HasPrefix(targetUriPath, "/openconfig-interfaces:interfaces/interface/openconfig-vlan:routed-vlan") ||
+		strings.HasPrefix(targetUriPath, "/openconfig-interfaces:interfaces/interface/routed-vlan") {
+		if IntfTypeVlan == intfType {
+			if strings.HasPrefix(targetUriPath, "/openconfig-interfaces:interfaces/interface/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv4/addresses/address/config") ||
+				strings.HasPrefix(targetUriPath, "/openconfig-interfaces:interfaces/interface/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv6/addresses/address/config") ||
+				strings.HasPrefix(targetUriPath, "/openconfig-interfaces:interfaces/interface/routed-vlan/ipv4/addresses/address/config") ||
+				strings.HasPrefix(targetUriPath, "/openconfig-interfaces:interfaces/interface/routed-vlan/ipv6/addresses/address/config") {
+				tblList = append(tblList, intTbl.cfgDb.intfTN)
+			} else if strings.HasPrefix(targetUriPath, "/openconfig-interfaces:interfaces/interface/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv4/addresses/address/state") ||
+				strings.HasPrefix(targetUriPath, "/openconfig-interfaces:interfaces/interface/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv6/addresses/address/state") ||
+				strings.HasPrefix(targetUriPath, "/openconfig-interfaces:interfaces/interface/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv6/state") ||
+				strings.HasPrefix(targetUriPath, "/openconfig-interfaces:interfaces/interface/routed-vlan/ipv4/addresses/address/state") ||
+				strings.HasPrefix(targetUriPath, "/openconfig-interfaces:interfaces/interface/routed-vlan/ipv6/addresses/address/state") ||
+				strings.HasPrefix(targetUriPath, "/openconfig-interfaces:interfaces/interface/routed-vlan/ipv6/state") {
+				tblList = append(tblList, intTbl.appDb.intfTN)
+			} else if strings.HasPrefix(targetUriPath, "/openconfig-interfaces:interfaces/interface/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv4/addresses") ||
+				strings.HasPrefix(targetUriPath, "/openconfig-interfaces:interfaces/interface/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv6/addresses") ||
+				strings.HasPrefix(targetUriPath, "/openconfig-interfaces:interfaces/interface/routed-vlan/ipv4/addresses") ||
+				strings.HasPrefix(targetUriPath, "/openconfig-interfaces:interfaces/interface/routed-vlan/ipv6/addresses") {
+				tblList = append(tblList, intTbl.cfgDb.intfTN)
+			} else {
+				tblList = append(tblList, intTbl.cfgDb.intfTN)
+			}
+		}
 	} else if strings.HasPrefix(targetUriPath, "/openconfig-interfaces:interfaces/interface/ethernet") ||
 		strings.HasPrefix(targetUriPath, "/openconfig-interfaces:interfaces/interface/openconfig-if-ethernet:ethernet") {
 		if inParams.oper != DELETE {
@@ -640,6 +723,47 @@ var DbToYang_intf_enabled_xfmr FieldXfmrDbtoYang = func(inParams XfmrParams) (ma
 	return result, err
 }
 
+func removeDuplicateStr(strSlice []string) []string {
+	allKeys := make(map[string]bool)
+	list := []string{}
+	for _, item := range strSlice {
+		if _, value := allKeys[item]; !value {
+			allKeys[item] = true
+			list = append(list, item)
+		}
+	}
+	return list
+}
+
+var YangToDb_intf_name_xfmr FieldXfmrYangToDb = func(inParams XfmrParams) (map[string]string, error) {
+	res_map := make(map[string]string)
+	var err error
+
+	pathInfo := NewPathInfo(inParams.uri)
+	ifName := pathInfo.Var("name")
+
+	if strings.HasPrefix(ifName, VLAN) {
+		vlanId := ifName[len("Vlan"):]
+		res_map["vlanid"] = vlanId
+	} else if strings.HasPrefix(ifName, PORTCHANNEL) {
+		res_map["NULL"] = "NULL"
+	} else if strings.HasPrefix(ifName, ETHERNET) {
+		res_map["NULL"] = "NULL"
+	}
+	log.Info("YangToDb_intf_name_xfmr: res_map:", res_map)
+	return res_map, err
+}
+
+var DbToYang_intf_name_xfmr FieldXfmrDbtoYang = func(inParams XfmrParams) (map[string]interface{}, error) {
+	res_map := make(map[string]interface{})
+
+	pathInfo := NewPathInfo(inParams.uri)
+	ifName := pathInfo.Var("name")
+	log.Info("DbToYang_intf_name_xfmr: Interface Name = ", ifName)
+	res_map["name"] = ifName
+	return res_map, nil
+}
+
 var YangToDb_intf_mtu_xfmr FieldXfmrYangToDb = func(inParams XfmrParams) (map[string]string, error) {
 	res_map := make(map[string]string)
 	var ifName string
@@ -740,6 +864,9 @@ var YangToDb_intf_eth_port_config_xfmr SubTreeXfmrYangToDb = func(inParams XfmrP
 		errStr := "Invalid Interface"
 		err = tlerr.InvalidArgsError{Format: errStr}
 		return nil, err
+	}
+	if IntfTypeVlan == intfType {
+		return memMap, nil
 	}
 
 	intfsObj := getIntfsRoot(inParams.ygRoot)
@@ -1592,7 +1719,8 @@ var intf_post_xfmr PostXfmrFunc = func(inParams XfmrParams) error {
 
 		/* For delete request and for fields with default value, transformer adds subOp map with update operation (to update with default value).
 		   So, adding code to clear the update SubOp map for delete operation to go through for the following requestUriPath */
-		if xpath == "/openconfig-interfaces:interfaces/interface/subinterfaces/subinterface/ipv6/config/enabled" {
+		if xpath == "/openconfig-interfaces:interfaces/interface/subinterfaces/subinterface/ipv6/config/enabled" ||
+			xpath == "/openconfig-interfaces:interfaces/interface/routed-vlan/ipv6/config/enabled" {
 			if len(inParams.subOpDataMap) > 0 {
 				dbMap := make(map[string]map[string]db.Value)
 				if inParams.subOpDataMap[UPDATE] != nil && (*inParams.subOpDataMap[UPDATE])[db.ConfigDB] != nil {
@@ -1843,7 +1971,8 @@ func getCachedAllIntfIpMap(dbCl *db.DB, tblName string, ipv4 bool, ipv6 bool, ip
 				continue
 			}
 			if ip != "" {
-				if ipB.String() != ip {
+				ipStr, _ := getNormalizedIpStr(ip)
+				if ipB.String() != ipStr {
 					continue
 				}
 			}
@@ -1858,6 +1987,90 @@ func getCachedAllIntfIpMap(dbCl *db.DB, tblName string, ipv4 bool, ipv6 bool, ip
 		intfIpMap[ifName][key.Get(1)] = ipInfo
 	}
 	return intfIpMap, err
+}
+
+/* Handle IP get & populate ip addresses ygot tree for all vlan interfaces */
+func handleAllVlanIntfIPGet(inParams XfmrParams) error {
+	var err error
+	intfsObj := getIntfsRoot(inParams.ygRoot)
+
+	var cfgTblPattern db.Table
+	var appTblPattern db.Table
+	// Get all entries with keys from VLAN_INTERFACE(ConfigDB) table matching specified pattern.
+	d1 := inParams.dbs[db.ConfigDB]
+	tsc := db.TableSpec{Name: VLAN_INTERFACE_TN, CompCt: 2}
+	keyPattern := db.Key{Comp: []string{"*", "*"}}
+	cfgTblPattern, err = d1.GetTablePattern(&tsc, keyPattern) //Key Pattern: VLAN_INTERFACE|*|*
+	if err != nil {
+		log.Warning("handleAllVlanIntfIPGet: GetTablePattern() returns err:  ", err)
+		return nil
+	}
+	// Get all entries with keys from INTF_TABLE(AppDB) table matching specified pattern.
+	d2 := inParams.dbs[db.ApplDB]
+	tsa := db.TableSpec{Name: INTF_TABLE_TN, CompCt: 2}
+	keyPattern = db.Key{Comp: []string{"Vlan*", "*"}}
+	appTblPattern, err = d2.GetTablePattern(&tsa, keyPattern) //Key Pattern: INTF_TABLE:Vlan*:*
+	if err != nil {
+		log.Warning("handleAllVlanIntfIPGet: GetTablePattern() returns err: ", err)
+		return nil
+	}
+
+	//Get interface to ip mapping for all vlan interfaces in cfgTblPattern
+	intfIpMapCfgDB, err := getCachedAllIntfIpMap(inParams.dbs[db.ConfigDB], VLAN_INTERFACE_TN, true, true, "", &cfgTblPattern)
+	if err != nil {
+		log.Warning("Get interface to ip mapping returned error: ", err)
+		return nil
+	}
+	if log.V(3) {
+		log.Info("handleAllVlanIntfIPGet: all VLAN interfaces config ipMap - : ", intfIpMapCfgDB)
+	}
+
+	//Get interface to ip mapping for all vlan interfaces in appTblPattern
+	intfIpMapAppDB, err := getCachedAllIntfIpMap(inParams.dbs[db.ApplDB], INTF_TABLE_TN, true, true, "", &appTblPattern)
+	if err != nil {
+		log.Warning("Get interface to ip mapping returned error: ", err)
+		return nil
+	}
+	if log.V(3) {
+		log.Info("handleAllVlanIntfIPGet: all VLAN interfaces: state ipMap - : ", intfIpMapAppDB)
+	}
+
+	if len(intfIpMapCfgDB) == 0 && len(intfIpMapAppDB) == 0 {
+		// No IP config on any VLAN interface
+		return nil
+	}
+
+	// YGOT filling for all vlan interfaces
+	for vlanName, ipMapConfigDB := range intfIpMapCfgDB {
+		intfObj := getIntfRoutedVlanObject(intfsObj, vlanName)
+		convertRoutedVlanIpMapToOC(ipMapConfigDB, intfObj, false, "")
+	}
+	for vlanName, ipMapAppDB := range intfIpMapAppDB {
+		intfObj := getIntfRoutedVlanObject(intfsObj, vlanName)
+		convertRoutedVlanIpMapToOC(ipMapAppDB, intfObj, true, "")
+	}
+
+	return nil
+}
+
+func getIntfRoutedVlanObject(intfsObj *ocbinds.OpenconfigInterfaces_Interfaces, vlanName string) *ocbinds.OpenconfigInterfaces_Interfaces_Interface {
+	var intfObj *ocbinds.OpenconfigInterfaces_Interfaces_Interface
+
+	if intfsObj != nil && intfsObj.Interface != nil && len(intfsObj.Interface) > 0 {
+		var ok bool = false
+		if intfObj, ok = intfsObj.Interface[vlanName]; !ok {
+			intfObj, _ = intfsObj.NewInterface(vlanName)
+		}
+		ygot.BuildEmptyTree(intfObj)
+		if intfObj.RoutedVlan == nil {
+			ygot.BuildEmptyTree(intfObj.RoutedVlan)
+		}
+	} else {
+		ygot.BuildEmptyTree(intfsObj)
+		intfObj, _ = intfsObj.NewInterface(vlanName)
+		ygot.BuildEmptyTree(intfObj)
+	}
+	return intfObj
 }
 
 func handleAllIntfIPGetForTable(inParams XfmrParams, tblName string, isAppDb bool) error {
@@ -1900,6 +2113,9 @@ func handleAllIntfIPGetForTable(inParams XfmrParams, tblName string, isAppDb boo
 
 	// YGOT filling
 	for intfName, ipMapDB := range intfIpMap {
+		if strings.HasPrefix(intfName, "Vlan") {
+			continue
+		}
 
 		var name string
 		name = *(&intfName)
@@ -1980,6 +2196,7 @@ func handleIntfIPGetByTargetURI(inParams XfmrParams, targetUriPath string, ifNam
 
 	pathInfo := NewPathInfo(inParams.uri)
 	ipAddr := pathInfo.Var("ip")
+	ipStr, _ := getNormalizedIpStr(ipAddr)
 	i32 := uint32(0)
 	intfType, _, ierr := getIntfTypeByName(ifName)
 	if intfType == IntfTypeUnset || ierr != nil {
@@ -1991,7 +2208,7 @@ func handleIntfIPGetByTargetURI(inParams XfmrParams, targetUriPath string, ifNam
 
 	if len(ipAddr) > 0 {
 		// Check if the given IP is configured on interface
-		keyPattern := ifName + ":" + ipAddr + "/*"
+		keyPattern := ifName + ":" + ipStr + "/*"
 		ipKeys, err := inParams.dbs[db.ApplDB].GetKeysByPattern(&db.TableSpec{Name: intTbl.appDb.intfTN}, keyPattern)
 		if err != nil || len(ipKeys) == 0 {
 			return tlerr.NotFound("Resource not found")
@@ -2096,7 +2313,7 @@ func convertIpMapToOC(intfIpMap map[string]db.Value, ifInfo *ocbinds.OpenconfigI
 			*ipStr = ipB.String()
 			v4Address.Ip = ipStr
 			prfxLen := new(uint8)
-			*prfxLen = ipNetB.Bits()
+			*prfxLen = uint8(ipNetB.Bits())
 			if isState {
 				v4Address.State.Ip = ipStr
 				v4Address.State.PrefixLength = prfxLen
@@ -2111,7 +2328,85 @@ func convertIpMapToOC(intfIpMap map[string]db.Value, ifInfo *ocbinds.OpenconfigI
 			*ipStr = ipB.String()
 			v6Address.Ip = ipStr
 			prfxLen := new(uint8)
-			*prfxLen = ipNetB.Bits()
+			*prfxLen = uint8(ipNetB.Bits())
+			if isState {
+				v6Address.State.Ip = ipStr
+				v6Address.State.PrefixLength = prfxLen
+			} else {
+				v6Address.Config.Ip = ipStr
+				v6Address.Config.PrefixLength = prfxLen
+			}
+		}
+	}
+	return err
+}
+
+func convertRoutedVlanIpMapToOC(intfIpMap map[string]db.Value, ifInfo *ocbinds.OpenconfigInterfaces_Interfaces_Interface, isState bool, uriIp string) error {
+	var routedVlan *ocbinds.OpenconfigInterfaces_Interfaces_Interface_RoutedVlan
+	var err error
+
+	routedVlan = ifInfo.RoutedVlan
+	ygot.BuildEmptyTree(routedVlan)
+	ygot.BuildEmptyTree(routedVlan.Ipv4)
+	ygot.BuildEmptyTree(routedVlan.Ipv6)
+
+	uriIpStr, _ := getNormalizedIpStr(uriIp)
+	for ipKey, _ := range intfIpMap {
+		log.Info("IP address = ", ipKey)
+		ipB, ipNetB, _ := parseCIDR(ipKey)
+		v4Flag := false
+		v6Flag := false
+
+		var v4Address *ocbinds.OpenconfigInterfaces_Interfaces_Interface_RoutedVlan_Ipv4_Addresses_Address
+		var v6Address *ocbinds.OpenconfigInterfaces_Interfaces_Interface_RoutedVlan_Ipv6_Addresses_Address
+		keyIpB := ipB.String()
+		if ipB.String() == uriIpStr {
+			keyIpB = uriIp
+		}
+		if validIPv4(ipB.String()) {
+			if _, ok := routedVlan.Ipv4.Addresses.Address[keyIpB]; !ok {
+				_, err = routedVlan.Ipv4.Addresses.NewAddress(keyIpB)
+			}
+			v4Address = routedVlan.Ipv4.Addresses.Address[keyIpB]
+			v4Flag = true
+		} else if validIPv6(ipB.String()) {
+			ipv6Key := new(string)
+			*ipv6Key = keyIpB
+			if _, ok := routedVlan.Ipv6.Addresses.Address[*ipv6Key]; !ok {
+				_, err = routedVlan.Ipv6.Addresses.NewAddress(*ipv6Key)
+			}
+			v6Address = routedVlan.Ipv6.Addresses.Address[*ipv6Key]
+			v6Flag = true
+		} else {
+			log.Warning("Invalid IP address " + ipB.String())
+			continue
+		}
+		if err != nil {
+			log.Warning("Creation of address subtree failed!")
+			return err
+		}
+		if v4Flag {
+			ygot.BuildEmptyTree(v4Address)
+			ipStr := new(string)
+			*ipStr = keyIpB
+			v4Address.Ip = ipStr
+			prfxLen := new(uint8)
+			*prfxLen = uint8(ipNetB.Bits())
+			if isState {
+				v4Address.State.Ip = ipStr
+				v4Address.State.PrefixLength = prfxLen
+			} else {
+				v4Address.Config.Ip = ipStr
+				v4Address.Config.PrefixLength = prfxLen
+			}
+		}
+		if v6Flag {
+			ygot.BuildEmptyTree(v6Address)
+			ipStr := new(string)
+			*ipStr = keyIpB
+			v6Address.Ip = ipStr
+			prfxLen := new(uint8)
+			*prfxLen = uint8(ipNetB.Bits())
 			if isState {
 				v6Address.State.Ip = ipStr
 				v6Address.State.PrefixLength = prfxLen
@@ -2165,6 +2460,11 @@ var DbToYang_intf_ip_addr_xfmr SubTreeXfmrDbToYang = func(inParams XfmrParams) e
 		var intfObj *ocbinds.OpenconfigInterfaces_Interfaces_Interface
 		ifName = *(&uriIfName)
 
+		intfType, _, _ := getIntfTypeByName(ifName)
+		if IntfTypeVlan == intfType {
+			return nil
+		}
+
 		if strings.HasPrefix(targetUriPath, "/openconfig-interfaces:interfaces/interface/subinterfaces") {
 			if intfsObj != nil && intfsObj.Interface != nil && len(intfsObj.Interface) > 0 {
 				var ok bool = false
@@ -2214,6 +2514,10 @@ var YangToDb_intf_ip_addr_xfmr SubTreeXfmrYangToDb = func(inParams XfmrParams) (
 	log.Infof("YangToDb_intf_ip_addr_xfmr: Interface name retrieved from alias : %s is %s", ifName, *sonicIfName)
 	ifName = *sonicIfName
 	intfType, _, ierr := getIntfTypeByName(ifName)
+
+	if IntfTypeVlan == intfType {
+		return subIntfmap, nil
+	}
 
 	intfsObj := getIntfsRoot(inParams.ygRoot)
 	if intfsObj == nil || len(intfsObj.Interface) < 1 {
@@ -2314,7 +2618,8 @@ var YangToDb_intf_ip_addr_xfmr SubTreeXfmrYangToDb = func(inParams XfmrParams) (
 				}
 				log.Info("prefix:=", *addr.Config.PrefixLength)
 
-				ipPref := *addr.Config.Ip + "/" + strconv.Itoa(int(*addr.Config.PrefixLength))
+				ipStr, _ := getNormalizedIpStr(*addr.Config.Ip)
+				ipPref := ipStr + "/" + strconv.Itoa(int(*addr.Config.PrefixLength))
 				/* Check for IP overlap */
 				overlapIP, oerr = validateIpOverlap(inParams.d, ifName, ipPref, tblName, true)
 
@@ -2368,7 +2673,8 @@ var YangToDb_intf_ip_addr_xfmr SubTreeXfmrYangToDb = func(inParams XfmrParams) (
 				log.Info("Ipv6 prefix:=", *addr.Config.PrefixLength)
 
 				/* Check for IPv6 overlap */
-				ipPref := *addr.Config.Ip + "/" + strconv.Itoa(int(*addr.Config.PrefixLength))
+				ipStr, _ := getNormalizedIpStr(*addr.Config.Ip)
+				ipPref := ipStr + "/" + strconv.Itoa(int(*addr.Config.PrefixLength))
 				overlapIP, oerr = validateIpOverlap(inParams.d, ifName, ipPref, tblName, true)
 
 				m := make(map[string]string)
@@ -2479,7 +2785,8 @@ func utlValidateIpTypeForCfgredDiffIp(m map[string]string, ipMap map[string]db.V
 }
 
 func intf_intf_tbl_key_gen(intfName string, ip string, prefixLen int, keySep string) string {
-	return intfName + keySep + ip + "/" + strconv.Itoa(prefixLen)
+	ipStr, _ := getNormalizedIpStr(ip)
+	return intfName + keySep + ipStr + "/" + strconv.Itoa(prefixLen)
 }
 func parseCIDR(ipPref string) (netaddr.IP, netaddr.IPPrefix, error) {
 	prefIdx := strings.LastIndexByte(ipPref, '/')
@@ -2534,7 +2841,9 @@ func getIntfIpByName(dbCl *db.DB, tblName string, ifName string, ipv4 bool, ipv6
 				continue
 			}
 			if ip != "" {
-				if ipB.String() != ip {
+				ipB_exp, _ := getNormalizedIpStr(ipB.String())
+				ip_exp, _ := getNormalizedIpStr(ip)
+				if ipB_exp != ip_exp {
 					continue
 				}
 			}
@@ -2735,6 +3044,132 @@ func interfaceIPcount(tblName string, d *db.DB, intfName *string, ipCnt *int) er
 	*ipCnt = len(ipKeys)
 	return nil
 }
+
+func routed_vlan_ip_addr_del(d *db.DB, ifName string, tblName string, routedVlanIntf *ocbinds.OpenconfigInterfaces_Interfaces_Interface_RoutedVlan) (map[string]map[string]db.Value, error) {
+	var err error
+	vlanIntfmap := make(map[string]map[string]db.Value)
+	intfIpMap := make(map[string]db.Value)
+
+	// Handles the case when the delete request at interfaces/interface[name] or at routed-vlan
+	if routedVlanIntf == nil || (routedVlanIntf.Ipv4 == nil && routedVlanIntf.Ipv6 == nil) {
+		ipMap, _ := getIntfIpByName(d, tblName, ifName, true, true, "")
+		if len(ipMap) > 0 {
+			for k, v := range ipMap {
+				intfIpMap[k] = v
+			}
+		}
+	}
+
+	// This handles the delete for a specific IPv4 address or a group of IPv4 addresses
+	if routedVlanIntf != nil && routedVlanIntf.Ipv4 != nil {
+		if routedVlanIntf.Ipv4.Addresses != nil {
+			if len(routedVlanIntf.Ipv4.Addresses.Address) < 1 {
+				ipMap, _ := getIntfIpByName(d, tblName, ifName, true, false, "")
+				if len(ipMap) > 0 {
+					for k, v := range ipMap {
+						intfIpMap[k] = v
+					}
+				}
+			} else {
+				for ip := range routedVlanIntf.Ipv4.Addresses.Address {
+					ipMap, _ := getIntfIpByName(d, tblName, ifName, true, false, ip)
+					if len(ipMap) > 0 {
+						for k, v := range ipMap {
+							intfIpMap[k] = v
+						}
+					}
+				}
+			}
+		} else {
+			// Case when delete request is at IPv4 container level
+			ipMap, _ := getIntfIpByName(d, tblName, ifName, true, false, "")
+			if len(ipMap) > 0 {
+				for k, v := range ipMap {
+					intfIpMap[k] = v
+				}
+			}
+		}
+	}
+
+	// This handles the delete for a specific IPv6 address or a group of IPv6 addresses
+	if routedVlanIntf != nil && routedVlanIntf.Ipv6 != nil {
+		if routedVlanIntf.Ipv6.Addresses != nil {
+			if len(routedVlanIntf.Ipv6.Addresses.Address) < 1 {
+				ipMap, _ := getIntfIpByName(d, tblName, ifName, false, true, "")
+				if len(ipMap) > 0 {
+					for k, v := range ipMap {
+						intfIpMap[k] = v
+					}
+				}
+			} else {
+				for ip := range routedVlanIntf.Ipv6.Addresses.Address {
+					ipMap, _ := getIntfIpByName(d, tblName, ifName, false, true, ip)
+
+					if len(ipMap) > 0 {
+						for k, v := range ipMap {
+							intfIpMap[k] = v
+						}
+					}
+				}
+			}
+		} else {
+			// Case when the delete request is at IPv6 container level
+			ipMap, _ := getIntfIpByName(d, tblName, ifName, false, true, "")
+			if len(ipMap) > 0 {
+				for k, v := range ipMap {
+					intfIpMap[k] = v
+				}
+			}
+		}
+	}
+
+	vlanIntfIpCount := 0
+	_ = interfaceIPcount(tblName, d, &ifName, &vlanIntfIpCount)
+	var data db.Value
+
+	// There is atleast one IP Address Configured on Vlan Intf
+	// Add the key "<ifname>|<IP>" to the Map
+	if len(intfIpMap) > 0 {
+		if _, ok := vlanIntfmap[tblName]; !ok {
+			vlanIntfmap[tblName] = make(map[string]db.Value)
+		}
+
+		for k := range intfIpMap {
+			ifKey := ifName + "|" + k
+			vlanIntfmap[tblName][ifKey] = data
+		}
+	}
+
+	// Case-1: Last IP Address getting deleted on Vlan Interface
+	// Case-2: Interface Vlan getting deleted with L3 Attributes Present
+	ipCntAfterDeletion := vlanIntfIpCount - len(intfIpMap)
+	IntfMapObj, dberr := d.GetEntry(&db.TableSpec{Name: tblName}, db.Key{Comp: []string{ifName}})
+	if dberr == nil && IntfMapObj.IsPopulated() && ipCntAfterDeletion == 0 {
+		IntfMap := IntfMapObj.Field
+		_, nullValPresent := IntfMap["NULL"]
+		// NULL indicates atleast one a) IP Address Config
+		// So delete only when it is the Last IP
+		if len(IntfMap) == 1 && nullValPresent {
+			if _, ok := vlanIntfmap[tblName]; !ok {
+				vlanIntfmap[tblName] = make(map[string]db.Value)
+			}
+			vlanIntfmap[tblName][ifName] = data
+		}
+		// Case-2: If deletion at parent container(routedVlanIntf)
+		if routedVlanIntf == nil {
+			if _, ok := vlanIntfmap[tblName]; !ok {
+				vlanIntfmap[tblName] = make(map[string]db.Value)
+			}
+			vlanIntfmap[tblName][ifName] = data
+		}
+	}
+
+	if log.V(3) {
+		log.Info("routed_vlan_ip_addr_del: Delete IP address list ", vlanIntfmap, " ", err)
+	}
+	return vlanIntfmap, err
+}
+
 func check_if_delete_l3_intf_entry(d *db.DB, tblName string, ifName string, ipCnt int, intfEntry *db.Value) bool {
 	if intfEntry == nil {
 		entry, err := d.GetEntry(&db.TableSpec{Name: tblName}, db.Key{Comp: []string{ifName}})
@@ -2777,13 +3212,18 @@ var Subscribe_intf_ip_addr_xfmr = func(inParams XfmrSubscInParams) (XfmrSubscOut
 		return result, nil
 	}
 	if inParams.subscProc == TRANSLATE_SUBSCRIBE {
+		isRoutedVlan := false
 
 		ifBasePath := "/openconfig-interfaces:interfaces/interface"
 		targetUriPath := origTargetUriPath[len(ifBasePath):]
 
 		if strings.HasPrefix(targetUriPath, "/subinterfaces") {
 			targetUriPath = targetUriPath[len("/subinterfaces/subinterface"):]
+		} else {
+			isRoutedVlan = true
+			targetUriPath = targetUriPath[len("/openconfig-vlan:routed-vlan"):]
 		}
+
 		if strings.HasPrefix(targetUriPath, "/openconfig-if-ip:ipv4") {
 			targetUriPath = targetUriPath[len("/openconfig-if-ip:ipv4/addresses"):]
 		} else {
@@ -2832,7 +3272,8 @@ var Subscribe_intf_ip_addr_xfmr = func(inParams XfmrSubscInParams) (XfmrSubscOut
 		}
 
 		if ipKey != "*" {
-			ipKey = ipKey + "/*"
+			uriIpStr, _ := getNormalizedIpStr(ipKey)
+			ipKey = uriIpStr + "/*"
 		}
 
 		log.Infof("path:%v ifKey:%v, ipKey:%v tbl:[%v]", origTargetUriPath, ifKey, ipKey, tableName)
@@ -2843,8 +3284,12 @@ var Subscribe_intf_ip_addr_xfmr = func(inParams XfmrSubscInParams) (XfmrSubscOut
 			if tableName != "" {
 				result.dbDataMap = RedisDbSubscribeMap{db.ConfigDB: {tableName: {keyName: {}}}}
 			} else {
-				result.dbDataMap = RedisDbSubscribeMap{db.ConfigDB: {"INTERFACE": {keyName: {}},
-					"PORTCHANNEL_INTERFACE": {keyName: {}}}}
+				if isRoutedVlan {
+					result.dbDataMap = RedisDbSubscribeMap{db.ConfigDB: {"VLAN_INTERFACE": {keyName: {}}}}
+				} else {
+					result.dbDataMap = RedisDbSubscribeMap{db.ConfigDB: {"INTERFACE": {keyName: {}},
+						"PORTCHANNEL_INTERFACE": {keyName: {}}}}
+				}
 			}
 		} else if targetUriPath == addressStatePath {
 			keyName = ifKey + ":" + ipKey
@@ -2887,9 +3332,337 @@ var Subscribe_intf_ip_addr_xfmr = func(inParams XfmrSubscInParams) (XfmrSubscOut
 	return result, err
 
 }
+
+var Subscribe_routed_vlan_ip_addr_xfmr = func(inParams XfmrSubscInParams) (XfmrSubscOutParams, error) {
+	return Subscribe_intf_ip_addr_xfmr(inParams)
+}
+
+var DbToYang_intf_routed_vlan_name_xfmr FieldXfmrDbtoYang = func(inParams XfmrParams) (map[string]interface{}, error) {
+	var err error
+	result := make(map[string]interface{})
+
+	pathInfo := NewPathInfo(inParams.uri)
+	ifName := pathInfo.Var("name")
+
+	log.Info("DbToYang_intf_routed_vlan_name_xfmr, interface name ", ifName)
+	intfType, _, ierr := getIntfTypeByName(ifName)
+	if ierr != nil || IntfTypeVlan != intfType {
+		log.Info("DbToYang_intf_routed_vlan_name_xfmr - interface type not IntfTypeVlan")
+		return nil, nil
+	}
+	/* Return only if vlan is routed by checking VLAN_INTERFACE table */
+	d1 := inParams.dbs[db.ConfigDB]
+	keyPattern := db.Key{Comp: []string{ifName, "*"}}
+	Keys, _ := d1.GetKeysPattern(&db.TableSpec{Name: VLAN_INTERFACE_TN}, keyPattern)
+	if len(Keys) == 0 {
+		return nil, nil
+	}
+	result["vlan"] = ifName
+	return result, err
+}
+
+var YangToDb_intf_routed_vlan_name_xfmr FieldXfmrYangToDb = func(inParams XfmrParams) (map[string]string, error) {
+	/* No action required for any set request */
+	log.Info("YangToDb_intf_routed_vlan_name_xfmr.")
+	return nil, nil
+}
+
+var YangToDb_routed_vlan_ip_addr_xfmr SubTreeXfmrYangToDb = func(inParams XfmrParams) (map[string]map[string]db.Value, error) {
+	var err, oerr error
+	subOpMap := make(map[db.DBNum]map[string]map[string]db.Value)
+	vlanIntfmap := make(map[string]map[string]db.Value)
+	vlanIntfmap_del := make(map[string]map[string]db.Value)
+	var value db.Value
+	var overlapIP string
+
+	pathInfo := NewPathInfo(inParams.uri)
+	ifName := pathInfo.Var("name")
+	intfType, _, ierr := getIntfTypeByName(ifName)
+
+	log.Info("arrived here")
+
+	intfsObj := getIntfsRoot(inParams.ygRoot)
+	if intfsObj == nil || len(intfsObj.Interface) < 1 {
+		if log.V(3) {
+			log.Info("YangToDb_routed_vlan_ip_addr_xfmr : IntfsObj/interface list is empty.")
+		}
+		return vlanIntfmap, errors.New("IntfsObj/Interface is not specified")
+	}
+
+	if ifName == "" {
+		errStr := "Interface KEY not present"
+		if log.V(3) {
+			log.Info("YangToDb_routed_vlan_ip_addr_xfmr: " + errStr)
+		}
+		return vlanIntfmap, errors.New(errStr)
+	}
+
+	if intfType == IntfTypeUnset || ierr != nil {
+		errStr := "Invalid interface type IntfTypeUnset"
+		if log.V(3) {
+			log.Info("YangToDb_routed_vlan_ip_addr_xfmr: " + errStr)
+		}
+		return vlanIntfmap, errors.New(errStr)
+	}
+
+	if IntfTypeVlan != intfType {
+		return vlanIntfmap, nil
+	}
+
+	if _, ok := intfsObj.Interface[ifName]; !ok {
+		errStr := "Interface entry not found in Ygot tree, ifname: " + ifName
+		if log.V(3) {
+			log.Info("YangToDb_routed_vlan_ip_addr_xfmr: " + errStr)
+		}
+		return vlanIntfmap, errors.New(errStr)
+	}
+
+	/* Set invokeCRUSubtreeOnce flag to invoke subtree once */
+	if inParams.invokeCRUSubtreeOnce != nil {
+		*inParams.invokeCRUSubtreeOnce = true
+	}
+
+	intTbl := IntfTypeTblMap[intfType]
+	tblName, _ := getIntfTableNameByDBId(intTbl, inParams.curDb)
+	log.Info("YangToDb_routed_vlan_ip_addr_xfmr: tblName: ", tblName)
+	intfObj := intfsObj.Interface[ifName]
+
+	if intfObj.RoutedVlan == nil {
+		// Handling the scenario for Interface instance delete at interfaces/interface[name] level or subinterfaces container level
+		if inParams.oper == DELETE {
+			if log.V(3) {
+				log.Info("YangToDb_routed_vlan_ip_addr_xfmr: Top level Interface instance delete or routed-vlan container delete for Interface: ", ifName)
+			}
+			return routed_vlan_ip_addr_del(inParams.d, ifName, tblName, nil)
+		}
+		errStr := "routed-vlan node doesn't exist"
+		if log.V(3) {
+			log.Info("YangToDb_routed_vlan_ip_xfmr : " + errStr)
+		}
+		err = tlerr.InvalidArgsError{Format: errStr}
+		return vlanIntfmap, err
+	}
+
+	vlanIntfObj := intfObj.RoutedVlan
+	if inParams.oper == DELETE {
+		return routed_vlan_ip_addr_del(inParams.d, ifName, tblName, vlanIntfObj)
+	}
+
+	entry, dbErr := inParams.d.GetEntry(&db.TableSpec{Name: intTbl.cfgDb.intfTN}, db.Key{Comp: []string{ifName}})
+	if dbErr != nil || !entry.IsPopulated() {
+		ifdb := make(map[string]string)
+		ifdb["NULL"] = "NULL"
+		value := db.Value{Field: ifdb}
+		if _, ok := vlanIntfmap[tblName]; !ok {
+			vlanIntfmap[tblName] = make(map[string]db.Value)
+		}
+		vlanIntfmap[tblName][ifName] = value
+
+	}
+
+	if vlanIntfObj.Ipv4 != nil && vlanIntfObj.Ipv4.Addresses != nil {
+		for ip := range vlanIntfObj.Ipv4.Addresses.Address {
+			addr := vlanIntfObj.Ipv4.Addresses.Address[ip]
+			if addr.Config != nil {
+				if addr.Config.Ip == nil {
+					addr.Config.Ip = new(string)
+					*addr.Config.Ip = ip
+				}
+				log.Info("Ip:=", *addr.Config.Ip)
+				if addr.Config.PrefixLength == nil {
+					log.Warning("Prefix Length empty!")
+					errStr := "Prefix Length not present"
+					err = tlerr.InvalidArgsError{Format: errStr}
+					return vlanIntfmap, err
+				}
+				if log.V(3) {
+					log.Info("prefix:=", *addr.Config.PrefixLength)
+				}
+
+				ipStr, _ := getNormalizedIpStr(*addr.Config.Ip)
+				ipPref := ipStr + "/" + strconv.Itoa(int(*addr.Config.PrefixLength))
+				/* Check for IP overlap */
+				overlapIP, oerr = validateIpOverlap(inParams.d, ifName, ipPref, tblName, true)
+
+				ipEntry, _ := inParams.d.GetEntry(&db.TableSpec{Name: intTbl.cfgDb.intfTN}, db.Key{Comp: []string{ifName, ipPref}})
+				ipMap, _ := getIntfIpByName(inParams.d, intTbl.cfgDb.intfTN, ifName, true, false, "")
+
+				m := make(map[string]string)
+				alrdyCfgredIP, primaryIpAlrdyCfgred, err := utlValidateIpTypeForCfgredDiffIp(m, ipMap, &ipEntry, &ipPref, &ifName)
+				if err != nil {
+					return nil, err
+				}
+				// Primary IP config already happened and replacing it with new one
+				if primaryIpAlrdyCfgred && len(alrdyCfgredIP) != 0 && alrdyCfgredIP != ipPref {
+					vlanIntfmap_del[tblName] = make(map[string]db.Value)
+					key := ifName + "|" + alrdyCfgredIP
+					vlanIntfmap_del[tblName][key] = value
+					subOpMap[db.ConfigDB] = vlanIntfmap_del
+					log.Info("subOpMap: ", subOpMap)
+					inParams.subOpDataMap[DELETE] = &subOpMap
+				}
+
+				intf_key := intf_intf_tbl_key_gen(ifName, *addr.Config.Ip, int(*addr.Config.PrefixLength), "|")
+				m["NULL"] = "NULL"
+				value := db.Value{Field: m}
+				if _, ok := vlanIntfmap[tblName]; !ok {
+					vlanIntfmap[tblName] = make(map[string]db.Value)
+				}
+				vlanIntfmap[tblName][intf_key] = value
+				log.Info("tblName :", tblName, " intf_key: ", intf_key, " data : ", value)
+			}
+		}
+	}
+	if vlanIntfObj.Ipv6 != nil && vlanIntfObj.Ipv6.Addresses != nil {
+		for ip := range vlanIntfObj.Ipv6.Addresses.Address {
+			addr := vlanIntfObj.Ipv6.Addresses.Address[ip]
+			if addr.Config != nil {
+				if addr.Config.Ip == nil {
+					addr.Config.Ip = new(string)
+					*addr.Config.Ip = ip
+				}
+				log.Info("Ipv6 IP:=", *addr.Config.Ip)
+				if addr.Config.PrefixLength == nil {
+					log.Warning("Prefix Length empty!")
+					errStr := "Prefix Length not present"
+					err = tlerr.InvalidArgsError{Format: errStr}
+					return vlanIntfmap, err
+				}
+				if log.V(3) {
+					log.Info("Ipv6 prefix:=", *addr.Config.PrefixLength)
+				}
+				/* Check for IPv6 overlap */
+				ipStr, _ := getNormalizedIpStr(*addr.Config.Ip)
+				ipPref := ipStr + "/" + strconv.Itoa(int(*addr.Config.PrefixLength))
+				overlapIP, oerr = validateIpOverlap(inParams.d, ifName, ipPref, tblName, true)
+
+				m := make(map[string]string)
+
+				intf_key := intf_intf_tbl_key_gen(ifName, *addr.Config.Ip, int(*addr.Config.PrefixLength), "|")
+				m["NULL"] = "NULL"
+				value := db.Value{Field: m}
+				if _, ok := vlanIntfmap[tblName]; !ok {
+					vlanIntfmap[tblName] = make(map[string]db.Value)
+				}
+				vlanIntfmap[tblName][intf_key] = value
+				log.Info("tblName :", tblName, " intf_key: ", intf_key, " data : ", value)
+			}
+		}
+	}
+
+	if oerr != nil {
+		if overlapIP == "" {
+			log.Warning(oerr)
+			return nil, tlerr.InvalidArgsError{Format: oerr.Error()}
+		} else {
+			vlanIntfmap_del[tblName] = make(map[string]db.Value)
+			key := ifName + "|" + overlapIP
+			vlanIntfmap_del[tblName][key] = value
+			subOpMap[db.ConfigDB] = vlanIntfmap_del
+			log.Info("subOpMap: ", subOpMap)
+			inParams.subOpDataMap[DELETE] = &subOpMap
+		}
+	}
+
+	if log.V(3) {
+		log.Info("YangToDb_routed_vlan_ip_addr_xfmr: vlanIntfmap : ", vlanIntfmap)
+	}
+	return vlanIntfmap, err
+}
+
+func handleVlanIntfIPGetByTargetURI(inParams XfmrParams, targetUriPath string, ifName string, intfObj *ocbinds.OpenconfigInterfaces_Interfaces_Interface) error {
+	var err error
+
+	pathInfo := NewPathInfo(inParams.uri)
+	ipAddr := pathInfo.Var("ip")
+	intfType, _, ierr := getIntfTypeByName(ifName)
+	if intfType == IntfTypeUnset || ierr != nil {
+		errStr := "Invalid interface type IntfTypeUnset"
+		if log.V(3) {
+			log.Info("handleVlanIntfIPGetByTargetURI: " + errStr)
+		}
+		return errors.New(errStr)
+	}
+	intTbl := IntfTypeTblMap[intfType]
+
+	var ipMap map[string]db.Value
+
+	if strings.HasPrefix(targetUriPath, "/openconfig-interfaces:interfaces/interface/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv4/addresses/address/config") ||
+		strings.HasPrefix(targetUriPath, "/openconfig-interfaces:interfaces/interface/routed-vlan/ipv4/addresses/address/config") {
+		ipMap, err = getIntfIpByName(inParams.dbs[db.ConfigDB], intTbl.cfgDb.intfTN, ifName, true, false, ipAddr)
+		if err == nil {
+			if log.V(3) {
+				log.Info("handleVlanIntfIPGetByTargetURI: ipv4 config ipMap - : ", ipMap)
+			}
+			convertRoutedVlanIpMapToOC(ipMap, intfObj, false, ipAddr)
+		}
+	} else if strings.HasPrefix(targetUriPath, "/openconfig-interfaces:interfaces/interface/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv6/addresses/address/config") ||
+		strings.HasPrefix(targetUriPath, "/openconfig-interfaces:interfaces/interface/routed-vlan/ipv6/addresses/address/config") {
+		ipMap, err = getIntfIpByName(inParams.dbs[db.ConfigDB], intTbl.cfgDb.intfTN, ifName, false, true, ipAddr)
+		if err == nil {
+			if log.V(3) {
+				log.Info("handleVlanIntfIPGetByTargetURI: ipv6 config ipMap - : ", ipMap)
+			}
+			convertRoutedVlanIpMapToOC(ipMap, intfObj, false, ipAddr)
+		}
+	} else if strings.HasPrefix(targetUriPath, "/openconfig-interfaces:interfaces/interface/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv4/addresses/address/state") ||
+		strings.HasPrefix(targetUriPath, "/openconfig-interfaces:interfaces/interface/routed-vlan/ipv4/addresses/address/state") {
+		ipMap, err = getIntfIpByName(inParams.dbs[db.ApplDB], intTbl.appDb.intfTN, ifName, true, false, ipAddr)
+		if err == nil {
+			if log.V(3) {
+				log.Info("handleVlanIntfIPGetByTargetURI: ipv4 state ipMap - : ", ipMap)
+			}
+			convertRoutedVlanIpMapToOC(ipMap, intfObj, true, ipAddr)
+		}
+	} else if strings.HasPrefix(targetUriPath, "/openconfig-interfaces:interfaces/interface/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv6/addresses/address/state") ||
+		strings.HasPrefix(targetUriPath, "/openconfig-interfaces:interfaces/interface/routed-vlan/ipv6/addresses/address/state") {
+		ipMap, err = getIntfIpByName(inParams.dbs[db.ApplDB], intTbl.appDb.intfTN, ifName, false, true, ipAddr)
+		if err == nil {
+			if log.V(3) {
+				log.Info("handleVlanIntfIPGetByTargetURI: ipv6 state ipMap - : ", ipMap)
+			}
+			convertRoutedVlanIpMapToOC(ipMap, intfObj, true, ipAddr)
+		}
+	} else if strings.HasPrefix(targetUriPath, "/openconfig-interfaces:interfaces/interface/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv4/addresses") ||
+		strings.HasPrefix(targetUriPath, "/openconfig-interfaces:interfaces/interface/routed-vlan/ipv4/addresses") {
+		ipMap, err = getIntfIpByName(inParams.dbs[db.ConfigDB], intTbl.cfgDb.intfTN, ifName, true, false, ipAddr)
+		if err == nil {
+			if log.V(3) {
+				log.Info("handleVlanIntfIPGetByTargetURI: ipv4 config ipMap - : ", ipMap)
+			}
+			convertRoutedVlanIpMapToOC(ipMap, intfObj, false, ipAddr)
+		}
+		ipMap, err = getIntfIpByName(inParams.dbs[db.ApplDB], intTbl.appDb.intfTN, ifName, true, false, ipAddr)
+		if err == nil {
+			if log.V(3) {
+				log.Info("handleVlanIntfIPGetByTargetURI: ipv4 state ipMap - : ", ipMap)
+			}
+			convertRoutedVlanIpMapToOC(ipMap, intfObj, true, ipAddr)
+		}
+	} else if strings.HasPrefix(targetUriPath, "/openconfig-interfaces:interfaces/interface/openconfig-vlan:routed-vlan/openconfig-if-ip:ipv6/addresses") ||
+		strings.HasPrefix(targetUriPath, "/openconfig-interfaces:interfaces/interface/routed-vlan/ipv6/addresses") {
+		ipMap, err = getIntfIpByName(inParams.dbs[db.ConfigDB], intTbl.cfgDb.intfTN, ifName, false, true, ipAddr)
+		if err == nil {
+			if log.V(3) {
+				log.Info("handleVlanIntfIPGetByTargetURI: ipv6 config ipMap - : ", ipMap)
+			}
+			convertRoutedVlanIpMapToOC(ipMap, intfObj, false, ipAddr)
+		}
+		ipMap, err = getIntfIpByName(inParams.dbs[db.ApplDB], intTbl.appDb.intfTN, ifName, false, true, ipAddr)
+		if err == nil {
+			if log.V(3) {
+				log.Info("handleVlanIntfIPGetByTargetURI: ipv6 state ipMap - : ", ipMap)
+			}
+			convertRoutedVlanIpMapToOC(ipMap, intfObj, true, ipAddr)
+		}
+	}
+	return err
+}
+
 var DbToYangPath_intf_ip_path_xfmr PathXfmrDbToYangFunc = func(params XfmrDbToYgPathParams) error {
 	ifRoot := "/openconfig-interfaces:interfaces/interface"
 	subIf := ifRoot + "/subinterfaces/subinterface"
+	routedVlan := ifRoot + "/openconfig-vlan:routed-vlan"
 	dbKey := ""
 
 	log.Info("DbToYangPath_intf_ip_path_xfmr: params: ", params)
@@ -2899,8 +3672,8 @@ var DbToYangPath_intf_ip_path_xfmr PathXfmrDbToYangFunc = func(params XfmrDbToYg
 
 	params.ygPathKeys[ifRoot+"/name"] = ifParts[0]
 
-	if params.tblName == "INTERFACE" || params.tblName == "INTF_TABLE" ||
-		params.tblName == "PORTCHANNEL_INTERFACE" {
+	if params.tblName == "INTERFACE" || params.tblName == "VLAN_INTERFACE" ||
+		params.tblName == "INTF_TABLE" || params.tblName == "PORTCHANNEL_INTERFACE" {
 
 		addrPath := "/openconfig-if-ip:ipv4/addresses/address/ip"
 
@@ -2916,13 +3689,17 @@ var DbToYangPath_intf_ip_path_xfmr PathXfmrDbToYangFunc = func(params XfmrDbToYg
 
 		ipKey := strings.Split(dbKey, "/")
 
-		if len(ifParts) > 1 {
-			err_str := "Subinterfaces not supported"
-			return tlerr.NotSupported(err_str)
+		if strings.HasPrefix(params.tblKeyComp[0], "Vlan") {
+			params.ygPathKeys[routedVlan+addrPath] = ipKey[0]
 		} else {
-			params.ygPathKeys[subIf+"/index"] = "0"
+			if len(ifParts) > 1 {
+				err_str := "Subinterfaces not supported"
+				return tlerr.NotSupported(err_str)
+			} else {
+				params.ygPathKeys[subIf+"/index"] = "0"
+			}
+			params.ygPathKeys[subIf+addrPath] = ipKey[0]
 		}
-		params.ygPathKeys[subIf+addrPath] = ipKey[0]
 	}
 
 	log.Infof("DbToYangPath_intf_ip_path_xfmr:  tblName:%v dbKey:[%v] params.ygPathKeys: %v", params.tblName, dbKey, params.ygPathKeys)
@@ -2985,7 +3762,7 @@ var YangToDb_ipv6_enabled_xfmr FieldXfmrYangToDb = func(inParams XfmrParams) (ma
 
 	// Vlan Interface (routed-vlan) contains only one Key "ifname"
 	// For all other interfaces (subinterfaces/subintfaces) will have 2 keys "ifname" & "subintf-index"
-	if len(pathInfo.Vars) < 2 {
+	if len(pathInfo.Vars) < 2 && intfType != IntfTypeVlan {
 		return res_map, errors.New("YangToDb_ipv6_enabled_xfmr, Error: Invalid Key length")
 	}
 
@@ -3143,4 +3920,50 @@ func retrievePortChannelAssociatedWithIntf(inParams *XfmrParams, ifName *string)
 		return &lagStr, err
 	}
 	return nil, err
+}
+
+var DbToYang_routed_vlan_ip_addr_xfmr SubTreeXfmrDbToYang = func(inParams XfmrParams) error {
+	var err error
+	intfsObj := getIntfsRoot(inParams.ygRoot)
+	pathInfo := NewPathInfo(inParams.uri)
+	intfName := pathInfo.Var("name")
+	targetUriPath := pathInfo.YangPath
+	log.Info("DbToYang_routed_vlan_ip_addr_xfmr: targetUriPath is ", targetUriPath)
+
+	if !strings.HasPrefix(targetUriPath, "/openconfig-interfaces:interfaces/interface/openconfig-vlan:routed-vlan") &&
+		!strings.HasPrefix(targetUriPath, "/openconfig-interfaces:interfaces/interface/routed-vlan") {
+		err = errors.New("Invalid URI : " + targetUriPath)
+		return err
+	}
+
+	requestUriPath := (NewPathInfo(inParams.requestUri)).YangPath
+	reqPathInfo := NewPathInfo(inParams.requestUri)
+	var reqUriIfName string = reqPathInfo.Var("name")
+
+	if requestUriPath == "/openconfig-interfaces:interfaces" || requestUriPath == "/openconfig-interfaces:interfaces/interface" && reqUriIfName == "" {
+		// Handle GET request for all vlan interfaces, populate ygot tree for all vlan interfaces in the first subtree invocation
+		var invoke_vlan_ip_addr_subtree_once bool
+		/* Using txCache to set a flag, in subsequent subtree invocations if flag already set
+		   in txcache return immediately as already done populating ygot tree */
+		if _, present := inParams.txCache.Load(invoke_vlan_ip_addr_subtree_once); !present {
+			inParams.txCache.Store(invoke_vlan_ip_addr_subtree_once, true)
+		} else {
+			return nil
+		}
+
+		err = handleAllVlanIntfIPGet(inParams)
+		if err != nil {
+			return err
+		}
+
+	} else {
+		// Handle GET requests for particular interface
+		intfObj := getIntfRoutedVlanObject(intfsObj, intfName)
+		err = handleVlanIntfIPGetByTargetURI(inParams, targetUriPath, intfName, intfObj)
+		if err != nil {
+			return err
+		}
+	}
+
+	return err
 }

--- a/translib/utils/utils.go
+++ b/translib/utils/utils.go
@@ -21,10 +21,11 @@ package utils
 
 import (
 	"fmt"
-	//"github.com/Azure/sonic-mgmt-common/translib/db"
 	"github.com/Azure/sonic-mgmt-common/cvl"
 	"github.com/Azure/sonic-mgmt-common/translib/db"
 	log "github.com/golang/glog"
+	"strconv"
+	"strings"
 )
 
 // SortAsPerTblDeps - sort transformer result table list based on dependencies (using CVL API) tables to be used for CRUD operations
@@ -64,4 +65,41 @@ func RemoveElement(sl []string, str string) []string {
 		}
 	}
 	return sl
+}
+
+// VlanDifference returns difference between existing list of Vlans and new list of Vlans.
+func VlanDifference(vlanList1, vlanList2 []string) []string {
+	mb := make(map[string]struct{}, len(vlanList2))
+	for _, ifName := range vlanList2 {
+		mb[ifName] = struct{}{}
+	}
+	var diff []string
+	for _, ifName := range vlanList1 {
+		if _, found := mb[ifName]; !found {
+			diff = append(diff, ifName)
+		}
+	}
+	return diff
+}
+
+// ExtractVlanIdsFromRange expands given range into list of individual VLANs
+// Param: A Range e.g. 1-3 or 1..3
+// Return: Expanded list e.g. [Vlan1, Vlan2, Vlan3] */
+func ExtractVlanIdsFromRange(rngStr string, vlanLst *[]string) error {
+	var err error
+	var res []string
+	if strings.Contains(rngStr, "..") {
+		res = strings.Split(rngStr, "..")
+	}
+	if strings.Contains(rngStr, "-") {
+		res = strings.Split(rngStr, "-")
+	}
+	if len(res) != 0 {
+		low, _ := strconv.Atoi(res[0])
+		high, _ := strconv.Atoi(res[1])
+		for id := low; id <= high; id++ {
+			*vlanLst = append(*vlanLst, "Vlan"+strconv.Itoa(id))
+		}
+	}
+	return err
 }


### PR DESCRIPTION
What we did:
Added transformer support for OpenConfig VLAN Interfaces as specified in the [HLD](https://github.com/sonic-net/SONiC/pull/2000/files).

Why we did it?
Earlier, intf_app.go was used for interfaces configuration. Replacing it with xfmr_intf.go to add transformer support for OpenConfig YANG VLAN interface and member configuration via REST and gNMI.

How did we verify the changes?
Verified by adding unit test files for REST and gNMI.

Unit test file changes:
vlan_openconfig_test.go – To test the VLAN parameters in the openconfig-interfaces.yang via REST.
[testapp.log](https://github.com/user-attachments/files/21221629/testapp.log)

gNMI is tested manually.
Log file for gNMI manual run (includes SET, GET, DELETE for VLAN interface, member, IP address config):
[gnmi_vlan.log](https://github.com/user-attachments/files/21222622/gnmi_vlan.log)

Support added:

Provide support for OpenConfig YANG models.
Configure/Set, GET, and Delete VLAN interfaces and interface attributes.
Support addition/deletion of Ethernet and PortChannel interfaces as VLAN members.
Support IPv4 and IPv6 address configuration on VLAN interfaces via REST and gNMI.
This does not cover the SONiC KLISH CLI.
This covers only the VLAN interface/member configuration.
This does not cover gNMI subscription.