### PR TITLE
Fix gNMI crash due to duplicate edges in dependency

### DIFF
--- a/cvl/cvl_api.go
+++ b/cvl/cvl_api.go
@@ -854,6 +854,13 @@ func (c *CVL) GetOrderedDepTables(yangModule, tableName string) ([]string, CVLRe
 		for _, tn := range tblLists {
 			for _, depTblName := range modelInfo.tableInfo[tn].dependentTables {
 				if tbl == depTblName {
+					toName, exists := dupEdgeCheck[depTblName]
+					if exists && (toName == redisTblTo) {
+						// Skip duplicate edge already added via leafref block.
+						// Duplicate AddEdge corrupts g.outputs index in go-toposort causing panic.
+						CVL_LOG(INFO_DEBUG, "GetOrderedDepTables(): Skipping duplicate edge %s -> %s", depTblName, redisTblTo)
+						continue
+					}
 					graph.AddNodes(depTblName)
 					graph.AddEdge(depTblName, redisTblTo)
 					dupEdgeCheck[depTblName] = redisTblTo


### PR DESCRIPTION
Fixes: https://github.com/sonic-net/sonic-gnmi/issues/670

RCA:
Duplicate edges were being added in GetOrderedDepTables() when both leafref and dependent-on pointed to the same table, causing go-toposort panic.

Sample reproduction scenario:
Adding BGP YANG modules to sonic-mgmt-common/models/yang/sonic/import.mk caused gNMI/translib to crash on startup, making gNMI unusable.

Fix:
Add duplicate edge check in dependent-on block to avoid adding the same edge twice. This is the same check which  is being leveraged in other places also in cvl_api.go to avoid such crashes.