### PR TITLE
fix: upgrade vulnerable Go dependencies to fix CRITICAL/HIGH CVEs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,9 @@ module github.com/Azure/sonic-mgmt-common
 
 require (
 	github.com/Workiva/go-datastructures v1.0.50
-	github.com/antchfx/jsonquery v1.1.4
-	github.com/antchfx/xmlquery v1.3.1
-	github.com/antchfx/xpath v1.1.10
+	github.com/antchfx/jsonquery v1.3.7
+	github.com/antchfx/xmlquery v1.5.1
+	github.com/antchfx/xpath v1.3.6
 	github.com/go-redis/redis/v7 v7.4.1
 	github.com/godbus/dbus/v5 v5.1.0
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
@@ -17,8 +17,8 @@ require (
 	github.com/philopon/go-toposort v0.0.0-20170620085441-9be86dbd762f
 	github.com/pkg/profile v1.7.0
 	github.com/redis/go-redis/v9 v9.6.1
-	golang.org/x/text v0.3.3
-	google.golang.org/grpc v1.28.0
+	golang.org/x/text v0.39.0
+	google.golang.org/grpc v1.82.1
 	inet.af/netaddr v0.0.0-20230525184311-b8eac61e914a
 )
 


### PR DESCRIPTION
## Why I did it

Trivy CVE scan identified multiple CRITICAL and HIGH severity vulnerabilities in the Go module dependencies of sonic-mgmt-common.

## How I did it

Updated `go.mod` with the following version bumps:

| Package | Old | New | CVEs Fixed |
|---|---|---|---|
| `google.golang.org/grpc` | v1.28.0 | **v1.82.1** | CVE-2026-33186, GHSA-hrxh-6v49-42gf |
| `golang.org/x/text` | v0.3.3 | **v0.39.0** | CVE-2020-14040, CVE-2021-38561, CVE-2022-32149, CVE-2026-56852 |
| `github.com/antchfx/xpath` | v1.1.10 | **v1.3.6** | CVE-2026-32287 (direct dependency) |
| `github.com/antchfx/jsonquery` | v1.1.4 | **v1.3.7** | (parent of vulnerable xpath) |
| `github.com/antchfx/xmlquery` | v1.3.1 | **v1.5.1** | (parent of vulnerable xpath) |

## How to verify it

```bash
trivy fs . --severity CRITICAL,HIGH
```

CRITICAL count should drop to 0 for these packages; HIGH count should decrease substantially.