### PR TITLE
Debian Trixie migration for sonic-mgmt-common

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,7 +33,7 @@ stages:
       vmImage: ubuntu-latest
 
     container:
-      image: sonicdev-microsoft.azurecr.io:443/sonic-slave-bookworm:latest
+      image: sonicdev-microsoft.azurecr.io:443/sonic-slave-trixie:latest
 
     steps:
     - checkout: self
@@ -50,8 +50,12 @@ stages:
         runVersion: 'latestFromBranch'
         runBranch: 'refs/heads/$(BUILD_BRANCH)'
         patterns: |
-            target/debs/bookworm/libyang*.deb
-            target/python-wheels/bookworm/sonic_yang_models*.whl
+            target/debs/trixie/libpcre3_*.deb
+            target/debs/trixie/libpcre16-3_*.deb
+            target/debs/trixie/libpcre32-3_*.deb
+            target/debs/trixie/libpcrecpp0v5_*.deb
+            target/debs/trixie/libyang*.deb
+            target/python-wheels/trixie/sonic_yang_models*.whl
       displayName: "Download sonic buildimage"
 
     - script: |
@@ -63,12 +67,18 @@ stages:
         sudo sed -ri 's/redis-server.sock/redis.sock/' /etc/redis/redis.conf
         sudo service redis-server start
 
+        # LIBPCRE3 (not in Trixie repos, required by libyang 1.0.73)
+        sudo dpkg -i ../target/debs/trixie/libpcre3_*.deb \
+                     ../target/debs/trixie/libpcre16-3_*.deb \
+                     ../target/debs/trixie/libpcre32-3_*.deb \
+                     ../target/debs/trixie/libpcrecpp0v5_*.deb
+
         # LIBYANG
-        sudo dpkg -i ../target/debs/bookworm/libyang*1.0.73*.deb
+        sudo dpkg -i ../target/debs/trixie/libyang*1.0.73*.deb
       displayName: "Install dependency"
 
     - script: |
-        sudo pip3 install ../target/python-wheels/bookworm/sonic_yang_models-1.0-py3-none-any.whl
+        sudo pip3 install ../target/python-wheels/trixie/sonic_yang_models-1.0-py3-none-any.whl
       displayName: "Install sonic yangs"
 
     - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -82,7 +82,7 @@ stages:
       displayName: "Install dependency"
 
     - script: |
-        sudo pip3 install ../target/python-wheels/trixie/sonic_yang_models-1.0-py3-none-any.whl
+        sudo pip3 install ../target/python-wheels/trixie/sonic_yang_models*.whl
       displayName: "Install sonic yangs"
 
     - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,6 +54,7 @@ stages:
             target/debs/trixie/libpcre16-3_*.deb
             target/debs/trixie/libpcre32-3_*.deb
             target/debs/trixie/libpcrecpp0v5_*.deb
+            target/debs/trixie/libpcre3-dev_*.deb
             target/debs/trixie/libyang*.deb
             target/python-wheels/trixie/sonic_yang_models*.whl
       displayName: "Download sonic buildimage"
@@ -72,6 +73,9 @@ stages:
                      ../target/debs/trixie/libpcre16-3_*.deb \
                      ../target/debs/trixie/libpcre32-3_*.deb \
                      ../target/debs/trixie/libpcrecpp0v5_*.deb
+
+        # LIBPCRE3-DEV (required by libyang-dev)
+        sudo dpkg -i ../target/debs/trixie/libpcre3-dev_*.deb
 
         # LIBYANG
         sudo dpkg -i ../target/debs/trixie/libyang*1.0.73*.deb

