### PR TITLE
Corrected openconfig system annotation for authz

### DIFF
--- a/models/yang/annotations/openconfig-system-annot.yang
+++ b/models/yang/annotations/openconfig-system-annot.yang
@@ -57,12 +57,13 @@ module openconfig-system-annot {
         sonic-ext:subtree-transformer "console_counters_xfmr";
       }
     }
-    deviation /oc-sys:system/oc-sys:aaa/oc-sys:authorization/oc-sys:state {
-      deviate add {
-        sonic-ext:db-name "STATE_DB";
-        sonic-ext:subtree-transformer "authz_policy_xfmr";
-      }
-    }
+
+   deviation /oc-sys:system/oc-sys:aaa/oc-sys:authorization/oc-sys:state {
+      deviate add {
+        sonic-ext:db-name "STATE_DB";
+        sonic-ext:subtree-transformer "authz_policy_xfmr";
+      }
+    }
 
     deviation /oc-sys:system/gnsi-pathz:gnmi-pathz-policies {
       deviate add {

--- a/models/yang/annotations/openconfig-system-annot.yang
+++ b/models/yang/annotations/openconfig-system-annot.yang
@@ -57,12 +57,13 @@ module openconfig-system-annot {
         sonic-ext:subtree-transformer "console_counters_xfmr";
       }
     }
-    deviation /oc-sys:system/oc-sys:aaa/oc-sys:authorization/oc-sys:state {
-      deviate add {
-        sonic-ext:db-name "STATE_DB";
-        sonic-ext:subtree-transformer "authz_policy_xfmr";
-      }
-    }
+
+    deviation /oc-sys:system/oc-sys:aaa/oc-sys:authorization/oc-sys:state {
+      deviate add {
+        sonic-ext:db-name "STATE_DB";
+        sonic-ext:subtree-transformer "authz_policy_xfmr";
+      }
+    }
 
     deviation /oc-sys:system/gnsi-pathz:gnmi-pathz-policies {
       deviate add {


### PR DESCRIPTION
This PR is created to fix the below issue.

This commit contains non-printable characters and causes syntax errors.

INFO mgmt-framework#supervisord: rest-server /usr/models/yang/openconfig-system-annot.yang:60:75: {: not an identifier
INFO mgmt-framework#supervisord: rest-server /usr/models/yang/openconfig-system-annot.yang:61:6:  deviate: syntax error
INFO mgmt-framework#supervisord: rest-server /usr/models/yang/openconfig-system-annot.yang:62:6:  : syntax error
INFO mgmt-framework#supervisord: rest-server /usr/models/yang/openconfig-system-annot.yang:63:6:  : syntax error
INFO mgmt-framework#supervisord: rest-server /usr/models/yang/openconfig-system-annot.yang:64:6:  : syntax error
INFO mgmt-framework#supervisord: rest-server /usr/models/yang/openconfig-system-annot.yang:65:5: }: syntax error