### PR TITLE
Add gNSI Authz, Certz, Pathz and Credentialz YANG models

### DIFF
--- a/config/transformer/models_list
+++ b/config/transformer/models_list
@@ -11,3 +11,7 @@ openconfig-if-aggregate.yang
 openconfig-mclag.yang
 openconfig-mclag-annot.yang
 openconfig-vlan.yang
+gnsi-authz.yang
+gnsi-pathz.yang
+gnsi-certz.yang
+openconfig-system-annot.yang

--- a/models/yang/annotations/openconfig-systen-annot.yang
+++ b/models/yang/annotations/openconfig-systen-annot.yang
@@ -1,0 +1,34 @@
+module openconfig-system-annot {
+
+    yang-version "1";
+
+    namespace "http://openconfig.net/yang/openconfig-system-annot";
+    prefix "oc-sys-annot";
+
+    import openconfig-system { prefix oc-sys; }
+    import sonic-extensions {prefix sonic-ext; }
+    import openconfig-system-grpc { prefix oc-sys-grpc; }
+
+    deviation /oc-sys:system/oc-sys:config {
+        deviate add {
+            sonic-ext:key-transformer "sys_config_key_xfmr";
+            sonic-ext:table-name "DEVICE_METADATA";
+            sonic-ext:subtree-transformer "sys_config_xfmr";
+        }
+    }
+   
+    deviation /oc-sys:system/oc-sys:ssh-server/oc-sys:state {
+      deviate add {
+        sonic-ext:db-name "STATE_DB";
+        sonic-ext:subtree-transformer "ssh_server_state_xfmr";
+      }
+    }
+
+    deviation /oc-sys:system/oc-sys-grpc:grpc-servers {
+        deviate add {
+            sonic-ext:key-transformer "grpc_server_key_xfmr";
+            sonic-ext:subtree-transformer "grpc_server_xfmr";
+        }
+    }
+}
+

