### PR TITLE
[cvl]: Escape Lua metacharacters in delete-dependency and must/when filters

### DIFF
--- a/cvl/cvl_api.go
+++ b/cvl/cvl_api.go
@@ -1105,13 +1105,16 @@ func (c *CVL) GetDepDataForDelete(redisKey string) []CVLDepDataForDelete {
 				mFilterScripts[refTbl.tableName] = make([]filterScript, 0)
 			}
 			fltScrs := mFilterScripts[refTbl.tableName]
+			// Escape Lua string metacharacters before embedding the key
+			// value in the filter script source.
+			luaEscKey := strings.NewReplacer("\\", "\\\\", "'", "\\'").Replace(key)
 			fltScrs = append(fltScrs, filterScript{
 				script: fmt.Sprintf("return (h['%s'] ~= nil and (h['%s'] == '%s' or h['%s'] == '[%s|%s]')) or "+
 					"(h['%s@'] ~= nil and ((h['%s@'] == '%s') or "+
-					"(string.find(h['%s@']..',', '%s,') ~= nil)))",
-					refTbl.field, refTbl.field, key, refTbl.field, tableName, key,
-					refTbl.field, refTbl.field, key,
-					refTbl.field, key),
+					"(string.find(h['%s@']..',', '%s,', 1, true) ~= nil)))",
+					refTbl.field, refTbl.field, luaEscKey, refTbl.field, tableName, luaEscKey,
+					refTbl.field, refTbl.field, luaEscKey,
+					refTbl.field, luaEscKey),
 				field: refTbl.field,
 				value: key,
 			})

