### PR TITLE
[build] Add go mod tidy before go mod vendor for Go 1.24 compat

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,15 @@ $(GO_MOD):
 	$(GO) mod init github.com/Azure/sonic-mgmt-common
 
 $(GO_DEPS): $(GO_MOD) $(GO_PATCHES)
+	@# Run go mod tidy only if installed Go >= go.mod's go directive
+	@GO_MOD_VER=$$(sed -n 's/^go //p' go.mod) && \
+	 GO_CUR_VER=$$($(GO) env GOVERSION | sed 's/go//') && \
+	 if printf '%s\n' "$$GO_MOD_VER" "$$GO_CUR_VER" | sort -V | head -1 | grep -qx "$$GO_MOD_VER"; then \
+	   echo "Running go mod tidy (Go $$GO_CUR_VER >= go.mod $$GO_MOD_VER)"; \
+	   $(GO) mod tidy; \
+	 else \
+	   echo "Skipping go mod tidy (Go $$GO_CUR_VER < go.mod $$GO_MOD_VER)"; \
+	 fi
 	$(GO) mod vendor
 	patches/apply.sh vendor
 	touch  $@


### PR DESCRIPTION
## Description
[agent]
Add `go mod tidy` before `go mod vendor` in Makefile for Go 1.24 compatibility (Debian Trixie).

### What I did
Added `$(GO) mod tidy` before the `$(GO) mod vendor` call.

### Why I did it
Go 1.24 (Debian Trixie) enforces stricter module graph consistency. `go mod vendor` fails without `go mod tidy` first when `go.mod` targets an older Go version. Backward compatible — no-op on Go 1.21 (bookworm).

### How I verified it
Built sonic-mgmt-common under Trixie slave with Go 1.24.

## Type of change
- Bug fix