--- a/cvl/cvl.go
+++ b/cvl/cvl.go
@@ -328,7 +328,7 @@ func loadSchemaFiles() CVLRetCode {
 		// Now parse each schema file
 		var module *yparser.YParserModule
 		if module, _ = yparser.ParseSchemaFile(modelFilePath); module == nil {
-			CVL_LOG(FATAL, fmt.Sprintf("Unable to parse schema file %s", modelFile))
+			CVL_LOG(FATAL, "Unable to parse schema file %s", modelFile)
 			return CVL_ERROR
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -34,4 +34,4 @@ require (
 	google.golang.org/protobuf v1.21.0 // indirect
 )
 
-go 1.21
+go 1.24.4

--- a/patches/apply.sh
+++ b/patches/apply.sh
@@ -36,6 +36,34 @@ copy github.com/openconfig/goyang v0.0.0-20200309174518-a00bece872fc .
 
 copy github.com/openconfig/gnmi v0.0.0-20200617225440-d2b4e6a45802 .
 
+# Update vendor/modules.txt to include the copied packages
+# This is needed for Go 1.24+ which validates modules.txt even for --mod=vendor
+function update_modules_txt() {
+    local modules_file="${DEST_DIR}/modules.txt"
+
+    # Add gnmi module entries if not already present
+    if ! grep -q '^github.com/openconfig/gnmi/ctree$' "${modules_file}" 2>/dev/null; then
+        echo "" >> "${modules_file}"
+        echo "# github.com/openconfig/gnmi v0.0.0-20200617225440-d2b4e6a45802" >> "${modules_file}"
+        echo "## explicit" >> "${modules_file}"
+        echo "github.com/openconfig/gnmi/ctree" >> "${modules_file}"
+        echo "github.com/openconfig/gnmi/errlist" >> "${modules_file}"
+        echo "github.com/openconfig/gnmi/proto/gnmi" >> "${modules_file}"
+    fi
+
+    # Add ygot module entries if not already present
+    if ! grep -q '^github.com/openconfig/ygot/ygen$' "${modules_file}" 2>/dev/null; then
+        echo "" >> "${modules_file}"
+        echo "# github.com/openconfig/ygot v0.7.1" >> "${modules_file}"
+        echo "## explicit" >> "${modules_file}"
+        echo "github.com/openconfig/ygot/genutil" >> "${modules_file}"
+        echo "github.com/openconfig/ygot/generator" >> "${modules_file}"
+        echo "github.com/openconfig/ygot/ygen" >> "${modules_file}"
+    fi
+}
+
+update_modules_txt
+
 # Apply patches
 
 patch -d ${DEST_DIR}/github.com/openconfig/ygot -p1 < ${PATCH_DIR}/ygot/ygot.patch

--- a/translib/Makefile
+++ b/translib/Makefile
@@ -69,17 +69,6 @@ $(TRANSFORMER_TEST_APP_BIN): $(TRANSFORMER_ALL_SRCS) $(TRANSLIB_MAIN_SRCS) $(YGO
 
 $(YGOT_BINDS): $(YANG_FILES)
 	$(RM) $@
-	# Go 1.24+ changed 'go mod vendor' to only include packages directly
-	# imported by the module. The ygot tool packages and their dependencies
-	# are used by 'go run' below but not directly imported, so they are no
-	# longer vendored automatically. Add them to vendor/modules.txt.
-	@grep -q 'github.com/openconfig/ygot/ygen' $(TOPDIR)/vendor/modules.txt 2>/dev/null || \
-		( echo "github.com/openconfig/gnmi/ctree" >> $(TOPDIR)/vendor/modules.txt && \
-		  echo "github.com/openconfig/gnmi/errlist" >> $(TOPDIR)/vendor/modules.txt && \
-		  echo "github.com/openconfig/gnmi/proto/gnmi" >> $(TOPDIR)/vendor/modules.txt && \
-		  echo "github.com/openconfig/ygot/genutil" >> $(TOPDIR)/vendor/modules.txt && \
-		  echo "github.com/openconfig/ygot/generator" >> $(TOPDIR)/vendor/modules.txt && \
-		  echo "github.com/openconfig/ygot/ygen" >> $(TOPDIR)/vendor/modules.txt )
 	$(GO) run \
 		--mod=vendor \
 		$(TOPDIR)/vendor/github.com/openconfig/ygot/generator/generator.go \

--- a/translib/Makefile
+++ b/translib/Makefile
@@ -69,6 +69,17 @@ $(TRANSFORMER_TEST_APP_BIN): $(TRANSFORMER_ALL_SRCS) $(TRANSLIB_MAIN_SRCS) $(YGO
 
 $(YGOT_BINDS): $(YANG_FILES)
 	$(RM) $@
+	# Go 1.24+ changed 'go mod vendor' to only include packages directly
+	# imported by the module. The ygot tool packages and their dependencies
+	# are used by 'go run' below but not directly imported, so they are no
+	# longer vendored automatically. Add them to vendor/modules.txt.
+	@grep -q 'github.com/openconfig/ygot/ygen' $(TOPDIR)/vendor/modules.txt 2>/dev/null || \
+		( echo "github.com/openconfig/gnmi/ctree" >> $(TOPDIR)/vendor/modules.txt && \
+		  echo "github.com/openconfig/gnmi/errlist" >> $(TOPDIR)/vendor/modules.txt && \
+		  echo "github.com/openconfig/gnmi/proto/gnmi" >> $(TOPDIR)/vendor/modules.txt && \
+		  echo "github.com/openconfig/ygot/genutil" >> $(TOPDIR)/vendor/modules.txt && \
+		  echo "github.com/openconfig/ygot/generator" >> $(TOPDIR)/vendor/modules.txt && \
+		  echo "github.com/openconfig/ygot/ygen" >> $(TOPDIR)/vendor/modules.txt )
 	$(GO) run \
 		--mod=vendor \
 		$(TOPDIR)/vendor/github.com/openconfig/ygot/generator/generator.go \


### PR DESCRIPTION
#### Why I did it - 
Required for https://github.com/sonic-net/SONiC/issues/2169 , sonic-mgmt-common is a dependency for sonic-mgmt-framework 

#### How I did it - 
Updated the package build configuration to support Trixie distro. Key changes include:
Updated Azure Pipelines to use sonic-slave-trixie container
Added libpcre3 dependencies (not available in Trixie repos)
Bumped Go version to 1.24.4 to align with Trixie's provided version
Fixed Go 1.24+ vendor module requirements for ygot tool

#### How to verify it - 
 The sonic-mgmt-framework container  builds successfully under BLDENV=trixie which in turn builds sonic-mgmt-common(the .deb built was correctly paced in target/debs/trixie). Installed sonic-mgmt-framework container  on a recent SONiC image and verified that the docker OS distribution shows Trixie and basic curl test on REST server hosted within the docker works fine.  Also executed the pipeline tests locally.
 
 **Note:**
 Dependent/Related PRs:
 https://github.com/sonic-net/sonic-buildimage/pull/26548
 https://github.com/sonic-net/sonic-mgmt-framework/pull/158