--- a/cvl/cvl_must_test.go
+++ b/cvl/cvl_must_test.go
@@ -206,23 +206,24 @@ func TestValidateEditConfig_Not_equal_in_predicate_postive(t *testing.T) {
 
 func TestValidateEditConfig_Not_equal_in_predicate_negative(t *testing.T) {
 
-	setupTestData(t, map[string]interface{}{
-		"EVPN_ETHERNET_SEGMENT": map[string]interface{}{
-			"test1": map[string]interface{}{
-				"ifname": "Ethernet0",
-			},
-			"test2": map[string]interface{}{
-				"ifname":     "Ethernet4",
-				"delay-time": "10",
-			},
-		}})
 	// Create of entry with already existing ifname
 	t.Run("create_entry_already_existing_port", func(tt *testing.T) {
+		setupTestData(tt, map[string]interface{}{
+			"EVPN_ETHERNET_SEGMENT": map[string]interface{}{
+				"mneg1": map[string]interface{}{
+					"ifname": "Ethernet0",
+				},
+				"mneg2": map[string]interface{}{
+					"ifname": "Ethernet4",
+				},
+			},
+		})
+
 		c := NewTestSession(tt)
 		res, _ := c.ValidateEditConfig([]CVLEditConfigData{{
 			VType: VALIDATE_ALL,
 			VOp:   OP_CREATE,
-			Key:   "EVPN_ETHERNET_SEGMENT|test3",
+			Key:   "EVPN_ETHERNET_SEGMENT|mneg3",
 			Data: map[string]string{
 				"ifname": "Ethernet0",
 			}}})
@@ -236,11 +237,100 @@ func TestValidateEditConfig_Not_equal_in_predicate_negative(t *testing.T) {
 
 	// Update of ifname to already used port name
 	t.Run("update_ifname_already_existing_port", func(tt *testing.T) {
+		setupTestData(tt, map[string]interface{}{
+			"EVPN_ETHERNET_SEGMENT": map[string]interface{}{
+				"mneg4": map[string]interface{}{
+					"ifname": "Ethernet0",
+				},
+				"mneg5": map[string]interface{}{
+					"ifname": "Ethernet4",
+				},
+			},
+		})
+
 		c := NewTestSession(tt)
 		res, _ := c.ValidateEditConfig([]CVLEditConfigData{{
 			VType: VALIDATE_ALL,
 			VOp:   OP_UPDATE,
-			Key:   "EVPN_ETHERNET_SEGMENT|test2",
+			Key:   "EVPN_ETHERNET_SEGMENT|mneg5",
+			Data: map[string]string{
+				"ifname": "Ethernet0",
+			}}})
+		verifyErr(tt, res, CVLErrorInfo{
+			ErrCode:   CVL_SEMANTIC_ERROR,
+			TableName: "EVPN_ETHERNET_SEGMENT",
+			Field:     "ifname",
+			Msg:       mustExpressionErrMessage,
+		})
+	})
+}
+
+func TestValidateEditConfig_Must_Predicate_Escape_SingleQuote(t *testing.T) {
+	setupTestData(t, map[string]interface{}{
+		"EVPN_ETHERNET_SEGMENT": map[string]interface{}{
+			"test'1": map[string]interface{}{
+				"ifname": "Ethernet0",
+			},
+		},
+	})
+
+	t.Run("create_entry_unique_ifname", func(tt *testing.T) {
+		c := NewTestSession(tt)
+		res, _ := c.ValidateEditConfig([]CVLEditConfigData{{
+			VType: VALIDATE_ALL,
+			VOp:   OP_CREATE,
+			Key:   "EVPN_ETHERNET_SEGMENT|test'2",
+			Data: map[string]string{
+				"ifname": "Ethernet4",
+			}}})
+		verifyErr(tt, res, Success)
+	})
+
+	t.Run("create_entry_duplicate_ifname", func(tt *testing.T) {
+		c := NewTestSession(tt)
+		res, _ := c.ValidateEditConfig([]CVLEditConfigData{{
+			VType: VALIDATE_ALL,
+			VOp:   OP_CREATE,
+			Key:   "EVPN_ETHERNET_SEGMENT|test'3",
+			Data: map[string]string{
+				"ifname": "Ethernet0",
+			}}})
+		verifyErr(tt, res, CVLErrorInfo{
+			ErrCode:   CVL_SEMANTIC_ERROR,
+			TableName: "EVPN_ETHERNET_SEGMENT",
+			Field:     "ifname",
+			Msg:       mustExpressionErrMessage,
+		})
+	})
+}
+
+func TestValidateEditConfig_Must_Predicate_Escape_Backslash(t *testing.T) {
+	setupTestData(t, map[string]interface{}{
+		"EVPN_ETHERNET_SEGMENT": map[string]interface{}{
+			`test\1`: map[string]interface{}{
+				"ifname": "Ethernet0",
+			},
+		},
+	})
+
+	t.Run("create_entry_unique_ifname", func(tt *testing.T) {
+		c := NewTestSession(tt)
+		res, _ := c.ValidateEditConfig([]CVLEditConfigData{{
+			VType: VALIDATE_ALL,
+			VOp:   OP_CREATE,
+			Key:   "EVPN_ETHERNET_SEGMENT|test\\2",
+			Data: map[string]string{
+				"ifname": "Ethernet4",
+			}}})
+		verifyErr(tt, res, Success)
+	})
+
+	t.Run("create_entry_duplicate_ifname", func(tt *testing.T) {
+		c := NewTestSession(tt)
+		res, _ := c.ValidateEditConfig([]CVLEditConfigData{{
+			VType: VALIDATE_ALL,
+			VOp:   OP_CREATE,
+			Key:   "EVPN_ETHERNET_SEGMENT|test\\3",
 			Data: map[string]string{
 				"ifname": "Ethernet0",
 			}}})

--- a/cvl/cvl_test.go
+++ b/cvl/cvl_test.go
@@ -3600,6 +3600,113 @@ func TestGetDepDataForDelete(t *testing.T) {
 	cvl.ValidationSessClose(cvSess)
 }
 
+func TestGetDepDataForDeleteSpecialKeyChars(t *testing.T) {
+	tests := []struct {
+		name       string
+		mirrorKey  string
+		decoyValue string
+	}{
+		{
+			name:       "single quote in key",
+			mirrorKey:  "sess'1",
+			decoyValue: "sess",
+		},
+		{
+			name:       "backslash in key",
+			mirrorKey:  `sess\1`,
+			decoyValue: "sess",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			setupTestData(t, map[string]interface{}{
+				"MIRROR_SESSION": map[string]interface{}{
+					tc.mirrorKey: map[string]interface{}{
+						"src_ip": "10.1.0.32",
+						"dst_ip": "2.2.2.2",
+					},
+				},
+				"ACL_RULE": map[string]interface{}{
+					"TestACL1|RuleMatch": map[string]interface{}{
+						"PACKET_ACTION": "FORWARD",
+						"MIRROR_ACTION": tc.mirrorKey,
+					},
+					"TestACL1|RuleDecoy": map[string]interface{}{
+						"PACKET_ACTION": "FORWARD",
+						"MIRROR_ACTION": tc.decoyValue,
+					},
+				},
+			})
+
+			cvSess, _ := NewCvlSession()
+			defer cvl.ValidationSessClose(cvSess)
+
+			depEntries := cvSess.GetDepDataForDelete("MIRROR_SESSION|" + tc.mirrorKey)
+			if len(depEntries) != 1 {
+				t.Fatalf("GetDepDataForDelete() returned %d entries, want 1", len(depEntries))
+			}
+
+			entryKey := ""
+			for k := range depEntries[0].Entry {
+				entryKey = k
+			}
+			if entryKey != "ACL_RULE|TestACL1|RuleMatch" {
+				t.Errorf("GetDepDataForDelete() matched wrong entry %q, want ACL_RULE|TestACL1|RuleMatch", entryKey)
+			}
+		})
+	}
+}
+
+func TestGetDepDataForDeleteLeafListPatternChars(t *testing.T) {
+	setupTestData(t, map[string]interface{}{
+		"PORT": map[string]interface{}{
+			"Po.1": map[string]interface{}{
+				"admin_status": "up",
+			},
+			"PoX1": map[string]interface{}{
+				"admin_status": "up",
+			},
+		},
+		"ACL_TABLE": map[string]interface{}{
+			"TestACL1": map[string]interface{}{
+				"stage":  "INGRESS",
+				"type":   "L3",
+				"ports@": "Po.1,Ethernet3",
+			},
+			"TestACL2": map[string]interface{}{
+				"stage":  "INGRESS",
+				"type":   "L3",
+				"ports@": "PoX1,Ethernet3",
+			},
+		},
+	})
+
+	cvSess, _ := NewCvlSession()
+	defer cvl.ValidationSessClose(cvSess)
+
+	depEntries := cvSess.GetDepDataForDelete("PORT|Po.1")
+	matchedACLs := map[string]bool{}
+	for _, dep := range depEntries {
+		for entryKey, fields := range dep.Entry {
+			if !strings.HasPrefix(entryKey, "ACL_TABLE|") {
+				continue
+			}
+			if val, exists := fields["ports@"]; exists && val == "Po.1" {
+				matchedACLs[entryKey] = true
+			}
+		}
+	}
+
+	if len(matchedACLs) != 1 {
+		t.Fatalf("GetDepDataForDelete() matched %d ACL_TABLE leaf-list entries, want 1: %v",
+			len(matchedACLs), matchedACLs)
+	}
+	if !matchedACLs["ACL_TABLE|TestACL1"] {
+		t.Errorf("GetDepDataForDelete() matched wrong ACL_TABLE entries: %v", matchedACLs)
+	}
+}
+
 func TestMaxElements_All_Entries_In_Request(t *testing.T) {
 	cvSess := NewTestSession(t)
 

--- a/cvl/cvl_when_test.go
+++ b/cvl/cvl_when_test.go
@@ -124,3 +124,105 @@ func TestValidateEditConfig_When_Exp_In_Leaf_Negative(t *testing.T) {
 		Msg:       whenExpressionErrMessage,
 	})
 }
+
+func TestValidateEditConfig_When_Predicate_Escape_SingleQuote(t *testing.T) {
+	t.Run("update_delay_time_unique_ifname", func(tt *testing.T) {
+		setupTestData(tt, map[string]interface{}{
+			"EVPN_ETHERNET_SEGMENT": map[string]interface{}{
+				"test'1": map[string]interface{}{
+					"ifname":     "Ethernet0",
+					"delay-time": "10",
+				},
+			},
+		})
+
+		c := NewTestSession(tt)
+		res, _ := c.ValidateEditConfig([]CVLEditConfigData{{
+			VType: VALIDATE_ALL,
+			VOp:   OP_UPDATE,
+			Key:   "EVPN_ETHERNET_SEGMENT|test'1",
+			Data: map[string]string{
+				"delay-time": "12",
+			}}})
+		verifyErr(tt, res, Success)
+	})
+
+	t.Run("update_delay_time_duplicate_ifname", func(tt *testing.T) {
+		setupTestData(tt, map[string]interface{}{
+			"EVPN_ETHERNET_SEGMENT": map[string]interface{}{
+				"test'1": map[string]interface{}{
+					"ifname":     "Ethernet0",
+					"delay-time": "10",
+				},
+				"test'2": map[string]interface{}{
+					"ifname": "Ethernet0",
+				},
+			},
+		})
+
+		c := NewTestSession(tt)
+		res, _ := c.ValidateEditConfig([]CVLEditConfigData{{
+			VType: VALIDATE_ALL,
+			VOp:   OP_UPDATE,
+			Key:   "EVPN_ETHERNET_SEGMENT|test'2",
+			Data: map[string]string{
+				"delay-time": "12",
+			}}})
+		verifyErr(tt, res, CVLErrorInfo{
+			ErrCode:   CVL_SEMANTIC_ERROR,
+			TableName: "EVPN_ETHERNET_SEGMENT",
+			Field:     "delay-time",
+			Msg:       whenExpressionErrMessage,
+		})
+	})
+}
+
+func TestValidateEditConfig_When_Predicate_Escape_Backslash(t *testing.T) {
+	t.Run("create_entry_unique_ifname", func(tt *testing.T) {
+		setupTestData(tt, map[string]interface{}{
+			"EVPN_ETHERNET_SEGMENT": map[string]interface{}{
+				`test\1`: map[string]interface{}{
+					"ifname": "Ethernet0",
+				},
+			},
+		})
+
+		c := NewTestSession(tt)
+		res, _ := c.ValidateEditConfig([]CVLEditConfigData{{
+			VType: VALIDATE_ALL,
+			VOp:   OP_CREATE,
+			Key:   "EVPN_ETHERNET_SEGMENT|test\\2",
+			Data: map[string]string{
+				"ifname":     "Ethernet4",
+				"delay-time": "12",
+			}}})
+		verifyErr(tt, res, Success)
+	})
+
+	t.Run("create_entry_duplicate_ifname", func(tt *testing.T) {
+		setupTestData(tt, map[string]interface{}{
+			"EVPN_ETHERNET_SEGMENT": map[string]interface{}{
+				`test\1`: map[string]interface{}{
+					"ifname":     "Ethernet0",
+					"delay-time": "10",
+				},
+			},
+		})
+
+		c := NewTestSession(tt)
+		res, _ := c.ValidateEditConfig([]CVLEditConfigData{{
+			VType: VALIDATE_ALL,
+			VOp:   OP_CREATE,
+			Key:   "EVPN_ETHERNET_SEGMENT|test\\3",
+			Data: map[string]string{
+				"ifname":     "Ethernet0",
+				"delay-time": "12",
+			}}})
+		verifyErr(tt, res, CVLErrorInfo{
+			ErrCode:   CVL_SEMANTIC_ERROR,
+			TableName: "EVPN_ETHERNET_SEGMENT",
+			Field:     "delay-time",
+			Msg:       whenExpressionErrMessage,
+		})
+	})
+}

--- a/cvl/internal/yparser/ly_path.go
+++ b/cvl/internal/yparser/ly_path.go
@@ -133,6 +133,15 @@ func parseFirstElem(p string) (elem lyPathElem, n int) {
 	return
 }
 
+// formatLyPredicateValue returns a libyang predicate value literal.
+// Libyang uses single quotes when the value has no single quotes; otherwise double quotes.
+func formatLyPredicateValue(value string) string {
+	if strings.Contains(value, "'") {
+		return `"` + value + `"`
+	}
+	return `'` + value + `'`
+}
+
 // lyPathElem represents a path element
 type lyPathElem struct {
 	name string   // element name

--- a/cvl/internal/yparser/yparser.go
+++ b/cvl/internal/yparser/yparser.go
@@ -1341,9 +1341,9 @@ func (yp *YParser) AddListNode(module *YParserModule, parent *YParserNode, name 
 
 			keylist += "["
 			keylist += keys[index].Name
-			keylist += "='"
-			keylist += keys[index].Value
-			keylist += "']"
+			keylist += "="
+			keylist += formatLyPredicateValue(keys[index].Value)
+			keylist += "]"
 		}
 	}
 

--- a/cvl/testdata/schema/sonic-bgp-global.yang
+++ b/cvl/testdata/schema/sonic-bgp-global.yang
@@ -303,6 +303,7 @@ module sonic-bgp-global {
                 }
                 leaf delay-time {
                     type uint16;
+                    when "count(../../EVPN_ETHERNET_SEGMENT_LIST[name!=current()/../name][ifname=current()/../ifname]) = 0";
                 }
             }
         }

--- a/patches/xpath.patch
+++ b/patches/xpath.patch
@@ -324,7 +324,7 @@ index 47f8076..2cfa07b 100644
 +	switch typ := q.(type) {
 +	case *currentQuery:
 +		if (val != nil) {
-+			typ.SFilter.Predicate = fmt.Sprintf("%v", val)
++			typ.SFilter.Predicate = strings.NewReplacer("\\", "\\\\", "'", "\\'").Replace(fmt.Sprintf("%v", val))
 +		}
 +		sf = &typ.SFilter
 +	case *childQuery:
@@ -415,7 +415,7 @@ index 47f8076..2cfa07b 100644
 +		sf = &typ.SFilter
 +	case *constantQuery:
 +		if (val != nil) {
-+			typ.SFilter.Predicate = fmt.Sprintf("%v", val)
++			typ.SFilter.Predicate = strings.NewReplacer("\\", "\\\\", "'", "\\'").Replace(fmt.Sprintf("%v", val))
 +		}
 +
 +		sf = &typ.SFilter
@@ -654,7 +654,7 @@ index 47f8076..2cfa07b 100644
  			c.posit++
 +			if (c.SFilter.Fields != *c.Name) {
 +				//If fields already retrieved from db don't overwrite
-+				c.SFilter.Predicate = node.Value()
++				c.SFilter.Predicate = strings.NewReplacer("\\", "\\\\", "'", "\\'").Replace(fmt.Sprintf("%v", node.Value()))
 +			}
  			return node
  		}


### PR DESCRIPTION
### Description of PR

Summary:

CVL interpolates Redis keys and YANG values into generated Lua and into
libyang3 list-key path predicates. Values that contain `'`, `\`, or `%`
can break those strings, so delete-dependency lookup, must/when evaluation,
and list-node creation fail or match the wrong entries.

This change:
- Escapes `\` and `'` before interpolating keys into delete-dependency Lua
  filters in `GetDepDataForDelete()`.
- Uses plain `string.find` (`plain=true`) so `%` is not treated as a Lua
  pattern character in leaf-list matching.
- Escapes the same characters when building must/when Lua predicates in the
  xpath engine patch.
- Quotes libyang3 list-key predicates the way libyang does: single quotes
  unless the value itself contains `'`, then double quotes
  (`formatLyPredicateValue()` used by `AddListNode()`).

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
- [x] Test case improvement

### Back port request

- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

### Tested branch

- [x] master
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] N/A

### Test result

Added / updated CVL unit tests:

- `TestGetDepDataForDeleteSpecialKeyChars` — keys containing `'`, `\`, `%`
- `TestGetDepDataForDeleteLeafListPatternChars` — leaf-list values with Lua
  pattern characters
- `TestValidateEditConfig_Must_Predicate_Escape_SingleQuote`
- `TestValidateEditConfig_Must_Predicate_Escape_Backslash`
- `TestValidateEditConfig_When_Predicate_Escape_SingleQuote`
- `TestValidateEditConfig_When_Predicate_Escape_Backslash`


### Approach

#### What is the motivation for this PR?

`GetDepDataForDelete()` embeds Redis key values into a Lua script using
`fmt.Sprintf` and `string.find`. Unescaped quotes break the Lua string, and
unescaped `%` is treated as a pattern. must/when predicates had the same
issue when config values were written into Lua predicate strings.

`AddListNode()` always wrapped list-key values in single quotes
(`[key='value']`). Libyang3 uses double quotes when the value contains `'`,
so keys with a single quote fail path parsing.

That can cause:
- failed or incomplete dependent-delete discovery
- incorrect must/when validation for values that contain `'`, `\`, or `%`
- failed list-node create when a key value contains `'`

#### How did you do it?

In `cvl/cvl_api.go` (`GetDepDataForDelete()`):
- Escape `\` and `'` in the key before building the Lua filter script.
- Call `string.find(..., 1, true)` so the search is a plain string match.

In `patches/xpath.patch`:
- Escape `\` and `'` when assigning `SFilter.Predicate` from config values
  (`currentQuery`, `constantQuery`, and `childQuery` evaluation).

In `cvl/internal/yparser/ly_path.go` and `cvl/internal/yparser/yparser.go`:
- Add `formatLyPredicateValue()` and use it in `AddListNode()` so list-key
  predicates match libyang quoting (`'value'` or `"value"`).

No change to Redis data; only generated Lua and libyang path strings are
sanitized.

#### How did you verify/test it?

CVL Go unit tests covering:
- delete-dependency filters with special characters in keys and leaf-lists
- must/when predicates whose values contain `'` or `\`

Existing `TestGetDepDataForDelete` coverage is unchanged.

#### Any platform specific information?

No. Generic CVL / Lua / libyang3 path behavior.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A
