### PR TITLE
cvl: don't duplicate list key leaves when adding table field data

### DIFF
--- a/cvl/cvl_leafref_test.go
+++ b/cvl/cvl_leafref_test.go
@@ -105,6 +105,75 @@ func TestValidateEditConfig_Create_Chained_Leafref_DepData_Positive(t *testing.T
 	}
 }
 
+// Reproduces https://github.com/sonic-net/sonic-buildimage SRV6_MY_SIDS.locator
+// leafref bug: even though the referenced SRV6_MY_LOCATORS entry already
+// exists in Redis, a standalone create of an SRV6_MY_SIDS entry referencing
+// it is rejected with "No instance found".
+func TestValidateEditConfig_Create_Leafref_Srv6Locator_Positive(t *testing.T) {
+	setupTestData(t, map[string]interface{}{
+		"VRF": map[string]interface{}{
+			"default": map[string]interface{}{
+				"fallback": "false",
+			},
+		},
+		"SRV6_MY_LOCATORS": map[string]interface{}{
+			"MAIN": map[string]interface{}{
+				"prefix": "fcbb:bbbb:3::",
+				"vrf":    "default",
+			},
+		},
+	})
+
+	cfgData := []cmn.CVLEditConfigData{
+		cmn.CVLEditConfigData{
+			cmn.VALIDATE_ALL,
+			cmn.OP_CREATE,
+			"SRV6_MY_SIDS|MAIN|fcbb:bbbb:3::/48",
+			map[string]string{
+				"action": "uN",
+			},
+			false,
+		},
+	}
+
+	verifyValidateEditConfig(t, cfgData, Success)
+}
+
+// Same as above but also passes the key leaf "locator" redundantly as a
+// data field (mirroring what translib's JSON->CVL field-map conversion
+// does for gNMI Set requests against a list instance path).
+func TestValidateEditConfig_Create_Leafref_Srv6Locator_KeyAsField_Positive(t *testing.T) {
+	setupTestData(t, map[string]interface{}{
+		"VRF": map[string]interface{}{
+			"default": map[string]interface{}{
+				"fallback": "false",
+			},
+		},
+		"SRV6_MY_LOCATORS": map[string]interface{}{
+			"MAIN": map[string]interface{}{
+				"prefix": "fcbb:bbbb:3::",
+				"vrf":    "default",
+			},
+		},
+	})
+
+	cfgData := []cmn.CVLEditConfigData{
+		cmn.CVLEditConfigData{
+			cmn.VALIDATE_ALL,
+			cmn.OP_CREATE,
+			"SRV6_MY_SIDS|MAIN|fcbb:bbbb:3::/48",
+			map[string]string{
+				"action":    "uN",
+				"locator":   "MAIN",
+				"ip_prefix": "fcbb:bbbb:3::/48",
+			},
+			false,
+		},
+	}
+
+	verifyValidateEditConfig(t, cfgData, Success)
+}
+
 func TestValidateEditConfig_Create_Leafref_To_NonKey_Positive(t *testing.T) {
 	setupTestData(t, map[string]interface{}{
 		"BGP_GLOBALS": map[string]interface{}{

--- a/cvl/cvl_syntax.go
+++ b/cvl/cvl_syntax.go
@@ -115,12 +115,40 @@ func (c *CVL) appendLeafValue(name string, value string, multileaf *[]*yparser.Y
 	*multileaf = append(*multileaf, &yparser.YParserLeafValue{Name: name, Value: value})
 }
 
+// isTableKeyField returns true if fieldName is one of the YANG list key
+// leaves for tableName.
+func isTableKeyField(tableName, fieldName string) bool {
+	for _, keyName := range modelInfo.tableInfo[tableName].keys {
+		if keyName == fieldName {
+			return true
+		}
+	}
+	return false
+}
+
 func (c *CVL) generateTableFieldsData(config bool, tableName string, jsonNode *jsonquery.Node,
 	parent *yparser.YParserNode, multileaf *[]*yparser.YParserLeafValue) CVLErrorInfo {
 	var cvlErrObj CVLErrorInfo
 
 	//Traverse fields
 	for jsonFieldNode := jsonNode.FirstChild; jsonFieldNode != nil; jsonFieldNode = jsonFieldNode.NextSibling {
+		//Skip fields that duplicate one of the list's key leaves. The key
+		//leaf value(s) were already added to the list node by the caller
+		//(generateTableData()'s addListNode() call using the Redis key).
+		//Some callers legitimately include key leaves as regular fields in
+		//the field map too (e.g. RFC 7951 JSON encoding of a YANG list
+		//includes key leaves as ordinary object members, and translib's
+		//generic/default JSON-to-CVL conversion passes them through as-is
+		//for models without a table-specific transformer). Adding such a
+		//field again here would create a second leaf instance with the
+		//same name under the same list entry, which libyang rejects with
+		//"Duplicate instance of <field>" -- surfaced by CVL as a confusing
+		//"Field <field> has invalid value" syntax error that looks like an
+		//unrelated (leafref/semantic) validation failure.
+		if isTableKeyField(tableName, jsonFieldNode.Data) {
+			continue
+		}
+
 		//Add fields as leaf to the list
 		if jsonFieldNode.Type == jsonquery.ElementNode &&
 			jsonFieldNode.FirstChild != nil &&

--- a/cvl/testdata/schema/sonic-srv6.yang
+++ b/cvl/testdata/schema/sonic-srv6.yang
@@ -1,0 +1,146 @@
+module sonic-srv6 {
+    namespace "http://github.com/sonic-net/sonic-srv6";
+    prefix srv6;
+    yang-version 1.1;
+
+	import ietf-inet-types {
+		prefix inet;
+	}
+
+    import sonic-vrf {
+		prefix vrf;
+	}
+
+    description
+        "Segment Routing over IPv6 (SRv6) configuration for SONiC.";
+
+    revision 2024-12-05 {
+		description
+			"Initial revision.";
+	}
+
+    container sonic-srv6 {
+
+        container SRV6_MY_LOCATORS {
+            description "SRv6 locator definitions partitioning the SID address space.";
+
+            list SRV6_MY_LOCATORS_LIST {
+                key "locator_name";
+
+                leaf locator_name {
+                    description "SRv6 locator name.";
+                    type string;
+                }
+
+                leaf prefix {
+                    description "IPv6 address prefix for this locator.";
+                    type inet:ipv6-address;
+                    mandatory true;
+                }
+
+                leaf block_len {
+                    description "Length in bits of the SRv6 locator block portion.";
+                    type uint8 {
+                        range "1..128";
+                    }
+
+                    default 32;
+                }
+
+                leaf node_len {
+                    description "Length in bits of the SRv6 locator node portion.";
+                    type uint8 {
+                        range "1..128";
+                    }
+
+                    default 16;
+                }
+
+                leaf func_len {
+                    description "Length in bits of the SRv6 SID function portion.";
+                    type uint8 {
+                        range "0..128";
+                    }
+
+                    default 16;
+                }
+
+                leaf arg_len {
+                    description "Length in bits of the SRv6 SID argument portion.";
+                    type uint8 {
+                        range "0..128";
+                    }
+
+                    default 0;
+                }
+
+                must 'block_len + node_len + func_len + arg_len <= 128';
+
+                leaf vrf {
+                    type union {
+                        type leafref {
+                            path "/vrf:sonic-vrf/vrf:VRF/vrf:VRF_LIST/vrf:vrf_name";
+                        }
+                        type string {
+                            pattern 'default';
+                        }
+                    }
+                    description "VRF name";
+
+                    default "default";
+                }
+            }
+        }
+
+        container SRV6_MY_SIDS {
+            description "Local SRv6 SID entries with endpoint behavior and decapsulation settings.";
+
+            list SRV6_MY_SIDS_LIST {
+                key "locator ip_prefix";
+
+                leaf ip_prefix {
+                    description "IPv6 prefix representing this SID.";
+                    type inet:ipv6-prefix;
+                }
+
+                leaf locator {
+                    description "Reference to the parent SRv6 locator.";
+                    type leafref {
+                        path "/srv6:sonic-srv6/srv6:SRV6_MY_LOCATORS/srv6:SRV6_MY_LOCATORS_LIST/srv6:locator_name";
+                    }
+                }
+
+                leaf action {
+                    description "SRv6 endpoint behavior (uN for prefix SID, uDT46 for decap with VRF lookup).";
+                    type enumeration {
+                        enum uN;
+                        enum uDT46;
+                    }
+                }
+
+                leaf decap_vrf {
+                    type union {
+                        type leafref {
+                            path "/vrf:sonic-vrf/vrf:VRF/vrf:VRF_LIST/vrf:vrf_name";
+                        }
+                        type string {
+                            pattern 'default';
+                        }
+                    }
+                    description "VRF name used for decapsulation";
+
+                    default "default";
+                }
+
+                leaf decap_dscp_mode {
+                    description "DSCP handling mode for decapsulated packets.";
+                    type enumeration {
+                        enum uniform;
+                        enum pipe;
+                    }
+                }
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
## Summary

`generateTableFieldsData()` in `cvl/cvl_syntax.go` added every field from the
caller's data map as a leaf node, even when a field's name matched one of the
table's own YANG list key leaves. The key leaf's value is already added to
the list node from the Redis key by `generateTableData()`/`addListNode()`, so
this created a duplicate leaf instance whenever a caller's field map also
included the key leaf(s) as regular fields — which is legitimate per RFC 7951
JSON encoding of a YANG list (key leaves appear as ordinary object members),
and is exactly what translib's generic/default JSON→CVL conversion does for
models without a table-specific transformer.

libyang rejects the resulting duplicate leaf instance with
`Duplicate instance of "<field>"`, which CVL surfaces as a generic
`Field "<field>" has invalid value` syntax error (`CVL_SYNTAX_ERROR`,
`YPC_SYNTAX_INVALID_INPUT_DATA`). If the duplicated key leaf also happens to
have a `leafref` type, this looks exactly like a leafref/semantic validation
failure, even though the leafref lookup itself is unaffected — this is a
false-positive rejection, not a real leafref problem.

Reproduced with the `sonic-srv6` module's `SRV6_MY_SIDS` table, whose key is
a leafref-typed leaf (`locator`, pointing at `SRV6_MY_LOCATORS_LIST.locator_name`)
plus `ip_prefix`. Creating an `SRV6_MY_SIDS` entry via a `CVLEditConfigData`
field map that includes both key leaves (as translib does for this model)
fails with:

```
ErrCode[1005]: ErrDetails[Invalid Input Data Received],
Msg[Field "locator" has invalid value],
Table[SRV6_MY_SIDS:[MAIN MAIN fcbb:bbbb:3::/48 fcbb:bbbb:3::/48]]
```

(note the duplicated key values in `Table[...]`). With `TRACE_LIBYANG`
enabled, the underlying libyang error is unambiguous:

```
[libyang Error] Duplicate instance of "locator".
(path: .../SRV6_MY_SIDS_LIST[locator='MAIN'][locator='MAIN'][ip_prefix='fcbb:bbbb:3::/48'][ip_prefix='fcbb:bbbb:3::/48']/locator)
```

even though the referenced `SRV6_MY_LOCATORS` entry is present and correct.

## Fix

Skip fields in `generateTableFieldsData()` whose name matches one of the
table's key leaves (`modelInfo.tableInfo[tableName].keys`), since that
leaf's value was already added via the list key.

## Test plan

- Added `TestValidateEditConfig_Create_Leafref_Srv6Locator_Positive` (baseline:
  the leafref check itself already worked when the field map doesn't
  redundantly include the keys) and
  `TestValidateEditConfig_Create_Leafref_Srv6Locator_KeyAsField_Positive` (the
  actual regression test, mirroring translib's field map shape) to
  `cvl/cvl_leafref_test.go`.
- Added `cvl/testdata/schema/sonic-srv6.yang` as the reproducing fixture
  (copied from the real `sonic-srv6.yang` model, with `vrf:name` →
  `vrf:vrf_name` to match this test suite's existing `sonic-vrf.yang` stub).
- Full `cvl` package test suite passes: 142/142, 0 regressions
  (`NOREPORT=1 tests/run_test.sh`).
- Verified live end-to-end against a SONiC VS instance (containerlab,
  `vrnetlab/sonic_sonic-vs:202605`, translib write enabled): before this fix,
  a `gnmic` `Set` against the `sonic_yang` origin creating an `SRV6_MY_SIDS`
  entry referencing an already-present `SRV6_MY_LOCATORS` entry failed with
  the exact error above; after rebuilding `telemetry` with this fix, the
  identical request succeeds and the entry is readable back correctly.