### PR TITLE
tools/pyang: exclude common YANG models from import to avoid duplicates

### DIFF
--- a/tools/pyang/import_yang.py
+++ b/tools/pyang/import_yang.py
@@ -77,6 +77,8 @@ class Preprocessor(object):
         ctx.keep_comments = options.keep_comments
 
         excludes = [f.stem for f in options.to_dir.glob("*.yang")]
+        # Exclude common yang-models since they are already included in sonic-mgmt-common
+        excludes += [f.stem for f in options.to_dir.glob("common/*.yang")]
         if options.exclude:
             excludes += [f.stem for f in options.exclude]
 


### PR DESCRIPTION
`sonic-mgmt-common` extension name:
```
extension custom-validation {
		description
			"Extension for custom validation. 
			 Platform specific validation can be implemented using custom validation.";
		argument "handler"; 
	}
```
`sonic-yang-models` auto-generated extension name:
```
extension custom-validation-cvl {
        description "Extension for registering cvl based custom validation handler.";
        argument "handler";
    }
```
`mgmt-framework` imports both, this conflict happens.

### Related issue:
- https://github.com/sonic-net/sonic-mgmt-common/issues/217