### PR TITLE
[go] Bump go version to 1.21 for Debian Trixie compatibility

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,4 +34,4 @@ require (
 	google.golang.org/protobuf v1.21.0 // indirect
 )
 
-go 1.19
+go 1.21

--- a/go.sum
+++ b/go.sum
@@ -109,7 +109,6 @@ golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20200301022130-244492dfa37a h1:GuSPYbZzB5/dcLNCwLQLsg3obCJtX9IJhpXkvY7kzk0=
 golang.org/x/net v0.0.0-20200301022130-244492dfa37a/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200813134508-3edf25e44fcc/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974 h1:IX6qOQeG5uLjB/hjjwjedwfjND0hgjPMMyO1RoIXQNI=
@@ -175,6 +174,5 @@ gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
-inet.af v0.0.0-20181218191229-53da77bc832c h1:U3RoiyEF5b3Y1SVL6NNvpkgqUz2qS3a0OJh9kpSCN04=
 inet.af/netaddr v0.0.0-20230525184311-b8eac61e914a h1:1XCVEdxrvL6c0TGOhecLuB7U9zYNdxZEjvOqJreKZiM=
 inet.af/netaddr v0.0.0-20230525184311-b8eac61e914a/go.mod h1:e83i32mAQOW1LAqEIweALsuK2Uw4mhQadA5r7b0Wobo=


### PR DESCRIPTION
Part of sonic-net/sonic-buildimage#25959

## Summary

Update the `go` directive in `go.mod` from `1.19` to `1.21` and remove two stale `go.sum` entries.

### Why

The trixie build environment (Go 1.24) enforces that `go.mod` is consistent with the actual module requirements before allowing `go mod vendor`. The module was already bumped to Go 1.21 functionally but `go.mod` still declared `go 1.19`, causing:

```
go: updates to go.mod needed; to update it:
        go mod tidy
make[2]: *** [Makefile:39: vendor/.done] Error 1
```

### Bookworm compatibility

Go 1.19 (bookworm slave) does not enforce the `go` directive as a minimum version — that behavior was introduced in Go 1.21. So this change is backward-compatible with the bookworm build.

This is a prerequisite for sonic-net/sonic-buildimage#25957 (migrating gnmi/telemetry containers to Debian Trixie).

---

> **Note:** This PR was created by an AI agent (Claude/Claw) acting on behalf of @hdwhdw (Dawei Huang).