### PR TITLE
NOS-12728: Added create-only extension to YANG

### DIFF
--- a/models/yang/sonic/common/sonic-extension.yang
+++ b/models/yang/sonic/common/sonic-extension.yang
@@ -17,6 +17,22 @@ module sonic-extension {
 			"Initial revision.";
 	}
 
+	extension create-only {
+		description
+			"During an apply-patch operation, indicates that a node can only be created
+			 or re-created (i.e., deleted and re-added) but cannot be updated in-place.
+			 Any update to a node carrying this extension is realized as a deletion and
+			 recreation of the corresponding object.
+
+			 This extension can be defined under:
+			 - leaf or leaf-list: The immutability restriction applies specifically to this field.
+			 - container or list: The restriction applies to the entire container/list, meaning
+			   a change to any field within it triggers a deletion and recreation of the entire entry
+			   (e.g., [table, '*', '*']).
+			 - grouping: The restriction applies to the target leaf/leaf-list at every 'uses' site where
+			   the grouping is expanded.";
+	}
+
 	extension db-name {
 		description
 			"DB name, e.g. APPL_DB, CONFIG_DB";

--- a/models/yang/version.xml
+++ b/models/yang/version.xml
@@ -28,7 +28,7 @@
   -->
   <yang-bundle-version>
     <Major>1</Major>
-    <Minor>0</Minor>
+    <Minor>1</Minor>
     <Patch>0</Patch>
   </yang-bundle-version>
 


### PR DESCRIPTION
# PR Description: Add create-only Extension to YANG Models

### Why I did it
To support dynamic discovery of immutable (create-only) database fields in the Generic Config Updater (GCU), we need a standardized way to annotate fields directly in the SONiC YANG models. Previously, `CreateOnlyFilter` in `sonic-utilities` relied on hardcoded lists of immutable fields (such as port lanes). This hardcoding makes the system difficult to maintain, scale, and extend as new tables or create-only attributes are introduced.

By defining an `ext:create-only` extension in `sonic-extension.yang`, we establish a clean, schema-driven approach. The GCU can compile these schemas using `libyang` and dynamically identify immutable fields during patch operations.