--- a/models/yang/gnsi-authz.yang
+++ b/models/yang/gnsi-authz.yang
@@ -1,0 +1,155 @@
+module gnsi-authz {
+    yang-version 1.1;
+    namespace "https://github.com/openconfig/gnsi/authz/yang";
+    prefix gnsi-authz;
+    import openconfig-system {
+        prefix oc-sys;
+    }
+    import openconfig-system-grpc {
+        prefix oc-sys-grpc;
+    }
+    import openconfig-types {
+        prefix oc-types;
+    }
+    import openconfig-yang-types {
+        prefix oc-yang;
+    }
+    organization
+        "Google LLC";
+    contact
+        "Google LLC";
+    description
+        "This module provides a data model for the metadata of the gRPC
+         authorization policies installed on a networking device.";
+    revision 2022-10-30 {
+        description
+            "Adds success/failure counters.";
+        reference "0.3.0";
+    }
+    revision 2022-08-01 {
+        description
+            "Single authz policy.";
+        reference "0.2.0";
+    }
+    revision 2022-01-17 {
+        description
+            "Initial revision.";
+        reference "0.1.0";
+    }
+    typedef version {
+        type string;
+        description
+            "The version ID of the gRPC authorization policy as provided by
+             the gRPC Authorization Policy Manager when the policy was pushed.
+             This leaf persists through a reboot.";
+    }
+    typedef created-on {
+        type oc-types:timeticks64;
+        description
+            "The creation time of the gRPC authorization policy as reported by
+             the gRPC Authorization Policy manager when the policy was pushed
+             to the device. This value is reported as nanoseconds since epoch
+             (January 1st, 1970 00:00:00 GMT). This leaf persists through
+             a reboot.";
+    }
+    // gRPC server authorization policy related definitions.
+    grouping counters {
+        description
+          "A collection of counters that were collected by the gNSI.authz
+           module while evaluating access to a RPC.";
+        leaf access-rejects {
+            type oc-yang:counter64;
+            description
+              "The total number of times the gNSI.authz module denied access
+               to a RPC.";
+        }
+        leaf last-access-reject {
+            type oc-types:timeticks64;
+            description
+              "A timestamp of the last time the gNSI.authz denied access to
+               a RPC.";
+        }
+        leaf access-accepts {
+            type oc-yang:counter64;
+            description
+              "The total number of times the gNSI.authz module allowed access
+               to a RPC.";
+        }
+        leaf last-access-accept {
+            type oc-types:timeticks64;
+            description
+              "A timestamp of the last time the gNSI.authz allowed access to
+               a RPC.";
+        }
+    }
+    grouping grpc-server-user-authz-policy-success-failure-counters {
+        description
+          "A collection of counters collected by the gNSI.authz module.";
+        container rpcs {
+            description
+              "A collection of counters collected by the gNSI.authz module
+               for each RPC separately.";
+            list rpc {
+                description
+                  "A collection of counters collected by the gNSI.authz module
+                   for a RPC identified by the `name`.";
+                key name;
+                leaf name {
+                    type leafref {
+                        path "../state/name";
+                    }
+                    description
+                      "The name of the RPC the counters were collected for.";
+                }
+                container state {
+                    leaf name {
+                        type string;
+                        description
+                            "The name of the RPC the counters were collected
+                             for.";
+                    }
+                    uses counters;
+                }
+            }
+        }
+    }
+    grouping grpc-server-authz-policy-success-failure-counters {
+        description
+          "A collection of counters collected by the gNSI.authz module.";
+        container authz-policy-counters {
+            description
+              "A collection of counters collected by the gNSI.authz module.";
+            config false;
+            uses grpc-server-user-authz-policy-success-failure-counters;
+        }
+    }
+    grouping grpc-server-authz-policy-state {
+        description
+            "gNMI server's gRPC authorization policy freshness-related data.";
+        leaf grpc-authz-policy-version {
+            type version;
+            description
+                "The version of the gRPC authorization policy that is used by
+                 this system.";
+        }
+        leaf grpc-authz-policy-created-on {
+            type created-on;
+            description
+                "The timestamp of the moment when the gRPC authorization policy
+                that is currently used by this system was created.";
+        }
+    }
+    // Augments section.
+    augment "/oc-sys:system/oc-sys:aaa/oc-sys:authorization/" +
+            "oc-sys:state" {
+        description
+            "A system's gRPC authorization policy freshness information.";
+        uses grpc-server-authz-policy-state;
+    }
+    augment "/oc-sys:system/oc-sys-grpc:grpc-servers/oc-sys-grpc:grpc-server" {
+        description
+            "Counters collected while evaluating access to a gRPC server using
+             the gNSI.authz authorization policy.";
+        uses grpc-server-authz-policy-success-failure-counters;
+    }
+}

