### PR TITLE
add l2mc yang

### DIFF
--- a/models/yang/sonic/import.mk
+++ b/models/yang/sonic/import.mk
@@ -14,3 +14,4 @@ SONICYANG_IMPORTS += sonic-mclag.yang
 SONICYANG_IMPORTS += sonic-types.yang
 SONICYANG_IMPORTS += sonic-vrf.yang
 SONICYANG_IMPORTS += sonic-igmp-snooping.yang
+SONICYANG_IMPORTS += sonic-mld-snooping.yang


### PR DESCRIPTION
Add igmp and mld snooping yang model for restconf
## Dependency
This PR is part of the "L2MC-Snooping" series.
It depends on PRs:

- sonic https://github.com/sonic-net/sonic-buildimage/pull/24327