### PR TITLE
Fix CVL request cache lookup for singleton mappings

### DIFF
--- a/cvl/cvl_must_test.go
+++ b/cvl/cvl_must_test.go
@@ -674,3 +674,59 @@ func testNullAdd(data ...cmn.CVLEditConfigData) func(*testing.T) {
 		}
 	}
 }
+
+// Regression coverage for sonic-net/sonic-buildimage#29052: CACHE_KEY_TEST is
+// a singleton container (Redis table "CACHE_KEY_TEST", key "GLOBAL") that
+// generate_yin.py converts into list CACHE_KEY_TEST_GLOBAL_LIST, so the Redis
+// table name and the generated YANG list name differ, same as SYSLOG_CONFIG /
+// SYSLOG_CONFIG_GLOBAL in the reported issue.
+func TestValidateEditConfig_Update_MismatchedTableName_MustExp_Positive(t *testing.T) {
+	setupTestData(t, map[string]interface{}{
+		"CACHE_KEY_TEST": map[string]interface{}{
+			"GLOBAL": map[string]interface{}{
+				"format": "welf",
+			},
+		},
+	})
+
+	cfgData := []cmn.CVLEditConfigData{
+		cmn.CVLEditConfigData{
+			cmn.VALIDATE_ALL,
+			cmn.OP_UPDATE,
+			"CACHE_KEY_TEST|GLOBAL",
+			map[string]string{
+				"welf_firewall_name": "test-fw",
+			},
+			false,
+		},
+	}
+
+	verifyValidateEditConfig(t, cfgData, Success)
+}
+
+func TestValidateEditConfig_Update_MismatchedTableName_MustExp_Negative(t *testing.T) {
+	setupTestData(t, map[string]interface{}{
+		"CACHE_KEY_TEST": map[string]interface{}{
+			"GLOBAL": map[string]interface{}{
+				"format": "standard",
+			},
+		},
+	})
+
+	cfgData := []cmn.CVLEditConfigData{
+		cmn.CVLEditConfigData{
+			cmn.VALIDATE_ALL,
+			cmn.OP_UPDATE,
+			"CACHE_KEY_TEST|GLOBAL",
+			map[string]string{
+				"welf_firewall_name": "test-fw",
+			},
+			false,
+		},
+	}
+
+	verifyValidateEditConfig(t, cfgData, CVLErrorInfo{
+		ErrCode: CVL_SEMANTIC_ERROR,
+		Msg:     mustExpressionErrMessage,
+	})
+}

--- a/cvl/cvl_semantics.go
+++ b/cvl/cvl_semantics.go
@@ -308,7 +308,7 @@ func (c *CVL) generateYangListData(jsonNode *jsonquery.Node,
 
 			if storeInReqCache {
 				//store the list pointer in requestCache against the table/key
-				reqCache, exists := c.requestCache[tableName][redisKey]
+				reqCache, exists := c.requestCache[origTableName][redisKey]
 				if exists {
 					//Store same list instance in all requests under same table/key
 					for idx := 0; idx < len(reqCache); idx++ {

--- a/cvl/testdata/schema/sonic-cvl-cache-key-test.yang
+++ b/cvl/testdata/schema/sonic-cvl-cache-key-test.yang
@@ -1,0 +1,44 @@
+module sonic-cvl-cache-key-test {
+    namespace "http://github.com/sonic-net/sonic-cvl-cache-key-test";
+    prefix cktest;
+    yang-version 1.1;
+
+    organization
+        "SONiC";
+
+    contact
+        "SONiC";
+
+    description
+        "Test schema for regression coverage of requestCache keying when the
+        Redis table name differs from the generated YANG list name (singleton
+        container auto-converted to a list by generate_yin.py). Should not be
+        used in production.";
+
+    revision 2026-08-22 {
+        description
+            "Initial revision.";
+    }
+
+    container sonic-cvl-cache-key-test {
+        container CACHE_KEY_TEST {
+            container GLOBAL {
+                leaf format {
+                    type enumeration {
+                        enum standard;
+                        enum welf;
+                    }
+                    default standard;
+                }
+
+                leaf welf_firewall_name {
+                    type string;
+                    must "../format = 'welf'" {
+                        error-message
+                            "welf_firewall_name requires format=welf";
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Description of PR

Summary:

Fixes sonic-net/sonic-buildimage#29052.

CVL stores request cache entries by Redis table name, but
`generateYangListData()` looked them up using the mapped YANG list name.

For singleton or multi-list mappings where those names differ, the lookup
misses and the request's `YangData` is not attached. Existing CONFIG_DB
values can then fail to merge into the request node, causing must expressions
to evaluate against YANG defaults instead of the actual stored sibling values.

Use the original Redis table name when looking up `requestCache`.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

Added focused CVL regression coverage for a singleton Redis table whose
generated YANG list name differs from the Redis table name.

The test schema generator successfully converts the singleton container to:

`CACHE_KEY_TEST_GLOBAL_LIST`

with:

`sonic-ext:tbl-key value="GLOBAL"`

Two `ValidateEditConfig()` cases cover:

- existing `format=welf` plus an UPDATE containing only
  `welf_firewall_name` — expected success;
- existing `format=standard` plus the same UPDATE — expected semantic failure.

Local validation completed:

- test schema generation passes;
- generated YIN contains the expected singleton list and `tbl-key`;
- `gofmt` passes;
- `git diff --check` passes.

The focused Go test was attempted locally but could not execute because the
local WSL environment does not have the SONiC libyang3 development headers
(`libyang/libyang.h`). The repository CI installs the SONiC libyang3 packages
before building and running CVL tests.

### Approach

#### What is the motivation for this PR?

For Redis-to-YANG mappings such as a singleton table, CVL can use different
names for the Redis table and generated YANG list.

`requestCache` is populated using the Redis table name. However,
`generateYangListData()` was indexing it after `tableName` had been replaced
with the mapped YANG list name.

That causes valid UPDATEs to lose their association with the generated YANG
node and can make must expressions evaluate against default values instead of
existing CONFIG_DB values.

#### How did you do it?

Changed the request cache lookup in `generateYangListData()` to use
`origTableName`, which retains the Redis table name:

`c.requestCache[origTableName][redisKey]`

instead of:

`c.requestCache[tableName][redisKey]`

For mappings where Redis and YANG names are identical, behavior is unchanged.

#### How did you verify/test it?

Added an end-to-end `ValidateEditConfig()` regression model using the same
singleton-container transformation path as the affected configuration model.

The generated YIN was inspected to confirm that the test exercises a real
Redis-table-to-different-YANG-list mapping rather than a manually named list.

#### Any platform specific information?

No. This is generic CVL validation behavior.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A