--- a/models/yang/gnsi-certz.yang
+++ b/models/yang/gnsi-certz.yang
@@ -1,0 +1,187 @@
+module gnsi-certz {
+    yang-version 1.1;
+    namespace "https://github.com/openconfig/gnsi/certz/yang";
+    prefix gnsi-certz;
+
+    import openconfig-system {
+        prefix oc-sys;
+    }
+    import openconfig-system-grpc {
+        prefix oc-sys-grpc;
+    }
+    import openconfig-types {
+        prefix oc-types;
+    }
+    import openconfig-yang-types {
+        prefix oc-yang;
+    }
+    organization
+        "Google LLC";
+
+    contact
+        "Google LLC";
+
+    description
+        "This module provides a data model for the metadata of gRPC credentials
+        installed on a networking device.";
+
+    revision 2023-02-13 {
+        description
+            "rename access/reject counters";
+        reference "0.5.0";
+    }
+
+    revision 2023-08-24 {
+        description
+            "Adds ssl-profile-id leaf";
+        reference "0.4.0";
+    }
+
+    revision 2023-05-10 {
+        description
+            "Adds authentication policy freshness information.";
+        reference "0.3.0";
+    }
+
+    revision 2022-10-30 {
+        description
+            "Adds success/failure counters.";
+        reference "0.2.0";
+    }
+
+    revision 2022-09-20 {
+        description
+            "Initial revision.";
+        reference "0.1.0";
+    }
+
+    typedef version {
+        type string;
+        description
+            "The version ID of the credential as provided by the credential
+            manager when the credential was pushed. This leaf persists through
+            a reboot.";
+    }
+
+    typedef created-on {
+        type oc-types:timeticks64;
+        description
+            "The creation time of the credential as reported by the credential
+            manager when the credential was pushed to the device. This value is
+            reported as nanoseconds since epoch (January 1st, 1970 00:00:00 GMT).
+            This leaf persists through a reboot.";
+    }
+    // gRPC server related definitions.
+    // Success/failure counters.
+    grouping counters {
+        description
+            "A collection of counters that were collected while attempting
+            to establish connections to the gRPC server.";
+
+        container counters {
+            config false;
+            description
+            "A collection of counters that were collected by the gRPC during
+            the authentication process.";
+
+            leaf connection-rejects {
+                type oc-yang:counter64;
+                description
+               "The total number of times that gRPC clients have failed
+               in establishing a connection to the server.";
+            }
+            leaf last-connection-reject {
+                type oc-types:timeticks64;
+                description
+                "A timestamp of the last time a gRPC client failed
+                in establishing a connection to the server.";
+            }
+            leaf connection-accepts {
+                type oc-yang:counter64;
+                description
+                "The total number of times that gRPC clients have succeeded
+                in establishing a connection to the server.";
+            }
+            leaf last-connection-accept {
+                type oc-types:timeticks64;
+                description
+                "A timestamp of the last time a gRPC client succeeded
+                in establishing a connection to the server.";
+            }
+        }
+    }
+
+    grouping grpc-server-credentials-state {
+        description
+            "gRPC server credentials freshness-related data.";
+
+        leaf certificate-version {
+            type version;
+            description
+                "The version of the certificate (and associated
+                private key) that is used by this gRPC server.";
+        }
+        leaf certificate-created-on {
+            type created-on;
+            description
+                "The timestamp of the moment when the certificate
+                (and associated private key) that is currently used
+                by this gRPC server was created.";
+        }
+        leaf ca-trust-bundle-version {
+            type version;
+            description
+                "The version of the bundle of the Certificate
+                Authority certificates a.k.a. trust bundle used by
+                this gRPC server.";
+        }
+        leaf ca-trust-bundle-created-on {
+            type created-on;
+            description
+                "The timestamp of the moment when the bundle of
+                the Certificate Authority certificates (a.k.a.
+                trust bundle) was created.";
+        }
+        leaf certificate-revocation-list-bundle-version {
+            type version;
+            description
+                "The version of the Certificate Revocation List bundle used by
+                this gRPC server.";
+        }
+        leaf certificate-revocation-list-bundle-created-on {
+            type created-on;
+            description
+                "The timestamp of the moment when the Certificate Revocation
+                List bundle was created.";
+        }
+        leaf authentication-policy-version {
+            type version;
+            description
+                "The version of the authentication policy that is used by
+                this gRPC server.";
+        }
+        leaf authentication-policy-created-on {
+            type created-on;
+            description
+                "The timestamp of the moment when the authentication policy
+                that is currently used by this gRPC server was created.";
+        }
+        leaf ssl-profile-id {
+            type string;
+            description
+                "The ID of this gRPC server's SSL profile
+                as used by the gNSI Certz service";
+        }
+    }
+
+    // Augments section.
+
+    augment "/oc-sys:system/oc-sys-grpc:grpc-servers/oc-sys-grpc:grpc-server/" +
+            "oc-sys-grpc:state" {
+        description
+            "A gRPC server credentials freshness information.";
+
+        uses grpc-server-credentials-state;
+        uses counters;
+    }
+}

--- a/models/yang/gnsi-credentialz.yang
+++ b/models/yang/gnsi-credentialz.yang
@@ -1,0 +1,299 @@
+module gnsi-credentialz {
+  yang-version 1.1;
+  namespace "https://github.com/openconfig/gnsi/credentialz/yang";
+  prefix gnsi-credz;
+
+  import openconfig-system {
+    prefix oc-sys;
+  }
+  import openconfig-types {
+    prefix oc-types;
+  }
+  import openconfig-yang-types {
+    prefix oc-yang;
+  }
+  organization
+    "Google LLC";
+
+  contact
+    "Google LLC";
+
+  description
+    "This module provides a data model for the metadata of SSH and console
+     credentials installed on a networking device.";
+
+  revision 2024-01-05 {
+    description
+      "Fix typo in YANG leaves";
+    reference
+      "0.5.0";
+  }
+
+  revision 2023-10-03 {
+    description
+      "Added state leaves for admin-user";
+    reference
+      "0.4.0";
+  }
+
+  revision 2023-08-18 {
+    description
+      "Fixed the canonical order of config field.";
+    reference
+      "0.3.0";
+  }
+
+  revision 2022-10-30 {
+    description
+      "Adds success/failure counters.";
+    reference
+      "0.2.0";
+  }
+
+  revision 2022-08-22 {
+    description
+      "Initial revision.";
+    reference
+      "0.1.0";
+  }
+
+  typedef version {
+    type string;
+    description
+      "The version ID of the credential as provided by the credential
+       manager when the credential was pushed. This leaf persists through
+       a reboot.";
+  }
+
+  typedef created-on {
+    type oc-types:timeticks64;
+    description
+      "The creation time of the credential as reported by the credential
+       manager when the credential was pushed to the device. This value is
+       reported as nanoseconds since epoch (January 1st, 1970 00:00:00 GMT).
+       This leaf persists through a reboot.";
+  }
+
+  // SSH server related definitions.
+  grouping ssh-server-credentials-version {
+    description
+      "SSH server credentials freshness-related data.";
+
+    leaf active-trusted-user-ca-keys-version {
+      type version;
+      description
+        "The version of the Certificate Authority keys.";
+    }
+
+    leaf active-trusted-user-ca-keys-created-on {
+      type created-on;
+      description
+        "The timestamp of the moment when the trusted user CA keys
+         were created.";
+    }
+
+    leaf active-host-certificate-version {
+      type version;
+      description
+        "The version of the host certificate.";
+    }
+
+    leaf active-host-certificate-created-on {
+      type created-on;
+      description
+        "The timestamp of the moment when the host certificate
+         was created.";
+    }
+
+    leaf active-host-key-version {
+      type version;
+      description
+        "The version of the host public key.";
+    }
+
+    leaf active-host-key-created-on {
+      type created-on;
+      description
+        "The timestamp of the moment when the host key was
+         created.";
+    }
+  }
+
+  // Success/failure counters.
+  grouping counters {
+    description
+      "A collection of counters that were collected while evaluating
+       access to the target.";
+
+    container counters {
+      config false;
+      description
+        "A collection of counters collected while authorizing users
+         accessing the target.";
+      leaf access-rejects {
+        type oc-yang:counter64;
+        description
+          "The total number of times access to the target has been
+           denied.";
+      }
+      leaf last-access-reject {
+        type oc-types:timeticks64;
+        description
+          "A timestamp of the last time access to the target has been
+           denied.";
+      }
+      leaf access-accepts {
+        type oc-yang:counter64;
+        description
+          "The total number of times access to the target has been
+           allowed.";
+      }
+      leaf last-access-accept {
+        type oc-types:timeticks64;
+        description
+          "A timestamp of the last time access to the target has been
+           allowed.";
+      }
+    }
+  }
+
+    // GLOME related definitions.
+
+  grouping glome-key-version {
+    description
+      "Version identifier for the configured GLOME key.";
+
+    leaf active-glome-key-version {
+      type version;
+      description
+        "The version of the GLOME key.";
+    }
+
+    leaf active-glome-key-created-on {
+      type created-on;
+      description
+        "The timestamp of the moment when the GLOME key
+        was created.";
+    }
+  }
+
+  // System role SSH related definitions.
+  grouping user-ssh-credentials-version {
+    description
+      "System role credentials freshness-related data.";
+
+    leaf authorized-principals-list-version {
+      type version;
+      description
+        "The version of the list of authorized principals currently
+         associated with this system role.";
+    }
+
+    leaf authorized-principals-list-created-on {
+      type created-on;
+      description
+        "The timestamp of the moment the currently used list of
+         authorized principals has been created.";
+    }
+
+    leaf authorized-keys-list-version {
+      type version;
+      description
+        "The version of the list of authorized keys that is currently
+         associated with this system role.";
+    }
+
+    leaf authorized-keys-list-created-on {
+      type created-on;
+      description
+        "The timestamp of the moment the currently used list of
+         authorized keys has been created.";
+    }
+  }
+
+  grouping console-config-state {
+    description
+      "Console-related configuration and state.";
+    container console {
+      description
+        "Console-related configuration and state.";
+
+      container config {
+        description
+          "Console-related configuration.";
+      }
+
+      container state {
+        config false;
+        description
+          "Console-related state.";
+
+        uses counters;
+
+        leaf enabled {
+          type boolean;
+          description
+            "Whether GLOME is enabled or not.";
+        }
+      }
+    }
+  }
+  // System role console related definitions.
+  grouping user-console-credentials-version {
+    description
+      "System role credentials freshness-related data.";
+
+    leaf password-version {
+      type version;
+      description
+        "The version of the password that is currently used to
+         authenticate this user account.";
+    }
+
+    leaf password-created-on {
+      type created-on;
+      description
+        "The timestamp of the moment the currently used password has
+         been created.";
+    }
+  }
+
+  // Augments section.
+  augment "/oc-sys:system" {
+    description
+      "Console credentials freshness data.";
+
+    uses console-config-state;
+  }
+  augment "/oc-sys:system/oc-sys:ssh-server/oc-sys:state" {
+    description
+      "SSH server credentials freshness data.";
+
+    uses ssh-server-credentials-version;
+    uses counters;
+  }
+  augment "/oc-sys:system/oc-sys:aaa/oc-sys:authentication/oc-sys:users/" +
+            "oc-sys:user/oc-sys:state" {
+    description
+      "A system role credentials freshness information.";
+
+    uses user-console-credentials-version;
+    uses user-ssh-credentials-version;
+  }
+  augment "/oc-sys:system/oc-sys:aaa/oc-sys:authentication/oc-sys:admin-user/" +
+            "oc-sys:state" {
+    description
+      "A system role credentials freshness information.";
+
+    uses user-console-credentials-version;
+    uses user-ssh-credentials-version;
+  }
+  deviation "/oc-sys:system/oc-sys:aaa/oc-sys:authentication/oc-sys:users/" +
+            "oc-sys:user/oc-sys:config/oc-sys:ssh-key" {
+    deviate not-supported;
+  }
+  deviation "/oc-sys:system/oc-sys:aaa/oc-sys:authentication/oc-sys:users/" +
+            "oc-sys:user/oc-sys:state/oc-sys:ssh-key" {
+    deviate not-supported;
+  }
+}

--- a/models/yang/gnsi-pathz.yang
+++ b/models/yang/gnsi-pathz.yang
@@ -1,0 +1,298 @@
+module gnsi-pathz {
+    yang-version 1.1;
+    namespace "https://github.com/openconfig/gnsi/pathz/yang";
+    prefix gnsi-pathz;
+
+    import openconfig-system {
+        prefix oc-sys;
+    }
+    import openconfig-system-grpc {
+        prefix oc-sys-grpc;
+    }
+    import openconfig-types {
+        prefix oc-types;
+    }
+    import openconfig-yang-types {
+        prefix oc-yang;
+    }
+
+    organization
+        "Google LLC";
+
+    contact
+        "Google LLC";
+
+    description
+        "This module provides a data model for the metadata of
+        OpenConfig-path-based authorization policies installed on a networking
+        device.";
+
+    revision 2022-10-30 {
+        description
+            "Adds success/failure counters.";
+        reference "0.2.0";
+    }
+
+    revision 2022-01-17 {
+        description
+            "Initial revision.";
+        reference "0.1.0";
+    }
+
+    typedef version {
+        type string;
+        description
+            "The version ID of the OpenConfig-path-based authorization policy
+            as provided by the OpenConfig-path-based Authorization Policy
+            Manager when the policy was pushed. This leaf persists through
+            a reboot.";
+    }
+
+    typedef created-on {
+        type oc-types:timeticks64;
+        description
+            "The creation time of the OpenConfig-path-based authorization policy
+            as reported by the OpenConfig-path-based Authorization Policy
+            manager when the policy was pushed to the device. This value is
+            reported as nanoseconds since epoch (January 1st, 1970 00:00:00 GMT).
+            This leaf persists through a reboot.";
+    }
+
+    // gRPC server related definitions.
+    grouping counters {
+        description
+            "A collection of counters that were collected by the gNSI.pathz
+            module while evaluating access to an OpenConfig path.";
+
+        leaf access-rejects {
+            type oc-yang:counter64;
+            description
+                "The total number of times the gNSI.pathz module denied access
+                to an OpenConfig path.";
+        }
+        leaf last-access-reject {
+            type oc-types:timeticks64;
+            description
+                "A timestamp of the last time the gNSI.pathz denied access to
+                an OpenConfig path";
+        }
+        leaf access-accepts {
+            type oc-yang:counter64;
+            description
+                "The total number of times the gNSI.pathz module allowed access
+                to an OpenConfig path.";
+        }
+        leaf last-access-accept {
+            type oc-types:timeticks64;
+            description
+                "A timestamp of the last time the gNSI.pathz allowed access to
+                an OpenConfig path";
+        }
+    }
+
+    grouping gnmi-pathz-policy-success-failure-counters {
+        description
+          "A collection of counters collected by the gNSI.pathz module.";
+
+        container gnmi-pathz-policy-counters {
+            config false;
+
+            uses gnmi-pathz-policy-xpath-success-failure-counters;
+        }
+    }
+
+    grouping gnmi-pathz-policy-xpath-success-failure-counters {
+        description
+            "A collection of per-OpenConfig path counters.";
+
+        container paths {
+            description
+                "A collection of per-OpenConfig path counters.";
+
+            list path {
+                key xpath;
+                leaf xpath {
+                    type leafref {
+                        path "../state/xpath";
+                    }
+                    description
+                        "A OpenConfig schema path (xpath) the counter were
+                        collected for.";
+                }
+                container state {
+                    leaf xpath {
+                        type string;
+                        description
+                            "A OpenConfig schema path (xpath) the counter were
+                            collected for.";
+                    }
+                    container reads {
+                        description
+                            "The counter were collected while
+                            performing a read operation on the
+                            `xpath`.";
+                        uses counters;
+                    }
+                    container writes {
+                        description
+                            "The counter were collected while
+                            performing a write operation on the
+                            `xpath`.";
+                        uses counters;
+                    }
+                }
+            }
+        }
+    }
+
+    grouping grpc-server-gnmi-pathz-policy-state {
+        description
+            "gNMI server OpenConfig-path-based authorization policy
+            freshness-related data.";
+
+        leaf gnmi-pathz-policy-version {
+            type version;
+            description
+                "The version of the OpenConfig-path-based authorization policy
+                that is used by this gNMI server.";
+        }
+        leaf gnmi-pathz-policy-created-on {
+            type created-on;
+            description
+                "The timestamp of the moment when the OpenConfig-path-based
+                authorization policy that is currently used by this gNMI server
+                was created.";
+        }
+    }
+
+    grouping gnmi-pathz-policy-state {
+        description
+            "Operational state data for a gNMI OpenConfig-path-based
+            authorization policy.";
+        leaf instance {
+            type enumeration {
+                enum ACTIVE {
+                    value 1;
+                    description
+                        "The policy that is currently used by the gNMI service
+                        to authorize access.";
+                }
+                enum SANDBOX {
+                    value 2;
+                    description
+                        "The most recent policy that has been uploaded during
+                        the Rotation() RPC. If there is no Rotate() RPC in
+                        progress, then referring to this instance of the policy
+                        will result in an error.";
+                }
+            }
+            description
+                "The instance identifier of the gNMI OpenConfig-path-based
+                authorization policy.";
+        }
+        leaf version {
+            type version;
+            description
+                "The version of the gNMI OpenConfig-path-based authorization
+                policy.";
+        }
+        leaf created-on {
+            type created-on;
+            description
+                "The timestamp of the moment when the policy was
+                created.";
+        }
+    }
+
+    grouping gnmi-pathz-policies {
+        description
+            "Collection of OpenConfig-path-based authorization policies that
+             have been installed on the device using the gNSI OpenConfig-path-
+             based authorization policy management service.
+             Each OpenConfig-path-based authorization policy listed here is
+             identified by its status (either ACTIVE or SANDBOX) and has its
+             version and creation date/time listed.";
+
+        container policies {
+            config false;
+            description
+                "Information about freshness of an OpenConfig-path-based
+                 authorization policy that have been installed
+                 on the device using the gNSI OpenConfig-path-based
+                 authorization policy management service.";
+
+            list policy {
+                key instance;
+                ordered-by system;
+                description
+                    "Information about the OpenConfig-path-based authorization
+                     policy that is identified by the `instance`.";
+                leaf instance {
+                    type leafref {
+                        path "../state/instance";
+                    }
+                    description
+                        "The ID of the OpenConfig-path-based authorization
+                         policy.";
+                }
+                container state {
+                    description
+                        "Operational state data for an OpenConfig-path-based
+                         authorization policies.";
+
+                    uses gnmi-pathz-policy-state;
+                }
+            }
+        }
+    }
+
+    grouping system-gnmi-pathz-policies {
+        description
+            "Collection of OpenConfig-path-based authorization policies that
+             have been installed on the device using the gNSI OpenConfig-path-
+             based authorization policy management service.
+             Each policy listed here is identified by its status (either ACTIVE
+             or SANDBOX) and has its version and creation date/time listed.";
+
+        container gnmi-pathz-policies {
+            config false;
+            description
+                "Collection of OpenConfig-path-based authorization policies that
+                have been installed on the device using the gNSI OpenConfig-
+                path-based authorization policy management service.
+                Each policy listed here is identified by its status (either
+                ACTIVE or SANDBOX) and has its version and creation date/time
+                listed.";
+
+            uses gnmi-pathz-policies;
+        }
+    }
+
+    // Augments section.
+
+    augment "/oc-sys:system" {
+        description
+            "Collection of OpenConfig-path-based authorization policies that
+             have been installed on the device using the gNSI OpenConfig-path-
+             based authorization policy management service.
+             Each policy listed here is identified by its status (either ACTIVE
+             or SANDBOX) and has its version and creation date/time listed.";
+
+        uses system-gnmi-pathz-policies;
+    }
+    augment "/oc-sys:system/oc-sys-grpc:grpc-servers/oc-sys-grpc:grpc-server/" +
+            "oc-sys-grpc:state" {
+        description
+            "A gNMI server OpenConfig-path-based authorization policy freshness
+            information.";
+
+        uses grpc-server-gnmi-pathz-policy-state;
+    }
+    augment "/oc-sys:system/oc-sys-grpc:grpc-servers/oc-sys-grpc:grpc-server" {
+        description
+            "A gNMI server OpenConfig-path-based authorization policy
+             success/failure counters.";
+
+            uses gnmi-pathz-policy-success-failure-counters;
+    }
+}


### PR DESCRIPTION
This PR introduces the new YANG models for gNSI Authz, Certz, Pathz and Credentialz. And updates the config model list to include the new models.